### PR TITLE
Obj shift

### DIFF
--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -73,8 +73,11 @@ int main(int argc, char **argv) {
     HighsPrintMessage(ML_ALWAYS, "Error loading file.\n");
     return (int)HighsStatus::LpError;
   } else {
-    HighsPrintMessage(ML_MINIMAL, "LP parsed from file: %s\n\n",
+    HighsPrintMessage(ML_MINIMAL, "LP       : %s\n",
                       lp.model_name_.c_str());
+    HighsPrintMessage(ML_MINIMAL,
+                      "Rows     : %d\nCols     : %d\nNonzeros : %d\n\n",
+                      lp.numRow_, lp.numCol_, lp.Avalue_.size());
   }
 
   Highs highs(options);

--- a/src/io/FilereaderMps.cpp
+++ b/src/io/FilereaderMps.cpp
@@ -36,7 +36,7 @@ FilereaderRetcode FilereaderMps::readModelFromFile(const HighsOptions &options,
       case FreeFormatParserReturnCode::FILENOTFOUND:
         return FilereaderRetcode::FILENOTFOUND;
       case FreeFormatParserReturnCode::FIXED_FORMAT:
-        HighsPrintMessage(ML_DETAILED | ML_VERBOSE | ML_ALWAYS, "%s %s\n",
+        HighsPrintMessage(ML_DETAILED | ML_VERBOSE, "%s %s\n",
                           "Whitespaces encountered in row / col name.",
                           "Switching to fixed format parser.");
         break;


### PR DESCRIPTION
reading in objective shift defined as an empty column in the Column sections or as a fixed column bound in the bounds section of a free format mps file. 