### PR TITLE
CMake compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # means, adding the subdirectories for all CMake projects in this tree, and
 # finding external libraries and turning them into imported targets.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
 project(HIGHS LANGUAGES CXX C)
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,6 +1,5 @@
 # create highs binary using library without pic
-add_executable(highs)
-target_sources(highs PRIVATE RunHighs.cpp)
+add_executable(highs RunHighs.cpp)
 target_include_directories(highs PRIVATE ${HIGHS_SOURCE_DIR}/app)
 target_link_libraries(highs libhighs)
 

--- a/src/presolve/PresolveComponent.cpp
+++ b/src/presolve/PresolveComponent.cpp
@@ -31,7 +31,7 @@ HighsStatus PresolveComponent::setOptions(const HighsOptions& options) {
 
   assert(options_.presolve_on);
   return HighsStatus::OK;
-};
+}
 
 void PresolveComponent::setBasisInfo(
     const std::vector<HighsBasisStatus>& pass_col_status,


### PR DESCRIPTION
### References Issues
Closes #339 

### Notes:
- Reduce required CMake version from 3.15 to 3.10 (lines up with version found in Ubuntu 18 package repository: [bionic](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=cmake))
- Remove extra semi-colon