### PR TITLE
GAMS interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.0.0)
 
-project(HIGHS LANGUAGES CXX)
+project(HIGHS LANGUAGES CXX C)
 
 set(HIGHS_VERSION_MAJOR 1)
 set(HIGHS_VERSION_MINOR 0)
@@ -82,6 +82,14 @@ find_package(PkgConfig)
 pkg_check_modules(OSI osi)
 # need to come before adding any targets (add_executable, add_library)
 link_directories(${OSI_LIBRARY_DIRS})
+
+option(GAMS_ROOT "GAMS root folder." "OFF")
+if (NOT (${GAMS_ROOT} STREQUAL "OFF"))
+    message(STATUS "GAMS root folder set: " ${GAMS_ROOT})
+    set(GAMS_FOUND ON)
+else ()
+    set(GAMS_FOUND OFF)
+endif ()
 
 # whether to use shared or static libraries
 option(SHARED "Build shared libraries" ON)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Set custom options with `-D<option>=<value>` during the configuration step (`cma
     on: Defined when CMAKE_BUILD_TYPE=Release
 - `OSI_ROOT`:
     path to COIN-OR/Osi build/install directory (OSI_ROOT/lib/pkg-config/osi.pc should exist)
+- `GAMS_ROOT`:
+    path to GAMS system: enables building of GAMS interface
 
 Testing
 -------
@@ -113,6 +115,16 @@ due to executing the command
     unset OMP_NUM_THREADS
 
 then all available threads will be used.
+
+If build with GAMS interface, then HiGHS can be made available as solver
+in GAMS by adding an entry for HiGHS to the file gmscmpun.txt in the GAMS
+system directory (gmscmpnt.txt on Windows):
+```
+HIGHS 11 5 0001020304 1 0 2 LP RMIP
+gmsgenus.run
+gmsgenux.out
+/path/to/libhighs.so his 1 1
+```
 
 Observations
 ------------

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -84,6 +84,10 @@ DEPENDS osi-unit-test-build)
 
 endif()
 
+if (GAMS_FOUND)
+add_test(NAME rungams COMMAND ${CMAKE_SOURCE_DIR}/check/rungams.sh ${GAMS_ROOT})
+endif (GAMS_FOUND)
+
 # An individual test can be added with the command below but the approach
 # above with a single add_test for all the unit tests automatically detects all
 # TEST_CASEs in the source files specified in TEST_SOURCES. Do not define any

--- a/check/rungams.sh
+++ b/check/rungams.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# stop on error
+set -e
+
+if [ "$1" == "" ] ; then
+  GAMSPATH=`dirname $(which gams)`
+else
+  GAMSPATH="$1"
+fi
+
+"$GAMSPATH/gamslib" trnsport
+
+# try to print log if below there is an error, e.g., gams fails or grep does not find
+trap "cat trnsport.log" ERR
+
+"$GAMSPATH/gams" trnsport.gms LP=HIGHS LO=2
+
+grep "**** SOLVER STATUS     1 Normal Completion" trnsport.lst
+grep "**** MODEL STATUS      1 Optimal" trnsport.lst
+grep "**** OBJECTIVE VALUE              153.6750" trnsport.lst
+
+rm -f trnsport.{gms,log,lst}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,6 @@ if (GAMS_FOUND)
     set(sources ${sources} interfaces/GAMS.cpp)
     set(sources ${sources} "${GAMS_ROOT}/apifiles/C/api/gmomcc.c")
     set(sources ${sources} "${GAMS_ROOT}/apifiles/C/api/gevmcc.c")
-    set(sources ${sources} "${GAMS_ROOT}/apifiles/C/api/optcc.c")
 endif()
 
 add_library(libhighs ${sources})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,7 +83,18 @@ set(headers
     Highs.h
 )
 
+if (GAMS_FOUND)
+    set(sources ${sources} interfaces/GAMS.cpp)
+    set(sources ${sources} "${GAMS_ROOT}/apifiles/C/api/gmomcc.c")
+    set(sources ${sources} "${GAMS_ROOT}/apifiles/C/api/gevmcc.c")
+    set(sources ${sources} "${GAMS_ROOT}/apifiles/C/api/optcc.c")
+endif()
+
 add_library(libhighs ${sources})
+
+if (GAMS_FOUND)
+    target_include_directories(libhighs PUBLIC "${GAMS_ROOT}/apifiles/C/api")
+endif()
 
 if(${BUILD_SHARED_LIBS})
     # put version information into shared library file

--- a/src/interfaces/GAMS.cpp
+++ b/src/interfaces/GAMS.cpp
@@ -1,0 +1,340 @@
+/* HiGHS link code */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+/* GAMS API */
+#include "gmomcc.h"
+#include "gevmcc.h"
+#include "optcc.h"
+
+/* HiGHS API */
+#include "Highs.h"
+
+#if defined(_WIN32)
+#if !defined(STDCALL)
+#define STDCALL __stdcall
+#endif
+#if !defined(DllExport)
+#define DllExport __declspec(dllexport)
+#endif
+#else
+#if !defined(STDCALL)
+#define STDCALL
+#endif
+#if !defined(DllExport)
+#define DllExport
+#endif
+#endif
+
+struct gamshighs_s
+{
+   gmoHandle_t gmo;
+   gevHandle_t gev;
+   optHandle_t opt;
+   int         debug;
+
+   Highs*      highs;
+   HighsLp*    lp;
+};
+typedef struct gamshighs_s gamshighs_t;
+
+static
+int setupProblem(
+   gamshighs_t* gh
+)
+{
+   int numCol;
+   int numRow;
+   int numNz;
+   int i;
+   int rc = 1;
+
+   assert(gh != NULL);
+   assert(gh->highs == NULL);
+   assert(gh->lp == NULL);
+
+   HighsOptions options;
+   gh->highs = new Highs(options);
+
+   numCol = gmoN(gh->gmo);
+   numRow = gmoM(gh->gmo);
+   numNz = gmoNZ(gh->gmo);
+
+   gh->lp = new HighsLp();
+
+   gh->lp->numRow_ = numRow;
+   gh->lp->numCol_ = numCol;
+   gh->lp->nnz_ = numNz;
+
+   /* columns */
+   gh->lp->colUpper_.resize(numCol);
+   gh->lp->colLower_.resize(numCol);
+   gmoGetVarLower(gh->gmo, &gh->lp->colLower_[0]);
+   gmoGetVarUpper(gh->gmo, &gh->lp->colUpper_[0]);
+
+   /* objective */
+   gh->lp->colCost_.resize(numCol);
+   gmoGetObjVector(gh->gmo, &gh->lp->colCost_[0], NULL);
+   if( gmoSense(gh->gmo) == gmoObj_Min )
+      gh->lp->sense_ = 1;
+   else
+      gh->lp->sense_ = -1;
+
+   /* row left- and right-hand-side */
+   gh->lp->rowLower_.resize(numRow);
+   gh->lp->rowUpper_.resize(numRow);
+   for( i = 0; i < numRow; ++i )
+   {
+      switch( gmoGetEquTypeOne(gh->gmo, i) )
+      {
+         case gmoequ_E :
+            gh->lp->rowLower_[i] = gh->lp->rowUpper_[i] = gmoGetRhsOne(gh->gmo, i);
+            break;
+
+         case gmoequ_G :
+            gh->lp->rowLower_[i] = gmoGetRhsOne(gh->gmo, i);
+            gh->lp->rowUpper_[i] = HIGHS_CONST_INF;
+            break;
+
+         case gmoequ_L :
+            gh->lp->rowLower_[i] = -HIGHS_CONST_INF;
+            gh->lp->rowUpper_[i] = gmoGetRhsOne(gh->gmo, i);
+            break;
+
+         case gmoequ_N:
+         case gmoequ_X:
+         case gmoequ_C:
+         case gmoequ_B:
+            /* these should not occur */
+            goto TERMINATE;
+      }
+   }
+
+   /* coefficients matrix */
+   gh->lp->Astart_.resize(numCol + 1);
+   gh->lp->Aindex_.resize(numNz);
+   gh->lp->Avalue_.resize(numNz);
+   gmoGetMatrixCol(gh->gmo, &gh->lp->Astart_[0], &gh->lp->Aindex_[0], &gh->lp->Avalue_[0], NULL);
+
+   gh->highs->initializeLp(*gh->lp);
+
+   rc = 0;
+TERMINATE:
+
+   return rc;
+}
+
+static
+int processSolve(
+   gamshighs_t* gh
+)
+{
+   double* x;
+   double* pi;
+
+   assert(gh != NULL);
+   assert(gh->highs != NULL);
+   assert(gh->lp != NULL);
+
+   gmoSetHeadnTail(gh->gmo, gmoHresused, gevTimeDiffStart(gh->gev));
+   gmoSetHeadnTail(gh->gmo, gmoHiterused, 42 /* FIXME number of iterations */);
+
+   /* FIXME below assumes best possible outcome: solved to optimality, have optimal primal and dual solution */
+
+   x = new double[gmoN(gh->gmo)];
+   pi = new double[gmoM(gh->gmo)];
+
+   /* TODO fill x with primal solution
+    * TODO fill pi with dual solution (w.r.t. rows)
+    * TODO probably should use gmoSetSolution or gmoSetSolution8
+    */
+
+   gmoSetSolution2(gh->gmo, x, pi);
+   gmoCompleteSolution(gh->gmo);
+
+   gmoModelStatSet(gh->gmo, gmoModelStat_OptimalGlobal);
+   gmoSolveStatSet(gh->gmo, gmoSolveStat_Normal);
+
+   delete[] x;
+   delete[] pi;
+
+   return 0;
+}
+
+
+extern "C"
+{
+
+
+void his_Initialize(void)
+{
+   gmoInitMutexes();
+   gevInitMutexes();
+   optInitMutexes();
+}
+
+void his_Finalize(void)
+{
+   gmoFiniMutexes();
+   gevFiniMutexes();
+   optFiniMutexes();
+}
+
+DllExport void STDCALL hisXCreate(void** Cptr)
+{
+   assert(Cptr != NULL);
+
+   *Cptr = calloc(1, sizeof(gamshighs_t));
+}
+
+DllExport int STDCALL hiscreate(void** Cptr, char* msgBuf, int msgBufLen)
+{
+   assert(Cptr != NULL);
+   assert(msgBufLen > 0);
+   assert(msgBuf != NULL);
+
+   *Cptr = calloc(1, sizeof(gamshighs_t));
+
+   msgBuf[0] = 0;
+
+   return 1;
+}
+
+DllExport void STDCALL hisXFree(void** Cptr)
+{
+   assert(Cptr != NULL);
+   assert(*Cptr != NULL);
+
+   free(*Cptr);
+   *Cptr = NULL;
+
+   gmoLibraryUnload();
+   gevLibraryUnload();
+}
+
+DllExport int STDCALL hisfree(void** Cptr)
+{
+   hisXFree(Cptr);
+
+   return 1;
+}
+
+/* comp returns the compatibility mode:
+           0: client is too old for the DLL, no compatibility
+           1: client version and DLL version are the same, full compatibility
+           2: client is older than DLL, but defined as compatible, backward compatibility
+           3: client is newer than DLL, forward compatibility
+           FIXME: for now, we just claim full compatibility
+ */
+DllExport int STDCALL C__hisXAPIVersion(int api, char* Msg, int* comp)
+{
+   *comp = 1;
+   return 1;
+}
+
+DllExport int STDCALL D__hisXAPIVersion(int api, char* Msg, int* comp)
+{
+   *comp = 1;
+   return 1;
+}
+
+DllExport int STDCALL C__hisXCheck(const char* funcn, int ClNrArg, int Clsign[], char* Msg) { return 1; }
+
+DllExport int STDCALL D__hisXCheck(const char* funcn, int ClNrArg, int Clsign[], char* Msg) { return 1; }
+
+DllExport int STDCALL C__hisReadyAPI(void* Cptr, gmoHandle_t Gptr, optHandle_t Optr)
+{
+   gamshighs_t* gh;
+
+   assert(Cptr != NULL);
+   assert(Gptr != NULL);
+
+   char msg[256];
+   if(!gmoGetReady(msg, sizeof(msg)))
+      return 1;
+   if(!gevGetReady(msg, sizeof(msg)))
+      return 1;
+
+   gh = (gamshighs_t*)Cptr;
+   gh->gmo = Gptr;
+   gh->gev = (gevHandle_t)gmoEnvironment(gh->gmo);
+   gh->opt = Optr;
+
+   return 0;
+}
+
+DllExport int STDCALL C__hisCallSolver(void* Cptr)
+{
+   int rc = 1;
+   char buffer[1024];
+   gamshighs_t* gh;
+
+   gh = (gamshighs_t*)Cptr;
+   assert(gh->gmo != NULL);
+   assert(gh->gev != NULL);
+
+   gevLogStat(gh->gev, "This is the GAMS link to HiGHS.");
+
+   gmoModelStatSet(gh->gmo, gmoModelStat_NoSolutionReturned);
+   gmoSolveStatSet(gh->gmo, gmoSolveStat_SystemErr);
+
+   /*
+   if( dooptions(highs) )
+      goto TERMINATE;
+    */
+
+
+   /* get the problem into a normal form */
+   gmoObjStyleSet(gh->gmo, gmoObjType_Fun);
+   gmoObjReformSet(gh->gmo, 1);
+   gmoIndexBaseSet(gh->gmo, 0);
+   gmoSetNRowPerm(gh->gmo); /* hide =N= rows */
+   gmoMinfSet(gh->gmo, -HIGHS_CONST_INF);
+   gmoPinfSet(gh->gmo,  HIGHS_CONST_INF);
+
+   if( !setupProblem(gh) )
+      goto TERMINATE;
+
+   /* set timelimit */
+//   gh->model->dblOption[DBLOPT_TIME_LIMIT] = gevGetDblOpt(gh->gev, gevResLim);
+
+   gevTimeSetStart(gh->gev);
+
+   /* TODO solve the problem here */
+
+   /* pass solution, status, etc back to GMO here */
+
+   /* process solve outcome */
+   if( !processSolve(gh) )
+      goto TERMINATE;
+
+   rc = 0;
+TERMINATE:
+
+   if( gh->opt != NULL )
+      optFree(&gh->opt);
+
+   delete gh->lp;
+   gh->lp = NULL;
+
+   delete gh->highs;
+   gh->highs= NULL;
+
+   return rc;
+}
+
+DllExport int STDCALL C__hisHaveModifyProblem(void* Cptr) { return 0; }
+
+DllExport int STDCALL C__hisModifyProblem(void* Cptr)
+{
+   assert(Cptr != NULL);
+   return 1;
+}
+
+void his_Initialize(void);
+void his_Finalize(void);
+
+} // extern "C"

--- a/src/interfaces/GAMS.cpp
+++ b/src/interfaces/GAMS.cpp
@@ -56,6 +56,9 @@ int setupOptions(
    gh->options->highs_run_time_limit = gevGetDblOpt(gh->gev, gevResLim);
    gh->options->simplex_iteration_limit = gevGetIntOpt(gh->gev, gevIterLim);
 
+   if( gevGetIntOpt(gh->gev, gevUseCutOff) )
+      gh->options->dual_objective_value_upper_bound = gevGetDblOpt(gh->gev, gevCutOff);
+
    if( gmoOptFile(gh->gmo) > 0 )
    {
       char optfilename[GMS_SSSIZE];
@@ -64,7 +67,6 @@ int setupOptions(
       if( !loadOptionsFromFile(*gh->options) )
          return 1;
    }
-   //gh->options->dual_objective_value_upper_bound
 
    return 0;
 }

--- a/src/interfaces/GAMS.cpp
+++ b/src/interfaces/GAMS.cpp
@@ -173,6 +173,7 @@ int processSolve(
 
    switch( status )
    {
+      case HighsStatus::NotSet:
       case HighsStatus::Init:
       case HighsStatus::LpError:
       case HighsStatus::OptionsError:
@@ -332,6 +333,9 @@ DllExport int STDCALL C__hisReadyAPI(void* Cptr, gmoHandle_t Gptr, optHandle_t O
    return 0;
 }
 
+#define XQUOTE(x) QUOTE(x)
+#define QUOTE(x) #x
+
 DllExport int STDCALL C__hisCallSolver(void* Cptr)
 {
    int rc = 1;
@@ -343,7 +347,8 @@ DllExport int STDCALL C__hisCallSolver(void* Cptr)
    assert(gh->gmo != NULL);
    assert(gh->gev != NULL);
 
-   gevLogStat(gh->gev, "This is the GAMS link to HiGHS.");
+   gevLogStatPChar(gh->gev, "HiGHS " XQUOTE(HIGHS_VERSION_MAJOR) "." XQUOTE(HIGHS_VERSION_MINOR) "." XQUOTE(HIGHS_VERSION_PATCH) " [date: " HIGHS_COMPILATION_DATE ", git hash: " HIGHS_GITHASH "]\n");
+   gevLogStatPChar(gh->gev, "Copyright (c) 2019 ERGO-Code under MIT licence terms.\n");
 
    gmoModelStatSet(gh->gmo, gmoModelStat_NoSolutionReturned);
    gmoSolveStatSet(gh->gmo, gmoSolveStat_SystemErr);


### PR DESCRIPTION
A first working GAMS interface.
Passes problem from GAMS to HiGHS, calls run(), and passes result back to GAMS.

Some more todos:
- [x] processing options and option files
- [x] redirecting output
- [x] test
- [x] install instructions

Todos for later:
- status-code cleanup (waits for changes in HiGHS status)
- initial basis (waiting for #113)
- more solution processing (e.g., basis status) (waiting for #113)
- Ctrl+C handling (waiting for #112)
- implement modifyProblem (resolve after changes in variable bounds, rhs, objective coefficients)

I based this on the OSIinterface branch because I also had to touch several CMakeLists.txt and want to avoid conflicts.