### PR TITLE
Improve interface example

### DIFF
--- a/examples/call_highs_from_c.c
+++ b/examples/call_highs_from_c.c
@@ -7,19 +7,29 @@
 // gcc call_highs_from_c.c -o highstest -I ../build/install_folder/include/ -L ../build/install_folder/lib/ -lhighs
 
 void minimal_api() {
+  // Form and solve the LP
+  // Min    f  = 2x_0 + 3x_1
+  // s.t.   8 <= 2x_0 +  x_1
+  //                    2x_1 <= 6
+  //       10 <=  x_0 + 2x_1 <= 14
+  // 0 <= x_0 <= 3; 1 <= x_1
+
   int numcol = 2;
-  int numrow = 2;
-  int nnz = 4;
+  int numrow = 3;
+  int nnz = 5;
   int i;
 
-  double cc[2] = {1.0, -2.0};
-  double cl[2] = {0.0, 0.0};
-  double cu[2] = {10.0, 10.0};
-  double rl[2] = {0.0, 0.0};
-  double ru[2] = {2.0, 1.0};
-  int astart[3] = {0, 2, 4};
-  int aindex[4] = {0, 1, 0, 1};
-  double avalue[4] = {1.0, 2.0, 1.0, 3.0};
+  // Define the column costs, lower bounds and upper bounds
+  double cc[2] = {2.0, 3.0};
+  double cl[2] = {0.0, 1.0};
+  double cu[2] = {3.0, 1.0e30};
+  // Define the row lower bounds and upper bounds
+  double rl[3] = {8.0, -1.0e30, 10.0};
+  double ru[3] = {1.0e30, 6.0, 14.0};
+  // Define the constraint matrix column-wise
+  int astart[3] = {0, 2, 5};
+  int aindex[5] = {0, 2, 0, 1, 2};
+  double avalue[5] = {2.0, 1.0, 1.0, 1.0, 2.0};
 
   double* cv = (double*)malloc(sizeof(double) * numcol);
   double* cd = (double*)malloc(sizeof(double) * numcol);
@@ -38,8 +48,14 @@ void minimal_api() {
 
   printf("Status: %d\nModelstatus:%d\n", status, modelstatus);
 
+  // Report the column primal and dual values, and basis status
   for (i = 0; i < numcol; i++) {
-    printf("x%d = %lf\n", i, cv[i]);
+    printf("Col%d = %lf; dual = %lf; status = %d; \n", i, cv[i], cd[i], cbs[i]);
+  }
+
+  // Report the row primal and dual values, and basis status
+  for (i = 0; i < numrow; i++) {
+    printf("Row%d = %lf; dual = %lf; status = %d; \n", i, rv[i], rd[i], rbs[i]);
   }
 
   free(cv);
@@ -51,23 +67,75 @@ void minimal_api() {
 }
 
 void full_api() {
+  // Form and solve the LP
+  // Min    f  = 2x_0 + 3x_1
+  // s.t.   8 <= 2x_0 +  x_1
+  //                    2x_1 <= 6
+  //       10 <=  x_0 + 2x_1 <= 14
+  // 0 <= x_0 <= 3; 1 <= x_1
+
   void* highs;
 
   highs = Highs_create();
 
-  double cc[2] = {1.0, -2.0};
-  double cl[2] = {0.0, 0.0};
-  double cu[2] = {10.0, 10.0};
-  double rl[2] = {0.0, 0.0};
-  double ru[2] = {2.0, 1.0};
-  int astart[3] = {0, 2, 4};
-  int aindex[4] = {0, 1, 0, 1};
-  double avalue[4] = {1.0, 2.0, 1.0, 3.0};
+  int numcol = 2;
+  int numrow = 3;
+  int nnz = 5;
+  int i;
 
+  // Define the column costs, lower bounds and upper bounds
+  double cc[2] = {2.0, 3.0};
+  double cl[2] = {0.0, 1.0};
+  double cu[2] = {3.0, 1.0e30};
+  // Define the row lower bounds and upper bounds
+  double rl[3] = {8.0, -1.0e30, 10.0};
+  double ru[3] = {1.0e30, 6.0, 14.0};
+  // Define the constraint matrix row-wise, as it is added to the LP
+  // with the rows
+  int arstart[4] = {0, 2, 3, 5};
+  int arindex[5] = {0, 1, 1, 0, 1};
+  double arvalue[5] = {2.0, 1.0, 1.0, 1.0, 2.0};
+
+  double* cv = (double*)malloc(sizeof(double) * numcol);
+  double* cd = (double*)malloc(sizeof(double) * numcol);
+  double* rv = (double*)malloc(sizeof(double) * numrow);
+  double* rd = (double*)malloc(sizeof(double) * numrow);
+
+  int* cbs = (int*)malloc(sizeof(int) * numcol);
+  int* rbs = (int*)malloc(sizeof(int) * numrow);
+
+  int modelstatus; 
+
+  // Add two columns to the empty LP
   assert( Highs_addCols(highs, 2, cc, cl, cu, 0, NULL, NULL, NULL) );
-  assert( Highs_addRows(highs, 2, rl, ru,  4, astart, aindex, avalue) );
+  // Add three rows to the 2-column LP
+  assert( Highs_addRows(highs, 3, rl, ru,  5, arstart, arindex, arvalue) );
 
   Highs_run(highs);
+  // Get the primal and dual solution 
+  Highs_getSolution(highs, cv, cd, rv, rd);
+  // Get the basis
+  Highs_getBasis(highs, cbs, rbs);
+  
+  //  printf("Status: %d\nModelstatus:%d\n", status, modelstatus);
+
+  // Report the column primal and dual values, and basis status
+  for (i = 0; i < numcol; i++) {
+    printf("Col%d = %lf; dual = %lf; status = %d; \n", i, cv[i], cd[i], cbs[i]);
+  }
+
+  // Report the row primal and dual values, and basis status
+  for (i = 0; i < numrow; i++) {
+    printf("Row%d = %lf; dual = %lf; status = %d; \n", i, rv[i], rd[i], rbs[i]);
+  }
+
+  free(cv);
+  free(cd);
+  free(rv);
+  free(rd);
+  free(cbs);
+  free(rbs);
+
   Highs_destroy(highs);
 }
 

--- a/examples/call_highs_from_c.c
+++ b/examples/call_highs_from_c.c
@@ -9,9 +9,9 @@
 void minimal_api() {
   // Form and solve the LP
   // Min    f  = 2x_0 + 3x_1
-  // s.t.   8 <= 2x_0 +  x_1
-  //                    2x_1 <= 6
+  // s.t.                x_1 <= 6
   //       10 <=  x_0 + 2x_1 <= 14
+  //        8 <= 2x_0 +  x_1
   // 0 <= x_0 <= 3; 1 <= x_1
 
   int numcol = 2;
@@ -24,12 +24,12 @@ void minimal_api() {
   double cl[2] = {0.0, 1.0};
   double cu[2] = {3.0, 1.0e30};
   // Define the row lower bounds and upper bounds
-  double rl[3] = {8.0, -1.0e30, 10.0};
-  double ru[3] = {1.0e30, 6.0, 14.0};
+  double rl[3] = {-1.0e30, 10.0, 8.0};
+  double ru[3] = {6.0, 14.0, 1.0e30};
   // Define the constraint matrix column-wise
   int astart[3] = {0, 2, 5};
-  int aindex[5] = {0, 2, 0, 1, 2};
-  double avalue[5] = {2.0, 1.0, 1.0, 1.0, 2.0};
+  int aindex[5] = {1, 2, 0, 1, 2};
+  double avalue[5] = {1.0, 2.0, 1.0, 2.0, 1.0};
 
   double* cv = (double*)malloc(sizeof(double) * numcol);
   double* cd = (double*)malloc(sizeof(double) * numcol);
@@ -69,9 +69,9 @@ void minimal_api() {
 void full_api() {
   // Form and solve the LP
   // Min    f  = 2x_0 + 3x_1
-  // s.t.   8 <= 2x_0 +  x_1
-  //                    2x_1 <= 6
+  // s.t.                x_1 <= 6
   //       10 <=  x_0 + 2x_1 <= 14
+  //        8 <= 2x_0 +  x_1
   // 0 <= x_0 <= 3; 1 <= x_1
 
   void* highs;
@@ -88,13 +88,13 @@ void full_api() {
   double cl[2] = {0.0, 1.0};
   double cu[2] = {3.0, 1.0e30};
   // Define the row lower bounds and upper bounds
-  double rl[3] = {8.0, -1.0e30, 10.0};
-  double ru[3] = {1.0e30, 6.0, 14.0};
+  double rl[3] = {-1.0e30, 10.0, 8.0};
+  double ru[3] = {6.0, 14.0, 1.0e30};
   // Define the constraint matrix row-wise, as it is added to the LP
   // with the rows
-  int arstart[4] = {0, 2, 3, 5};
-  int arindex[5] = {0, 1, 1, 0, 1};
-  double arvalue[5] = {2.0, 1.0, 1.0, 1.0, 2.0};
+  int arstart[4] = {0, 1, 3, 5};
+  int arindex[5] = {1, 0, 1, 0, 1};
+  double arvalue[5] = {1.0, 1.0, 2.0, 2.0, 1.0};
 
   double* cv = (double*)malloc(sizeof(double) * numcol);
   double* cd = (double*)malloc(sizeof(double) * numcol);

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -95,7 +95,7 @@ int Highs_passLp(void* highs, int numcol, int numrow, int numnz,
   lp.colUpper_.assign(colupper, colupper + numcol);
 
   lp.rowLower_.assign(rowlower, rowlower + numrow);
-  lp.rowUpper_.assign(rowupper, rowupper + numcol);
+  lp.rowUpper_.assign(rowupper, rowupper + numrow);
   lp.Astart_.assign(astart, astart + numcol + 1);
   lp.Aindex_.assign(aindex, aindex + numnz);
   lp.Avalue_.assign(avalue, avalue + numnz);

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -20,7 +20,7 @@ int Highs_call(int numcol, int numrow, int numnz, double* colcost,
   Highs highs;
 
   int status =
-      Highs_passLp(&highs, numcol, numrow, numnz, colcost, collower, colupper,
+    Highs_passLp(&highs, numcol, numrow, numnz, colcost, collower, colupper,
                    rowlower, rowupper, astart, aindex, avalue);
   if (status != 0) {
     return status;
@@ -103,10 +103,49 @@ int Highs_passLp(void* highs, int numcol, int numrow, int numnz,
   return (int)((Highs*)highs)->passModel(lp);
 }
 
+int Highs_setHighsIntOptionValue(void* highs, const char* option,
+                              const int value) {
+  return (int)((Highs*)highs)
+      ->setHighsOptionValue(std::string(option), value);
+}
+
+int Highs_setHighsDoubleOptionValue(void* highs, const char* option,
+				    const double value) {
+  return (int)((Highs*)highs)
+      ->setHighsOptionValue(std::string(option), value);
+}
+
+int Highs_setHighsStringOptionValue(void* highs, const char* option,
+                              const char* value) {
+  return (int)((Highs*)highs)
+      ->setHighsOptionValue(std::string(option), std::string(value));
+}
+
 int Highs_setHighsOptionValue(void* highs, const char* option,
                               const char* value) {
   return (int)((Highs*)highs)
       ->setHighsOptionValue(std::string(option), std::string(value));
+}
+
+int Highs_getHighsIntOptionValue(void* highs, const char* option,
+                              int* value) {
+  return (int)((Highs*)highs)
+      ->getHighsOptionValue(std::string(option), *value);
+}
+
+int Highs_getHighsDoubleOptionValue(void* highs, const char* option,
+				    double* value) {
+  return (int)((Highs*)highs)
+      ->getHighsOptionValue(std::string(option), *value);
+}
+
+int Highs_getIntHighsInfoValue(void* highs, const char* info, int* value) {
+  return (int)((Highs*)highs)->getHighsInfoValue(info, *value);
+}
+
+int Highs_getDoubleHighsInfoValue(void* highs, const char* info,
+                                  double* value) {
+  return (int)((Highs*)highs)->getHighsInfoValue(info, *value);
 }
 
 void Highs_getSolution(void* highs, double* colvalue, double* coldual,
@@ -140,15 +179,6 @@ void Highs_getBasis(void* highs, int* colstatus, int* rowstatus) {
   for (int i = 0; i < (int)basis.row_status.size(); i++) {
     rowstatus[i] = (int)basis.row_status[i];
   }
-}
-
-int Highs_getIntHighsInfoValue(void* highs, const char* info, int& value) {
-  return (int)((Highs*)highs)->getHighsInfoValue(info, value);
-}
-
-int Highs_getDoubleHighsInfoValue(void* highs, const char* info,
-                                  double& value) {
-  return (int)((Highs*)highs)->getHighsInfoValue(info, value);
 }
 
 int Highs_addRow(void* highs, const double lower, const double upper,

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -20,7 +20,7 @@ int Highs_call(int numcol, int numrow, int numnz, double* colcost,
   Highs highs;
 
   int status =
-    Highs_passLp(&highs, numcol, numrow, numnz, colcost, collower, colupper,
+      Highs_passLp(&highs, numcol, numrow, numnz, colcost, collower, colupper,
                    rowlower, rowupper, astart, aindex, avalue);
   if (status != 0) {
     return status;
@@ -104,19 +104,17 @@ int Highs_passLp(void* highs, int numcol, int numrow, int numnz,
 }
 
 int Highs_setHighsIntOptionValue(void* highs, const char* option,
-                              const int value) {
-  return (int)((Highs*)highs)
-      ->setHighsOptionValue(std::string(option), value);
+                                 const int value) {
+  return (int)((Highs*)highs)->setHighsOptionValue(std::string(option), value);
 }
 
 int Highs_setHighsDoubleOptionValue(void* highs, const char* option,
-				    const double value) {
-  return (int)((Highs*)highs)
-      ->setHighsOptionValue(std::string(option), value);
+                                    const double value) {
+  return (int)((Highs*)highs)->setHighsOptionValue(std::string(option), value);
 }
 
 int Highs_setHighsStringOptionValue(void* highs, const char* option,
-                              const char* value) {
+                                    const char* value) {
   return (int)((Highs*)highs)
       ->setHighsOptionValue(std::string(option), std::string(value));
 }
@@ -127,23 +125,20 @@ int Highs_setHighsOptionValue(void* highs, const char* option,
       ->setHighsOptionValue(std::string(option), std::string(value));
 }
 
-int Highs_getHighsIntOptionValue(void* highs, const char* option,
-                              int* value) {
-  return (int)((Highs*)highs)
-      ->getHighsOptionValue(std::string(option), *value);
+int Highs_getHighsIntOptionValue(void* highs, const char* option, int* value) {
+  return (int)((Highs*)highs)->getHighsOptionValue(std::string(option), *value);
 }
 
 int Highs_getHighsDoubleOptionValue(void* highs, const char* option,
-				    double* value) {
-  return (int)((Highs*)highs)
-      ->getHighsOptionValue(std::string(option), *value);
+                                    double* value) {
+  return (int)((Highs*)highs)->getHighsOptionValue(std::string(option), *value);
 }
 
-int Highs_getIntHighsInfoValue(void* highs, const char* info, int* value) {
+int Highs_getHighsIntInfoValue(void* highs, const char* info, int* value) {
   return (int)((Highs*)highs)->getHighsInfoValue(info, *value);
 }
 
-int Highs_getDoubleHighsInfoValue(void* highs, const char* info,
+int Highs_getHighsDoubleInfoValue(void* highs, const char* info,
                                   double* value) {
   return (int)((Highs*)highs)->getHighsInfoValue(info, *value);
 }
@@ -179,6 +174,52 @@ void Highs_getBasis(void* highs, int* colstatus, int* rowstatus) {
   for (int i = 0; i < (int)basis.row_status.size(); i++) {
     rowstatus[i] = (int)basis.row_status[i];
   }
+}
+
+int Highs_getModelStatus(void* highs, const int scaled_model) {
+  return (int)((Highs*)highs)->getModelStatus(scaled_model);
+}
+
+int Highs_getBasicVariables(void* highs, int* basic_variables) {
+  return (int)((Highs*)highs)->getBasicVariables(basic_variables);
+}
+
+int Highs_getBasisInverseRow(void* highs, const int row, double* row_vector,
+                             int* row_num_nz, int* row_indices) {
+  return (int)((Highs*)highs)
+      ->getBasisInverseRow(row, row_vector, row_num_nz, row_indices);
+}
+
+int Highs_getBasisInverseCol(void* highs, const int col, double* col_vector,
+                             int* col_num_nz, int* col_indices) {
+  return (int)((Highs*)highs)
+      ->getBasisInverseCol(col, col_vector, col_num_nz, col_indices);
+}
+
+int Highs_getBasisSolve(void* highs, const double* rhs, double* solution_vector,
+                        int* solution_num_nz, int* solution_indices) {
+  return (int)((Highs*)highs)
+      ->getBasisSolve(rhs, solution_vector, solution_num_nz, solution_indices);
+}
+
+int Highs_getBasisTransposeSolve(void* highs, const double* rhs,
+                                 double* solution_vector, int* solution_nz,
+                                 int* solution_indices) {
+  return (int)((Highs*)highs)
+      ->getBasisTransposeSolve(rhs, solution_vector, solution_nz,
+                               solution_indices);
+}
+
+int Highs_getReducedRow(void* highs, const int row, double* row_vector,
+                        int* row_num_nz, int* row_indices) {
+  return (int)((Highs*)highs)
+      ->getReducedRow(row, row_vector, row_num_nz, row_indices);
+}
+
+int Highs_getReducedColumn(void* highs, const int col, double* col_vector,
+                           int* col_num_nz, int* col_indices) {
+  return (int)((Highs*)highs)
+      ->getReducedColumn(col, col_vector, col_num_nz, col_indices);
 }
 
 int Highs_addRow(void* highs, const double lower, const double upper,
@@ -378,50 +419,4 @@ int Highs_getNumNz(void* highs) {
   int numCol = Highs_getNumCols(highs);
   if (numCol <= 0) return 0;
   return ((Highs*)highs)->getLp().Astart_[numCol];
-}
-
-int Highs_getModelStatus(void* highs, const bool scaled_model) {
-  return (int)((Highs*)highs)->getModelStatus(scaled_model);
-}
-
-int Highs_getBasicVariables(void* highs, int* basic_variables) {
-  return (int)((Highs*)highs)->getBasicVariables(basic_variables);
-}
-
-int Highs_getBasisInverseRow(void* highs, const int row, double* row_vector,
-                             int* row_num_nz, int* row_indices) {
-  return (int)((Highs*)highs)
-      ->getBasisInverseRow(row, row_vector, row_num_nz, row_indices);
-}
-
-int Highs_getBasisInverseCol(void* highs, const int col, double* col_vector,
-                             int* col_num_nz, int* col_indices) {
-  return (int)((Highs*)highs)
-      ->getBasisInverseCol(col, col_vector, col_num_nz, col_indices);
-}
-
-int Highs_getBasisSolve(void* highs, const double* rhs, double* solution_vector,
-                        int* solution_num_nz, int* solution_indices) {
-  return (int)((Highs*)highs)
-      ->getBasisSolve(rhs, solution_vector, solution_num_nz, solution_indices);
-}
-
-int Highs_getBasisTransposeSolve(void* highs, const double* rhs,
-                                 double* solution_vector, int* solution_nz,
-                                 int* solution_indices) {
-  return (int)((Highs*)highs)
-      ->getBasisTransposeSolve(rhs, solution_vector, solution_nz,
-                               solution_indices);
-}
-
-int Highs_getReducedRow(void* highs, const int row, double* row_vector,
-                        int* row_num_nz, int* row_indices) {
-  return (int)((Highs*)highs)
-      ->getReducedRow(row, row_vector, row_num_nz, row_indices);
-}
-
-int Highs_getReducedColumn(void* highs, const int col, double* col_vector,
-                           int* col_num_nz, int* col_indices) {
-  return (int)((Highs*)highs)
-      ->getReducedColumn(col, col_vector, col_num_nz, col_indices);
 }

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -75,8 +75,8 @@ int Highs_run(void* highs  //!< HiGHS object reference
 /*
  * @brief Reports the solution and basis status
  */
-int Highs_writeSolution(void* highs,         //!< HiGHS object reference
-                        const char* filename //!< filename
+int Highs_writeSolution(void* highs,          //!< HiGHS object reference
+                        const char* filename  //!< filename
 );
 
 /*
@@ -101,25 +101,25 @@ int Highs_passLp(
 /*
  * @brief
  */
-int Highs_setHighsIntOptionValue(void* highs,         //!< HiGHS object reference
-                              const char* option,  //!< name of the option
-                              const int value    //!< new value of option
+int Highs_setHighsIntOptionValue(void* highs,  //!< HiGHS object reference
+                                 const char* option,  //!< name of the option
+                                 const int value      //!< new value of option
 );
 
 /*
  * @brief
  */
-int Highs_setHighsDoubleOptionValue(void* highs,         //!< HiGHS object reference
-                              const char* option,  //!< name of the option
-                              const double value    //!< new value of option
+int Highs_setHighsDoubleOptionValue(void* highs,  //!< HiGHS object reference
+                                    const char* option,  //!< name of the option
+                                    const double value  //!< new value of option
 );
 
 /*
  * @brief
  */
-int Highs_setHighsStringOptionValue(void* highs,         //!< HiGHS object reference
-                              const char* option,  //!< name of the option
-                              const char* value    //!< new value of option
+int Highs_setHighsStringOptionValue(void* highs,  //!< HiGHS object reference
+                                    const char* option,  //!< name of the option
+                                    const char* value  //!< new value of option
 );
 
 /*
@@ -133,23 +133,23 @@ int Highs_setHighsOptionValue(void* highs,         //!< HiGHS object reference
 /*
  * @brief
  */
-int Highs_getHighsIntOptionValue(void* highs,         //!< HiGHS object reference
-                              const char* option,  //!< name of the option
-                              int* value    //!< value of option
+int Highs_getHighsIntOptionValue(void* highs,  //!< HiGHS object reference
+                                 const char* option,  //!< name of the option
+                                 int* value           //!< value of option
 );
 
 /*
  * @brief
  */
-int Highs_getHighsDoubleOptionValue(void* highs,         //!< HiGHS object reference
-                              const char* option,  //!< name of the option
-                              double* value    //!< value of option
+int Highs_getHighsDoubleOptionValue(void* highs,  //!< HiGHS object reference
+                                    const char* option,  //!< name of the option
+                                    double* value        //!< value of option
 );
 
 /*
  * @brief
  */
-int Highs_getIntHighsInfoValue(void* highs,       //!< HiGHS object reference
+int Highs_getHighsIntInfoValue(void* highs,       //!< HiGHS object reference
                                const char* info,  //!< The info name
                                int* value         //!< The info value
 );
@@ -157,7 +157,7 @@ int Highs_getIntHighsInfoValue(void* highs,       //!< HiGHS object reference
 /*
  * @brief
  */
-int Highs_getDoubleHighsInfoValue(void* highs,       //!< HiGHS object reference
+int Highs_getHighsDoubleInfoValue(void* highs,       //!< HiGHS object reference
                                   const char* info,  //!< The info name
                                   double* value      //!< The info value
 );
@@ -180,6 +180,88 @@ void Highs_getBasis(
     int* colstatus,  //!< array of length [numcol], filled with column basis
                      //!< stati
     int* rowstatus   //!< array of length [numrow], filled with row basis stati
+);
+
+/**
+ * @brief Returns the status of the (scaled) model
+ */
+int Highs_getModelStatus(
+    void* highs,            //!< HiGHS object reference
+    const int scaled_model  //!< 0 (nonzero) for status of (scaled) model
+);
+
+/**
+ * @brief Gets the basic variables in the order corresponding to
+ * calls to getBasisInverseRow, getBasisInverseCol, getBasisSolve,
+ * getBasisTransposeSolve, getReducedRow and getReducedColumn. As
+ * required by SCIP, non-negative entries are indices of columns,
+ * and negative entries are -(row_index+1).
+ */
+int Highs_getBasicVariables(void* highs,          //!< HiGHS object reference,
+                            int* basic_variables  //!< Basic variables
+);
+
+/**
+ * @brief Gets a row of \f$B^{-1}\f$ for basis matrix \f$B\f$
+ */
+int Highs_getBasisInverseRow(void* highs,         //!< HiGHS object reference
+                             const int row,       //!< Index of row required
+                             double* row_vector,  //!< Row required
+                             int* row_num_nz,     //!< Number of nonzeros
+                             int* row_indices     //!< Indices of nonzeros
+);
+
+/**
+ * @brief Gets a column of \f$B^{-1}\f$ for basis matrix \f$B\f$
+ */
+int Highs_getBasisInverseCol(void* highs,         //!< HiGHS object reference
+                             const int col,       //!< Index of column required
+                             double* col_vector,  //!< Column required
+                             int* col_num_nz,     //!< Number of nonzeros
+                             int* col_indices     //!< Indices of nonzeros
+);
+
+/**
+ * @brief Forms \f$\mathbf{x}=B^{-1}\mathbf{b}\f$ for a given vector
+ * \f$\mathbf{b}\f$
+ */
+int Highs_getBasisSolve(void* highs,              //!< HiGHS object reference
+                        const double* rhs,        //!< RHS \f$\mathbf{b}\f$
+                        double* solution_vector,  //!< Solution \f$\mathbf{x}\f$
+                        int* solution_num_nz,     //!< Number of nonzeros
+                        int* solution_indices     //!< Indices of nonzeros
+);
+
+/**
+ * @brief Forms \f$\mathbf{x}=B^{-T}\mathbf{b}\f$ for a given vector
+ * \f$\mathbf{b}\f$
+ */
+int Highs_getBasisTransposeSolve(
+    void* highs,              //!< HiGHS object reference
+    const double* rhs,        //!< RHS \f$\mathbf{b}\f$
+    double* solution_vector,  //!< Solution  \f$\mathbf{x}\f$
+    int* solution_nz,         //!< Number of nonzeros
+    int* solution_indices     //!< Indices of nonzeros
+);
+
+/**
+ * @brief Forms a row of \f$B^{-1}A\f$
+ */
+int Highs_getReducedRow(void* highs,         //!< HiGHS object reference
+                        const int row,       //!< Index of row required
+                        double* row_vector,  //!< Row required
+                        int* row_num_nz,     //!< Number of nonzeros
+                        int* row_indices     //!< Indices of nonzeros
+);
+
+/**
+ * @brief Forms a column of \f$B^{-1}A\f$
+ */
+int Highs_getReducedColumn(void* highs,         //!< HiGHS object reference
+                           const int col,       //!< Index of column required
+                           double* col_vector,  //!< Column required
+                           int* col_num_nz,     //!< Number of nonzeros
+                           int* col_indices     //!< Indices of nonzeros
 );
 
 /**
@@ -552,88 +634,6 @@ int Highs_getNumRows(void* highs  //!< HiGHS object reference
  * @brief Returns the number of nonzeroes of the current model
  */
 int Highs_getNumNz(void* highs  //!< HiGHS object reference
-);
-
-/**
- * @brief Returns the status of the (scaled) model
- */
-int Highs_getModelStatus(
-    void* highs,            //!< HiGHS object reference
-    const int scaled_model  //!< 0 (nonzero) for status of (scaled) model
-);
-
-/**
- * @brief Gets the basic variables in the order corresponding to
- * calls to getBasisInverseRow, getBasisInverseCol, getBasisSolve,
- * getBasisTransposeSolve, getReducedRow and getReducedColumn. As
- * required by SCIP, non-negative entries are indices of columns,
- * and negative entries are -(row_index+1).
- */
-int Highs_getBasicVariables(void* highs,          //!< HiGHS object reference,
-                            int* basic_variables  //!< Basic variables
-);
-
-/**
- * @brief Gets a row of \f$B^{-1}\f$ for basis matrix \f$B\f$
- */
-int Highs_getBasisInverseRow(void* highs,         //!< HiGHS object reference
-                             const int row,       //!< Index of row required
-                             double* row_vector,  //!< Row required
-                             int* row_num_nz,     //!< Number of nonzeros
-                             int* row_indices     //!< Indices of nonzeros
-);
-
-/**
- * @brief Gets a column of \f$B^{-1}\f$ for basis matrix \f$B\f$
- */
-int Highs_getBasisInverseCol(void* highs,         //!< HiGHS object reference
-                             const int col,       //!< Index of column required
-                             double* col_vector,  //!< Column required
-                             int* col_num_nz,     //!< Number of nonzeros
-                             int* col_indices     //!< Indices of nonzeros
-);
-
-/**
- * @brief Forms \f$\mathbf{x}=B^{-1}\mathbf{b}\f$ for a given vector
- * \f$\mathbf{b}\f$
- */
-int Highs_getBasisSolve(void* highs,              //!< HiGHS object reference
-                        const double* rhs,        //!< RHS \f$\mathbf{b}\f$
-                        double* solution_vector,  //!< Solution \f$\mathbf{x}\f$
-                        int* solution_num_nz,     //!< Number of nonzeros
-                        int* solution_indices     //!< Indices of nonzeros
-);
-
-/**
- * @brief Forms \f$\mathbf{x}=B^{-T}\mathbf{b}\f$ for a given vector
- * \f$\mathbf{b}\f$
- */
-int Highs_getBasisTransposeSolve(
-    void* highs,              //!< HiGHS object reference
-    const double* rhs,        //!< RHS \f$\mathbf{b}\f$
-    double* solution_vector,  //!< Solution  \f$\mathbf{x}\f$
-    int* solution_nz,         //!< Number of nonzeros
-    int* solution_indices     //!< Indices of nonzeros
-);
-
-/**
- * @brief Forms a row of \f$B^{-1}A\f$
- */
-int Highs_getReducedRow(void* highs,         //!< HiGHS object reference
-                        const int row,       //!< Index of row required
-                        double* row_vector,  //!< Row required
-                        int* row_num_nz,     //!< Number of nonzeros
-                        int* row_indices     //!< Indices of nonzeros
-);
-
-/**
- * @brief Forms a column of \f$B^{-1}A\f$
- */
-int Highs_getReducedColumn(void* highs,         //!< HiGHS object reference
-                           const int col,       //!< Index of column required
-                           double* col_vector,  //!< Column required
-                           int* col_num_nz,     //!< Number of nonzeros
-                           int* col_indices     //!< Indices of nonzeros
 );
 
 // /**

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -55,12 +55,6 @@ void Highs_destroy(void* highs  //!< HiGHS object reference
 /*
  * @brief
  */
-int Highs_run(void* highs  //!< HiGHS object reference
-);
-
-/*
- * @brief
- */
 int Highs_readModel(void* highs,          //!< HiGHS object reference
                     const char* filename  //!< filename
 );
@@ -70,6 +64,19 @@ int Highs_readModel(void* highs,          //!< HiGHS object reference
  */
 int Highs_writeModel(void* highs,          //!< HiGHS object reference
                      const char* filename  //!< filename
+);
+
+/*
+ * @brief Runs HiGHS
+ */
+int Highs_run(void* highs  //!< HiGHS object reference
+);
+
+/*
+ * @brief Reports the solution and basis status
+ */
+int Highs_writeSolution(void* highs,         //!< HiGHS object reference
+                        const char* filename //!< filename
 );
 
 /*
@@ -94,11 +101,66 @@ int Highs_passLp(
 /*
  * @brief
  */
+int Highs_setHighsIntOptionValue(void* highs,         //!< HiGHS object reference
+                              const char* option,  //!< name of the option
+                              const int value    //!< new value of option
+);
+
+/*
+ * @brief
+ */
+int Highs_setHighsDoubleOptionValue(void* highs,         //!< HiGHS object reference
+                              const char* option,  //!< name of the option
+                              const double value    //!< new value of option
+);
+
+/*
+ * @brief
+ */
+int Highs_setHighsStringOptionValue(void* highs,         //!< HiGHS object reference
+                              const char* option,  //!< name of the option
+                              const char* value    //!< new value of option
+);
+
+/*
+ * @brief
+ */
 int Highs_setHighsOptionValue(void* highs,         //!< HiGHS object reference
                               const char* option,  //!< name of the option
                               const char* value    //!< new value of option
 );
 
+/*
+ * @brief
+ */
+int Highs_getHighsIntOptionValue(void* highs,         //!< HiGHS object reference
+                              const char* option,  //!< name of the option
+                              int* value    //!< value of option
+);
+
+/*
+ * @brief
+ */
+int Highs_getHighsDoubleOptionValue(void* highs,         //!< HiGHS object reference
+                              const char* option,  //!< name of the option
+                              double* value    //!< value of option
+);
+
+/*
+ * @brief
+ */
+int Highs_getIntHighsInfoValue(void* highs,       //!< HiGHS object reference
+                               const char* info,  //!< The info name
+                               int* value         //!< The info value
+);
+
+/*
+ * @brief
+ */
+int Highs_getDoubleHighsInfoValue(void* highs,       //!< HiGHS object reference
+                                  const char* info,  //!< The info name
+                                  double* value      //!< The info value
+);
 /*
  * @brief
  */
@@ -118,22 +180,6 @@ void Highs_getBasis(
     int* colstatus,  //!< array of length [numcol], filled with column basis
                      //!< stati
     int* rowstatus   //!< array of length [numrow], filled with row basis stati
-);
-
-/*
- * @brief
- */
-int Highs_getIntHighsInfoValue(void* highs,       //!< HiGHS object reference
-                               const char* info,  //!< The info name
-                               int* value         //!< The info value
-);
-
-/*
- * @brief
- */
-int Highs_getDoubleHighsInfoValue(void* highs,       //!< HiGHS object reference
-                                  const char* info,  //!< The info name
-                                  double* value      //!< The info value
 );
 
 /**
@@ -628,12 +674,6 @@ int Highs_getReducedColumn(void* highs,         //!< HiGHS object reference
 //  * LP of the (first?) HighsModelObject
 //  */
 // HighsStatus setBasis(const HighsBasis &basis);
-
-// /**
-//  * @brief Reports the solution and basis status for the LP of the
-//  * (first?) HighsModelObject
-//  */
-// void writeSolution(const std::string filename);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Changed the example LP in call_highs_from_c.c from 2x2 to 3x2 - exposing a bug in the C interface as a consequence. Reordered methods in highs_c_api.h/cpp to correspond to HiGHS.h and added getters and setters for integer and double HighsOptions and getters for integer and double HighsInfo.