### PR TITLE
Fix phase one

### DIFF
--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -232,10 +232,10 @@ void testSolvers(Highs& highs, IterationCount& model_iteration_count,
   int from_i = (int)SimplexStrategy::SIMPLEX_STRATEGY_MIN;
   int to_i = (int)SimplexStrategy::SIMPLEX_STRATEGY_NUM;
   for (int i = from_i; i < to_i; i++) {
-    if (!have_omp) {
-      if (i == (int)SimplexStrategy::SIMPLEX_STRATEGY_DUAL_TASKS) continue;
-      if (i == (int)SimplexStrategy::SIMPLEX_STRATEGY_DUAL_MULTI) continue;
-    }
+    //    if (!have_omp) {
+    if (i == (int)SimplexStrategy::SIMPLEX_STRATEGY_DUAL_TASKS) continue;
+    if (i == (int)SimplexStrategy::SIMPLEX_STRATEGY_DUAL_MULTI) continue;
+    //    }
     model_iteration_count.simplex = simplex_strategy_iteration_count[i];
     testSolver(highs, "simplex", model_iteration_count, i);
   }

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1877,47 +1877,44 @@ void HDual::assessPhase1Optimality() {
     // bounds, have to got back to rebuild()
     if (dualInfeasCount == 0) {
       // No dual infeasibilities with respect to phase 1 bounds. In
-      // this case, hsol jumps straight to phase 2.  However, that's
-      // wrong if the dual objective is (sufficiently) positive, since
-      // that implies that the LP is dual infeasible.
+      // this case, although the LP is dual infeasible if the dual
+      // objective is (sufficiently) positive, no conclusions on the
+      // primal LP can be deduced. Have to shift any dual
+      // infeasibilities and go to dual phase 2 to determine whether
+      // dual unboundedness implies that the LP is primal
+      // infeasible. If dual phase 2 finds a primal feasible point
+      // then the shifts are removed and primal phase 2 will identify
+      // whether the LP is primal unbounded.
       //
-      // If zero phase 1 objective then go to phase 2
-      const bool as_hsol = false;
-      if (simplex_info.dual_objective_value == 0 || as_hsol) {
+      if (simplex_info.dual_objective_value == 0) {
         HighsLogMessage(
             workHMO.options_.logfile, HighsMessageType::INFO,
-            "Still dual feasible after removing cost perturbation, and dual "
-            "objective is %10.4g, so go to phase 2",
-            simplex_info.dual_objective_value);
-        solvePhase = 2;
+            "LP is dual feasible after removing cost perturbations so go to phase 2");
       } else {
-        HighsLogMessage(
-            workHMO.options_.logfile, HighsMessageType::INFO,
-            "Not going to phase 2 immediately as hsol would, since dual "
-            "objective is %10.4g, not zero",
-            simplex_info.dual_objective_value);
-        // Determine whether we go to phase 2 or deduce dual infeasibility
-        assessPhase1OptimalityWithOriginalCosts();
+        reportOnPossibleLpDualInfeasibility();
       }
-    }
-    if (dualInfeasCount > 0) {
-      // Must still be solvePhase = 1 since dual infeasibilities with
-      // respect to phase 1 bounds mean that primal values must
-      // change, so primal feasibility is unknown
-      assert(solvePhase == 1);
-    } else {
-      // Must be solvePhase = -1 (if dual infeasible) or 2 (if dual feasible)
-      assert(solvePhase == -1 || solvePhase == 2);
+      solvePhase = 2;
     }
   } else {
     // Phase 1 problem is optimal with original costs and negative
-    // dual activity In this case, hsol deduces dual
-    // infeasibility. However, what if there are dual infeasibilities
-    // below the tolerance?
+    // dual objective. In this case, hsol deduces dual infeasibility
+    // and returns UNBOUNDED as a status, but this is wrong if the LP
+    // is primal infeasible. As discvussed above, this can only be
+    // determined by going to dual phase 2.
     //
-    // Determine whether we go to phase 2 or deduce dual infeasibility
-    assessPhase1OptimalityWithOriginalCosts();
+    reportOnPossibleLpDualInfeasibility();
+    solvePhase = 2;
   }
+  if (dualInfeasCount > 0) {
+    // Must still be solvePhase = 1 since dual infeasibilities with
+    // respect to phase 1 bounds mean that primal values must
+    // change, so primal feasibility is unknown
+    assert(solvePhase == 1);
+  } else {
+    // Optimal in dual phase 1, so must go to phase 2
+    assert(solvePhase == 2);
+  }
+
   if (solvePhase == -1) {
     // Report dual infeasible
     HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
@@ -1926,32 +1923,32 @@ void HDual::assessPhase1Optimality() {
   }
 }
 
-void HDual::assessPhase1OptimalityWithOriginalCosts() {
+void HDual::reportOnPossibleLpDualInfeasibility() {
+  HighsSimplexInfo& simplex_info = workHMO.simplex_info_;
   assert(solvePhase == 1);
   assert(rowOut == -1);
-  assert(workHMO.simplex_info_.dual_objective_value < 0);
-  assert(!workHMO.simplex_info_.costs_perturbed);
+  assert(simplex_info.dual_objective_value < 0);
+  assert(!simplex_info.costs_perturbed);
   const int num_lp_dual_infeasibilities =
       workHMO.scaled_solution_params_.num_dual_infeasibilities;
   const double max_lp_dual_infeasibility =
       workHMO.scaled_solution_params_.max_dual_infeasibility;
   const double sum_lp_dual_infeasibilities =
       workHMO.scaled_solution_params_.sum_dual_infeasibilities;
+  std::string lp_dual_status;
   if (num_lp_dual_infeasibilities) {
-    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
-                    "Phase 1 problem is optimal with original costs but num / "
-                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
-                    num_lp_dual_infeasibilities, max_lp_dual_infeasibility,
-                    sum_lp_dual_infeasibilities);
-    solvePhase = -1;
+    lp_dual_status = "feasible";
   } else {
-    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
-                    "Phase 1 problem is optimal with original costs and num / "
-                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
-                    num_lp_dual_infeasibilities, max_lp_dual_infeasibility,
-                    sum_lp_dual_infeasibilities);
-    solvePhase = 2;
+    lp_dual_status = "infeasible";
   }
+    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
+                    "LP is dual %s with dual phase 1 objective %10.4g and num / "
+                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
+                    lp_dual_status.c_str(),
+		    simplex_info.dual_objective_value,
+		    num_lp_dual_infeasibilities,
+		    max_lp_dual_infeasibility,
+                    sum_lp_dual_infeasibilities);
 }
 
 bool HDual::dualInfoOk(const HighsLp& lp) {

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1887,9 +1887,9 @@ void HDual::assessPhase1Optimality() {
       // whether the LP is primal unbounded.
       //
       if (simplex_info.dual_objective_value == 0) {
-        HighsLogMessage(
-            workHMO.options_.logfile, HighsMessageType::INFO,
-            "LP is dual feasible after removing cost perturbations so go to phase 2");
+        HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
+                        "LP is dual feasible after removing cost perturbations "
+                        "so go to phase 2");
       } else {
         reportOnPossibleLpDualInfeasibility();
       }
@@ -1917,7 +1917,6 @@ void HDual::assessPhase1Optimality() {
     // so that their duals are zero
     exitPhase1ResetDuals();
   }
-
 }
 
 void HDual::exitPhase1ResetDuals() {
@@ -1925,14 +1924,16 @@ void HDual::exitPhase1ResetDuals() {
   const SimplexBasis& simplex_basis = workHMO.simplex_basis_;
   HighsSimplexInfo& simplex_info = workHMO.simplex_info_;
 
-  const bool reperturb_costs = false;
+  const bool reperturb_costs = true;
   if (reperturb_costs) {
     if (simplex_info.costs_perturbed) {
-    	HighsPrintMessage(
-              workHMO.options_.output,
-              workHMO.options_.message_level, ML_MINIMAL,
-              "Costs are already perturbed in exitPhase1ResetDuals\n");
+      HighsPrintMessage(
+          workHMO.options_.output, workHMO.options_.message_level, ML_MINIMAL,
+          "Costs are already perturbed in exitPhase1ResetDuals\n");
     } else {
+      HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
+                        ML_DETAILED,
+                        "Re-perturbing costs when optimal in phase 1\n");
       initialise_cost(workHMO, 1);
       analysis->simplexTimerStart(ComputeDualClock);
       computeDual(workHMO);
@@ -1948,31 +1949,32 @@ void HDual::exitPhase1ResetDuals() {
       double lp_lower;
       double lp_upper;
       if (iVar < simplex_lp.numCol_) {
-	lp_lower = simplex_lp.colLower_[iVar];
-	lp_upper = simplex_lp.colUpper_[iVar];
+        lp_lower = simplex_lp.colLower_[iVar];
+        lp_upper = simplex_lp.colUpper_[iVar];
       } else {
-	int iRow = iVar - simplex_lp.numCol_;
-	lp_lower = simplex_lp.rowLower_[iRow];
-	lp_upper = simplex_lp.rowUpper_[iRow];
+        int iRow = iVar - simplex_lp.numCol_;
+        lp_lower = simplex_lp.rowLower_[iRow];
+        lp_upper = simplex_lp.rowUpper_[iRow];
       }
       if (lp_lower <= -HIGHS_CONST_INF && lp_upper >= HIGHS_CONST_INF) {
-	const double shift = -simplex_info.workDual_[iVar];
-	simplex_info.workDual_[iVar] = 0;
-	simplex_info.workCost_[iVar] = simplex_info.workCost_[iVar] + shift;
-	num_shift++;
-	sum_shift += fabs(shift);
-	HighsPrintMessage(
-              workHMO.options_.output,
-              workHMO.options_.message_level, ML_VERBOSE,
-              "Variable %d is free: shift cost to zero dual of %g\n", iVar, shift);
+        const double shift = -simplex_info.workDual_[iVar];
+        simplex_info.workDual_[iVar] = 0;
+        simplex_info.workCost_[iVar] = simplex_info.workCost_[iVar] + shift;
+        num_shift++;
+        sum_shift += fabs(shift);
+        HighsPrintMessage(
+            workHMO.options_.output, workHMO.options_.message_level, ML_VERBOSE,
+            "Variable %d is free: shift cost to zero dual of %g\n", iVar,
+            shift);
       }
     }
   }
   if (num_shift)
-    HighsPrintMessage(
-        workHMO.options_.output,
-        workHMO.options_.message_level, ML_DETAILED,
-        "Performed %d cost shift(s) for free variables to zero dual values: total = %g\n", num_shift, sum_shift);
+    HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
+                      ML_DETAILED,
+                      "Performed %d cost shift(s) for free variables to zero "
+                      "dual values: total = %g\n",
+                      num_shift, sum_shift);
 }
 
 void HDual::reportOnPossibleLpDualInfeasibility() {
@@ -1993,14 +1995,12 @@ void HDual::reportOnPossibleLpDualInfeasibility() {
   } else {
     lp_dual_status = "feasible";
   }
-    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
-                    "LP is dual %s with dual phase 1 objective %10.4g and num / "
-                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
-                    lp_dual_status.c_str(),
-		    simplex_info.dual_objective_value,
-		    num_lp_dual_infeasibilities,
-		    max_lp_dual_infeasibility,
-                    sum_lp_dual_infeasibilities);
+  HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
+                  "LP is dual %s with dual phase 1 objective %10.4g and num / "
+                  "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
+                  lp_dual_status.c_str(), simplex_info.dual_objective_value,
+                  num_lp_dual_infeasibilities, max_lp_dual_infeasibility,
+                  sum_lp_dual_infeasibilities);
 }
 
 bool HDual::dualInfoOk(const HighsLp& lp) {

--- a/src/simplex/HDual.h
+++ b/src/simplex/HDual.h
@@ -386,7 +386,7 @@ class HDual {
   void majorRollback();
 
   void assessPhase1Optimality();
-  void assessPhase1OptimalityWithOriginalCosts();
+  void reportOnPossibleLpDualInfeasibility();
 
   bool checkNonUnitWeightError(std::string message);
   bool dualInfoOk(const HighsLp& lp);

--- a/src/simplex/HDual.h
+++ b/src/simplex/HDual.h
@@ -386,6 +386,7 @@ class HDual {
   void majorRollback();
 
   void assessPhase1Optimality();
+  void exitPhase1ResetDuals();
   void reportOnPossibleLpDualInfeasibility();
 
   bool checkNonUnitWeightError(std::string message);

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -3522,7 +3522,7 @@ void correctDual(HighsModelObject& highs_model_object,
           HighsPrintMessage(
               highs_model_object.options_.output,
               highs_model_object.options_.message_level, ML_VERBOSE,
-              "Move %s: shift = %g; objective change = %g\n", direction.c_str(),
+              "Move %s: cost shift = %g; objective change = %g\n", direction.c_str(),
               shift, local_dual_objective_change);
         }
       }
@@ -3538,7 +3538,7 @@ void correctDual(HighsModelObject& highs_model_object,
     HighsPrintMessage(
         highs_model_object.options_.output,
         highs_model_object.options_.message_level, ML_DETAILED,
-        "Performed %d shift(s): total = %g; objective change = %g\n", num_shift,
+        "Performed %d cost shift(s): total = %g; objective change = %g\n", num_shift,
         sum_shift, shift_dual_objective_value_change);
   *free_infeasibility_count = workCount;
 }

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -3522,8 +3522,8 @@ void correctDual(HighsModelObject& highs_model_object,
           HighsPrintMessage(
               highs_model_object.options_.output,
               highs_model_object.options_.message_level, ML_VERBOSE,
-              "Move %s: cost shift = %g; objective change = %g\n", direction.c_str(),
-              shift, local_dual_objective_change);
+              "Move %s: cost shift = %g; objective change = %g\n",
+              direction.c_str(), shift, local_dual_objective_change);
         }
       }
     }
@@ -3538,8 +3538,8 @@ void correctDual(HighsModelObject& highs_model_object,
     HighsPrintMessage(
         highs_model_object.options_.output,
         highs_model_object.options_.message_level, ML_DETAILED,
-        "Performed %d cost shift(s): total = %g; objective change = %g\n", num_shift,
-        sum_shift, shift_dual_objective_value_change);
+        "Performed %d cost shift(s): total = %g; objective change = %g\n",
+        num_shift, sum_shift, shift_dual_objective_value_change);
   *free_infeasibility_count = workCount;
 }
 


### PR DESCRIPTION
HiGHS is now forced to move to Phase 2 on dual phase 1 optimality, even if infeasible. This is because no conclusions on the primal LP can be deduced. After re-perturbing the costs, have to shift any dual infeasibilities for free variables (since it's not done in phase 2 rebuild) and go to dual phase 2 to determine whether dual unboundedness implies that the LP is primal infeasible. If dual phase 2 finds a primal feasible point then the shifts are removed and primal phase 2 will identify whether the LP is primal unbounded.

Checked on primal unbounded LPs gas11 and adlittle_max, and issue334 - which is both primal and dual infeasible. Still gets the right answers for the unbounded unit tests, too.