### PR TITLE
use pkg-config to find Osi, etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,17 +70,16 @@ if (NOT (${HiGHSDEV} STREQUAL  "OFF"))
     message(STATUS "HiGHS development: " ${HiGHSDEV})
 endif()
 
-# osi off by default, unless given a path to installation
-set(OSI false CACHE BOOL "Use OSI interface")
-set(OSI_DIR "" CACHE STRING "OSI interface root folder")
 option(OSI_ROOT "Osi root folder." "OFF")
-if (NOT (${OSI_ROOT} STREQUAL  "OFF"))
-    message(STATUS "OSI root folder: " ${OSI_ROOT})
-    set(OSI true)
-    set(OSI_DIR ${OSI_ROOT})
-endif()
+if (NOT (${OSI_ROOT} STREQUAL "OFF"))
+    # if OSI_ROOT is set, then overwrite PKG_CONFIG_PATH
+    message(STATUS "OSI root folder set: " ${OSI_ROOT})
+    set(ENV{PKG_CONFIG_PATH}  "${OSI_ROOT}/lib/pkgconfig")
+endif ()
 unset(OSI_ROOT CACHE)
 
+find_package(PkgConfig)
+pkg_check_modules(OSI osi)
 
 # whether to use shared or static libraries
 option(SHARED "Build shared libraries" ON)

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -16,14 +16,13 @@ set(TEST_SOURCES
 add_executable(unit_tests ${TEST_SOURCES})
 target_link_libraries(unit_tests libhighs Catch)
 
-if (OSI)
-    string(CONCAT ROOT_OSI "${OSI_DIR}" "/")
-    include_directories(${ROOT_OSI}include/coin)
+pkg_check_modules(OSITEST osi osi-unittests)
+if (OSITEST_FOUND)
     include_directories(${CMAKE_SOURCE_DIR}/src)
-    find_library(OSI_LIB Osi HINTS ${ROOT_OSI}lib)
-    find_library(OSI_UNIT_TEST_LIB OsiCommonTests HINTS ${ROOT_OSI}lib)
-    add_executable(osi_unit_tests  OsiUnitTest.cpp)
-    target_link_libraries(osi_unit_tests libhighs Catch ${OSI_UNIT_TEST_LIB} ${OSI_LIB})
+    add_executable(osi_unit_tests OsiUnitTest.cpp)
+    target_link_libraries(osi_unit_tests libhighs Catch ${OSITEST_LINK_LIBRARIES})
+    target_include_directories(osi_unit_tests PUBLIC ${OSITEST_INCLUDE_DIRS})
+    target_compile_options(osi_unit_tests PUBLIC ${OSITEST_CFLAGS_OTHER})
 endif()
 
 # Check whether test executable builds OK.
@@ -45,7 +44,7 @@ set_tests_properties(unit_tests_all
                     PROPERTIES
                     DEPENDS unit-test-build)
 
-if (OSI) 
+if (OSITEST_FOUND)
 
 add_test(NAME osi-unit-test-build
          COMMAND ${CMAKE_COMMAND}
@@ -59,7 +58,7 @@ PROPERTIES
 RESOURCE_LOCK osiunittestbin)
 
 # create a binary running all the tests in the executable
-add_test(NAME osi_unit_tests_all COMMAND osi_unit_tests -mpsDir=${ROOT_OSI}/share/coin/Data/Sample -netlibDir=${ROOT_OSI}/share/coin/Data/Netlib)
+add_test(NAME osi_unit_tests_all COMMAND osi_unit_tests -mpsDir=${OSITEST_PREFIX}/share/coin/Data/Sample -netlibDir=${OSITEST_PREFIX}/share/coin/Data/Netlib)
 set_tests_properties(osi_unit_tests_all
 PROPERTIES
 DEPENDS osi-unit-test-build)

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -57,8 +57,20 @@ set_tests_properties(osi-unit-test-build
 PROPERTIES
 RESOURCE_LOCK osiunittestbin)
 
+pkg_search_module(COINSAMPLE coindatasample)
+if (COINSAMPLE_FOUND)
+   pkg_get_variable(COINSAMPLEDIR coindatasample datadir)
+   set(OSIUNITTESTFLAGS ${OSIUNITTESTFLAGS} -mpsDir=${COINSAMPLEDIR})
+endif ()
+
+pkg_search_module(COINNETLIB coindatanetlib)
+if (COINNETLIB_FOUND)
+   pkg_get_variable(COINNETLIBDIR coindatanetlib datadir)
+   set(OSIUNITTESTFLAGS ${OSIUNITTESTFLAGS} -netlibDir=${COINNETLIBDIR})
+endif ()
+
 # create a binary running all the tests in the executable
-add_test(NAME osi_unit_tests_all COMMAND osi_unit_tests -mpsDir=${OSITEST_PREFIX}/share/coin/Data/Sample -netlibDir=${OSITEST_PREFIX}/share/coin/Data/Netlib)
+add_test(NAME osi_unit_tests_all COMMAND osi_unit_tests ${OSIUNITTESTFLAGS})
 set_tests_properties(osi_unit_tests_all
 PROPERTIES
 DEPENDS osi-unit-test-build)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,18 +83,17 @@ set(headers
     Highs.h
 )
 
-if (OSI)
+if (OSI_FOUND)
     set(sources ${sources} interfaces/OsiHiGHSSolverInterface.cpp)
     set(headers ${headers} interfaces/OsiHiGHSSolverInterface.hpp)
 endif()
 
 add_library(libhighs ${sources})
 
-if (OSI)
-    string(CONCAT ROOT_OSI "${OSI_DIR}" "/")
-    include_directories(${ROOT_OSI}include/coin)
-    find_library(OSI_LIB Osi HINTS ${ROOT_OSI}lib)
-    target_link_libraries(libhighs PUBLIC ${OSI_LIB})
+if (OSI_FOUND)
+    target_include_directories(libhighs PUBLIC ${OSI_INCLUDE_DIRS})
+    target_link_libraries(libhighs PUBLIC ${OSI_LINK_LIBRARIES})
+    target_compile_options(libhighs PUBLIC ${OSI_CFLAGS_OTHER})
 endif()
 
 # put version information into shared library file


### PR DESCRIPTION
Reads the osi.pc, etc., files to figure out compiler and linker flags to build against Osi lib and Osi test lib.
Also uses pkg-config to look for COIN-OR's Data/Sample and Data/Netlib, used in unittest.

OSI_ROOT can be set.
If not set, but Osi is installed in the system (in a path where pkg-config will looks into), the Osi interface would also be build.