### PR TITLE
void signature for create

### DIFF
--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -35,7 +35,7 @@ int Highs_call(
 /*
  * @brief creates a HiGHS object and returns the reference
  */
-void* Highs_create();
+void* Highs_create(void);
 
 /*
  * @brief destroys a HiGHS object


### PR DESCRIPTION
I realized while generating the Julia API that there is a function which should take 0 argument but has an unspecified number in the current version:
`void* Highs_create(void);` vs `void* Highs_create();`
