### PR TITLE
Better top level presolve and lp solve timing

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -748,6 +748,12 @@ basis_.valid_, hmos_[0].basis_.valid_);
   }
   HighsPrintMessage(options_.output, options_.message_level, ML_MINIMAL,
                     "Time       : %0.3g\n", this_solve_time);
+  HighsPrintMessage(options_.output, options_.message_level, ML_MINIMAL,
+                    "Time Pre   : %0.3g\n", this_presolve_time);
+  HighsPrintMessage(options_.output, options_.message_level, ML_MINIMAL,
+                    "Time PreLP : %0.3g\n", this_solve_presolved_lp_time);
+  HighsPrintMessage(options_.output, options_.message_level, ML_MINIMAL,
+                    "Time PostLP: %0.3g\n", this_solve_original_lp_time);
   if (this_solve_time > 0) {
     HighsPrintMessage(options_.output, options_.message_level, ML_MINIMAL,
                       "For LP %16s",

--- a/src/presolve/Presolve.cpp
+++ b/src/presolve/Presolve.cpp
@@ -96,7 +96,7 @@ void printMainLoop(const MainLoop& l) {
 }
 
 void printDevStats(const DevStats& stats) {
-  assert(stats.n_loops == stats.loops.size());
+  assert(stats.n_loops == (int)stats.loops.size());
   if (iPrint == 0) return;
 
   std::cout << "dev-presolve-stats::" << std::endl;


### PR DESCRIPTION
Added the top level reporting of timing of presolve, solve with presolved LP and solve after postsolve that was marooned in presolve-quick-log

Cleared a couple of compiler warnings in Presolve.cpp