### PR TITLE
fixed parsing of long section keyword with capital letters

### DIFF
--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -485,10 +485,12 @@ LpSectionKeyword FilereaderLp::tryParseLongSectionKeyword(const char* str,
   int nread = sscanf(str, "%s %s%n", s1, s2, characters);
   if (nread == 2) {
     sprintf(s3, "%s %s", s1, s2);
-    if (strcmp(s3, LP_KEYWORD_ST[0]) == 0) {
+    char* s4 = strClone(s3);
+    strToLower(s4);
+    if (strcmp(s4, LP_KEYWORD_ST[0]) == 0) {
       return LpSectionKeyword::CON;
     }
-    if (strcmp(s3, LP_KEYWORD_ST[1]) == 0) {
+    if (strcmp(s4, LP_KEYWORD_ST[1]) == 0) {
       return LpSectionKeyword::CON;
     }
   }


### PR DESCRIPTION
the constraint section identifier was not correctly recognized if written as either "subject to" or "such that" if not all characters were lowercase