### PR TITLE
Simplex max iter

### DIFF
--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -104,8 +104,9 @@ int Highs_passLp(void* highs, int numcol, int numrow, int numnz,
 }
 
 int Highs_setHighsBoolOptionValue(void* highs, const char* option,
-                                 const int value) {
-  return (int)((Highs*)highs)->setHighsOptionValue(std::string(option), (bool)value);
+                                  const int value) {
+  return (int)((Highs*)highs)
+      ->setHighsOptionValue(std::string(option), (bool)value);
 }
 
 int Highs_setHighsIntOptionValue(void* highs, const char* option,
@@ -132,7 +133,8 @@ int Highs_setHighsOptionValue(void* highs, const char* option,
 
 int Highs_getHighsBoolOptionValue(void* highs, const char* option, int* value) {
   bool v;
-  int retcode = (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
+  int retcode =
+      (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
   *value = (int)v;
   return retcode;
 }
@@ -149,11 +151,11 @@ int Highs_getHighsDoubleOptionValue(void* highs, const char* option,
 int Highs_getHighsStringOptionValue(void* highs, const char* option,
                                     char* value) {
   std::string v;
-  int retcode = (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
+  int retcode =
+      (int)((Highs*)highs)->getHighsOptionValue(std::string(option), v);
   strcpy(value, v.c_str());
   return retcode;
 }
-
 
 int Highs_getHighsIntInfoValue(void* highs, const char* info, int* value) {
   return (int)((Highs*)highs)->getHighsInfoValue(info, *value);

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -102,8 +102,8 @@ int Highs_passLp(
  * @brief
  */
 int Highs_setHighsBoolOptionValue(void* highs,  //!< HiGHS object reference
-                                 const char* option,  //!< name of the option
-                                 const int value      //!< new value of option
+                                  const char* option,  //!< name of the option
+                                  const int value      //!< new value of option
 );
 
 /*
@@ -142,8 +142,8 @@ int Highs_setHighsOptionValue(void* highs,         //!< HiGHS object reference
  * @brief
  */
 int Highs_getHighsBoolOptionValue(void* highs,  //!< HiGHS object reference
-                                 const char* option,  //!< name of the option
-                                 int* value           //!< value of option
+                                  const char* option,  //!< name of the option
+                                  int* value           //!< value of option
 );
 
 /*
@@ -165,9 +165,10 @@ int Highs_getHighsDoubleOptionValue(void* highs,  //!< HiGHS object reference
 /*
  * @brief
  */
-int Highs_getHighsStringOptionValue(void* highs,  //!< HiGHS object reference
-                                    const char* option,  //!< name of the option
-                                    char* value          //!< pointer to allocated memory to store value of option
+int Highs_getHighsStringOptionValue(
+    void* highs,         //!< HiGHS object reference
+    const char* option,  //!< name of the option
+    char* value  //!< pointer to allocated memory to store value of option
 );
 
 /*

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -280,6 +280,8 @@ HighsMipStatus HighsMipSolver::solveNode(Node& node, bool hotstart) {
     case HighsStatus::Warning:
       if (use_model_status == HighsModelStatus::REACHED_TIME_LIMIT)
         return HighsMipStatus::kTimeout;
+      if (use_model_status == HighsModelStatus::REACHED_ITERATION_LIMIT)
+        return HighsMipStatus::kReachedSimplexIterationLimit;
       return HighsMipStatus::kNodeNotOptimal;
     case HighsStatus::Error:
       return HighsMipStatus::kNodeError;
@@ -298,6 +300,8 @@ HighsMipStatus HighsMipSolver::solveNode(Node& node, bool hotstart) {
       return HighsMipStatus::kNodeUnbounded;
     case HighsModelStatus::REACHED_TIME_LIMIT:
       return HighsMipStatus::kTimeout;
+    case HighsModelStatus::REACHED_ITERATION_LIMIT:
+      return HighsMipStatus::kReachedSimplexIterationLimit;
     case HighsModelStatus::NOTSET:
       return HighsMipStatus::kNodeError;
     default:
@@ -414,6 +418,8 @@ HighsMipStatus HighsMipSolver::solveTree(Node& root) {
         break;
       case HighsMipStatus::kTimeout:
         return HighsMipStatus::kTimeout;
+      case HighsMipStatus::kReachedSimplexIterationLimit:
+        return HighsMipStatus::kReachedSimplexIterationLimit;
       case HighsMipStatus::kNodeUnbounded:
         return HighsMipStatus::kNodeUnbounded;
       default:
@@ -459,6 +465,9 @@ void HighsMipSolver::reportMipSolverProgress(const HighsMipStatus mip_status) {
         break;
       case HighsMipStatus::kTimeout:
         reportMipSolverProgressLine("Timeout");
+        break;
+      case HighsMipStatus::kReachedSimplexIterationLimit:
+        reportMipSolverProgressLine("Reached simplex iteration limit");
         break;
       case HighsMipStatus::kError:
         reportMipSolverProgressLine("Error");
@@ -561,6 +570,9 @@ std::string HighsMipSolver::highsMipStatusToString(
       break;
     case HighsMipStatus::kTimeout:
       return "Timeout";
+      break;
+    case HighsMipStatus::kReachedSimplexIterationLimit:
+      return "Reached simplex iteration limit";
       break;
     case HighsMipStatus::kError:
       return "Error";

--- a/src/mip/HighsMipSolver.h
+++ b/src/mip/HighsMipSolver.h
@@ -17,6 +17,7 @@
 enum class HighsMipStatus {
   kOptimal,
   kTimeout,
+  kReachedSimplexIterationLimit,
   kError,
   kNodeOptimal,
   kNodeInfeasible,

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -570,7 +570,7 @@ void HDual::solvePhase1() {
       solve_bailout = true;
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       break;
-    } else if (scaled_solution_params.simplex_iteration_count >
+    } else if (workHMO.scaled_solution_params_.simplex_iteration_count >
 	workHMO.options_.simplex_iteration_limit) {
       solve_bailout = true;
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
@@ -714,7 +714,7 @@ void HDual::solvePhase2() {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       solve_bailout = true;
       break;
-    } else if (scaled_solution_params.simplex_iteration_count >
+    } else if (workHMO.scaled_solution_params_.simplex_iteration_count >
 	workHMO.options_.simplex_iteration_limit) {
       solve_bailout = true;
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -261,6 +261,8 @@ HighsStatus HDual::solve() {
     assert(workHMO.scaled_model_status_ ==
                HighsModelStatus::REACHED_TIME_LIMIT ||
            workHMO.scaled_model_status_ ==
+               HighsModelStatus::REACHED_ITERATION_LIMIT ||
+           workHMO.scaled_model_status_ ==
                HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND);
     return HighsStatus::Warning;
   }
@@ -568,6 +570,11 @@ void HDual::solvePhase1() {
       solve_bailout = true;
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       break;
+    } else if (scaled_solution_params.simplex_iteration_count >
+	workHMO.options_.simplex_iteration_limit) {
+      solve_bailout = true;
+      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
+      break;
     }
     // If the data are fresh from rebuild(), break out of
     // the outer loop to see what's ocurred
@@ -579,6 +586,8 @@ void HDual::solvePhase1() {
   if (solve_bailout) {
     assert(workHMO.scaled_model_status_ ==
                HighsModelStatus::REACHED_TIME_LIMIT ||
+           workHMO.scaled_model_status_ ==
+               HighsModelStatus::REACHED_ITERATION_LIMIT ||
            workHMO.scaled_model_status_ ==
                HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND);
     return;
@@ -705,6 +714,11 @@ void HDual::solvePhase2() {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       solve_bailout = true;
       break;
+    } else if (scaled_solution_params.simplex_iteration_count >
+	workHMO.options_.simplex_iteration_limit) {
+      solve_bailout = true;
+      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
+      break;
     }
     // If the data are fresh from rebuild(), break out of
     // the outer loop to see what's ocurred
@@ -716,6 +730,8 @@ void HDual::solvePhase2() {
   if (solve_bailout) {
     assert(workHMO.scaled_model_status_ ==
                HighsModelStatus::REACHED_TIME_LIMIT ||
+           workHMO.scaled_model_status_ ==
+               HighsModelStatus::REACHED_ITERATION_LIMIT ||
            workHMO.scaled_model_status_ ==
                HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND);
     return;

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1807,31 +1807,32 @@ bool HDual::dualInfoOk(const HighsLp& lp) {
 
 bool HDual::bailout() {
   if (solve_bailout) {
-    // Bailout has already been decided: check that it's for one of these reasons
+    // Bailout has already been decided: check that it's for one of these
+    // reasons
     assert(workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_TIME_LIMIT ||
+               HighsModelStatus::REACHED_TIME_LIMIT ||
            workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_ITERATION_LIMIT ||
+               HighsModelStatus::REACHED_ITERATION_LIMIT ||
            workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND);
+               HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND);
   } else if (workHMO.timer_.readRunHighsClock() > workHMO.options_.time_limit) {
     solve_bailout = true;
     workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
   } else if (workHMO.scaled_solution_params_.simplex_iteration_count >=
-	     workHMO.options_.simplex_iteration_limit) {
+             workHMO.options_.simplex_iteration_limit) {
     solve_bailout = true;
     workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
   } else if (solvePhase == 2 &&
-	     (workHMO.simplex_info_.updated_dual_objective_value >
-	      workHMO.options_.dual_objective_value_upper_bound)) {
+             (workHMO.simplex_info_.updated_dual_objective_value >
+              workHMO.options_.dual_objective_value_upper_bound)) {
 #ifdef SCIP_DEV
     printf("HDual::solvePhase2: %12g = Objective > ObjectiveUB\n",
-	   workHMO.simplex_info_.updated_dual_objective_value,
-	   workHMO.options_.dual_objective_value_upper_bound);
+           workHMO.simplex_info_.updated_dual_objective_value,
+           workHMO.options_.dual_objective_value_upper_bound);
 #endif
     solve_bailout = true;
     workHMO.scaled_model_status_ =
-      HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND;
+        HighsModelStatus::REACHED_DUAL_OBJECTIVE_VALUE_UPPER_BOUND;
   }
   return solve_bailout;
 }

--- a/src/simplex/HDual.h
+++ b/src/simplex/HDual.h
@@ -386,8 +386,8 @@ class HDual {
 
   bool checkNonUnitWeightError(std::string message);
   bool dualInfoOk(const HighsLp& lp);
+  bool bailout();
 
-  int Crash_Mode = 0;  //!< Crash mode. TODO: handle this otherwise
   bool solve_bailout;  //!< Set true if control is to be returned immediately to
                        //!< calling function
 

--- a/src/simplex/HPrimal.cpp
+++ b/src/simplex/HPrimal.cpp
@@ -102,7 +102,7 @@ HighsStatus HPrimal::solve() {
   solvePhase = ??InfeasCount > 0 ? 1 : 2;
   */
   solvePhase = 0;  // Frig to skip while (solvePhase) {*}
-
+  solve_bailout = false;
   // Check that the model is OK to solve:
   //
   // Level 0 just checks the flags
@@ -152,18 +152,18 @@ HighsStatus HPrimal::solve() {
     */
   }
   solvePhase = 2;
-  if (workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
-      workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT) {
-    if (solvePhase == 2) {
-      int it0 = scaled_solution_params.simplex_iteration_count;
+  assert(workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
+	 workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT);
+  if (solvePhase == 2) {
+    int it0 = scaled_solution_params.simplex_iteration_count;
+    
+    analysis->simplexTimerStart(SimplexPrimalPhase2Clock);
+    solvePhase2();
+    analysis->simplexTimerStop(SimplexPrimalPhase2Clock);
 
-      analysis->simplexTimerStart(SimplexPrimalPhase2Clock);
-      solvePhase2();
-      analysis->simplexTimerStop(SimplexPrimalPhase2Clock);
-
-      simplex_info.primal_phase2_iteration_count +=
-          (scaled_solution_params.simplex_iteration_count - it0);
-    }
+    simplex_info.primal_phase2_iteration_count +=
+      (scaled_solution_params.simplex_iteration_count - it0);
+    if (bailout()) return HighsStatus::Warning;
   }
   /*
   // ToDo Adapt ok_to_solve to be used by primal
@@ -175,7 +175,6 @@ HighsStatus HPrimal::solve() {
 }
 
 void HPrimal::solvePhase2() {
-  HighsTimer& timer = workHMO.timer_;
   HighsSimplexInfo& simplex_info = workHMO.simplex_info_;
   HighsSimplexLpStatus& simplex_lp_status = workHMO.simplex_lp_status_;
 
@@ -188,6 +187,7 @@ void HPrimal::solvePhase2() {
   invertHint = INVERT_HINT_NO;
   // Set solvePhase=2 so it's set if solvePhase2() is called directly
   solvePhase = 2;
+  solve_bailout = false;
   // Set up local copies of model dimensions
   solver_num_col = workHMO.simplex_lp_.numCol_;
   solver_num_row = workHMO.simplex_lp_.numRow_;
@@ -257,30 +257,19 @@ void HPrimal::solvePhase2() {
         break;
       }
       primalUpdate();
+      if (bailout()) return;
       if (invertHint) {
         break;
       }
     }
-
-    double currentRunHighsTime = timer.readRunHighsClock();
-    if (currentRunHighsTime > workHMO.options_.time_limit) {
-      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
-      break;
-    } else if (workHMO.scaled_solution_params_.simplex_iteration_count >
-	workHMO.options_.simplex_iteration_limit) {
-      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
-      break;
-    }
+    if (bailout()) return;
     // If the data are fresh from rebuild() and no flips have occurred, break
     // out of the outer loop to see what's ocurred
     if (simplex_lp_status.has_fresh_rebuild && num_flip_since_rebuild == 0)
       break;
   }
-
-  if (workHMO.scaled_model_status_ == HighsModelStatus::REACHED_TIME_LIMIT ||
-      workHMO.scaled_model_status_ == HighsModelStatus::REACHED_ITERATION_LIMIT) {
-    return;
-  }
+  // If bailing out, should have returned already
+  assert(!solve_bailout);
 
   if (columnIn == -1) {
     HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
@@ -814,3 +803,22 @@ void HPrimal::reportRebuild(const int rebuild_invert_hint) {
   analysis->invert_hint = rebuild_invert_hint;
   analysis->invertReport();
 }
+
+bool HPrimal::bailout() {
+  if (solve_bailout) {
+    // Bailout has already been decided: check that it's for one of these reasons
+    assert(workHMO.scaled_model_status_ ==
+	   HighsModelStatus::REACHED_TIME_LIMIT ||
+           workHMO.scaled_model_status_ ==
+	   HighsModelStatus::REACHED_ITERATION_LIMIT);
+  } else if (workHMO.timer_.readRunHighsClock() > workHMO.options_.time_limit) {
+    solve_bailout = true;
+    workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
+  } else if (workHMO.scaled_solution_params_.simplex_iteration_count >=
+	     workHMO.options_.simplex_iteration_limit) {
+    solve_bailout = true;
+    workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
+  } 
+  return solve_bailout;
+}
+

--- a/src/simplex/HPrimal.cpp
+++ b/src/simplex/HPrimal.cpp
@@ -266,9 +266,8 @@ void HPrimal::solvePhase2() {
     if (currentRunHighsTime > workHMO.options_.time_limit) {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       break;
-    } else if (scaled_solution_params.simplex_iteration_count >
+    } else if (workHMO.scaled_solution_params_.simplex_iteration_count >
 	workHMO.options_.simplex_iteration_limit) {
-      solve_bailout = true;
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
       break;
     }

--- a/src/simplex/HPrimal.cpp
+++ b/src/simplex/HPrimal.cpp
@@ -152,7 +152,8 @@ HighsStatus HPrimal::solve() {
     */
   }
   solvePhase = 2;
-  if (workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT) {
+  if (workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
+      workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT) {
     if (solvePhase == 2) {
       int it0 = scaled_solution_params.simplex_iteration_count;
 
@@ -265,6 +266,11 @@ void HPrimal::solvePhase2() {
     if (currentRunHighsTime > workHMO.options_.time_limit) {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       break;
+    } else if (scaled_solution_params.simplex_iteration_count >
+	workHMO.options_.simplex_iteration_limit) {
+      solve_bailout = true;
+      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
+      break;
     }
     // If the data are fresh from rebuild() and no flips have occurred, break
     // out of the outer loop to see what's ocurred
@@ -272,7 +278,8 @@ void HPrimal::solvePhase2() {
       break;
   }
 
-  if (workHMO.scaled_model_status_ == HighsModelStatus::REACHED_TIME_LIMIT) {
+  if (workHMO.scaled_model_status_ == HighsModelStatus::REACHED_TIME_LIMIT ||
+      workHMO.scaled_model_status_ == HighsModelStatus::REACHED_ITERATION_LIMIT) {
     return;
   }
 

--- a/src/simplex/HPrimal.cpp
+++ b/src/simplex/HPrimal.cpp
@@ -153,16 +153,18 @@ HighsStatus HPrimal::solve() {
   }
   solvePhase = 2;
   assert(workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
-	 workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT);
+         workHMO.scaled_model_status_ !=
+             HighsModelStatus::REACHED_ITERATION_LIMIT);
+  analysis = &workHMO.simplex_analysis_;
   if (solvePhase == 2) {
     int it0 = scaled_solution_params.simplex_iteration_count;
-    
+
     analysis->simplexTimerStart(SimplexPrimalPhase2Clock);
     solvePhase2();
     analysis->simplexTimerStop(SimplexPrimalPhase2Clock);
 
     simplex_info.primal_phase2_iteration_count +=
-      (scaled_solution_params.simplex_iteration_count - it0);
+        (scaled_solution_params.simplex_iteration_count - it0);
     if (bailout()) return HighsStatus::Warning;
   }
   /*
@@ -806,19 +808,19 @@ void HPrimal::reportRebuild(const int rebuild_invert_hint) {
 
 bool HPrimal::bailout() {
   if (solve_bailout) {
-    // Bailout has already been decided: check that it's for one of these reasons
+    // Bailout has already been decided: check that it's for one of these
+    // reasons
     assert(workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_TIME_LIMIT ||
+               HighsModelStatus::REACHED_TIME_LIMIT ||
            workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_ITERATION_LIMIT);
+               HighsModelStatus::REACHED_ITERATION_LIMIT);
   } else if (workHMO.timer_.readRunHighsClock() > workHMO.options_.time_limit) {
     solve_bailout = true;
     workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
   } else if (workHMO.scaled_solution_params_.simplex_iteration_count >=
-	     workHMO.options_.simplex_iteration_limit) {
+             workHMO.options_.simplex_iteration_limit) {
     solve_bailout = true;
     workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
-  } 
+  }
   return solve_bailout;
 }
-

--- a/src/simplex/HPrimal.h
+++ b/src/simplex/HPrimal.h
@@ -48,6 +48,9 @@ class HPrimal {
   void iterationAnalysisData();
   void iterationAnalysis();
   void reportRebuild(const int rebuild_invert_hint = -1);
+  bool bailout();
+  bool solve_bailout;  //!< Set true if control is to be returned immediately to
+                       //!< calling function
 
   // Model pointer
   HighsModelObject& workHMO;

--- a/src/simplex/HQPrimal.cpp
+++ b/src/simplex/HQPrimal.cpp
@@ -309,7 +309,7 @@ void HQPrimal::solvePhase2() {
     if (currentRunHighsTime > workHMO.options_.time_limit) {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       break;
-    } else if (scaled_solution_params.simplex_iteration_count >
+    } else if (workHMO.scaled_solution_params_.simplex_iteration_count >
 	workHMO.options_.simplex_iteration_limit) {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
       break;

--- a/src/simplex/HQPrimal.cpp
+++ b/src/simplex/HQPrimal.cpp
@@ -102,7 +102,7 @@ HighsStatus HQPrimal::solve() {
   solvePhase = ??InfeasCount > 0 ? 1 : 2;
   */
   solvePhase = 0;  // Frig to skip while (solvePhase) {*}
-
+  solve_bailout = false;
   // Check that the model is OK to solve:
   //
   // Level 0 just checks the flags
@@ -157,18 +157,18 @@ HighsStatus HQPrimal::solve() {
     */
   }
   solvePhase = 2;
-  if (workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
-      workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT) {
-    if (solvePhase == 2) {
-      int it0 = scaled_solution_params.simplex_iteration_count;
-
-      analysis->simplexTimerStart(SimplexPrimalPhase2Clock);
-      solvePhase2();
-      analysis->simplexTimerStop(SimplexPrimalPhase2Clock);
-
-      simplex_info.primal_phase2_iteration_count +=
-          (scaled_solution_params.simplex_iteration_count - it0);
-    }
+  assert(workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
+	 workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT);
+  if (solvePhase == 2) {
+    int it0 = scaled_solution_params.simplex_iteration_count;
+    
+    analysis->simplexTimerStart(SimplexPrimalPhase2Clock);
+    solvePhase2();
+    analysis->simplexTimerStop(SimplexPrimalPhase2Clock);
+    
+    simplex_info.primal_phase2_iteration_count +=
+      (scaled_solution_params.simplex_iteration_count - it0);
+    if (bailout()) return HighsStatus::Warning;
   }
   /*
   // ToDo Adapt ok_to_solve to be used by primal
@@ -182,7 +182,6 @@ HighsStatus HQPrimal::solve() {
 void HQPrimal::solvePhase2() {
   HighsSimplexInfo& simplex_info = workHMO.simplex_info_;
   HighsSimplexLpStatus& simplex_lp_status = workHMO.simplex_lp_status_;
-  HighsTimer& timer = workHMO.timer_;
   printf("HQPrimal::solvePhase2\n");
   // When starting a new phase the (updated) primal objective function
   // value isn't known. Indicate this so that when the value
@@ -193,6 +192,7 @@ void HQPrimal::solvePhase2() {
   invertHint = INVERT_HINT_NO;
   // Set solvePhase=2 so it's set if solvePhase2() is called directly
   solvePhase = 2;
+  solve_bailout = false;
   // Set up local copies of model dimensions
   solver_num_col = workHMO.simplex_lp_.numCol_;
   solver_num_row = workHMO.simplex_lp_.numRow_;
@@ -277,7 +277,9 @@ void HQPrimal::solvePhase2() {
         if (invertHint) {
           break;
         }
+	if (bailout()) break;
       }
+      if (bailout()) break;
       /* Go to the next rebuild */
       if (invertHint) {
         /* Stop when the invert is new */
@@ -287,6 +289,7 @@ void HQPrimal::solvePhase2() {
         continue;
       }
     }
+    if (bailout()) return;
 
     for (;;) {
       primalChooseColumn();
@@ -300,30 +303,19 @@ void HQPrimal::solvePhase2() {
         break;
       }
       primalUpdate();
+      if (bailout()) return;
       if (invertHint) {
         break;
       }
     }
-
-    double currentRunHighsTime = timer.readRunHighsClock();
-    if (currentRunHighsTime > workHMO.options_.time_limit) {
-      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
-      break;
-    } else if (workHMO.scaled_solution_params_.simplex_iteration_count >
-	workHMO.options_.simplex_iteration_limit) {
-      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
-      break;
-    }
+    if (bailout()) return;
     // If the data are fresh from rebuild() and no flips have occurred, break
     // out of the outer loop to see what's ocurred
     if (simplex_lp_status.has_fresh_rebuild && num_flip_since_rebuild == 0)
       break;
   }
-
-  if (workHMO.scaled_model_status_ == HighsModelStatus::REACHED_TIME_LIMIT ||
-      workHMO.scaled_model_status_ == HighsModelStatus::REACHED_ITERATION_LIMIT) {
-    return;
-  }
+  // If bailing out, should have returned already
+  assert(!solve_bailout);
 
   if (columnIn == -1) {
     HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
@@ -1346,3 +1338,22 @@ void HQPrimal::reportRebuild(const int rebuild_invert_hint) {
   analysis->invert_hint = rebuild_invert_hint;
   analysis->invertReport();
 }
+
+bool HQPrimal::bailout() {
+  if (solve_bailout) {
+    // Bailout has already been decided: check that it's for one of these reasons
+    assert(workHMO.scaled_model_status_ ==
+	   HighsModelStatus::REACHED_TIME_LIMIT ||
+           workHMO.scaled_model_status_ ==
+	   HighsModelStatus::REACHED_ITERATION_LIMIT);
+  } else if (workHMO.timer_.readRunHighsClock() > workHMO.options_.time_limit) {
+    solve_bailout = true;
+    workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
+  } else if (workHMO.scaled_solution_params_.simplex_iteration_count >=
+	     workHMO.options_.simplex_iteration_limit) {
+    solve_bailout = true;
+    workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
+  } 
+  return solve_bailout;
+}
+

--- a/src/simplex/HQPrimal.cpp
+++ b/src/simplex/HQPrimal.cpp
@@ -157,7 +157,8 @@ HighsStatus HQPrimal::solve() {
     */
   }
   solvePhase = 2;
-  if (workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT) {
+  if (workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
+      workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT) {
     if (solvePhase == 2) {
       int it0 = scaled_solution_params.simplex_iteration_count;
 
@@ -308,6 +309,10 @@ void HQPrimal::solvePhase2() {
     if (currentRunHighsTime > workHMO.options_.time_limit) {
       workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
       break;
+    } else if (scaled_solution_params.simplex_iteration_count >
+	workHMO.options_.simplex_iteration_limit) {
+      workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
+      break;
     }
     // If the data are fresh from rebuild() and no flips have occurred, break
     // out of the outer loop to see what's ocurred
@@ -315,7 +320,8 @@ void HQPrimal::solvePhase2() {
       break;
   }
 
-  if (workHMO.scaled_model_status_ == HighsModelStatus::REACHED_TIME_LIMIT) {
+  if (workHMO.scaled_model_status_ == HighsModelStatus::REACHED_TIME_LIMIT ||
+      workHMO.scaled_model_status_ == HighsModelStatus::REACHED_ITERATION_LIMIT) {
     return;
   }
 

--- a/src/simplex/HQPrimal.cpp
+++ b/src/simplex/HQPrimal.cpp
@@ -158,16 +158,18 @@ HighsStatus HQPrimal::solve() {
   }
   solvePhase = 2;
   assert(workHMO.scaled_model_status_ != HighsModelStatus::REACHED_TIME_LIMIT &&
-	 workHMO.scaled_model_status_ != HighsModelStatus::REACHED_ITERATION_LIMIT);
+         workHMO.scaled_model_status_ !=
+             HighsModelStatus::REACHED_ITERATION_LIMIT);
+  analysis = &workHMO.simplex_analysis_;
   if (solvePhase == 2) {
     int it0 = scaled_solution_params.simplex_iteration_count;
-    
+
     analysis->simplexTimerStart(SimplexPrimalPhase2Clock);
     solvePhase2();
     analysis->simplexTimerStop(SimplexPrimalPhase2Clock);
-    
+
     simplex_info.primal_phase2_iteration_count +=
-      (scaled_solution_params.simplex_iteration_count - it0);
+        (scaled_solution_params.simplex_iteration_count - it0);
     if (bailout()) return HighsStatus::Warning;
   }
   /*
@@ -277,7 +279,7 @@ void HQPrimal::solvePhase2() {
         if (invertHint) {
           break;
         }
-	if (bailout()) break;
+        if (bailout()) break;
       }
       if (bailout()) break;
       /* Go to the next rebuild */
@@ -1341,19 +1343,19 @@ void HQPrimal::reportRebuild(const int rebuild_invert_hint) {
 
 bool HQPrimal::bailout() {
   if (solve_bailout) {
-    // Bailout has already been decided: check that it's for one of these reasons
+    // Bailout has already been decided: check that it's for one of these
+    // reasons
     assert(workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_TIME_LIMIT ||
+               HighsModelStatus::REACHED_TIME_LIMIT ||
            workHMO.scaled_model_status_ ==
-	   HighsModelStatus::REACHED_ITERATION_LIMIT);
+               HighsModelStatus::REACHED_ITERATION_LIMIT);
   } else if (workHMO.timer_.readRunHighsClock() > workHMO.options_.time_limit) {
     solve_bailout = true;
     workHMO.scaled_model_status_ = HighsModelStatus::REACHED_TIME_LIMIT;
   } else if (workHMO.scaled_solution_params_.simplex_iteration_count >=
-	     workHMO.options_.simplex_iteration_limit) {
+             workHMO.options_.simplex_iteration_limit) {
     solve_bailout = true;
     workHMO.scaled_model_status_ = HighsModelStatus::REACHED_ITERATION_LIMIT;
-  } 
+  }
   return solve_bailout;
 }
-

--- a/src/simplex/HQPrimal.h
+++ b/src/simplex/HQPrimal.h
@@ -71,6 +71,9 @@ class HQPrimal {
    * @brief Single line report after rebuild
    */
   void reportRebuild(const int rebuild_invert_hint = -1);
+  bool bailout();
+  bool solve_bailout;  //!< Set true if control is to be returned immediately to
+                       //!< calling function
 
   // Model pointer
   HighsModelObject& workHMO;

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -3928,7 +3928,8 @@ getPrimalDualInfeasibilitiesAndNewTolerancesFromSimplexBasicSolution(
   // The scaled infeasibility parameters are not known if the time (or
   // iteration?) limit has been reached
   const bool check_scaled_solution_params =
-      scaled_model_status != HighsModelStatus::REACHED_TIME_LIMIT;
+      scaled_model_status != HighsModelStatus::REACHED_TIME_LIMIT &&
+      scaled_model_status != HighsModelStatus::REACHED_ITERATION_LIMIT;
 
   const double scaled_primal_feasibility_tolerance =
       scaled_solution_params.primal_feasibility_tolerance;


### PR DESCRIPTION
Simplex now returns on reaching the iteration limit. This is another "bailout", and added method to handle bailouts more neatly then previously. Deleted lines from HDual/HPrimal/HQPrimal so they look cleaner now. :-) 

Exposed the fact that HPrimal/HQPrimal were broken in master. Hence need a unit test is needed for them - and the parallel solver - a swell a unit tests to check that iteration count, timeout and dual objective bailouts still work. 