### PR TITLE
Fix a build warning in lp_solver.cc with GCC 9

### DIFF
--- a/src/ipm/ipx/src/lp_solver.cc
+++ b/src/ipm/ipx/src/lp_solver.cc
@@ -62,7 +62,7 @@ Int LpSolver::Solve(Int num_var, const double* obj, const double* lb,
         }
         PrintSummary();
     }
-    catch (std::bad_alloc) {
+    catch (const std::bad_alloc&) {
         control_.Log() << " out of memory\n";
         info_.status = IPX_STATUS_out_of_memory;
     }


### PR DESCRIPTION
```
HiGHS/src/ipm/ipx/src/lp_solver.cc:65:17: warning: catching polymorphic type
‘class std::bad_alloc’ by value [-Wcatch-value=]
   65 |     catch (std::bad_alloc) {
```