### PR TITLE
Issue287

### DIFF
--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -104,8 +104,9 @@ int Highs_passLp(void* highs, int numcol, int numrow, int numnz,
 }
 
 int Highs_setHighsBoolOptionValue(void* highs, const char* option,
-                                 const int value) {
-  return (int)((Highs*)highs)->setHighsOptionValue(std::string(option), (bool)value);
+                                  const int value) {
+  return (int)((Highs*)highs)
+      ->setHighsOptionValue(std::string(option), (bool)value);
 }
 
 int Highs_setHighsIntOptionValue(void* highs, const char* option,
@@ -132,7 +133,8 @@ int Highs_setHighsOptionValue(void* highs, const char* option,
 
 int Highs_getHighsBoolOptionValue(void* highs, const char* option, int* value) {
   bool v;
-  int retcode = (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
+  int retcode =
+      (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
   *value = (int)v;
   return retcode;
 }
@@ -149,11 +151,11 @@ int Highs_getHighsDoubleOptionValue(void* highs, const char* option,
 int Highs_getHighsStringOptionValue(void* highs, const char* option,
                                     char* value) {
   std::string v;
-  int retcode = (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
+  int retcode =
+      (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
   strcpy(value, v.c_str());
   return retcode;
 }
-
 
 int Highs_getHighsIntInfoValue(void* highs, const char* info, int* value) {
   return (int)((Highs*)highs)->getHighsInfoValue(info, *value);

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -102,8 +102,8 @@ int Highs_passLp(
  * @brief
  */
 int Highs_setHighsBoolOptionValue(void* highs,  //!< HiGHS object reference
-                                 const char* option,  //!< name of the option
-                                 const int value      //!< new value of option
+                                  const char* option,  //!< name of the option
+                                  const int value      //!< new value of option
 );
 
 /*
@@ -142,8 +142,8 @@ int Highs_setHighsOptionValue(void* highs,         //!< HiGHS object reference
  * @brief
  */
 int Highs_getHighsBoolOptionValue(void* highs,  //!< HiGHS object reference
-                                 const char* option,  //!< name of the option
-                                 int* value           //!< value of option
+                                  const char* option,  //!< name of the option
+                                  int* value           //!< value of option
 );
 
 /*
@@ -165,9 +165,10 @@ int Highs_getHighsDoubleOptionValue(void* highs,  //!< HiGHS object reference
 /*
  * @brief
  */
-int Highs_getHighsStringOptionValue(void* highs,  //!< HiGHS object reference
-                                    const char* option,  //!< name of the option
-                                    char* value          //!< pointer to allocated memory to store value of option
+int Highs_getHighsStringOptionValue(
+    void* highs,         //!< HiGHS object reference
+    const char* option,  //!< name of the option
+    char* value  //!< pointer to allocated memory to store value of option
 );
 
 /*

--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -441,9 +441,11 @@ typename HMpsFF::parsekey HMpsFF::parseCols(FILE* logfile,
                       "COLUMNS section contains row %s not in ROWS section",
                       marker.c_str());
     } else {
-      parsename(marker);  // rowidx set
       double value = atof(word.c_str());
-      addtuple(value);
+      if (value) {
+        parsename(marker);  // rowidx set and nnz incremented
+        addtuple(value);
+      }
     }
 
     if (!is_end(strline, end)) {
@@ -472,10 +474,11 @@ typename HMpsFF::parsekey HMpsFF::parseCols(FILE* logfile,
             marker.c_str());
         continue;
       };
-
       double value = atof(word.c_str());
-      parsename(marker);  // rowidx set
-      addtuple(value);
+      if (value) {
+        parsename(marker);  // rowidx set and nnz incremented
+        addtuple(value);
+      }
     }
   }
 

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -77,6 +77,12 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options,
     return_status =
         interpretCallStatus(call_status, return_status, "assessMatrix");
     if (return_status == HighsStatus::Error) return return_status;
+    if ((int)lp.Aindex_.size() > lp_num_nz || (int)lp.Avalue_.size() > lp_num_nz) {
+      // Entries have been removed from the matrix so resize the index
+      // and value vectors to prevent bug in presolve
+      if ((int)lp.Aindex_.size() > lp_num_nz) lp.Aindex_.resize(lp_num_nz);
+      if ((int)lp.Avalue_.size() > lp_num_nz) lp.Avalue_.resize(lp_num_nz);
+    }
     lp.Astart_[lp.numCol_] = lp_num_nz;
   }
   if (return_status == HighsStatus::Error)

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -77,7 +77,8 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options,
     return_status =
         interpretCallStatus(call_status, return_status, "assessMatrix");
     if (return_status == HighsStatus::Error) return return_status;
-    if ((int)lp.Aindex_.size() > lp_num_nz || (int)lp.Avalue_.size() > lp_num_nz) {
+    if ((int)lp.Aindex_.size() > lp_num_nz ||
+        (int)lp.Avalue_.size() > lp_num_nz) {
       // Entries have been removed from the matrix so resize the index
       // and value vectors to prevent bug in presolve
       if ((int)lp.Aindex_.size() > lp_num_nz) lp.Aindex_.resize(lp_num_nz);

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -77,13 +77,10 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options,
     return_status =
         interpretCallStatus(call_status, return_status, "assessMatrix");
     if (return_status == HighsStatus::Error) return return_status;
-    if ((int)lp.Aindex_.size() > lp_num_nz ||
-        (int)lp.Avalue_.size() > lp_num_nz) {
-      // Entries have been removed from the matrix so resize the index
-      // and value vectors to prevent bug in presolve
-      if ((int)lp.Aindex_.size() > lp_num_nz) lp.Aindex_.resize(lp_num_nz);
-      if ((int)lp.Avalue_.size() > lp_num_nz) lp.Avalue_.resize(lp_num_nz);
-    }
+    // If entries have been removed from the matrix, resize the index
+    // and value vectors to prevent bug in presolve
+    if ((int)lp.Aindex_.size() > lp_num_nz) lp.Aindex_.resize(lp_num_nz);
+    if ((int)lp.Avalue_.size() > lp_num_nz) lp.Avalue_.resize(lp_num_nz);
     lp.Astart_[lp.numCol_] = lp_num_nz;
   }
   if (return_status == HighsStatus::Error)


### PR DESCRIPTION
- The free format reader skips the explicit zero in the matrix - but still adds the column, even if the matrix zero is the only "entry" and there's no cost. 
- lp.Aindex_ and lp.Avalue_ are resized so their sizes are lp.Astart_[lp.numCol_]