### PR TITLE
Fix phase one ( #341) and Fix free list size

### DIFF
--- a/check/TestSpecialLps.cpp
+++ b/check/TestSpecialLps.cpp
@@ -374,7 +374,7 @@ TEST_CASE("test-special-lps", "[TestSpecialLps]") {
   issue280(highs);
   issue282(highs);
   issue285(highs);
-  //  issue295(highs);
+  issue295(highs);
   issue306(highs);
   issue316(highs);
   mpsUnbounded(highs);

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1877,47 +1877,44 @@ void HDual::assessPhase1Optimality() {
     // bounds, have to got back to rebuild()
     if (dualInfeasCount == 0) {
       // No dual infeasibilities with respect to phase 1 bounds. In
-      // this case, hsol jumps straight to phase 2.  However, that's
-      // wrong if the dual objective is (sufficiently) positive, since
-      // that implies that the LP is dual infeasible.
+      // this case, although the LP is dual infeasible if the dual
+      // objective is (sufficiently) positive, no conclusions on the
+      // primal LP can be deduced. Have to shift any dual
+      // infeasibilities and go to dual phase 2 to determine whether
+      // dual unboundedness implies that the LP is primal
+      // infeasible. If dual phase 2 finds a primal feasible point
+      // then the shifts are removed and primal phase 2 will identify
+      // whether the LP is primal unbounded.
       //
-      // If zero phase 1 objective then go to phase 2
-      const bool as_hsol = false;
-      if (simplex_info.dual_objective_value == 0 || as_hsol) {
+      if (simplex_info.dual_objective_value == 0) {
         HighsLogMessage(
             workHMO.options_.logfile, HighsMessageType::INFO,
-            "Still dual feasible after removing cost perturbation, and dual "
-            "objective is %10.4g, so go to phase 2",
-            simplex_info.dual_objective_value);
-        solvePhase = 2;
+            "LP is dual feasible after removing cost perturbations so go to phase 2");
       } else {
-        HighsLogMessage(
-            workHMO.options_.logfile, HighsMessageType::INFO,
-            "Not going to phase 2 immediately as hsol would, since dual "
-            "objective is %10.4g, not zero",
-            simplex_info.dual_objective_value);
-        // Determine whether we go to phase 2 or deduce dual infeasibility
-        assessPhase1OptimalityWithOriginalCosts();
+        reportOnPossibleLpDualInfeasibility();
       }
-    }
-    if (dualInfeasCount > 0) {
-      // Must still be solvePhase = 1 since dual infeasibilities with
-      // respect to phase 1 bounds mean that primal values must
-      // change, so primal feasibility is unknown
-      assert(solvePhase == 1);
-    } else {
-      // Must be solvePhase = -1 (if dual infeasible) or 2 (if dual feasible)
-      assert(solvePhase == -1 || solvePhase == 2);
+      solvePhase = 2;
     }
   } else {
     // Phase 1 problem is optimal with original costs and negative
-    // dual activity In this case, hsol deduces dual
-    // infeasibility. However, what if there are dual infeasibilities
-    // below the tolerance?
+    // dual objective. In this case, hsol deduces dual infeasibility
+    // and returns UNBOUNDED as a status, but this is wrong if the LP
+    // is primal infeasible. As discvussed above, this can only be
+    // determined by going to dual phase 2.
     //
-    // Determine whether we go to phase 2 or deduce dual infeasibility
-    assessPhase1OptimalityWithOriginalCosts();
+    reportOnPossibleLpDualInfeasibility();
+    solvePhase = 2;
   }
+  if (dualInfeasCount > 0) {
+    // Must still be solvePhase = 1 since dual infeasibilities with
+    // respect to phase 1 bounds mean that primal values must
+    // change, so primal feasibility is unknown
+    assert(solvePhase == 1);
+  } else {
+    // Optimal in dual phase 1, so must go to phase 2
+    assert(solvePhase == 2);
+  }
+
   if (solvePhase == -1) {
     // Report dual infeasible
     HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
@@ -1926,32 +1923,32 @@ void HDual::assessPhase1Optimality() {
   }
 }
 
-void HDual::assessPhase1OptimalityWithOriginalCosts() {
+void HDual::reportOnPossibleLpDualInfeasibility() {
+  HighsSimplexInfo& simplex_info = workHMO.simplex_info_;
   assert(solvePhase == 1);
   assert(rowOut == -1);
-  assert(workHMO.simplex_info_.dual_objective_value < 0);
-  assert(!workHMO.simplex_info_.costs_perturbed);
+  assert(simplex_info.dual_objective_value < 0);
+  assert(!simplex_info.costs_perturbed);
   const int num_lp_dual_infeasibilities =
       workHMO.scaled_solution_params_.num_dual_infeasibilities;
   const double max_lp_dual_infeasibility =
       workHMO.scaled_solution_params_.max_dual_infeasibility;
   const double sum_lp_dual_infeasibilities =
       workHMO.scaled_solution_params_.sum_dual_infeasibilities;
+  std::string lp_dual_status;
   if (num_lp_dual_infeasibilities) {
-    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
-                    "Phase 1 problem is optimal with original costs but num / "
-                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
-                    num_lp_dual_infeasibilities, max_lp_dual_infeasibility,
-                    sum_lp_dual_infeasibilities);
-    solvePhase = -1;
+    lp_dual_status = "feasible";
   } else {
-    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
-                    "Phase 1 problem is optimal with original costs and num / "
-                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
-                    num_lp_dual_infeasibilities, max_lp_dual_infeasibility,
-                    sum_lp_dual_infeasibilities);
-    solvePhase = 2;
+    lp_dual_status = "infeasible";
   }
+    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
+                    "LP is dual %s with dual phase 1 objective %10.4g and num / "
+                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
+                    lp_dual_status.c_str(),
+		    simplex_info.dual_objective_value,
+		    num_lp_dual_infeasibilities,
+		    max_lp_dual_infeasibility,
+                    sum_lp_dual_infeasibilities);
 }
 
 bool HDual::dualInfoOk(const HighsLp& lp) {

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1887,9 +1887,9 @@ void HDual::assessPhase1Optimality() {
       // whether the LP is primal unbounded.
       //
       if (simplex_info.dual_objective_value == 0) {
-        HighsLogMessage(
-            workHMO.options_.logfile, HighsMessageType::INFO,
-            "LP is dual feasible after removing cost perturbations so go to phase 2");
+        HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
+                        "LP is dual feasible after removing cost perturbations "
+                        "so go to phase 2");
       } else {
         reportOnPossibleLpDualInfeasibility();
       }
@@ -1917,7 +1917,6 @@ void HDual::assessPhase1Optimality() {
     // so that their duals are zero
     exitPhase1ResetDuals();
   }
-
 }
 
 void HDual::exitPhase1ResetDuals() {
@@ -1925,14 +1924,16 @@ void HDual::exitPhase1ResetDuals() {
   const SimplexBasis& simplex_basis = workHMO.simplex_basis_;
   HighsSimplexInfo& simplex_info = workHMO.simplex_info_;
 
-  const bool reperturb_costs = false;
+  const bool reperturb_costs = true;
   if (reperturb_costs) {
     if (simplex_info.costs_perturbed) {
-    	HighsPrintMessage(
-              workHMO.options_.output,
-              workHMO.options_.message_level, ML_MINIMAL,
-              "Costs are already perturbed in exitPhase1ResetDuals\n");
+      HighsPrintMessage(
+          workHMO.options_.output, workHMO.options_.message_level, ML_MINIMAL,
+          "Costs are already perturbed in exitPhase1ResetDuals\n");
     } else {
+      HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
+                        ML_DETAILED,
+                        "Re-perturbing costs when optimal in phase 1\n");
       initialise_cost(workHMO, 1);
       analysis->simplexTimerStart(ComputeDualClock);
       computeDual(workHMO);
@@ -1948,31 +1949,32 @@ void HDual::exitPhase1ResetDuals() {
       double lp_lower;
       double lp_upper;
       if (iVar < simplex_lp.numCol_) {
-	lp_lower = simplex_lp.colLower_[iVar];
-	lp_upper = simplex_lp.colUpper_[iVar];
+        lp_lower = simplex_lp.colLower_[iVar];
+        lp_upper = simplex_lp.colUpper_[iVar];
       } else {
-	int iRow = iVar - simplex_lp.numCol_;
-	lp_lower = simplex_lp.rowLower_[iRow];
-	lp_upper = simplex_lp.rowUpper_[iRow];
+        int iRow = iVar - simplex_lp.numCol_;
+        lp_lower = simplex_lp.rowLower_[iRow];
+        lp_upper = simplex_lp.rowUpper_[iRow];
       }
       if (lp_lower <= -HIGHS_CONST_INF && lp_upper >= HIGHS_CONST_INF) {
-	const double shift = -simplex_info.workDual_[iVar];
-	simplex_info.workDual_[iVar] = 0;
-	simplex_info.workCost_[iVar] = simplex_info.workCost_[iVar] + shift;
-	num_shift++;
-	sum_shift += fabs(shift);
-	HighsPrintMessage(
-              workHMO.options_.output,
-              workHMO.options_.message_level, ML_VERBOSE,
-              "Variable %d is free: shift cost to zero dual of %g\n", iVar, shift);
+        const double shift = -simplex_info.workDual_[iVar];
+        simplex_info.workDual_[iVar] = 0;
+        simplex_info.workCost_[iVar] = simplex_info.workCost_[iVar] + shift;
+        num_shift++;
+        sum_shift += fabs(shift);
+        HighsPrintMessage(
+            workHMO.options_.output, workHMO.options_.message_level, ML_VERBOSE,
+            "Variable %d is free: shift cost to zero dual of %g\n", iVar,
+            shift);
       }
     }
   }
   if (num_shift)
-    HighsPrintMessage(
-        workHMO.options_.output,
-        workHMO.options_.message_level, ML_DETAILED,
-        "Performed %d cost shift(s) for free variables to zero dual values: total = %g\n", num_shift, sum_shift);
+    HighsPrintMessage(workHMO.options_.output, workHMO.options_.message_level,
+                      ML_DETAILED,
+                      "Performed %d cost shift(s) for free variables to zero "
+                      "dual values: total = %g\n",
+                      num_shift, sum_shift);
 }
 
 void HDual::reportOnPossibleLpDualInfeasibility() {
@@ -1993,14 +1995,12 @@ void HDual::reportOnPossibleLpDualInfeasibility() {
   } else {
     lp_dual_status = "feasible";
   }
-    HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
-                    "LP is dual %s with dual phase 1 objective %10.4g and num / "
-                    "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
-                    lp_dual_status.c_str(),
-		    simplex_info.dual_objective_value,
-		    num_lp_dual_infeasibilities,
-		    max_lp_dual_infeasibility,
-                    sum_lp_dual_infeasibilities);
+  HighsLogMessage(workHMO.options_.logfile, HighsMessageType::INFO,
+                  "LP is dual %s with dual phase 1 objective %10.4g and num / "
+                  "max / sum dual infeasibilities = %d / %9.4g / %9.4g",
+                  lp_dual_status.c_str(), simplex_info.dual_objective_value,
+                  num_lp_dual_infeasibilities, max_lp_dual_infeasibility,
+                  sum_lp_dual_infeasibilities);
 }
 
 bool HDual::dualInfoOk(const HighsLp& lp) {

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1033,7 +1033,7 @@ void HDual::iterationAnalysisData() {
   analysis->leaving_variable = columnOut;
   analysis->entering_variable = columnIn;
   analysis->invert_hint = invertHint;
-  analysis->freelist_size = dualRow.freeListSize;
+  analysis->freelist_num_entries = dualRow.freelist_num_entries;
   analysis->reduced_rhs_value = 0;
   analysis->reduced_cost_value = 0;
   analysis->edge_weight = 0;

--- a/src/simplex/HDual.cpp
+++ b/src/simplex/HDual.cpp
@@ -1033,7 +1033,6 @@ void HDual::iterationAnalysisData() {
   analysis->leaving_variable = columnOut;
   analysis->entering_variable = columnIn;
   analysis->invert_hint = invertHint;
-  analysis->freelist_num_entries = dualRow.freelist_num_entries;
   analysis->reduced_rhs_value = 0;
   analysis->reduced_cost_value = 0;
   analysis->edge_weight = 0;

--- a/src/simplex/HDual.h
+++ b/src/simplex/HDual.h
@@ -386,7 +386,7 @@ class HDual {
   void majorRollback();
 
   void assessPhase1Optimality();
-  void assessPhase1OptimalityWithOriginalCosts();
+  void reportOnPossibleLpDualInfeasibility();
 
   bool checkNonUnitWeightError(std::string message);
   bool dualInfoOk(const HighsLp& lp);

--- a/src/simplex/HDual.h
+++ b/src/simplex/HDual.h
@@ -386,6 +386,7 @@ class HDual {
   void majorRollback();
 
   void assessPhase1Optimality();
+  void exitPhase1ResetDuals();
   void reportOnPossibleLpDualInfeasibility();
 
   bool checkNonUnitWeightError(std::string message);

--- a/src/simplex/HDualRow.cpp
+++ b/src/simplex/HDualRow.cpp
@@ -340,9 +340,10 @@ void HDualRow::updateDual(double theta) {
 
 void HDualRow::createFreelist() {
   freeList.clear();
-  for (int i = 0; i < workHMO.simplex_lp_.numCol_ + workHMO.simplex_lp_.numRow_; i++) {
+  for (int i = 0; i < workHMO.simplex_lp_.numCol_ + workHMO.simplex_lp_.numRow_;
+       i++) {
     if (workHMO.simplex_basis_.nonbasicFlag_[i] &&
-	highs_isInfinity(-workHMO.simplex_info_.workLower_[i]) &&
+        highs_isInfinity(-workHMO.simplex_info_.workLower_[i]) &&
         highs_isInfinity(workHMO.simplex_info_.workUpper_[i]))
       freeList.insert(i);
   }
@@ -383,8 +384,7 @@ void HDualRow::deleteFreemove() {
 
 void HDualRow::deleteFreelist(int iColumn) {
   if (!freeList.empty()) {
-    if (freeList.count(iColumn))
-      freeList.erase(iColumn);
+    if (freeList.count(iColumn)) freeList.erase(iColumn);
   }
 }
 

--- a/src/simplex/HDualRow.cpp
+++ b/src/simplex/HDualRow.cpp
@@ -19,6 +19,7 @@
 #include "lp_data/HConst.h"
 #include "lp_data/HighsModelObject.h"
 #include "simplex/HSimplex.h"
+#include "simplex/HSimplexDebug.h"
 #include "simplex/HVector.h"
 #include "simplex/SimplexTimer.h"
 
@@ -51,13 +52,13 @@ void HDualRow::setup() {
 
   // delete_Freelist() is being called in Phase 1 and Phase 2 since
   // it's in updatePivots(), but create_Freelist() is only called in
-  // Phase 2. Hence freeList and freeListSize are not initialised when
-  // freeList.empty() is used to identify that freeListSize should be
-  // tested for zero. Suddenly freeListSize is 1212631365 rather than
-  // zero when uninitialised, triggering a warning. So, let's set
-  // clear freeList and set freeListSize = 0.
+  // Phase 2. Hence freeList and freelist_num_entries are not initialised when
+  // freeList.empty() is used to identify that freelist_num_entries should be
+  // tested for zero. Suddenly freelist_num_entries is 1212631365 rather than
+  // zero when uninitialised, triggering a warning. So, let's clear
+  // freeList and set freelist_num_entries = 0.
   freeList.clear();
-  freeListSize = 0;
+  freelist_num_entries = 0;
 }
 
 void HDualRow::clear() {
@@ -346,27 +347,27 @@ void HDualRow::createFreelist() {
   double* workUpper = &workHMO.simplex_info_.workUpper_[0];
   freeList.clear();
   const int* nonbasicFlag = &workHMO.simplex_basis_.nonbasicFlag_[0];
-  int ckFreeListSize = 0;
+  int check_freelist_num_entries = 0;
   const int numTot = workHMO.simplex_lp_.numCol_ + workHMO.simplex_lp_.numRow_;
   for (int i = 0; i < numTot; i++) {
     //    if (nonbasicFlag[i] && workRange[i] > 1.5 * HIGHS_CONST_INF) {
     if (nonbasicFlag[i] && highs_isInfinity(-workLower[i]) &&
         highs_isInfinity(workUpper[i])) {
       freeList.insert(i);
-      ckFreeListSize++;
+      check_freelist_num_entries++;
     }
   }
   if (freeList.size() > 0) {
     //  int freeListSa = *freeList.begin();
     //  int freeListE = *freeList.end();
-    freeListSize = *freeList.end();
-    if (freeListSize != ckFreeListSize) {
-      printf("!! STRANGE: freeListSize != ckFreeListSize\n");
+    freelist_num_entries = *freeList.end();
+    if (freelist_num_entries != check_freelist_num_entries) {
+      printf("!! STRANGE: freelist_num_entries != check_freelist_num_entries\n");
     }
     // const int numTot = workHMO.simplex_lp_.numCol_ +
     // workHMO.simplex_lp_.numRow_;
     //  printf("Create Freelist %d:%d has size %d (%3d%%)\n", freeListSa,
-    //  freeListE, freeListSize, 100*freeListSize/numTot);
+    //  freeListE, freelist_num_entries, 100*freelist_num_entries/numTot);
   }
 }
 
@@ -407,25 +408,25 @@ void HDualRow::deleteFreelist(int iColumn) {
     if (freeList.count(iColumn)) freeList.erase(iColumn);
     //  int freeListSa = *freeList.begin();
     //  int freeListE = *freeList.end();
-    int ckFreeListSize = 0;
+    int check_freelist_num_entries = 0;
     set<int>::iterator sit;
-    for (sit = freeList.begin(); sit != freeList.end(); sit++) ckFreeListSize++;
-    freeListSize = *freeList.end();
-    if (freeListSize != ckFreeListSize) {
-      printf("!! STRANGE: freeListSize != ckFreeListSize\n");
+    for (sit = freeList.begin(); sit != freeList.end(); sit++) check_freelist_num_entries++;
+    freelist_num_entries = *freeList.end();
+    if (freelist_num_entries != check_freelist_num_entries) {
+      printf("!! STRANGE: freelist_num_entries != check_freelist_num_entries\n");
     }
     // const int numTot = workHMO.simplex_lp_.numCol_ +
     // workHMO.simplex_lp_.numRow_;
     //  printf("Update Freelist %d:%d has size %d (%3d%%)\n", freeListSa,
-    //  freeListE, freeListSize, 100*freeListSize/numTot); if
+    //  freeListE, freelist_num_entries, 100*freelist_num_entries/numTot); if
     //  (freeList.empty()) {
     //    printf("Empty  Freelist\n");
     //  } else {
     //    printf("\n");
     //  }
   } else {
-    if (freeListSize > 0)
-      printf("!! STRANGE: Empty Freelist has size %d\n", freeListSize);
+    if (freelist_num_entries > 0)
+      printf("!! STRANGE: Empty Freelist has size %d\n", freelist_num_entries);
   }
 }
 

--- a/src/simplex/HDualRow.h
+++ b/src/simplex/HDualRow.h
@@ -132,7 +132,6 @@ class HDualRow {
 
   // Freelist:
   std::set<int> freeList;  //!< Freelist itself
-  int freelist_num_entries = 0;    //!< Number of entries in freeList
 
   // packed data:
   int packCount;                  //!< number of packed indices/values

--- a/src/simplex/HDualRow.h
+++ b/src/simplex/HDualRow.h
@@ -132,7 +132,7 @@ class HDualRow {
 
   // Freelist:
   std::set<int> freeList;  //!< Freelist itself
-  int freeListSize = 0;    //!< Number of entries in freeList
+  int freelist_num_entries = 0;    //!< Number of entries in freeList
 
   // packed data:
   int packCount;                  //!< number of packed indices/values

--- a/src/simplex/HPrimal.cpp
+++ b/src/simplex/HPrimal.cpp
@@ -783,7 +783,7 @@ void HPrimal::iterationAnalysisData() {
   analysis->leaving_variable = columnOut;
   analysis->entering_variable = columnIn;
   analysis->invert_hint = invertHint;
-  analysis->freelist_size = 0;
+  analysis->freelist_num_entries = 0;
   analysis->reduced_rhs_value = 0;
   analysis->reduced_cost_value = 0;
   analysis->edge_weight = 0;

--- a/src/simplex/HPrimal.cpp
+++ b/src/simplex/HPrimal.cpp
@@ -783,7 +783,6 @@ void HPrimal::iterationAnalysisData() {
   analysis->leaving_variable = columnOut;
   analysis->entering_variable = columnIn;
   analysis->invert_hint = invertHint;
-  analysis->freelist_num_entries = 0;
   analysis->reduced_rhs_value = 0;
   analysis->reduced_cost_value = 0;
   analysis->edge_weight = 0;

--- a/src/simplex/HQPrimal.cpp
+++ b/src/simplex/HQPrimal.cpp
@@ -1320,7 +1320,7 @@ void HQPrimal::iterationAnalysisData() {
   analysis->leaving_variable = columnOut;
   analysis->entering_variable = columnIn;
   analysis->invert_hint = invertHint;
-  analysis->freelist_size = 0;
+  analysis->freelist_num_entries = 0;
   analysis->reduced_rhs_value = 0;
   analysis->reduced_cost_value = 0;
   analysis->edge_weight = 0;

--- a/src/simplex/HQPrimal.cpp
+++ b/src/simplex/HQPrimal.cpp
@@ -1320,7 +1320,6 @@ void HQPrimal::iterationAnalysisData() {
   analysis->leaving_variable = columnOut;
   analysis->entering_variable = columnIn;
   analysis->invert_hint = invertHint;
-  analysis->freelist_num_entries = 0;
   analysis->reduced_rhs_value = 0;
   analysis->reduced_cost_value = 0;
   analysis->edge_weight = 0;

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -3522,7 +3522,7 @@ void correctDual(HighsModelObject& highs_model_object,
           HighsPrintMessage(
               highs_model_object.options_.output,
               highs_model_object.options_.message_level, ML_VERBOSE,
-              "Move %s: shift = %g; objective change = %g\n", direction.c_str(),
+              "Move %s: cost shift = %g; objective change = %g\n", direction.c_str(),
               shift, local_dual_objective_change);
         }
       }
@@ -3538,7 +3538,7 @@ void correctDual(HighsModelObject& highs_model_object,
     HighsPrintMessage(
         highs_model_object.options_.output,
         highs_model_object.options_.message_level, ML_DETAILED,
-        "Performed %d shift(s): total = %g; objective change = %g\n", num_shift,
+        "Performed %d cost shift(s): total = %g; objective change = %g\n", num_shift,
         sum_shift, shift_dual_objective_value_change);
   *free_infeasibility_count = workCount;
 }

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -3522,8 +3522,8 @@ void correctDual(HighsModelObject& highs_model_object,
           HighsPrintMessage(
               highs_model_object.options_.output,
               highs_model_object.options_.message_level, ML_VERBOSE,
-              "Move %s: cost shift = %g; objective change = %g\n", direction.c_str(),
-              shift, local_dual_objective_change);
+              "Move %s: cost shift = %g; objective change = %g\n",
+              direction.c_str(), shift, local_dual_objective_change);
         }
       }
     }
@@ -3538,8 +3538,8 @@ void correctDual(HighsModelObject& highs_model_object,
     HighsPrintMessage(
         highs_model_object.options_.output,
         highs_model_object.options_.message_level, ML_DETAILED,
-        "Performed %d cost shift(s): total = %g; objective change = %g\n", num_shift,
-        sum_shift, shift_dual_objective_value_change);
+        "Performed %d cost shift(s): total = %g; objective change = %g\n",
+        num_shift, sum_shift, shift_dual_objective_value_change);
   *free_infeasibility_count = workCount;
 }
 

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -751,3 +751,7 @@ HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
       cleanup_relative_nonbasic_dual_change_norm, num_dual_sign_change);
   return return_status;
 }
+
+HighsDebugStatus debugFreeListNumEn() {
+  return HighsDebugStatus::OK;			    
+}

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -752,6 +752,7 @@ HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
   return return_status;
 }
 
-HighsDebugStatus debugFreeListNumEn() {
+HighsDebugStatus debugFreeListNumEn(const HighsModelObject& highs_model_object,
+				    const std::set<int>& freeList, const bool setup) {
   return HighsDebugStatus::OK;			    
 }

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -86,6 +86,10 @@ const double cleanup_excessive_absolute_nonbasic_dual_change_norm =
 const double cleanup_excessive_relative_nonbasic_dual_change_norm =
     sqrt(cleanup_large_relative_nonbasic_dual_change_norm);
 
+const double freelist_excessive_pct_num_entries = 25.0;
+const double freelist_large_pct_num_entries = 10.0;
+const double freelist_fair_pct_num_entries = 1.0;
+
 HighsDebugStatus debugComputePrimal(const HighsModelObject& highs_model_object,
                                     const std::vector<double>& primal_rhs) {
   // Non-trivially expensive analysis of computed primal values.
@@ -752,7 +756,46 @@ HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
   return return_status;
 }
 
-HighsDebugStatus debugFreeListNumEn(const HighsModelObject& highs_model_object,
-				    const std::set<int>& freeList, const bool setup) {
-  return HighsDebugStatus::OK;			    
+HighsDebugStatus debugFreeListNumEntries(const HighsModelObject& highs_model_object,
+					 const std::set<int>& freeList) {
+  //  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
+  //    return HighsDebugStatus::NOT_CHECKED;
+
+  int freelist_num_entries = 0;
+  if (freeList.size() > 0) {
+    std::set<int>::iterator sit;
+    for (sit = freeList.begin(); sit != freeList.end(); sit++)
+      freelist_num_entries++;
+  }
+  
+  const int numTot = highs_model_object.simplex_lp_.numCol_ +
+    highs_model_object.simplex_lp_.numRow_;
+  double pct_freelist_num_entries = (100.0 * freelist_num_entries) / numTot;
+
+  std::string value_adjective;
+  int report_level;
+  HighsDebugStatus return_status = HighsDebugStatus::NOT_CHECKED;
+  
+  if (pct_freelist_num_entries > freelist_excessive_pct_num_entries) {
+    value_adjective = "Excessive";
+    report_level = ML_ALWAYS;
+  } else if (pct_freelist_num_entries > freelist_large_pct_num_entries) {
+    value_adjective = "Large";
+    report_level = ML_DETAILED;
+  } else if (pct_freelist_num_entries > freelist_fair_pct_num_entries) {
+    value_adjective = "Fair";
+    report_level = ML_VERBOSE;
+  } else {
+    value_adjective = "OK";
+    report_level = ML_ALWAYS;//ML_VERBOSE;
+    return_status = HighsDebugStatus::OK;
+  }
+
+  HighsPrintMessage(
+      highs_model_object.options_.output,
+      highs_model_object.options_.message_level, report_level,
+      "FreeList   :   %-9s percentage (%6.2g) of %d variables on free list\n",
+      value_adjective.c_str(), pct_freelist_num_entries, numTot);
+
+  return return_status;
 }

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -756,9 +756,10 @@ HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
   return return_status;
 }
 
-HighsDebugStatus debugFreeListNumEntries(const HighsModelObject& highs_model_object,
-					 const std::set<int>& freeList) {
-  //  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
+HighsDebugStatus debugFreeListNumEntries(
+    const HighsModelObject& highs_model_object, const std::set<int>& freeList) {
+  //  if (highs_model_object.options_.highs_debug_level <
+  //  HIGHS_DEBUG_LEVEL_CHEAP)
   //    return HighsDebugStatus::NOT_CHECKED;
 
   int freelist_num_entries = 0;
@@ -767,15 +768,15 @@ HighsDebugStatus debugFreeListNumEntries(const HighsModelObject& highs_model_obj
     for (sit = freeList.begin(); sit != freeList.end(); sit++)
       freelist_num_entries++;
   }
-  
+
   const int numTot = highs_model_object.simplex_lp_.numCol_ +
-    highs_model_object.simplex_lp_.numRow_;
+                     highs_model_object.simplex_lp_.numRow_;
   double pct_freelist_num_entries = (100.0 * freelist_num_entries) / numTot;
 
   std::string value_adjective;
   int report_level;
   HighsDebugStatus return_status = HighsDebugStatus::NOT_CHECKED;
-  
+
   if (pct_freelist_num_entries > freelist_excessive_pct_num_entries) {
     value_adjective = "Excessive";
     report_level = ML_ALWAYS;
@@ -787,7 +788,7 @@ HighsDebugStatus debugFreeListNumEntries(const HighsModelObject& highs_model_obj
     report_level = ML_VERBOSE;
   } else {
     value_adjective = "OK";
-    report_level = ML_ALWAYS;//ML_VERBOSE;
+    report_level = ML_ALWAYS;  // ML_VERBOSE;
     return_status = HighsDebugStatus::OK;
   }
 

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -758,8 +758,8 @@ HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
 
 HighsDebugStatus debugFreeListNumEntries(
     const HighsModelObject& highs_model_object, const std::set<int>& freeList) {
-  //  if (highs_model_object.options_.highs_debug_level <
-  //  HIGHS_DEBUG_LEVEL_CHEAP)
+  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
+    printf("FreeList   :   Reporting nonzero free list size\n");
   //    return HighsDebugStatus::NOT_CHECKED;
 
   int freelist_num_entries = 0;
@@ -788,7 +788,11 @@ HighsDebugStatus debugFreeListNumEntries(
     report_level = ML_VERBOSE;
   } else {
     value_adjective = "OK";
-    report_level = ML_ALWAYS;  // ML_VERBOSE;
+    if (freelist_num_entries) {
+      report_level = ML_ALWAYS;
+    } else {
+      report_level = ML_VERBOSE;
+    }
     return_status = HighsDebugStatus::OK;
   }
 

--- a/src/simplex/HSimplexDebug.h
+++ b/src/simplex/HSimplexDebug.h
@@ -14,6 +14,7 @@
 #ifndef SIMPLEX_HSIMPLEXDEBUG_H_
 #define SIMPLEX_HSIMPLEXDEBUG_H_
 
+#include <set>
 #include "lp_data/HighsModelObject.h"
 #include "lp_data/HighsOptions.h"
 #include "simplex/SimplexConst.h"
@@ -41,5 +42,7 @@ HighsDebugStatus debugBasisCondition(const HighsModelObject& highs_model_object,
                                      const std::string message);
 HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
                               const std::vector<double>& original_dual);
-HighsDebugStatus debugFreeListNumEn();
+HighsDebugStatus debugFreeListNumEn(const HighsModelObject& highs_model_object,
+				    const std::set<int>& freeList,
+				    const bool setup = false);
 #endif  // SIMPLEX_HSIMPLEXDEBUG_H_

--- a/src/simplex/HSimplexDebug.h
+++ b/src/simplex/HSimplexDebug.h
@@ -15,6 +15,7 @@
 #define SIMPLEX_HSIMPLEXDEBUG_H_
 
 #include <set>
+
 #include "lp_data/HighsModelObject.h"
 #include "lp_data/HighsOptions.h"
 #include "simplex/SimplexConst.h"
@@ -42,6 +43,6 @@ HighsDebugStatus debugBasisCondition(const HighsModelObject& highs_model_object,
                                      const std::string message);
 HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
                               const std::vector<double>& original_dual);
-HighsDebugStatus debugFreeListNumEntries(const HighsModelObject& highs_model_object,
-					 const std::set<int>& freeList);
+HighsDebugStatus debugFreeListNumEntries(
+    const HighsModelObject& highs_model_object, const std::set<int>& freeList);
 #endif  // SIMPLEX_HSIMPLEXDEBUG_H_

--- a/src/simplex/HSimplexDebug.h
+++ b/src/simplex/HSimplexDebug.h
@@ -42,7 +42,6 @@ HighsDebugStatus debugBasisCondition(const HighsModelObject& highs_model_object,
                                      const std::string message);
 HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
                               const std::vector<double>& original_dual);
-HighsDebugStatus debugFreeListNumEn(const HighsModelObject& highs_model_object,
-				    const std::set<int>& freeList,
-				    const bool setup = false);
+HighsDebugStatus debugFreeListNumEntries(const HighsModelObject& highs_model_object,
+					 const std::set<int>& freeList);
 #endif  // SIMPLEX_HSIMPLEXDEBUG_H_

--- a/src/simplex/HSimplexDebug.h
+++ b/src/simplex/HSimplexDebug.h
@@ -41,4 +41,5 @@ HighsDebugStatus debugBasisCondition(const HighsModelObject& highs_model_object,
                                      const std::string message);
 HighsDebugStatus debugCleanup(HighsModelObject& highs_model_object,
                               const std::vector<double>& original_dual);
+HighsDebugStatus debugFreeListNumEn();
 #endif  // SIMPLEX_HSIMPLEXDEBUG_H_

--- a/src/simplex/HighsSimplexAnalysis.cpp
+++ b/src/simplex/HighsSimplexAnalysis.cpp
@@ -1205,13 +1205,13 @@ void HighsSimplexAnalysis::reportIterationData(const bool header,
   }
 }
 
-void HighsSimplexAnalysis::reportFreeListSize(const bool header,
+void HighsSimplexAnalysis::reportFreeListNumEntries(const bool header,
                                               const int this_message_level) {
   if (header) {
     HighsPrintMessage(output, message_level, this_message_level, " FreeLsZ");
   } else {
     HighsPrintMessage(output, message_level, this_message_level, " %7d",
-                      freelist_size);
+                      freelist_num_entries);
   }
 }
 

--- a/src/simplex/HighsSimplexAnalysis.cpp
+++ b/src/simplex/HighsSimplexAnalysis.cpp
@@ -1048,7 +1048,6 @@ void HighsSimplexAnalysis::iterationReport(const bool header) {
 #ifdef HiGHSDEV
   reportDensity(header, iteration_report_message_level);
   reportIterationData(header, iteration_report_message_level);
-  //  reportFreeListSize(header, iteration_report_message_level);
 #endif
   HighsPrintMessage(output, message_level, iteration_report_message_level,
                     "\n");
@@ -1202,16 +1201,6 @@ void HighsSimplexAnalysis::reportIterationData(const bool header,
                       numerical_trouble, pivotal_row_index, leaving_variable,
                       entering_variable, primal_delta, dual_step, primal_step,
                       pivot_value_from_column);
-  }
-}
-
-void HighsSimplexAnalysis::reportFreeListNumEntries(const bool header,
-                                              const int this_message_level) {
-  if (header) {
-    HighsPrintMessage(output, message_level, this_message_level, " FreeLsZ");
-  } else {
-    HighsPrintMessage(output, message_level, this_message_level, " %7d",
-                      freelist_num_entries);
   }
 }
 

--- a/src/simplex/HighsSimplexAnalysis.h
+++ b/src/simplex/HighsSimplexAnalysis.h
@@ -187,7 +187,7 @@ class HighsSimplexAnalysis {
   int num_primal_infeasibilities = 0;
   int num_dual_infeasibilities = 0;
   int invert_hint = 0;
-  int freelist_size = 0;
+  int freelist_num_entries = 0;
   double reduced_rhs_value = 0;
   double reduced_cost_value = 0;
   double edge_weight = 0;

--- a/src/simplex/HighsSimplexAnalysis.h
+++ b/src/simplex/HighsSimplexAnalysis.h
@@ -187,7 +187,6 @@ class HighsSimplexAnalysis {
   int num_primal_infeasibilities = 0;
   int num_dual_infeasibilities = 0;
   int invert_hint = 0;
-  int freelist_num_entries = 0;
   double reduced_rhs_value = 0;
   double reduced_cost_value = 0;
   double edge_weight = 0;


### PR DESCRIPTION
With  #341 failing because the Windows debug build was failing, this combines #341 and the fix to code for assessing free list size that was causing the build fail.

Fix phase one ( #341)

HiGHS is now forced to move to Phase 2 on dual phase 1 optimality, even if infeasible. This is because no conclusions on the primal LP can be deduced. After re-perturbing the costs, have to shift any dual infeasibilities for free variables (since it's not done in phase 2 rebuild) and go to dual phase 2 to determine whether dual unboundedness implies that the LP is primal infeasible. If dual phase 2 finds a primal feasible point then the shifts are removed and primal phase 2 will identify whether the LP is primal unbounded.

Checked on primal unbounded LPs gas11 and adlittle_max, and issue334 - which is both primal and dual infeasible. Still gets the right answers for the unbounded unit tests, too.

Fix free list size

The dodgy setting of freeListSize = *freeList.end(); has been removed. freeListSize was only ever used for reporting and debugging, and now the analysis of freeList has been moved to a method in HDmplexDebug.