### PR TITLE
Fix issue in load_mpsLine for empty line

### DIFF
--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -411,7 +411,7 @@ bool load_mpsLine(FILE* file, int& integerVar, int lmax, char* line, char* flag,
     // Line input
     fgets_rt = fgets(line, lmax, file);
     if (fgets_rt == NULL) {
-      printf("load_mpsLine: fgets_rt = %s\n", fgets_rt);
+      printf("load_mpsLine empty, line: %s\n", line);
       return false;
     }
     // Line trim   -- to delete tailing white spaces


### PR DESCRIPTION
Build warning before this fix:
```
HiGHS/src/io/HMPSIO.cpp:414:13: warning: ‘%s’ directive argument is
null [-Wformat-overflow=]
  414 |       printf("load_mpsLine: fgets_rt = %s\n", fgets_rt);
```

I assume the intent was to print the line number; printing nothing would
also be fine.