### PR TITLE
ENH: Toggle crossover and add push counts to IPX info

### DIFF
--- a/src/ipm/IpxWrapper.h
+++ b/src/ipm/IpxWrapper.h
@@ -559,6 +559,8 @@ HighsStatus solveLpIpx(const HighsOptions& options, HighsTimer& timer,
   // Determine the run time allowed for IPX
   parameters.time_limit = options.time_limit - timer.readRunHighsClock();
   parameters.ipm_maxiter = options.ipm_iteration_limit - iteration_counts.ipm;
+  // Determine if crossover is to be run or not
+  parameters.crossover = options.run_crossover;
   // Set the internal IPX parameters
   lps.SetParameters(parameters);
 
@@ -582,6 +584,7 @@ HighsStatus solveLpIpx(const HighsOptions& options, HighsTimer& timer,
   ipx::Info ipx_info = lps.GetInfo();
   iteration_counts.ipm += (int)ipx_info.iter;
   //  iteration_counts.crossover += (int)ipx_info.updates_crossover;
+  iteration_counts.crossover += (int)ipx_info.pushes_crossover;
 
   // If not solved...
   if (solve_status != IPX_STATUS_solved) {

--- a/src/ipm/ipx/include/ipx_info.h
+++ b/src/ipm/ipx/include/ipx_info.h
@@ -56,6 +56,7 @@ struct ipx_info {
     ipxint updates_start;       /* # basis updates for starting basis */
     ipxint updates_ipm;         /* # basis updates in IPM */
     ipxint updates_crossover;   /* # basis updates in crossover */
+    ipxint pushes_crossover;    /* # Primal/Dual pushes in crossover */
 
     /* major computation times */
     double time_total;          /* total runtime (wallclock) */

--- a/src/ipm/ipx/src/crossover.cc
+++ b/src/ipm/ipx/src/crossover.cc
@@ -1,10 +1,12 @@
 // Copyright (c) 2018 ERGO-Code. See license.txt for license.
 
 #include "crossover.h"
+
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
 #include <valarray>
+
 #include "time.h"
 #include "utils.h"
 
@@ -14,451 +16,426 @@ Crossover::Crossover(const Control& control) : control_(control) {}
 
 void Crossover::PushAll(Basis* basis, Vector& x, Vector& y, Vector& z,
                         const double* weights, Info* info) {
-    const Model& model = basis->model();
-    const Int m = model.rows();
-    const Int n = model.cols();
-    const Vector& lb = model.lb();
-    const Vector& ub = model.ub();
-    std::vector<Int> perm = Sortperm(n+m, weights, false);
+  const Model& model = basis->model();
+  const Int m = model.rows();
+  const Int n = model.cols();
+  const Vector& lb = model.lb();
+  const Vector& ub = model.ub();
+  std::vector<Int> perm = Sortperm(n + m, weights, false);
 
-    control_.Log()
-        << Textline("Primal residual before push phase:")
-        << sci2(PrimalResidual(model, x)) << '\n'
-        << Textline("Dual residual before push phase:")
-        << sci2(DualResidual(model, y, z)) << '\n';
+  control_.Log() << Textline("Primal residual before push phase:")
+                 << sci2(PrimalResidual(model, x)) << '\n'
+                 << Textline("Dual residual before push phase:")
+                 << sci2(DualResidual(model, y, z)) << '\n';
 
-    // Run dual push phase.
-    std::vector<Int> dual_superbasics;
-    for (Int p = 0; p < (Int) perm.size(); p++) {
-        Int j = perm[p];
-        if (basis->IsBasic(j) && z[j] != 0.0)
-            dual_superbasics.push_back(j);
-    }
-    control_.Log()
-        << Textline("Number of dual pushes required:")
-        << dual_superbasics.size() << '\n';
-    PushDual(basis, y, z, dual_superbasics, x, info);
-    assert(DualInfeasibility(model, x, z) == 0.0);
-    if (info->status_crossover != IPX_STATUS_optimal)
-        return;
+  // Run dual push phase.
+  std::vector<Int> dual_superbasics;
+  for (Int p = 0; p < (Int)perm.size(); p++) {
+    Int j = perm[p];
+    if (basis->IsBasic(j) && z[j] != 0.0) dual_superbasics.push_back(j);
+  }
+  control_.Log() << Textline("Number of dual pushes required:")
+                 << dual_superbasics.size() << '\n';
+  PushDual(basis, y, z, dual_superbasics, x, info);
+  assert(DualInfeasibility(model, x, z) == 0.0);
+  if (info->status_crossover != IPX_STATUS_optimal) return;
 
-    // Run primal push phase. Because z[j]==0 for all basic variables, none of
-    // the primal variables is fixed at its bound.
-    std::vector<Int> primal_superbasics;
-    for (Int p = perm.size()-1; p >= 0; p--) {
-        Int j = perm[p];
-        if (basis->IsNonbasic(j) && x[j] != lb[j] && x[j] != ub[j] &&
-            !(std::isinf(lb[j]) && std::isinf(ub[j]) && x[j] == 0.0))
-            primal_superbasics.push_back(j);
-    }
-    control_.Log()
-        << Textline("Number of primal pushes required:")
-        << primal_superbasics.size() << '\n';
-    PushPrimal(basis, x, primal_superbasics, nullptr, info);
-    assert(PrimalInfeasibility(model, x) == 0.0);
-    if (info->status_crossover != IPX_STATUS_optimal)
-        return;
+  // Run primal push phase. Because z[j]==0 for all basic variables, none of
+  // the primal variables is fixed at its bound.
+  std::vector<Int> primal_superbasics;
+  for (Int p = perm.size() - 1; p >= 0; p--) {
+    Int j = perm[p];
+    if (basis->IsNonbasic(j) && x[j] != lb[j] && x[j] != ub[j] &&
+        !(std::isinf(lb[j]) && std::isinf(ub[j]) && x[j] == 0.0))
+      primal_superbasics.push_back(j);
+  }
+  control_.Log() << Textline("Number of primal pushes required:")
+                 << primal_superbasics.size() << '\n';
+  PushPrimal(basis, x, primal_superbasics, nullptr, info);
+  assert(PrimalInfeasibility(model, x) == 0.0);
+  if (info->status_crossover != IPX_STATUS_optimal) return;
 
-    control_.Debug()
-        << Textline("Primal residual after push phase:")
-        << sci2(PrimalResidual(model, x)) << '\n'
-        << Textline("Dual residual after push phase:")
-        << sci2(DualResidual(model, y, z)) << '\n';
-    info->status_crossover = IPX_STATUS_optimal;
+  control_.Debug() << Textline("Primal residual after push phase:")
+                   << sci2(PrimalResidual(model, x)) << '\n'
+                   << Textline("Dual residual after push phase:")
+                   << sci2(DualResidual(model, y, z)) << '\n';
+  info->status_crossover = IPX_STATUS_optimal;
 }
 
 void Crossover::PushPrimal(Basis* basis, Vector& x,
                            const std::vector<Int>& variables,
                            const bool* fixed_at_bound, Info* info) {
-    Timer timer;
-    const Model& model = basis->model();
-    const Int m = model.rows();
-    const Int n = model.cols();
-    const Vector& lb = model.lb();
-    const Vector& ub = model.ub();
-    IndexedVector ftran(m);
-    const double feastol = model.dualized() ?
-        control_.dfeasibility_tol() : control_.pfeasibility_tol();
-    primal_pushes_ = 0;
-    primal_pivots_ = 0;
+  Timer timer;
+  const Model& model = basis->model();
+  const Int m = model.rows();
+  const Int n = model.cols();
+  const Vector& lb = model.lb();
+  const Vector& ub = model.ub();
+  IndexedVector ftran(m);
+  const double feastol = model.dualized() ? control_.dfeasibility_tol()
+                                          : control_.pfeasibility_tol();
+  primal_pushes_ = 0;
+  primal_pivots_ = 0;
 
-    // Check that variables are nonbasic and that x satisfies bound condition.
-    for (Int j : variables) {
-        if (!basis->IsNonbasic(j))
-            throw std::logic_error("invalid variable in Crossover::PushPrimal");
+  // Check that variables are nonbasic and that x satisfies bound condition.
+  for (Int j : variables) {
+    if (!basis->IsNonbasic(j))
+      throw std::logic_error("invalid variable in Crossover::PushPrimal");
+  }
+  for (Int j = 0; j < n + m; j++) {
+    if (x[j] < lb[j] || x[j] > ub[j])
+      throw std::logic_error(
+          "bound condition violated in Crossover::PushPrimal");
+    if (fixed_at_bound && fixed_at_bound[j] && x[j] != lb[j] && x[j] != ub[j])
+      throw std::logic_error(
+          "bound condition violated in Crossover::PushPrimal");
+  }
+
+  // Maintain a copy of primal basic variables and their bounds for faster
+  // ratio test. Fixed-at-bound variables are handled by setting their bounds
+  // equal.
+  Vector xbasic = CopyBasic(x, *basis);
+  Vector lbbasic = CopyBasic(lb, *basis);
+  Vector ubbasic = CopyBasic(ub, *basis);
+  if (fixed_at_bound) {
+    for (Int p = 0; p < m; p++) {
+      Int j = (*basis)[p];
+      if (fixed_at_bound[j]) lbbasic[p] = ubbasic[p] = x[j];
     }
-    for (Int j = 0; j < n+m; j++) {
-        if (x[j] < lb[j] || x[j] > ub[j])
-            throw std::logic_error(
-                "bound condition violated in Crossover::PushPrimal");
-        if (fixed_at_bound && fixed_at_bound[j] &&
-            x[j] != lb[j] && x[j] != ub[j])
-            throw std::logic_error(
-                "bound condition violated in Crossover::PushPrimal");
+  }
+
+  control_.ResetPrintInterval();
+  Int next = 0;
+  while (next < (Int)variables.size()) {
+    if ((info->errflag = control_.InterruptCheck()) != 0) break;
+
+    const Int jn = variables[next];
+    if (x[jn] == lb[jn] || x[jn] == ub[jn] ||
+        (x[jn] == 0.0 && std::isinf(lb[jn]) && std::isinf(ub[jn]))) {
+      // nothing to do
+      next++;
+      continue;
     }
+    // Choose bound to push to. If the variable has two finite bounds, move
+    // to the nearer. If it has none, move to zero.
+    double move_to = 0.0;
+    if (std::isfinite(lb[jn]) && std::isfinite(ub[jn]))
+      move_to = x[jn] - lb[jn] <= ub[jn] - x[jn] ? lb[jn] : ub[jn];
+    else if (std::isfinite(lb[jn]))
+      move_to = lb[jn];
+    else if (std::isfinite(ub[jn]))
+      move_to = ub[jn];
 
-    // Maintain a copy of primal basic variables and their bounds for faster
-    // ratio test. Fixed-at-bound variables are handled by setting their bounds
-    // equal.
-    Vector xbasic  = CopyBasic(x,  *basis);
-    Vector lbbasic = CopyBasic(lb, *basis);
-    Vector ubbasic = CopyBasic(ub, *basis);
-    if (fixed_at_bound) {
-        for (Int p = 0; p < m; p++) {
-            Int j = (*basis)[p];
-            if (fixed_at_bound[j])
-                lbbasic[p] = ubbasic[p] = x[j];
-        }
+    // A full step is such that x[jn]-step is at its bound.
+    double step = x[jn] - move_to;
+
+    basis->SolveForUpdate(jn, ftran);
+    bool block_at_lb;
+    Int pblock = PrimalRatioTest(xbasic, ftran, lbbasic, ubbasic, step, feastol,
+                                 &block_at_lb);
+    Int jb = pblock >= 0 ? (*basis)[pblock] : -1;
+
+    // If step was blocked, update basis and compute step size.
+    if (pblock >= 0) {
+      double pivot = ftran[pblock];
+      assert(pivot != 0.0);
+      if (std::abs(pivot) < 1e-4)
+        control_.Debug(3) << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
+      bool exchanged;
+      info->errflag = basis->ExchangeIfStable(jb, jn, pivot, -1, &exchanged);
+      if (info->errflag) {
+        control_.Debug() << Textline("Minimum singular value of basis matrix:")
+                         << sci2(basis->MinSingularValue()) << '\n';
+        break;
+      }
+      if (!exchanged)  // factorization was unstable, try again
+        continue;
+      primal_pivots_++;
+      // We must use lbbasic[pblock] and ubbasic[pblock] (and not lb[jb]
+      // and ub[jb]) so that step is 0.0 if a fixed-at-bound variable
+      // blocked.
+      if (block_at_lb)
+        step = (lbbasic[pblock] - xbasic[pblock]) / ftran[pblock];
+      else
+        step = (ubbasic[pblock] - xbasic[pblock]) / ftran[pblock];
     }
-
-    control_.ResetPrintInterval();
-    Int next = 0;
-    while (next < (Int) variables.size()) {
-        if ((info->errflag = control_.InterruptCheck()) != 0)
-            break;
-
-        const Int jn = variables[next];
-        if (x[jn] == lb[jn] || x[jn] == ub[jn] ||
-            (x[jn] == 0.0 && std::isinf(lb[jn]) && std::isinf(ub[jn]))) {
-            // nothing to do
-            next++;
-            continue;
-        }
-        // Choose bound to push to. If the variable has two finite bounds, move
-        // to the nearer. If it has none, move to zero.
-        double move_to = 0.0;
-        if (std::isfinite(lb[jn]) && std::isfinite(ub[jn]))
-            move_to = x[jn]-lb[jn] <= ub[jn]-x[jn] ? lb[jn] : ub[jn];
-        else if (std::isfinite(lb[jn]))
-            move_to = lb[jn];
-        else if (std::isfinite(ub[jn]))
-            move_to = ub[jn];
-
-        // A full step is such that x[jn]-step is at its bound.
-        double step = x[jn]-move_to;
-
-        basis->SolveForUpdate(jn, ftran);
-        bool block_at_lb;
-        Int pblock = PrimalRatioTest(xbasic, ftran, lbbasic, ubbasic,
-                                     step, feastol, &block_at_lb);
-        Int jb = pblock >= 0 ? (*basis)[pblock] : -1;
-
-        // If step was blocked, update basis and compute step size.
-        if (pblock >= 0) {
-            double pivot = ftran[pblock];
-            assert(pivot != 0.0);
-            if (std::abs(pivot) < 1e-4)
-                control_.Debug(3)
-                    << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
-            bool exchanged;
-            info->errflag = basis->ExchangeIfStable(jb, jn, pivot, -1,
-                                                    &exchanged);
-            if (info->errflag) {
-                control_.Debug()
-                    << Textline("Minimum singular value of basis matrix:")
-                    << sci2(basis->MinSingularValue()) << '\n';
-                break;
-            }
-            if (!exchanged)     // factorization was unstable, try again
-                continue;
-            primal_pivots_++;
-            // We must use lbbasic[pblock] and ubbasic[pblock] (and not lb[jb]
-            // and ub[jb]) so that step is 0.0 if a fixed-at-bound variable
-            // blocked.
-            if (block_at_lb)
-                step = (lbbasic[pblock]-xbasic[pblock]) / ftran[pblock];
-            else
-                step = (ubbasic[pblock]-xbasic[pblock]) / ftran[pblock];
-        }
-        // Update solution.
-        if (step != 0.0) {
-            auto update = [&](Int p, double pivot) {
-                xbasic[p] += step * pivot;
-                xbasic[p] = std::max(xbasic[p], lbbasic[p]);
-                xbasic[p] = std::min(xbasic[p], ubbasic[p]);
-            };
-            for_each_nonzero(ftran, update);
-            x[jn] -= step;
-        }
-        if (pblock >= 0) {
-            // make clean
-            x[jb] = block_at_lb ? lbbasic[pblock] : ubbasic[pblock];
-            assert(std::isfinite(x[jb]));
-            // Update copy of basic variables and bounds. Note: jn cannot be
-            // a fixed-at-bound variable since it was pushed to a bound.
-            xbasic[pblock] = x[jn];
-            lbbasic[pblock] = lb[jn];
-            ubbasic[pblock] = ub[jn];
-        } else {
-            x[jn] = move_to; // make clean
-            assert(std::isfinite(x[jn]));
-        }
-
-        primal_pushes_++;
-        next++;
-        control_.IntervalLog()
-            << " " << Format(static_cast<Int>(variables.size()-next), 8)
-            << " primal pushes remaining"
-            << " (" << Format(primal_pivots_, 7) << " pivots)\n";
+    // Update solution.
+    if (step != 0.0) {
+      auto update = [&](Int p, double pivot) {
+        xbasic[p] += step * pivot;
+        xbasic[p] = std::max(xbasic[p], lbbasic[p]);
+        xbasic[p] = std::min(xbasic[p], ubbasic[p]);
+      };
+      for_each_nonzero(ftran, update);
+      x[jn] -= step;
     }
-    for (Int p = 0; p < m; p++)
-        x[(*basis)[p]] = xbasic[p];
-
-    // Set status flag.
-    if (info->errflag == IPX_ERROR_interrupt_time) {
-        info->errflag = 0;
-        info->status_crossover = IPX_STATUS_time_limit;
-    } else if (info->errflag != 0) {
-        info->status_crossover = IPX_STATUS_failed;
+    if (pblock >= 0) {
+      // make clean
+      x[jb] = block_at_lb ? lbbasic[pblock] : ubbasic[pblock];
+      assert(std::isfinite(x[jb]));
+      // Update copy of basic variables and bounds. Note: jn cannot be
+      // a fixed-at-bound variable since it was pushed to a bound.
+      xbasic[pblock] = x[jn];
+      lbbasic[pblock] = lb[jn];
+      ubbasic[pblock] = ub[jn];
     } else {
-        info->status_crossover = IPX_STATUS_optimal;
+      x[jn] = move_to;  // make clean
+      assert(std::isfinite(x[jn]));
     }
-    time_primal_ = timer.Elapsed();
+
+    primal_pushes_++;
+    next++;
+    control_.IntervalLog() << " "
+                           << Format(static_cast<Int>(variables.size() - next),
+                                     8)
+                           << " primal pushes remaining"
+                           << " (" << Format(primal_pivots_, 7) << " pivots)\n";
+  }
+  for (Int p = 0; p < m; p++) x[(*basis)[p]] = xbasic[p];
+
+  // Set status flag.
+  if (info->errflag == IPX_ERROR_interrupt_time) {
+    info->errflag = 0;
+    info->status_crossover = IPX_STATUS_time_limit;
+  } else if (info->errflag != 0) {
+    info->status_crossover = IPX_STATUS_failed;
+  } else {
+    info->status_crossover = IPX_STATUS_optimal;
+  }
+  time_primal_ = timer.Elapsed();
 }
 
 void Crossover::PushPrimal(Basis* basis, Vector& x,
-                           const std::vector<Int>& variables,
-                           const Vector& z, Info* info) {
-    std::valarray<bool> bound_restrict = z != 0.0;
-    PushPrimal(basis, x, variables, &bound_restrict[0], info);
+                           const std::vector<Int>& variables, const Vector& z,
+                           Info* info) {
+  std::valarray<bool> bound_restrict = z != 0.0;
+  PushPrimal(basis, x, variables, &bound_restrict[0], info);
 }
 
 void Crossover::PushDual(Basis* basis, Vector& y, Vector& z,
                          const std::vector<Int>& variables,
                          const int sign_restrict[], Info* info) {
-    Timer timer;
-    const Model& model = basis->model();
-    const Int m = model.rows();
-    const Int n = model.cols();
-    IndexedVector btran(m), row(n+m);
-    const double feastol = model.dualized() ?
-        control_.pfeasibility_tol() : control_.dfeasibility_tol();
-    dual_pushes_ = 0;
-    dual_pivots_ = 0;
+  Timer timer;
+  const Model& model = basis->model();
+  const Int m = model.rows();
+  const Int n = model.cols();
+  IndexedVector btran(m), row(n + m);
+  const double feastol = model.dualized() ? control_.pfeasibility_tol()
+                                          : control_.dfeasibility_tol();
+  dual_pushes_ = 0;
+  dual_pivots_ = 0;
 
-    // Check that variables are basic and that z satisfies sign condition.
-    for (Int j : variables) {
-        if (!basis->IsBasic(j))
-            throw std::logic_error("invalid variable in Crossover::PushDual");
+  // Check that variables are basic and that z satisfies sign condition.
+  for (Int j : variables) {
+    if (!basis->IsBasic(j))
+      throw std::logic_error("invalid variable in Crossover::PushDual");
+  }
+  for (Int j = 0; j < n + m; j++) {
+    if (((sign_restrict[j] & 1) && z[j] < 0.0) ||
+        ((sign_restrict[j] & 2) && z[j] > 0.0))
+      throw std::logic_error("sign condition violated in Crossover::PushDual");
+  }
+
+  control_.ResetPrintInterval();
+  Int next = 0;
+  while (next < (Int)variables.size()) {
+    if ((info->errflag = control_.InterruptCheck()) != 0) break;
+
+    const Int jb = variables[next];
+    if (z[jb] == 0.0) {
+      // nothing to do
+      next++;
+      continue;
     }
-    for (Int j = 0; j < n+m; j++) {
-        if (((sign_restrict[j] & 1) && z[j] < 0.0) ||
-            ((sign_restrict[j] & 2) && z[j] > 0.0))
-            throw std::logic_error(
-                "sign condition violated in Crossover::PushDual");
+    // The update operation applied below is
+    // y := y + step*btran, z := z - step*row, z[jb] := z[jb] - step,
+    // where row is the tableau row for variable jb. In exact arithmetic
+    // this leaves A'y+z unchanged.
+    basis->TableauRow(jb, btran, row);
+    double step = z[jb];
+    Int jn = DualRatioTest(z, row, sign_restrict, step, feastol);
+
+    // If step was blocked, update basis and compute step size.
+    if (jn >= 0) {
+      assert(basis->IsNonbasic(jn));
+      double pivot = row[jn];
+      assert(pivot);
+      if (std::abs(pivot) < 1e-4)
+        control_.Debug(3) << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
+      bool exchanged;
+      info->errflag = basis->ExchangeIfStable(jb, jn, pivot, 1, &exchanged);
+      if (info->errflag) {
+        control_.Debug() << Textline("Minimum singular value of basis matrix:")
+                         << sci2(basis->MinSingularValue()) << '\n';
+        break;
+      }
+      if (!exchanged)  // factorization was unstable, try again
+        continue;
+      dual_pivots_++;
+      step = z[jn] / row[jn];
+      // Update must move z[jb] toward zero.
+      if (sign_restrict[jb] & 1) assert(step >= 0.0);
+      if (sign_restrict[jb] & 2) assert(step <= 0.0);
     }
-
-    control_.ResetPrintInterval();
-    Int next = 0;
-    while (next < (Int) variables.size()) {
-        if ((info->errflag = control_.InterruptCheck()) != 0)
-            break;
-
-        const Int jb = variables[next];
-        if (z[jb] == 0.0) {
-            // nothing to do
-            next++;
-            continue;
-        }
-        // The update operation applied below is
-        // y := y + step*btran, z := z - step*row, z[jb] := z[jb] - step,
-        // where row is the tableau row for variable jb. In exact arithmetic
-        // this leaves A'y+z unchanged.
-        basis->TableauRow(jb, btran, row);
-        double step = z[jb];
-        Int jn = DualRatioTest(z, row, sign_restrict, step, feastol);
-
-        // If step was blocked, update basis and compute step size.
-        if (jn >= 0) {
-            assert(basis->IsNonbasic(jn));
-            double pivot = row[jn];
-            assert(pivot);
-            if (std::abs(pivot) < 1e-4)
-                control_.Debug(3)
-                    << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
-            bool exchanged;
-            info->errflag = basis->ExchangeIfStable(jb, jn, pivot, 1,
-                                                    &exchanged);
-            if (info->errflag) {
-                control_.Debug()
-                    << Textline("Minimum singular value of basis matrix:")
-                    << sci2(basis->MinSingularValue()) << '\n';
-                break;
-            }
-            if (!exchanged)     // factorization was unstable, try again
-                continue;
-            dual_pivots_++;
-            step = z[jn]/row[jn];
-            // Update must move z[jb] toward zero.
-            if (sign_restrict[jb] & 1)
-                assert(step >= 0.0);
-            if (sign_restrict[jb] & 2)
-                assert(step <= 0.0);
-        }
-        // Update solution.
-        if (step != 0.0) {
-            auto update_y = [&](Int i, double x) {
-                y[i] += step*x;
-            };
-            for_each_nonzero(btran, update_y);
-            auto update_z = [&](Int j, double pivot) {
-                z[j] -= step * pivot;
-                if (sign_restrict[j] & 1)
-                    z[j] = std::max(z[j], 0.0);
-                if (sign_restrict[j] & 2)
-                    z[j] = std::min(z[j], 0.0);
-            };
-            for_each_nonzero(row, update_z);
-            z[jb] -= step;
-        }
-        if (jn >= 0)
-            z[jn] = 0.0; // make clean
-        else
-            assert(z[jb] == 0.0);
-
-        dual_pushes_++;
-        next++;
-        control_.IntervalLog()
-            << " " << Format(static_cast<Int>(variables.size()-next), 8)
-            << " dual pushes remaining"
-            << " (" << Format(dual_pivots_, 7) << " pivots)\n";
+    // Update solution.
+    if (step != 0.0) {
+      auto update_y = [&](Int i, double x) { y[i] += step * x; };
+      for_each_nonzero(btran, update_y);
+      auto update_z = [&](Int j, double pivot) {
+        z[j] -= step * pivot;
+        if (sign_restrict[j] & 1) z[j] = std::max(z[j], 0.0);
+        if (sign_restrict[j] & 2) z[j] = std::min(z[j], 0.0);
+      };
+      for_each_nonzero(row, update_z);
+      z[jb] -= step;
     }
+    if (jn >= 0)
+      z[jn] = 0.0;  // make clean
+    else
+      assert(z[jb] == 0.0);
 
-    // Set status flag.
-    if (info->errflag == IPX_ERROR_interrupt_time) {
-        info->errflag = 0;
-        info->status_crossover = IPX_STATUS_time_limit;
-    } else if (info->errflag != 0) {
-        info->status_crossover = IPX_STATUS_failed;
-    } else {
-        info->status_crossover = IPX_STATUS_optimal;
-    }
-    time_dual_ = timer.Elapsed();
+    dual_pushes_++;
+    next++;
+    control_.IntervalLog() << " "
+                           << Format(static_cast<Int>(variables.size() - next),
+                                     8)
+                           << " dual pushes remaining"
+                           << " (" << Format(dual_pivots_, 7) << " pivots)\n";
+  }
+
+  // Set status flag.
+  if (info->errflag == IPX_ERROR_interrupt_time) {
+    info->errflag = 0;
+    info->status_crossover = IPX_STATUS_time_limit;
+  } else if (info->errflag != 0) {
+    info->status_crossover = IPX_STATUS_failed;
+  } else {
+    info->status_crossover = IPX_STATUS_optimal;
+  }
+  time_dual_ = timer.Elapsed();
 }
 
 void Crossover::PushDual(Basis* basis, Vector& y, Vector& z,
-                         const std::vector<Int>& variables,
-                         const Vector& x, Info* info) {
-    const Model& model = basis->model();
-    const Int m = model.rows();
-    const Int n = model.cols();
-    const Vector& lb = model.lb();
-    const Vector& ub = model.ub();
+                         const std::vector<Int>& variables, const Vector& x,
+                         Info* info) {
+  const Model& model = basis->model();
+  const Int m = model.rows();
+  const Int n = model.cols();
+  const Vector& lb = model.lb();
+  const Vector& ub = model.ub();
 
-    std::vector<int> sign_restrict(n+m);
-    for (Int j = 0; j < (Int) sign_restrict.size(); j++) {
-        if (x[j] != ub[j]) sign_restrict[j] |= 1;
-        if (x[j] != lb[j]) sign_restrict[j] |= 2;
-    }
-    PushDual(basis, y, z, variables, sign_restrict.data(), info);
+  std::vector<int> sign_restrict(n + m);
+  for (Int j = 0; j < (Int)sign_restrict.size(); j++) {
+    if (x[j] != ub[j]) sign_restrict[j] |= 1;
+    if (x[j] != lb[j]) sign_restrict[j] |= 2;
+  }
+  PushDual(basis, y, z, variables, sign_restrict.data(), info);
 }
 
 Int Crossover::PrimalRatioTest(const Vector& xbasic, const IndexedVector& ftran,
                                const Vector& lbbasic, const Vector& ubbasic,
                                double step, double feastol, bool* block_at_lb) {
-    Int pblock = -1;            // return value
-    *block_at_lb = true;
+  Int pblock = -1;  // return value
+  *block_at_lb = true;
 
-    // First pass: determine maximum step size exploiting feasibility tol.
-    auto update_step = [&](Int p, double pivot) {
-        if (std::abs(pivot) > kPivotZeroTol) {
-            // test block at lower bound
-            if (xbasic[p] + step*pivot < lbbasic[p]-feastol) {
-                step = (lbbasic[p]-xbasic[p]-feastol) / pivot;
-                pblock = p;
-                *block_at_lb = true;
-            }
-            // test block at upper bound
-            if (xbasic[p] + step*pivot > ubbasic[p]+feastol) {
-                step = (ubbasic[p]-xbasic[p]+feastol) / pivot;
-                pblock = p;
-                *block_at_lb = false;
-            }
+  // First pass: determine maximum step size exploiting feasibility tol.
+  auto update_step = [&](Int p, double pivot) {
+    if (std::abs(pivot) > kPivotZeroTol) {
+      // test block at lower bound
+      if (xbasic[p] + step * pivot < lbbasic[p] - feastol) {
+        step = (lbbasic[p] - xbasic[p] - feastol) / pivot;
+        pblock = p;
+        *block_at_lb = true;
+      }
+      // test block at upper bound
+      if (xbasic[p] + step * pivot > ubbasic[p] + feastol) {
+        step = (ubbasic[p] - xbasic[p] + feastol) / pivot;
+        pblock = p;
+        *block_at_lb = false;
+      }
+    }
+  };
+  for_each_nonzero(ftran, update_step);
+
+  // If the step was not blocked, we are done.
+  if (pblock < 0) return pblock;
+
+  // Second pass: choose maximum pivot among all that block within step.
+  pblock = -1;
+  double max_pivot = kPivotZeroTol;
+  auto update_max = [&](Int p, double pivot) {
+    if (std::abs(pivot) > max_pivot) {
+      // test block at lower bound
+      if (step * pivot < 0.0) {
+        double step_p = (lbbasic[p] - xbasic[p]) / pivot;
+        if (std::abs(step_p) <= std::abs(step)) {
+          pblock = p;
+          *block_at_lb = true;
+          max_pivot = std::abs(pivot);
         }
-    };
-    for_each_nonzero(ftran, update_step);
-
-    // If the step was not blocked, we are done.
-    if (pblock < 0)
-        return pblock;
-
-    // Second pass: choose maximum pivot among all that block within step.
-    pblock = -1;
-    double max_pivot = kPivotZeroTol;
-    auto update_max = [&](Int p, double pivot) {
-        if (std::abs(pivot) > max_pivot) {
-            // test block at lower bound
-            if (step*pivot < 0.0) {
-                double step_p = (lbbasic[p]-xbasic[p]) / pivot;
-                if (std::abs(step_p) <= std::abs(step)) {
-                    pblock = p;
-                    *block_at_lb = true;
-                    max_pivot = std::abs(pivot);
-                }
-            }
-            // test block at upper bound
-            if (step*pivot > 0.0) {
-                double step_p = (ubbasic[p]-xbasic[p]) / pivot;
-                if (std::abs(step_p) <= std::abs(step)) {
-                    pblock = p;
-                    *block_at_lb = false;
-                    max_pivot = std::abs(pivot);
-                }
-            }
+      }
+      // test block at upper bound
+      if (step * pivot > 0.0) {
+        double step_p = (ubbasic[p] - xbasic[p]) / pivot;
+        if (std::abs(step_p) <= std::abs(step)) {
+          pblock = p;
+          *block_at_lb = false;
+          max_pivot = std::abs(pivot);
         }
-    };
-    for_each_nonzero(ftran, update_max);
-    assert(pblock >= 0);
-    return pblock;
+      }
+    }
+  };
+  for_each_nonzero(ftran, update_max);
+  assert(pblock >= 0);
+  return pblock;
 }
 
 Int Crossover::DualRatioTest(const Vector& z, const IndexedVector& row,
                              const int sign_restrict[], double step,
                              double feastol) {
-    Int jblock = -1;            // return value
+  Int jblock = -1;  // return value
 
-    // First pass: determine maximum step size exploiting feasibility tol.
-    auto update_step = [&](Int j, double pivot) {
-        if (std::abs(pivot) > kPivotZeroTol) {
-            if ((sign_restrict[j] & 1) && z[j]-step*pivot < -feastol) {
-                step = (z[j]+feastol) / pivot;
-                jblock = j;
-                assert(z[j] >= 0.0);
-                assert(step*pivot > 0.0);
-            }
-            if ((sign_restrict[j] & 2) && z[j]-step*pivot > feastol) {
-                step = (z[j]-feastol) / pivot;
-                jblock = j;
-                assert(z[j] <= 0.0);
-                assert(step*pivot < 0.0);
-            }
-        }
-    };
-    for_each_nonzero(row, update_step);
+  // First pass: determine maximum step size exploiting feasibility tol.
+  auto update_step = [&](Int j, double pivot) {
+    if (std::abs(pivot) > kPivotZeroTol) {
+      if ((sign_restrict[j] & 1) && z[j] - step * pivot < -feastol) {
+        step = (z[j] + feastol) / pivot;
+        jblock = j;
+        assert(z[j] >= 0.0);
+        assert(step * pivot > 0.0);
+      }
+      if ((sign_restrict[j] & 2) && z[j] - step * pivot > feastol) {
+        step = (z[j] - feastol) / pivot;
+        jblock = j;
+        assert(z[j] <= 0.0);
+        assert(step * pivot < 0.0);
+      }
+    }
+  };
+  for_each_nonzero(row, update_step);
 
-    // If step was not block, we are done.
-    if (jblock < 0)
-        return jblock;
+  // If step was not block, we are done.
+  if (jblock < 0) return jblock;
 
-    // Second pass: choose maximum pivot among all that block within step.
-    jblock = -1;
-    double max_pivot = kPivotZeroTol;
-    auto update_max = [&](Int j, double pivot) {
-        if (std::abs(pivot) > max_pivot &&
-            std::abs(z[j]/pivot) <= std::abs(step)) {
-            if ((sign_restrict[j] & 1) && step*pivot > 0.0) {
-                jblock = j;
-                max_pivot = std::abs(pivot);
-            }
-            if ((sign_restrict[j] & 2) && step*pivot < 0.0) {
-                jblock = j;
-                max_pivot = std::abs(pivot);
-            }
-        }
-    };
-    for_each_nonzero(row, update_max);
-    assert(jblock >= 0);
-    return jblock;
+  // Second pass: choose maximum pivot among all that block within step.
+  jblock = -1;
+  double max_pivot = kPivotZeroTol;
+  auto update_max = [&](Int j, double pivot) {
+    if (std::abs(pivot) > max_pivot &&
+        std::abs(z[j] / pivot) <= std::abs(step)) {
+      if ((sign_restrict[j] & 1) && step * pivot > 0.0) {
+        jblock = j;
+        max_pivot = std::abs(pivot);
+      }
+      if ((sign_restrict[j] & 2) && step * pivot < 0.0) {
+        jblock = j;
+        max_pivot = std::abs(pivot);
+      }
+    }
+  };
+  for_each_nonzero(row, update_max);
+  assert(jblock >= 0);
+  return jblock;
 }
 
 }  // namespace ipx

--- a/src/ipm/ipx/src/crossover.cc
+++ b/src/ipm/ipx/src/crossover.cc
@@ -9,7 +9,7 @@
 
 #include "time.h"
 #include "utils.h"
-
+ 
 namespace ipx {
 
 Crossover::Crossover(const Control& control) : control_(control) {}

--- a/src/ipm/ipx/src/crossover.cc
+++ b/src/ipm/ipx/src/crossover.cc
@@ -1,441 +1,464 @@
 // Copyright (c) 2018 ERGO-Code. See license.txt for license.
 
 #include "crossover.h"
-
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
 #include <valarray>
-
 #include "time.h"
 #include "utils.h"
- 
+
 namespace ipx {
 
 Crossover::Crossover(const Control& control) : control_(control) {}
 
 void Crossover::PushAll(Basis* basis, Vector& x, Vector& y, Vector& z,
                         const double* weights, Info* info) {
-  const Model& model = basis->model();
-  const Int m = model.rows();
-  const Int n = model.cols();
-  const Vector& lb = model.lb();
-  const Vector& ub = model.ub();
-  std::vector<Int> perm = Sortperm(n + m, weights, false);
+    const Model& model = basis->model();
+    const Int m = model.rows();
+    const Int n = model.cols();
+    const Vector& lb = model.lb();
+    const Vector& ub = model.ub();
+    std::vector<Int> perm = Sortperm(n+m, weights, false);
 
-  control_.Log() << Textline("Primal residual before push phase:")
-                 << sci2(PrimalResidual(model, x)) << '\n'
-                 << Textline("Dual residual before push phase:")
-                 << sci2(DualResidual(model, y, z)) << '\n';
+    control_.Log()
+        << Textline("Primal residual before push phase:")
+        << sci2(PrimalResidual(model, x)) << '\n'
+        << Textline("Dual residual before push phase:")
+        << sci2(DualResidual(model, y, z)) << '\n';
 
-  // Run dual push phase.
-  std::vector<Int> dual_superbasics;
-  for (Int p = 0; p < (Int)perm.size(); p++) {
-    Int j = perm[p];
-    if (basis->IsBasic(j) && z[j] != 0.0) dual_superbasics.push_back(j);
-  }
-  control_.Log() << Textline("Number of dual pushes required:")
-                 << dual_superbasics.size() << '\n';
-  PushDual(basis, y, z, dual_superbasics, x, info);
-  assert(DualInfeasibility(model, x, z) == 0.0);
-  if (info->status_crossover != IPX_STATUS_optimal) return;
+    // Run dual push phase.
+    std::vector<Int> dual_superbasics;
+    for (Int p = 0; p < (Int) perm.size(); p++) {
+        Int j = perm[p];
+        if (basis->IsBasic(j) && z[j] != 0.0)
+            dual_superbasics.push_back(j);
+    }
+    control_.Log()
+        << Textline("Number of dual pushes required:")
+        << dual_superbasics.size() << '\n';
+    PushDual(basis, y, z, dual_superbasics, x, info);
+    assert(DualInfeasibility(model, x, z) == 0.0);
+    if (info->status_crossover != IPX_STATUS_optimal)
+        return;
 
-  // Run primal push phase. Because z[j]==0 for all basic variables, none of
-  // the primal variables is fixed at its bound.
-  std::vector<Int> primal_superbasics;
-  for (Int p = perm.size() - 1; p >= 0; p--) {
-    Int j = perm[p];
-    if (basis->IsNonbasic(j) && x[j] != lb[j] && x[j] != ub[j] &&
-        !(std::isinf(lb[j]) && std::isinf(ub[j]) && x[j] == 0.0))
-      primal_superbasics.push_back(j);
-  }
-  control_.Log() << Textline("Number of primal pushes required:")
-                 << primal_superbasics.size() << '\n';
-  PushPrimal(basis, x, primal_superbasics, nullptr, info);
-  assert(PrimalInfeasibility(model, x) == 0.0);
-  if (info->status_crossover != IPX_STATUS_optimal) return;
+    // Run primal push phase. Because z[j]==0 for all basic variables, none of
+    // the primal variables is fixed at its bound.
+    std::vector<Int> primal_superbasics;
+    for (Int p = perm.size()-1; p >= 0; p--) {
+        Int j = perm[p];
+        if (basis->IsNonbasic(j) && x[j] != lb[j] && x[j] != ub[j] &&
+            !(std::isinf(lb[j]) && std::isinf(ub[j]) && x[j] == 0.0))
+            primal_superbasics.push_back(j);
+    }
+    control_.Log()
+        << Textline("Number of primal pushes required:")
+        << primal_superbasics.size() << '\n';
+    PushPrimal(basis, x, primal_superbasics, nullptr, info);
+    assert(PrimalInfeasibility(model, x) == 0.0);
+    if (info->status_crossover != IPX_STATUS_optimal)
+        return;
 
-  control_.Debug() << Textline("Primal residual after push phase:")
-                   << sci2(PrimalResidual(model, x)) << '\n'
-                   << Textline("Dual residual after push phase:")
-                   << sci2(DualResidual(model, y, z)) << '\n';
-  info->status_crossover = IPX_STATUS_optimal;
+    control_.Debug()
+        << Textline("Primal residual after push phase:")
+        << sci2(PrimalResidual(model, x)) << '\n'
+        << Textline("Dual residual after push phase:")
+        << sci2(DualResidual(model, y, z)) << '\n';
+    info->status_crossover = IPX_STATUS_optimal;
 }
 
 void Crossover::PushPrimal(Basis* basis, Vector& x,
                            const std::vector<Int>& variables,
                            const bool* fixed_at_bound, Info* info) {
-  Timer timer;
-  const Model& model = basis->model();
-  const Int m = model.rows();
-  const Int n = model.cols();
-  const Vector& lb = model.lb();
-  const Vector& ub = model.ub();
-  IndexedVector ftran(m);
-  const double feastol = model.dualized() ? control_.dfeasibility_tol()
-                                          : control_.pfeasibility_tol();
-  primal_pushes_ = 0;
-  primal_pivots_ = 0;
+    Timer timer;
+    const Model& model = basis->model();
+    const Int m = model.rows();
+    const Int n = model.cols();
+    const Vector& lb = model.lb();
+    const Vector& ub = model.ub();
+    IndexedVector ftran(m);
+    const double feastol = model.dualized() ?
+        control_.dfeasibility_tol() : control_.pfeasibility_tol();
+    primal_pushes_ = 0;
+    primal_pivots_ = 0;
 
-  // Check that variables are nonbasic and that x satisfies bound condition.
-  for (Int j : variables) {
-    if (!basis->IsNonbasic(j))
-      throw std::logic_error("invalid variable in Crossover::PushPrimal");
-  }
-  for (Int j = 0; j < n + m; j++) {
-    if (x[j] < lb[j] || x[j] > ub[j])
-      throw std::logic_error(
-          "bound condition violated in Crossover::PushPrimal");
-    if (fixed_at_bound && fixed_at_bound[j] && x[j] != lb[j] && x[j] != ub[j])
-      throw std::logic_error(
-          "bound condition violated in Crossover::PushPrimal");
-  }
-
-  // Maintain a copy of primal basic variables and their bounds for faster
-  // ratio test. Fixed-at-bound variables are handled by setting their bounds
-  // equal.
-  Vector xbasic = CopyBasic(x, *basis);
-  Vector lbbasic = CopyBasic(lb, *basis);
-  Vector ubbasic = CopyBasic(ub, *basis);
-  if (fixed_at_bound) {
-    for (Int p = 0; p < m; p++) {
-      Int j = (*basis)[p];
-      if (fixed_at_bound[j]) lbbasic[p] = ubbasic[p] = x[j];
+    // Check that variables are nonbasic and that x satisfies bound condition.
+    for (Int j : variables) {
+        if (!basis->IsNonbasic(j))
+            throw std::logic_error("invalid variable in Crossover::PushPrimal");
     }
-  }
-
-  control_.ResetPrintInterval();
-  Int next = 0;
-  while (next < (Int)variables.size()) {
-    if ((info->errflag = control_.InterruptCheck()) != 0) break;
-
-    const Int jn = variables[next];
-    if (x[jn] == lb[jn] || x[jn] == ub[jn] ||
-        (x[jn] == 0.0 && std::isinf(lb[jn]) && std::isinf(ub[jn]))) {
-      // nothing to do
-      next++;
-      continue;
+    for (Int j = 0; j < n+m; j++) {
+        if (x[j] < lb[j] || x[j] > ub[j])
+            throw std::logic_error(
+                "bound condition violated in Crossover::PushPrimal");
+        if (fixed_at_bound && fixed_at_bound[j] &&
+            x[j] != lb[j] && x[j] != ub[j])
+            throw std::logic_error(
+                "bound condition violated in Crossover::PushPrimal");
     }
-    // Choose bound to push to. If the variable has two finite bounds, move
-    // to the nearer. If it has none, move to zero.
-    double move_to = 0.0;
-    if (std::isfinite(lb[jn]) && std::isfinite(ub[jn]))
-      move_to = x[jn] - lb[jn] <= ub[jn] - x[jn] ? lb[jn] : ub[jn];
-    else if (std::isfinite(lb[jn]))
-      move_to = lb[jn];
-    else if (std::isfinite(ub[jn]))
-      move_to = ub[jn];
 
-    // A full step is such that x[jn]-step is at its bound.
-    double step = x[jn] - move_to;
-
-    basis->SolveForUpdate(jn, ftran);
-    bool block_at_lb;
-    Int pblock = PrimalRatioTest(xbasic, ftran, lbbasic, ubbasic, step, feastol,
-                                 &block_at_lb);
-    Int jb = pblock >= 0 ? (*basis)[pblock] : -1;
-
-    // If step was blocked, update basis and compute step size.
-    if (pblock >= 0) {
-      double pivot = ftran[pblock];
-      assert(pivot != 0.0);
-      if (std::abs(pivot) < 1e-4)
-        control_.Debug(3) << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
-      bool exchanged;
-      info->errflag = basis->ExchangeIfStable(jb, jn, pivot, -1, &exchanged);
-      if (info->errflag) {
-        control_.Debug() << Textline("Minimum singular value of basis matrix:")
-                         << sci2(basis->MinSingularValue()) << '\n';
-        break;
-      }
-      if (!exchanged)  // factorization was unstable, try again
-        continue;
-      primal_pivots_++;
-      // We must use lbbasic[pblock] and ubbasic[pblock] (and not lb[jb]
-      // and ub[jb]) so that step is 0.0 if a fixed-at-bound variable
-      // blocked.
-      if (block_at_lb)
-        step = (lbbasic[pblock] - xbasic[pblock]) / ftran[pblock];
-      else
-        step = (ubbasic[pblock] - xbasic[pblock]) / ftran[pblock];
+    // Maintain a copy of primal basic variables and their bounds for faster
+    // ratio test. Fixed-at-bound variables are handled by setting their bounds
+    // equal.
+    Vector xbasic  = CopyBasic(x,  *basis);
+    Vector lbbasic = CopyBasic(lb, *basis);
+    Vector ubbasic = CopyBasic(ub, *basis);
+    if (fixed_at_bound) {
+        for (Int p = 0; p < m; p++) {
+            Int j = (*basis)[p];
+            if (fixed_at_bound[j])
+                lbbasic[p] = ubbasic[p] = x[j];
+        }
     }
-    // Update solution.
-    if (step != 0.0) {
-      auto update = [&](Int p, double pivot) {
-        xbasic[p] += step * pivot;
-        xbasic[p] = std::max(xbasic[p], lbbasic[p]);
-        xbasic[p] = std::min(xbasic[p], ubbasic[p]);
-      };
-      for_each_nonzero(ftran, update);
-      x[jn] -= step;
+
+    control_.ResetPrintInterval();
+    Int next = 0;
+    while (next < (Int) variables.size()) {
+        if ((info->errflag = control_.InterruptCheck()) != 0)
+            break;
+
+        const Int jn = variables[next];
+        if (x[jn] == lb[jn] || x[jn] == ub[jn] ||
+            (x[jn] == 0.0 && std::isinf(lb[jn]) && std::isinf(ub[jn]))) {
+            // nothing to do
+            next++;
+            continue;
+        }
+        // Choose bound to push to. If the variable has two finite bounds, move
+        // to the nearer. If it has none, move to zero.
+        double move_to = 0.0;
+        if (std::isfinite(lb[jn]) && std::isfinite(ub[jn]))
+            move_to = x[jn]-lb[jn] <= ub[jn]-x[jn] ? lb[jn] : ub[jn];
+        else if (std::isfinite(lb[jn]))
+            move_to = lb[jn];
+        else if (std::isfinite(ub[jn]))
+            move_to = ub[jn];
+
+        // A full step is such that x[jn]-step is at its bound.
+        double step = x[jn]-move_to;
+
+        basis->SolveForUpdate(jn, ftran);
+        bool block_at_lb;
+        Int pblock = PrimalRatioTest(xbasic, ftran, lbbasic, ubbasic,
+                                     step, feastol, &block_at_lb);
+        Int jb = pblock >= 0 ? (*basis)[pblock] : -1;
+
+        // If step was blocked, update basis and compute step size.
+        if (pblock >= 0) {
+            double pivot = ftran[pblock];
+            assert(pivot != 0.0);
+            if (std::abs(pivot) < 1e-4)
+                control_.Debug(3)
+                    << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
+            bool exchanged;
+            info->errflag = basis->ExchangeIfStable(jb, jn, pivot, -1,
+                                                    &exchanged);
+            if (info->errflag) {
+                control_.Debug()
+                    << Textline("Minimum singular value of basis matrix:")
+                    << sci2(basis->MinSingularValue()) << '\n';
+                break;
+            }
+            if (!exchanged)     // factorization was unstable, try again
+                continue;
+            primal_pivots_++;
+            // We must use lbbasic[pblock] and ubbasic[pblock] (and not lb[jb]
+            // and ub[jb]) so that step is 0.0 if a fixed-at-bound variable
+            // blocked.
+            if (block_at_lb)
+                step = (lbbasic[pblock]-xbasic[pblock]) / ftran[pblock];
+            else
+                step = (ubbasic[pblock]-xbasic[pblock]) / ftran[pblock];
+        }
+        // Update solution.
+        if (step != 0.0) {
+            auto update = [&](Int p, double pivot) {
+                xbasic[p] += step * pivot;
+                xbasic[p] = std::max(xbasic[p], lbbasic[p]);
+                xbasic[p] = std::min(xbasic[p], ubbasic[p]);
+            };
+            for_each_nonzero(ftran, update);
+            x[jn] -= step;
+        }
+        if (pblock >= 0) {
+            // make clean
+            x[jb] = block_at_lb ? lbbasic[pblock] : ubbasic[pblock];
+            assert(std::isfinite(x[jb]));
+            // Update copy of basic variables and bounds. Note: jn cannot be
+            // a fixed-at-bound variable since it was pushed to a bound.
+            xbasic[pblock] = x[jn];
+            lbbasic[pblock] = lb[jn];
+            ubbasic[pblock] = ub[jn];
+        } else {
+            x[jn] = move_to; // make clean
+            assert(std::isfinite(x[jn]));
+        }
+
+        primal_pushes_++;
+        next++;
+        control_.IntervalLog()
+            << " " << Format(static_cast<Int>(variables.size()-next), 8)
+            << " primal pushes remaining"
+            << " (" << Format(primal_pivots_, 7) << " pivots)\n";
     }
-    if (pblock >= 0) {
-      // make clean
-      x[jb] = block_at_lb ? lbbasic[pblock] : ubbasic[pblock];
-      assert(std::isfinite(x[jb]));
-      // Update copy of basic variables and bounds. Note: jn cannot be
-      // a fixed-at-bound variable since it was pushed to a bound.
-      xbasic[pblock] = x[jn];
-      lbbasic[pblock] = lb[jn];
-      ubbasic[pblock] = ub[jn];
+    for (Int p = 0; p < m; p++)
+        x[(*basis)[p]] = xbasic[p];
+
+    // Set status flag.
+    if (info->errflag == IPX_ERROR_interrupt_time) {
+        info->errflag = 0;
+        info->status_crossover = IPX_STATUS_time_limit;
+    } else if (info->errflag != 0) {
+        info->status_crossover = IPX_STATUS_failed;
     } else {
-      x[jn] = move_to;  // make clean
-      assert(std::isfinite(x[jn]));
+        info->status_crossover = IPX_STATUS_optimal;
     }
-
-    primal_pushes_++;
-    next++;
-    control_.IntervalLog() << " "
-                           << Format(static_cast<Int>(variables.size() - next),
-                                     8)
-                           << " primal pushes remaining"
-                           << " (" << Format(primal_pivots_, 7) << " pivots)\n";
-  }
-  for (Int p = 0; p < m; p++) x[(*basis)[p]] = xbasic[p];
-
-  // Set status flag.
-  if (info->errflag == IPX_ERROR_interrupt_time) {
-    info->errflag = 0;
-    info->status_crossover = IPX_STATUS_time_limit;
-  } else if (info->errflag != 0) {
-    info->status_crossover = IPX_STATUS_failed;
-  } else {
-    info->status_crossover = IPX_STATUS_optimal;
-  }
-  time_primal_ = timer.Elapsed();
+    time_primal_ = timer.Elapsed();
 }
 
 void Crossover::PushPrimal(Basis* basis, Vector& x,
-                           const std::vector<Int>& variables, const Vector& z,
-                           Info* info) {
-  std::valarray<bool> bound_restrict = z != 0.0;
-  PushPrimal(basis, x, variables, &bound_restrict[0], info);
+                           const std::vector<Int>& variables,
+                           const Vector& z, Info* info) {
+    std::valarray<bool> bound_restrict = z != 0.0;
+    PushPrimal(basis, x, variables, &bound_restrict[0], info);
 }
 
 void Crossover::PushDual(Basis* basis, Vector& y, Vector& z,
                          const std::vector<Int>& variables,
                          const int sign_restrict[], Info* info) {
-  Timer timer;
-  const Model& model = basis->model();
-  const Int m = model.rows();
-  const Int n = model.cols();
-  IndexedVector btran(m), row(n + m);
-  const double feastol = model.dualized() ? control_.pfeasibility_tol()
-                                          : control_.dfeasibility_tol();
-  dual_pushes_ = 0;
-  dual_pivots_ = 0;
+    Timer timer;
+    const Model& model = basis->model();
+    const Int m = model.rows();
+    const Int n = model.cols();
+    IndexedVector btran(m), row(n+m);
+    const double feastol = model.dualized() ?
+        control_.pfeasibility_tol() : control_.dfeasibility_tol();
+    dual_pushes_ = 0;
+    dual_pivots_ = 0;
 
-  // Check that variables are basic and that z satisfies sign condition.
-  for (Int j : variables) {
-    if (!basis->IsBasic(j))
-      throw std::logic_error("invalid variable in Crossover::PushDual");
-  }
-  for (Int j = 0; j < n + m; j++) {
-    if (((sign_restrict[j] & 1) && z[j] < 0.0) ||
-        ((sign_restrict[j] & 2) && z[j] > 0.0))
-      throw std::logic_error("sign condition violated in Crossover::PushDual");
-  }
-
-  control_.ResetPrintInterval();
-  Int next = 0;
-  while (next < (Int)variables.size()) {
-    if ((info->errflag = control_.InterruptCheck()) != 0) break;
-
-    const Int jb = variables[next];
-    if (z[jb] == 0.0) {
-      // nothing to do
-      next++;
-      continue;
+    // Check that variables are basic and that z satisfies sign condition.
+    for (Int j : variables) {
+        if (!basis->IsBasic(j))
+            throw std::logic_error("invalid variable in Crossover::PushDual");
     }
-    // The update operation applied below is
-    // y := y + step*btran, z := z - step*row, z[jb] := z[jb] - step,
-    // where row is the tableau row for variable jb. In exact arithmetic
-    // this leaves A'y+z unchanged.
-    basis->TableauRow(jb, btran, row);
-    double step = z[jb];
-    Int jn = DualRatioTest(z, row, sign_restrict, step, feastol);
-
-    // If step was blocked, update basis and compute step size.
-    if (jn >= 0) {
-      assert(basis->IsNonbasic(jn));
-      double pivot = row[jn];
-      assert(pivot);
-      if (std::abs(pivot) < 1e-4)
-        control_.Debug(3) << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
-      bool exchanged;
-      info->errflag = basis->ExchangeIfStable(jb, jn, pivot, 1, &exchanged);
-      if (info->errflag) {
-        control_.Debug() << Textline("Minimum singular value of basis matrix:")
-                         << sci2(basis->MinSingularValue()) << '\n';
-        break;
-      }
-      if (!exchanged)  // factorization was unstable, try again
-        continue;
-      dual_pivots_++;
-      step = z[jn] / row[jn];
-      // Update must move z[jb] toward zero.
-      if (sign_restrict[jb] & 1) assert(step >= 0.0);
-      if (sign_restrict[jb] & 2) assert(step <= 0.0);
+    for (Int j = 0; j < n+m; j++) {
+        if (((sign_restrict[j] & 1) && z[j] < 0.0) ||
+            ((sign_restrict[j] & 2) && z[j] > 0.0))
+            throw std::logic_error(
+                "sign condition violated in Crossover::PushDual");
     }
-    // Update solution.
-    if (step != 0.0) {
-      auto update_y = [&](Int i, double x) { y[i] += step * x; };
-      for_each_nonzero(btran, update_y);
-      auto update_z = [&](Int j, double pivot) {
-        z[j] -= step * pivot;
-        if (sign_restrict[j] & 1) z[j] = std::max(z[j], 0.0);
-        if (sign_restrict[j] & 2) z[j] = std::min(z[j], 0.0);
-      };
-      for_each_nonzero(row, update_z);
-      z[jb] -= step;
+
+    control_.ResetPrintInterval();
+    Int next = 0;
+    while (next < (Int) variables.size()) {
+        if ((info->errflag = control_.InterruptCheck()) != 0)
+            break;
+
+        const Int jb = variables[next];
+        if (z[jb] == 0.0) {
+            // nothing to do
+            next++;
+            continue;
+        }
+        // The update operation applied below is
+        // y := y + step*btran, z := z - step*row, z[jb] := z[jb] - step,
+        // where row is the tableau row for variable jb. In exact arithmetic
+        // this leaves A'y+z unchanged.
+        basis->TableauRow(jb, btran, row);
+        double step = z[jb];
+        Int jn = DualRatioTest(z, row, sign_restrict, step, feastol);
+
+        // If step was blocked, update basis and compute step size.
+        if (jn >= 0) {
+            assert(basis->IsNonbasic(jn));
+            double pivot = row[jn];
+            assert(pivot);
+            if (std::abs(pivot) < 1e-4)
+                control_.Debug(3)
+                    << " |pivot| = " << sci2(std::abs(pivot)) << '\n';
+            bool exchanged;
+            info->errflag = basis->ExchangeIfStable(jb, jn, pivot, 1,
+                                                    &exchanged);
+            if (info->errflag) {
+                control_.Debug()
+                    << Textline("Minimum singular value of basis matrix:")
+                    << sci2(basis->MinSingularValue()) << '\n';
+                break;
+            }
+            if (!exchanged)     // factorization was unstable, try again
+                continue;
+            dual_pivots_++;
+            step = z[jn]/row[jn];
+            // Update must move z[jb] toward zero.
+            if (sign_restrict[jb] & 1)
+                assert(step >= 0.0);
+            if (sign_restrict[jb] & 2)
+                assert(step <= 0.0);
+        }
+        // Update solution.
+        if (step != 0.0) {
+            auto update_y = [&](Int i, double x) {
+                y[i] += step*x;
+            };
+            for_each_nonzero(btran, update_y);
+            auto update_z = [&](Int j, double pivot) {
+                z[j] -= step * pivot;
+                if (sign_restrict[j] & 1)
+                    z[j] = std::max(z[j], 0.0);
+                if (sign_restrict[j] & 2)
+                    z[j] = std::min(z[j], 0.0);
+            };
+            for_each_nonzero(row, update_z);
+            z[jb] -= step;
+        }
+        if (jn >= 0)
+            z[jn] = 0.0; // make clean
+        else
+            assert(z[jb] == 0.0);
+
+        dual_pushes_++;
+        next++;
+        control_.IntervalLog()
+            << " " << Format(static_cast<Int>(variables.size()-next), 8)
+            << " dual pushes remaining"
+            << " (" << Format(dual_pivots_, 7) << " pivots)\n";
     }
-    if (jn >= 0)
-      z[jn] = 0.0;  // make clean
-    else
-      assert(z[jb] == 0.0);
 
-    dual_pushes_++;
-    next++;
-    control_.IntervalLog() << " "
-                           << Format(static_cast<Int>(variables.size() - next),
-                                     8)
-                           << " dual pushes remaining"
-                           << " (" << Format(dual_pivots_, 7) << " pivots)\n";
-  }
-
-  // Set status flag.
-  if (info->errflag == IPX_ERROR_interrupt_time) {
-    info->errflag = 0;
-    info->status_crossover = IPX_STATUS_time_limit;
-  } else if (info->errflag != 0) {
-    info->status_crossover = IPX_STATUS_failed;
-  } else {
-    info->status_crossover = IPX_STATUS_optimal;
-  }
-  time_dual_ = timer.Elapsed();
+    // Set status flag.
+    if (info->errflag == IPX_ERROR_interrupt_time) {
+        info->errflag = 0;
+        info->status_crossover = IPX_STATUS_time_limit;
+    } else if (info->errflag != 0) {
+        info->status_crossover = IPX_STATUS_failed;
+    } else {
+        info->status_crossover = IPX_STATUS_optimal;
+    }
+    time_dual_ = timer.Elapsed();
 }
 
 void Crossover::PushDual(Basis* basis, Vector& y, Vector& z,
-                         const std::vector<Int>& variables, const Vector& x,
-                         Info* info) {
-  const Model& model = basis->model();
-  const Int m = model.rows();
-  const Int n = model.cols();
-  const Vector& lb = model.lb();
-  const Vector& ub = model.ub();
+                         const std::vector<Int>& variables,
+                         const Vector& x, Info* info) {
+    const Model& model = basis->model();
+    const Int m = model.rows();
+    const Int n = model.cols();
+    const Vector& lb = model.lb();
+    const Vector& ub = model.ub();
 
-  std::vector<int> sign_restrict(n + m);
-  for (Int j = 0; j < (Int)sign_restrict.size(); j++) {
-    if (x[j] != ub[j]) sign_restrict[j] |= 1;
-    if (x[j] != lb[j]) sign_restrict[j] |= 2;
-  }
-  PushDual(basis, y, z, variables, sign_restrict.data(), info);
+    std::vector<int> sign_restrict(n+m);
+    for (Int j = 0; j < (Int) sign_restrict.size(); j++) {
+        if (x[j] != ub[j]) sign_restrict[j] |= 1;
+        if (x[j] != lb[j]) sign_restrict[j] |= 2;
+    }
+    PushDual(basis, y, z, variables, sign_restrict.data(), info);
 }
 
 Int Crossover::PrimalRatioTest(const Vector& xbasic, const IndexedVector& ftran,
                                const Vector& lbbasic, const Vector& ubbasic,
                                double step, double feastol, bool* block_at_lb) {
-  Int pblock = -1;  // return value
-  *block_at_lb = true;
+    Int pblock = -1;            // return value
+    *block_at_lb = true;
 
-  // First pass: determine maximum step size exploiting feasibility tol.
-  auto update_step = [&](Int p, double pivot) {
-    if (std::abs(pivot) > kPivotZeroTol) {
-      // test block at lower bound
-      if (xbasic[p] + step * pivot < lbbasic[p] - feastol) {
-        step = (lbbasic[p] - xbasic[p] - feastol) / pivot;
-        pblock = p;
-        *block_at_lb = true;
-      }
-      // test block at upper bound
-      if (xbasic[p] + step * pivot > ubbasic[p] + feastol) {
-        step = (ubbasic[p] - xbasic[p] + feastol) / pivot;
-        pblock = p;
-        *block_at_lb = false;
-      }
-    }
-  };
-  for_each_nonzero(ftran, update_step);
-
-  // If the step was not blocked, we are done.
-  if (pblock < 0) return pblock;
-
-  // Second pass: choose maximum pivot among all that block within step.
-  pblock = -1;
-  double max_pivot = kPivotZeroTol;
-  auto update_max = [&](Int p, double pivot) {
-    if (std::abs(pivot) > max_pivot) {
-      // test block at lower bound
-      if (step * pivot < 0.0) {
-        double step_p = (lbbasic[p] - xbasic[p]) / pivot;
-        if (std::abs(step_p) <= std::abs(step)) {
-          pblock = p;
-          *block_at_lb = true;
-          max_pivot = std::abs(pivot);
+    // First pass: determine maximum step size exploiting feasibility tol.
+    auto update_step = [&](Int p, double pivot) {
+        if (std::abs(pivot) > kPivotZeroTol) {
+            // test block at lower bound
+            if (xbasic[p] + step*pivot < lbbasic[p]-feastol) {
+                step = (lbbasic[p]-xbasic[p]-feastol) / pivot;
+                pblock = p;
+                *block_at_lb = true;
+            }
+            // test block at upper bound
+            if (xbasic[p] + step*pivot > ubbasic[p]+feastol) {
+                step = (ubbasic[p]-xbasic[p]+feastol) / pivot;
+                pblock = p;
+                *block_at_lb = false;
+            }
         }
-      }
-      // test block at upper bound
-      if (step * pivot > 0.0) {
-        double step_p = (ubbasic[p] - xbasic[p]) / pivot;
-        if (std::abs(step_p) <= std::abs(step)) {
-          pblock = p;
-          *block_at_lb = false;
-          max_pivot = std::abs(pivot);
+    };
+    for_each_nonzero(ftran, update_step);
+
+    // If the step was not blocked, we are done.
+    if (pblock < 0)
+        return pblock;
+
+    // Second pass: choose maximum pivot among all that block within step.
+    pblock = -1;
+    double max_pivot = kPivotZeroTol;
+    auto update_max = [&](Int p, double pivot) {
+        if (std::abs(pivot) > max_pivot) {
+            // test block at lower bound
+            if (step*pivot < 0.0) {
+                double step_p = (lbbasic[p]-xbasic[p]) / pivot;
+                if (std::abs(step_p) <= std::abs(step)) {
+                    pblock = p;
+                    *block_at_lb = true;
+                    max_pivot = std::abs(pivot);
+                }
+            }
+            // test block at upper bound
+            if (step*pivot > 0.0) {
+                double step_p = (ubbasic[p]-xbasic[p]) / pivot;
+                if (std::abs(step_p) <= std::abs(step)) {
+                    pblock = p;
+                    *block_at_lb = false;
+                    max_pivot = std::abs(pivot);
+                }
+            }
         }
-      }
-    }
-  };
-  for_each_nonzero(ftran, update_max);
-  assert(pblock >= 0);
-  return pblock;
+    };
+    for_each_nonzero(ftran, update_max);
+    assert(pblock >= 0);
+    return pblock;
 }
 
 Int Crossover::DualRatioTest(const Vector& z, const IndexedVector& row,
                              const int sign_restrict[], double step,
                              double feastol) {
-  Int jblock = -1;  // return value
+    Int jblock = -1;            // return value
 
-  // First pass: determine maximum step size exploiting feasibility tol.
-  auto update_step = [&](Int j, double pivot) {
-    if (std::abs(pivot) > kPivotZeroTol) {
-      if ((sign_restrict[j] & 1) && z[j] - step * pivot < -feastol) {
-        step = (z[j] + feastol) / pivot;
-        jblock = j;
-        assert(z[j] >= 0.0);
-        assert(step * pivot > 0.0);
-      }
-      if ((sign_restrict[j] & 2) && z[j] - step * pivot > feastol) {
-        step = (z[j] - feastol) / pivot;
-        jblock = j;
-        assert(z[j] <= 0.0);
-        assert(step * pivot < 0.0);
-      }
-    }
-  };
-  for_each_nonzero(row, update_step);
+    // First pass: determine maximum step size exploiting feasibility tol.
+    auto update_step = [&](Int j, double pivot) {
+        if (std::abs(pivot) > kPivotZeroTol) {
+            if ((sign_restrict[j] & 1) && z[j]-step*pivot < -feastol) {
+                step = (z[j]+feastol) / pivot;
+                jblock = j;
+                assert(z[j] >= 0.0);
+                assert(step*pivot > 0.0);
+            }
+            if ((sign_restrict[j] & 2) && z[j]-step*pivot > feastol) {
+                step = (z[j]-feastol) / pivot;
+                jblock = j;
+                assert(z[j] <= 0.0);
+                assert(step*pivot < 0.0);
+            }
+        }
+    };
+    for_each_nonzero(row, update_step);
 
-  // If step was not block, we are done.
-  if (jblock < 0) return jblock;
+    // If step was not block, we are done.
+    if (jblock < 0)
+        return jblock;
 
-  // Second pass: choose maximum pivot among all that block within step.
-  jblock = -1;
-  double max_pivot = kPivotZeroTol;
-  auto update_max = [&](Int j, double pivot) {
-    if (std::abs(pivot) > max_pivot &&
-        std::abs(z[j] / pivot) <= std::abs(step)) {
-      if ((sign_restrict[j] & 1) && step * pivot > 0.0) {
-        jblock = j;
-        max_pivot = std::abs(pivot);
-      }
-      if ((sign_restrict[j] & 2) && step * pivot < 0.0) {
-        jblock = j;
-        max_pivot = std::abs(pivot);
-      }
-    }
-  };
-  for_each_nonzero(row, update_max);
-  assert(jblock >= 0);
-  return jblock;
+    // Second pass: choose maximum pivot among all that block within step.
+    jblock = -1;
+    double max_pivot = kPivotZeroTol;
+    auto update_max = [&](Int j, double pivot) {
+        if (std::abs(pivot) > max_pivot &&
+            std::abs(z[j]/pivot) <= std::abs(step)) {
+            if ((sign_restrict[j] & 1) && step*pivot > 0.0) {
+                jblock = j;
+                max_pivot = std::abs(pivot);
+            }
+            if ((sign_restrict[j] & 2) && step*pivot < 0.0) {
+                jblock = j;
+                max_pivot = std::abs(pivot);
+            }
+        }
+    };
+    for_each_nonzero(row, update_max);
+    assert(jblock >= 0);
+    return jblock;
 }
 
 }  // namespace ipx

--- a/src/ipm/ipx/src/info.cc
+++ b/src/ipm/ipx/src/info.cc
@@ -64,6 +64,7 @@ std::ostream& operator<<(std::ostream& os, const Info& info) {
     dump(os, "updates_start", info.updates_start);
     dump(os, "updates_ipm", info.updates_ipm);
     dump(os, "updates_crossover", info.updates_crossover);
+    dump(os, "pushes_crossover", info.pushes_crossover);
 
     dump(os, "time_total", fix2(info.time_total));
     dump(os, "time_ipm1", fix2(info.time_ipm1));

--- a/src/ipm/ipx/src/lp_solver.cc
+++ b/src/ipm/ipx/src/lp_solver.cc
@@ -1,12 +1,10 @@
 // Copyright (c) 2018 ERGO-Code. See license.txt for license.
 
 #include "lp_solver.h"
-
 #include <algorithm>
 #include <cassert>
-#include <utility>
 #include <vector>
-
+#include <utility>
 #include "crossover.h"
 #include "info.h"
 #include "kkt_solver_basis.h"
@@ -20,417 +18,441 @@ Int LpSolver::Solve(Int num_var, const double* obj, const double* lb,
                     const double* ub, Int num_constr, const Int* Ap,
                     const Int* Ai, const double* Ax, const double* rhs,
                     const char* constr_type) {
-  ClearModel();
-  control_.ResetTimer();
-  control_.OpenLogfile();
-  control_.Log() << "IPX version 1.0\n";
-  try {
-    model_.Load(control_, num_constr, num_var, Ap, Ai, Ax, rhs, constr_type,
-                obj, lb, ub, &info_);
-    if (info_.errflag) {
-      control_.CloseLogfile();
-      return info_.status = IPX_STATUS_invalid_input;
+    ClearModel();
+    control_.ResetTimer();
+    control_.OpenLogfile();
+    control_.Log() << "IPX version 1.0\n";
+    try {
+        model_.Load(control_, num_constr, num_var, Ap, Ai, Ax, rhs, constr_type,
+                    obj, lb, ub, &info_);
+        if (info_.errflag) {
+            control_.CloseLogfile();
+            return info_.status = IPX_STATUS_invalid_input;
+        }
+        InteriorPointSolve();
+        if ((info_.status_ipm == IPX_STATUS_optimal ||
+             info_.status_ipm == IPX_STATUS_imprecise) && control_.crossover())
+            RunCrossover();
+        if (basis_) {
+            info_.ftran_sparse = basis_->frac_ftran_sparse();
+            info_.btran_sparse = basis_->frac_btran_sparse();
+            info_.time_lu_invert = basis_->time_factorize();
+            info_.time_lu_update = basis_->time_update();
+            info_.time_ftran = basis_->time_ftran();
+            info_.time_btran = basis_->time_btran();
+            info_.mean_fill = basis_->mean_fill();
+            info_.max_fill = basis_->max_fill();
+        }
+        if (info_.status_ipm == IPX_STATUS_primal_infeas ||
+            info_.status_ipm == IPX_STATUS_dual_infeas ||
+            info_.status_crossover == IPX_STATUS_primal_infeas ||
+            info_.status_crossover == IPX_STATUS_dual_infeas) {
+            // When IPM or crossover detect the model to be infeasible
+            // (currently only the former is implemented), then the problem is
+            // solved.
+            info_.status = IPX_STATUS_solved;
+        } else {
+            Int method_status = control_.crossover() ?
+                info_.status_crossover : info_.status_ipm;
+            if (method_status == IPX_STATUS_optimal ||
+                method_status == IPX_STATUS_imprecise)
+                info_.status = IPX_STATUS_solved;
+            else
+                info_.status = IPX_STATUS_stopped;
+        }
+        PrintSummary();
     }
-    InteriorPointSolve();
-    if ((info_.status_ipm == IPX_STATUS_optimal ||
-         info_.status_ipm == IPX_STATUS_imprecise) &&
-        control_.crossover())
-      RunCrossover();
-    if (basis_) {
-      info_.ftran_sparse = basis_->frac_ftran_sparse();
-      info_.btran_sparse = basis_->frac_btran_sparse();
-      info_.time_lu_invert = basis_->time_factorize();
-      info_.time_lu_update = basis_->time_update();
-      info_.time_ftran = basis_->time_ftran();
-      info_.time_btran = basis_->time_btran();
-      info_.mean_fill = basis_->mean_fill();
-      info_.max_fill = basis_->max_fill();
+    catch (const std::bad_alloc&) {
+        control_.Log() << " out of memory\n";
+        info_.status = IPX_STATUS_out_of_memory;
     }
-    if (info_.status_ipm == IPX_STATUS_primal_infeas ||
-        info_.status_ipm == IPX_STATUS_dual_infeas ||
-        info_.status_crossover == IPX_STATUS_primal_infeas ||
-        info_.status_crossover == IPX_STATUS_dual_infeas) {
-      // When IPM or crossover detect the model to be infeasible
-      // (currently only the former is implemented), then the problem is
-      // solved.
-      info_.status = IPX_STATUS_solved;
-    } else {
-      Int method_status =
-          control_.crossover() ? info_.status_crossover : info_.status_ipm;
-      if (method_status == IPX_STATUS_optimal ||
-          method_status == IPX_STATUS_imprecise)
-        info_.status = IPX_STATUS_solved;
-      else
-        info_.status = IPX_STATUS_stopped;
+    catch (const std::exception& e) {
+        control_.Log() << " internal error: " << e.what() << '\n';
+        info_.status = IPX_STATUS_internal_error;
     }
-    PrintSummary();
-  } catch (const std::bad_alloc&) {
-    control_.Log() << " out of memory\n";
-    info_.status = IPX_STATUS_out_of_memory;
-  } catch (const std::exception& e) {
-    control_.Log() << " internal error: " << e.what() << '\n';
-    info_.status = IPX_STATUS_internal_error;
-  }
-  info_.time_total = control_.Elapsed();
-  control_.Debug(2) << info_;
-  control_.CloseLogfile();
-  return info_.status;
+    info_.time_total = control_.Elapsed();
+    control_.Debug(2) << info_;
+    control_.CloseLogfile();
+    return info_.status;
 }
 
-Info LpSolver::GetInfo() const { return info_; }
+Info LpSolver::GetInfo() const {
+    return info_;
+}
 
 Int LpSolver::GetInteriorSolution(double* x, double* xl, double* xu,
                                   double* slack, double* y, double* zl,
                                   double* zu) const {
-  if (!iterate_) return -1;
-  model_.PostsolveInteriorSolution(
-      iterate_->x(), iterate_->xl(), iterate_->xu(), iterate_->y(),
-      iterate_->zl(), iterate_->zu(), x, xl, xu, slack, y, zl, zu);
-  return 0;
+    if (!iterate_)
+        return -1;
+    model_.PostsolveInteriorSolution(
+        iterate_->x(), iterate_->xl(), iterate_->xu(),
+        iterate_->y(), iterate_->zl(), iterate_->zu(),
+        x, xl, xu, slack, y, zl, zu);
+    return 0;
 }
 
 Int LpSolver::GetBasicSolution(double* x, double* slack, double* y, double* z,
                                Int* cbasis, Int* vbasis) const {
-  if (basic_statuses_.empty()) return -1;
-  model_.PostsolveBasicSolution(x_crossover_, y_crossover_, z_crossover_,
-                                basic_statuses_, x, slack, y, z);
-  model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
-  return 0;
+    if (basic_statuses_.empty())
+        return -1;
+    model_.PostsolveBasicSolution(x_crossover_, y_crossover_, z_crossover_,
+                                  basic_statuses_, x, slack, y, z);
+    model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
+    return 0;
 }
 
-Parameters LpSolver::GetParameters() const { return control_.parameters(); }
+Parameters LpSolver::GetParameters() const {
+    return control_.parameters();
+}
 
 void LpSolver::SetParameters(Parameters new_parameters) {
-  control_.parameters(new_parameters);
+    control_.parameters(new_parameters);
 }
 
 void LpSolver::ClearModel() {
-  info_ = Info();
-  model_.clear();
-  iterate_.reset(nullptr);
-  basis_.reset(nullptr);
-  x_crossover_.resize(0);
-  y_crossover_.resize(0);
-  z_crossover_.resize(0);
-  basic_statuses_.clear();
-  basic_statuses_.shrink_to_fit();
+    info_ = Info();
+    model_.clear();
+    iterate_.reset(nullptr);
+    basis_.reset(nullptr);
+    x_crossover_.resize(0);
+    y_crossover_.resize(0);
+    z_crossover_.resize(0);
+    basic_statuses_.clear();
+    basic_statuses_.shrink_to_fit();
 }
 
 Int LpSolver::GetIterate(double* x, double* y, double* zl, double* zu,
                          double* xl, double* xu) {
-  if (!iterate_) return -1;
-  if (x) std::copy(std::begin(iterate_->x()), std::end(iterate_->x()), x);
-  if (y) std::copy(std::begin(iterate_->y()), std::end(iterate_->y()), y);
-  if (zl) std::copy(std::begin(iterate_->zl()), std::end(iterate_->zl()), zl);
-  if (zu) std::copy(std::begin(iterate_->zu()), std::end(iterate_->zu()), zu);
-  if (xl) std::copy(std::begin(iterate_->xl()), std::end(iterate_->xl()), xl);
-  if (xu) std::copy(std::begin(iterate_->xu()), std::end(iterate_->xu()), xu);
-  return 0;
+    if (!iterate_)
+        return -1;
+    if (x)
+        std::copy(std::begin(iterate_->x()), std::end(iterate_->x()), x);
+    if (y)
+        std::copy(std::begin(iterate_->y()), std::end(iterate_->y()), y);
+    if (zl)
+        std::copy(std::begin(iterate_->zl()), std::end(iterate_->zl()), zl);
+    if (zu)
+        std::copy(std::begin(iterate_->zu()), std::end(iterate_->zu()), zu);
+    if (xl)
+        std::copy(std::begin(iterate_->xl()), std::end(iterate_->xl()), xl);
+    if (xu)
+        std::copy(std::begin(iterate_->xu()), std::end(iterate_->xu()), xu);
+    return 0;
 }
 
 // Returns a vector of basic statuses that is consistent with the basis and
 // the bounds from the model.
 static std::vector<Int> BuildBasicStatuses(const Basis& basis) {
-  const Model& model = basis.model();
-  const Int m = model.rows();
-  const Int n = model.cols();
-  const Vector& lb = model.lb();
-  const Vector& ub = model.ub();
-  std::vector<Int> basic_statuses(n + m);
-  for (Int j = 0; j < n + m; j++) {
-    if (basis.IsBasic(j)) {
-      basic_statuses[j] = IPX_basic;
-    } else if (std::isfinite(lb[j])) {
-      basic_statuses[j] = IPX_nonbasic_lb;
-    } else if (std::isfinite(ub[j])) {
-      basic_statuses[j] = IPX_nonbasic_ub;
-    } else {
-      basic_statuses[j] = IPX_superbasic;
+    const Model& model = basis.model();
+    const Int m = model.rows();
+    const Int n = model.cols();
+    const Vector& lb = model.lb();
+    const Vector& ub = model.ub();
+    std::vector<Int> basic_statuses(n+m);
+    for (Int j = 0; j < n+m; j++) {
+        if (basis.IsBasic(j)) {
+            basic_statuses[j] = IPX_basic;
+        } else if (std::isfinite(lb[j])) {
+            basic_statuses[j] = IPX_nonbasic_lb;
+        } else if (std::isfinite(ub[j])) {
+            basic_statuses[j] = IPX_nonbasic_ub;
+        } else {
+            basic_statuses[j] = IPX_superbasic;
+        }
     }
-  }
-  return basic_statuses;
+    return basic_statuses;
 }
 
 Int LpSolver::GetBasis(Int* cbasis, Int* vbasis) {
-  if (!basis_) return -1;
-  if (!basic_statuses_.empty()) {
-    // crossover provides basic statuses
-    model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
-  } else {
-    model_.PostsolveBasis(BuildBasicStatuses(*basis_), cbasis, vbasis);
-  }
-  return 0;
+    if (!basis_)
+        return -1;
+    if (!basic_statuses_.empty()) {
+        // crossover provides basic statuses
+        model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
+    } else {
+        model_.PostsolveBasis(BuildBasicStatuses(*basis_), cbasis, vbasis);
+    }
+    return 0;
 }
 
 Int LpSolver::GetKKTMatrix(Int* AIp, Int* AIi, double* AIx, double* g) {
-  if (!iterate_) return -1;
-  if (AIp && AIi && AIx) {
-    const SparseMatrix& AI = model_.AI();
-    std::copy_n(AI.colptr(), AI.cols() + 1, AIp);
-    std::copy_n(AI.rowidx(), AI.entries(), AIi);
-    std::copy_n(AI.values(), AI.entries(), AIx);
-  }
-  if (g) {
-    Int m = model_.rows();
-    Int n = model_.cols();
-    for (Int j = 0; j < n + m; j++) {
-      switch (iterate_->StateOf(j)) {
-        case Iterate::State::fixed:
-          g[j] = INFINITY;
-          break;
-        case Iterate::State::free:
-          g[j] = 0.0;
-          break;
-        case Iterate::State::barrier:
-          g[j] = iterate_->zl(j) / iterate_->xl(j) +
-                 iterate_->zu(j) / iterate_->xu(j);
-          assert(std::isfinite(g[j]));
-          assert(g[j] > 0.0);
-          break;
-        default:
-          assert(0);
-      }
+    if (!iterate_)
+        return -1;
+    if (AIp && AIi && AIx) {
+        const SparseMatrix& AI = model_.AI();
+        std::copy_n(AI.colptr(), AI.cols()+1, AIp);
+        std::copy_n(AI.rowidx(), AI.entries(), AIi);
+        std::copy_n(AI.values(), AI.entries(), AIx);
     }
-  }
-  return 0;
+    if (g) {
+        Int m = model_.rows();
+        Int n = model_.cols();
+        for (Int j = 0; j < n+m; j++) {
+            switch (iterate_->StateOf(j)) {
+            case Iterate::State::fixed:
+                g[j] = INFINITY;
+                break;
+            case Iterate::State::free:
+                g[j] = 0.0;
+                break;
+            case Iterate::State::barrier:
+                g[j] = iterate_->zl(j)/iterate_->xl(j) +
+                    iterate_->zu(j)/iterate_->xu(j);
+                assert(std::isfinite(g[j]));
+                assert(g[j] > 0.0);
+                break;
+            default:
+                assert(0);
+            }
+        }
+    }
+    return 0;
 }
 
 Int LpSolver::SymbolicInvert(Int* rowcounts, Int* colcounts) {
-  if (!basis_) return -1;
-  basis_->SymbolicInvert(rowcounts, colcounts);
-  return 0;
+    if (!basis_)
+        return -1;
+    basis_->SymbolicInvert(rowcounts, colcounts);
+    return 0;
 }
 
 void LpSolver::InteriorPointSolve() {
-  control_.Log() << "Interior Point Solve\n";
+    control_.Log() << "Interior Point Solve\n";
 
-  // Allocate new iterate and set tolerances for IPM termination test.
-  iterate_.reset(new Iterate(model_));
-  iterate_->feasibility_tol(control_.ipm_feasibility_tol());
-  iterate_->optimality_tol(control_.ipm_optimality_tol());
-  if (control_.crossover())
-    iterate_->crossover_start(control_.crossover_start());
+    // Allocate new iterate and set tolerances for IPM termination test.
+    iterate_.reset(new Iterate(model_));
+    iterate_->feasibility_tol(control_.ipm_feasibility_tol());
+    iterate_->optimality_tol(control_.ipm_optimality_tol());
+    if (control_.crossover())
+        iterate_->crossover_start(control_.crossover_start());
 
-  RunIPM();
+    RunIPM();
 
-  iterate_->Postprocess();
-  iterate_->EvaluatePostsolved(&info_);
+    iterate_->Postprocess();
+    iterate_->EvaluatePostsolved(&info_);
 
-  // Declare status_ipm "imprecise" if the IPM terminated optimal but the
-  // solution after postprocessing/postsolve does not satisfy tolerances.
-  if (info_.status_ipm == IPX_STATUS_optimal) {
-    if (std::abs(info_.rel_objgap) > control_.ipm_optimality_tol() ||
-        info_.rel_presidual > control_.ipm_feasibility_tol() ||
-        info_.rel_dresidual > control_.ipm_feasibility_tol())
-      info_.status_ipm = IPX_STATUS_imprecise;
-  }
+    // Declare status_ipm "imprecise" if the IPM terminated optimal but the
+    // solution after postprocessing/postsolve does not satisfy tolerances.
+    if (info_.status_ipm == IPX_STATUS_optimal) {
+        if (std::abs(info_.rel_objgap) > control_.ipm_optimality_tol() ||
+            info_.rel_presidual > control_.ipm_feasibility_tol() ||
+            info_.rel_dresidual > control_.ipm_feasibility_tol())
+            info_.status_ipm = IPX_STATUS_imprecise;
+    }
 }
 
 void LpSolver::RunIPM() {
-  IPM ipm(control_);
+    IPM ipm(control_);
 
-  ComputeStartingPoint(ipm);
-  if (info_.status_ipm != IPX_STATUS_not_run) return;
-  RunInitialIPM(ipm);
-  if (info_.status_ipm != IPX_STATUS_not_run) return;
-  BuildStartingBasis();
-  if (info_.status_ipm != IPX_STATUS_not_run) return;
-  RunMainIPM(ipm);
+    ComputeStartingPoint(ipm);
+    if (info_.status_ipm != IPX_STATUS_not_run)
+        return;
+    RunInitialIPM(ipm);
+    if (info_.status_ipm != IPX_STATUS_not_run)
+        return;
+    BuildStartingBasis();
+    if (info_.status_ipm != IPX_STATUS_not_run)
+        return;
+    RunMainIPM(ipm);
 }
 
 void LpSolver::ComputeStartingPoint(IPM& ipm) {
-  Timer timer;
-  KKTSolverDiag kkt(control_, model_);
+    Timer timer;
+    KKTSolverDiag kkt(control_, model_);
 
-  // If the starting point procedure fails, then iterate_ remains as
-  // initialized by the constructor, which is a valid state for
-  // postprocessing/postsolving.
-  ipm.StartingPoint(&kkt, iterate_.get(), &info_);
-  info_.time_ipm1 += timer.Elapsed();
+    // If the starting point procedure fails, then iterate_ remains as
+    // initialized by the constructor, which is a valid state for
+    // postprocessing/postsolving.
+    ipm.StartingPoint(&kkt, iterate_.get(), &info_);
+    info_.time_ipm1 += timer.Elapsed();
 }
 
 void LpSolver::RunInitialIPM(IPM& ipm) {
-  Timer timer;
-  KKTSolverDiag kkt(control_, model_);
+    Timer timer;
+    KKTSolverDiag kkt(control_, model_);
 
-  Int switchiter = control_.switchiter();
-  if (switchiter < 0) {
-    // Switch iteration not specified by user. Run as long as KKT solver
-    // converges within min(500,10+m/20) iterations.
-    Int m = model_.rows();
-    kkt.maxiter(std::min(500l, (long)(10 + m / 20)));
-    ipm.maxiter(control_.ipm_maxiter());
-  } else {
-    ipm.maxiter(std::min(switchiter, control_.ipm_maxiter()));
-  }
-  ipm.Driver(&kkt, iterate_.get(), &info_);
-  switch (info_.status_ipm) {
+    Int switchiter = control_.switchiter();
+    if (switchiter < 0) {
+        // Switch iteration not specified by user. Run as long as KKT solver
+        // converges within min(500,10+m/20) iterations.
+        Int m = model_.rows();
+        kkt.maxiter(std::min(500l, (long) (10+m/20) ));
+        ipm.maxiter(control_.ipm_maxiter());
+    } else {
+        ipm.maxiter(std::min(switchiter, control_.ipm_maxiter()));
+    }
+    ipm.Driver(&kkt, iterate_.get(), &info_);
+    switch (info_.status_ipm) {
     case IPX_STATUS_optimal:
-      // If the IPM reached its termination criterion in the initial
-      // iterations (happens rarely), we still call the IPM again with basis
-      // preconditioning. In exact arithmetic it would terminate without an
-      // additional iteration. A starting basis is then available for
-      // crossover.
-      info_.status_ipm = IPX_STATUS_not_run;
-      break;
-    case IPX_STATUS_no_progress:
-      info_.status_ipm = IPX_STATUS_not_run;
-      break;
-    case IPX_STATUS_failed:
-      info_.status_ipm = IPX_STATUS_not_run;
-      info_.errflag = 0;
-      break;
-    case IPX_STATUS_iter_limit:
-      if (info_.iter < control_.ipm_maxiter())  // stopped at switchiter
+        // If the IPM reached its termination criterion in the initial
+        // iterations (happens rarely), we still call the IPM again with basis
+        // preconditioning. In exact arithmetic it would terminate without an
+        // additional iteration. A starting basis is then available for
+        // crossover.
         info_.status_ipm = IPX_STATUS_not_run;
-  }
-  info_.time_ipm1 += timer.Elapsed();
+        break;
+    case IPX_STATUS_no_progress:
+        info_.status_ipm = IPX_STATUS_not_run;
+        break;
+    case IPX_STATUS_failed:
+        info_.status_ipm = IPX_STATUS_not_run;
+        info_.errflag = 0;
+        break;
+    case IPX_STATUS_iter_limit:
+        if (info_.iter < control_.ipm_maxiter()) // stopped at switchiter
+            info_.status_ipm = IPX_STATUS_not_run;
+    }
+    info_.time_ipm1 += timer.Elapsed();
 }
 
 void LpSolver::BuildStartingBasis() {
-  if (control_.stop_at_switch() < 0) {
-    info_.status_ipm = IPX_STATUS_debug;
-    return;
-  }
-  basis_.reset(new Basis(control_, model_));
-  control_.Log() << " Constructing starting basis...\n";
-  StartingBasis(iterate_.get(), basis_.get(), &info_);
-  if (info_.errflag == IPX_ERROR_interrupt_time) {
-    info_.errflag = 0;
-    info_.status_ipm = IPX_STATUS_time_limit;
-    return;
-  } else if (info_.errflag) {
-    info_.status_ipm = IPX_STATUS_failed;
-    return;
-  }
-  if (model_.dualized()) {
-    std::swap(info_.dependent_rows, info_.dependent_cols);
-    std::swap(info_.rows_inconsistent, info_.cols_inconsistent);
-  }
-  if (control_.stop_at_switch() > 0) {
-    info_.status_ipm = IPX_STATUS_debug;
-    return;
-  }
-  if (info_.rows_inconsistent) {
-    info_.status_ipm = IPX_STATUS_primal_infeas;
-    return;
-  }
-  if (info_.cols_inconsistent) {
-    info_.status_ipm = IPX_STATUS_dual_infeas;
-    return;
-  }
+    if (control_.stop_at_switch() < 0) {
+        info_.status_ipm = IPX_STATUS_debug;
+        return;
+    }
+    basis_.reset(new Basis(control_, model_));
+    control_.Log() << " Constructing starting basis...\n";
+    StartingBasis(iterate_.get(), basis_.get(), &info_);
+    if (info_.errflag == IPX_ERROR_interrupt_time) {
+        info_.errflag = 0;
+        info_.status_ipm = IPX_STATUS_time_limit;
+        return;
+    } else if (info_.errflag) {
+        info_.status_ipm = IPX_STATUS_failed;
+        return;
+    }
+    if (model_.dualized()) {
+        std::swap(info_.dependent_rows, info_.dependent_cols);
+        std::swap(info_.rows_inconsistent, info_.cols_inconsistent);
+    }
+    if (control_.stop_at_switch() > 0) {
+        info_.status_ipm = IPX_STATUS_debug;
+        return;
+    }
+    if (info_.rows_inconsistent) {
+        info_.status_ipm = IPX_STATUS_primal_infeas;
+        return;
+    }
+    if (info_.cols_inconsistent) {
+        info_.status_ipm = IPX_STATUS_dual_infeas;
+        return;
+    }
 }
 
 void LpSolver::RunMainIPM(IPM& ipm) {
-  KKTSolverBasis kkt(control_, *basis_);
-  Timer timer;
-  ipm.maxiter(control_.ipm_maxiter());
-  ipm.Driver(&kkt, iterate_.get(), &info_);
-  info_.time_ipm2 = timer.Elapsed();
+    KKTSolverBasis kkt(control_, *basis_);
+    Timer timer;
+    ipm.maxiter(control_.ipm_maxiter());
+    ipm.Driver(&kkt, iterate_.get(), &info_);
+    info_.time_ipm2 = timer.Elapsed();
 }
 
 void LpSolver::RunCrossover() {
-  control_.Log() << "Crossover\n";
-  assert(basis_);
-  const Int m = model_.rows();
-  const Int n = model_.cols();
-  const Vector& lb = model_.lb();
-  const Vector& ub = model_.ub();
-  basic_statuses_.clear();
+    control_.Log() << "Crossover\n";
+    assert(basis_);
+    const Int m = model_.rows();
+    const Int n = model_.cols();
+    const Vector& lb = model_.lb();
+    const Vector& ub = model_.ub();
+    basic_statuses_.clear();
 
-  // Construct a complementary primal-dual point from the final IPM iterate.
-  // This usually increases the residuals to Ax=b and A'y+z=c.
-  x_crossover_.resize(n + m);
-  y_crossover_.resize(m);
-  z_crossover_.resize(n + m);
-  iterate_->DropToComplementarity(x_crossover_, y_crossover_, z_crossover_);
+    // Construct a complementary primal-dual point from the final IPM iterate.
+    // This usually increases the residuals to Ax=b and A'y+z=c.
+    x_crossover_.resize(n+m);
+    y_crossover_.resize(m);
+    z_crossover_.resize(n+m);
+    iterate_->DropToComplementarity(x_crossover_, y_crossover_, z_crossover_);
 
-  // Run crossover. Perform dual pushes in increasing order and primal pushes
-  // in decreasing order of the scaling factors from the final IPM iterate.
-  {
-    Vector weights(n + m);
-    for (Int j = 0; j < n + m; j++) weights[j] = iterate_->ScalingFactor(j);
-    Crossover crossover(control_);
-    crossover.PushAll(basis_.get(), x_crossover_, y_crossover_, z_crossover_,
-                      &weights[0], &info_);
-    info_.time_crossover = crossover.time_primal() + crossover.time_dual();
-    info_.updates_crossover =
-        crossover.primal_pivots() + crossover.dual_pivots();
-    info_.pushes_crossover =
-        crossover.primal_pushes() + crossover.dual_pushes();
-    if (info_.status_crossover != IPX_STATUS_optimal) {
-      // Crossover failed. Discard solution.
-      x_crossover_.resize(0);
-      y_crossover_.resize(0);
-      z_crossover_.resize(0);
-      return;
+    // Run crossover. Perform dual pushes in increasing order and primal pushes
+    // in decreasing order of the scaling factors from the final IPM iterate.
+    {
+        Vector weights(n+m);
+        for (Int j = 0; j < n+m; j++)
+            weights[j] = iterate_->ScalingFactor(j);
+        Crossover crossover(control_);
+        crossover.PushAll(basis_.get(), x_crossover_, y_crossover_,
+                          z_crossover_, &weights[0], &info_);
+        info_.time_crossover =
+            crossover.time_primal() + crossover.time_dual();
+        info_.updates_crossover =
+            crossover.primal_pivots() + crossover.dual_pivots();
+        info_.pushes_crossover =
+            crossover.primal_pushes() + crossover.dual_pushes();
+        if (info_.status_crossover != IPX_STATUS_optimal) {
+            // Crossover failed. Discard solution.
+            x_crossover_.resize(0);
+            y_crossover_.resize(0);
+            z_crossover_.resize(0);
+            return;
+        }
     }
-  }
 
-  // Recompute vertex solution and set basic statuses.
-  basis_->ComputeBasicSolution(x_crossover_, y_crossover_, z_crossover_);
-  basic_statuses_.resize(n + m);
-  for (Int j = 0; j < (Int)basic_statuses_.size(); j++) {
-    if (basis_->IsBasic(j)) {
-      basic_statuses_[j] = IPX_basic;
-    } else {
-      if (lb[j] == ub[j])
-        basic_statuses_[j] =
-            z_crossover_[j] >= 0.0 ? IPX_nonbasic_lb : IPX_nonbasic_ub;
-      else if (x_crossover_[j] == lb[j])
-        basic_statuses_[j] = IPX_nonbasic_lb;
-      else if (x_crossover_[j] == ub[j])
-        basic_statuses_[j] = IPX_nonbasic_ub;
-      else
-        basic_statuses_[j] = IPX_superbasic;
+    // Recompute vertex solution and set basic statuses.
+    basis_->ComputeBasicSolution(x_crossover_, y_crossover_, z_crossover_);
+    basic_statuses_.resize(n+m);
+    for (Int j = 0; j < (Int) basic_statuses_.size(); j++) {
+        if (basis_->IsBasic(j)) {
+            basic_statuses_[j] = IPX_basic;
+        } else {
+            if (lb[j] == ub[j])
+                basic_statuses_[j] = z_crossover_[j] >= 0.0 ?
+                    IPX_nonbasic_lb : IPX_nonbasic_ub;
+            else if (x_crossover_[j] == lb[j])
+                basic_statuses_[j] = IPX_nonbasic_lb;
+            else if (x_crossover_[j] == ub[j])
+                basic_statuses_[j] = IPX_nonbasic_ub;
+            else
+                basic_statuses_[j] = IPX_superbasic;
+        }
     }
-  }
-  control_.Debug() << Textline("Bound violation of basic solution:")
-                   << sci2(PrimalInfeasibility(model_, x_crossover_)) << '\n'
-                   << Textline("Dual sign violation of basic solution:")
-                   << sci2(
-                          DualInfeasibility(model_, x_crossover_, z_crossover_))
-                   << '\n';
-  control_.Debug() << Textline("Minimum singular value of basis matrix:")
-                   << sci2(basis_->MinSingularValue()) << '\n';
+    control_.Debug()
+        << Textline("Bound violation of basic solution:")
+        << sci2(PrimalInfeasibility(model_, x_crossover_)) << '\n'
+        << Textline("Dual sign violation of basic solution:")
+        << sci2(DualInfeasibility(model_, x_crossover_, z_crossover_)) << '\n';
+    control_.Debug()
+        << Textline("Minimum singular value of basis matrix:")
+        << sci2(basis_->MinSingularValue()) << '\n';
 
-  // Declare crossover status "imprecise" if the vertex solution defined by
-  // the final basis does not satisfy tolerances.
-  model_.EvaluateBasicSolution(x_crossover_, y_crossover_, z_crossover_,
-                               basic_statuses_, &info_);
-  if (info_.primal_infeas > control_.pfeasibility_tol() ||
-      info_.dual_infeas > control_.dfeasibility_tol())
-    info_.status_crossover = IPX_STATUS_imprecise;
+    // Declare crossover status "imprecise" if the vertex solution defined by
+    // the final basis does not satisfy tolerances.
+    model_.EvaluateBasicSolution(x_crossover_, y_crossover_, z_crossover_,
+                                 basic_statuses_, &info_);
+    if (info_.primal_infeas > control_.pfeasibility_tol() ||
+        info_.dual_infeas > control_.dfeasibility_tol())
+        info_.status_crossover = IPX_STATUS_imprecise;
 }
 
 void LpSolver::PrintSummary() {
-  control_.Log() << "Summary\n"
-                 << Textline("Runtime:") << fix2(control_.Elapsed()) << "s\n"
-                 << Textline("Status interior point solve:")
-                 << StatusString(info_.status_ipm) << '\n'
-                 << Textline("Status crossover:")
-                 << StatusString(info_.status_crossover) << '\n';
-  if (info_.status_ipm == IPX_STATUS_optimal ||
-      info_.status_ipm == IPX_STATUS_imprecise) {
-    control_.Log() << Textline("objective value:") << sci8(info_.pobjval)
-                   << '\n'
-                   << Textline("interior solution primal residual (abs/rel):")
-                   << sci2(info_.abs_presidual) << " / "
-                   << sci2(info_.rel_presidual) << '\n'
-                   << Textline("interior solution dual residual (abs/rel):")
-                   << sci2(info_.abs_dresidual) << " / "
-                   << sci2(info_.rel_dresidual) << '\n'
-                   << Textline("interior solution objective gap (abs/rel):")
-                   << sci2(info_.pobjval - info_.dobjval) << " / "
-                   << sci2(info_.rel_objgap) << '\n';
-  }
-  if (info_.status_crossover == IPX_STATUS_optimal ||
-      info_.status_crossover == IPX_STATUS_imprecise) {
-    control_.Log() << Textline("basic solution primal infeasibility:")
-                   << sci2(info_.primal_infeas) << '\n'
-                   << Textline("basic solution dual infeasibility:")
-                   << sci2(info_.dual_infeas) << '\n';
-  }
+    control_.Log() << "Summary\n"
+                   << Textline("Runtime:") << fix2(control_.Elapsed()) << "s\n"
+                   << Textline("Status interior point solve:")
+                   << StatusString(info_.status_ipm) << '\n'
+                   << Textline("Status crossover:")
+                   << StatusString(info_.status_crossover) << '\n';
+    if (info_.status_ipm == IPX_STATUS_optimal ||
+        info_.status_ipm == IPX_STATUS_imprecise) {
+        control_.Log()
+            << Textline("objective value:") << sci8(info_.pobjval) << '\n'
+            << Textline("interior solution primal residual (abs/rel):")
+            << sci2(info_.abs_presidual) << " / " << sci2(info_.rel_presidual)
+            << '\n'
+            << Textline("interior solution dual residual (abs/rel):")
+            << sci2(info_.abs_dresidual) << " / " << sci2(info_.rel_dresidual)
+            << '\n'
+            << Textline("interior solution objective gap (abs/rel):")
+            << sci2(info_.pobjval-info_.dobjval) << " / "
+            << sci2(info_.rel_objgap)  << '\n';
+    }
+    if (info_.status_crossover == IPX_STATUS_optimal ||
+        info_.status_crossover == IPX_STATUS_imprecise) {
+        control_.Log()
+            << Textline("basic solution primal infeasibility:")
+            << sci2(info_.primal_infeas) << '\n'
+            << Textline("basic solution dual infeasibility:")
+            << sci2(info_.dual_infeas) << '\n';
+    }
 }
 
 }  // namespace ipx

--- a/src/ipm/ipx/src/lp_solver.cc
+++ b/src/ipm/ipx/src/lp_solver.cc
@@ -1,10 +1,12 @@
 // Copyright (c) 2018 ERGO-Code. See license.txt for license.
 
 #include "lp_solver.h"
+
 #include <algorithm>
 #include <cassert>
-#include <vector>
 #include <utility>
+#include <vector>
+
 #include "crossover.h"
 #include "info.h"
 #include "kkt_solver_basis.h"
@@ -18,439 +20,417 @@ Int LpSolver::Solve(Int num_var, const double* obj, const double* lb,
                     const double* ub, Int num_constr, const Int* Ap,
                     const Int* Ai, const double* Ax, const double* rhs,
                     const char* constr_type) {
-    ClearModel();
-    control_.ResetTimer();
-    control_.OpenLogfile();
-    control_.Log() << "IPX version 1.0\n";
-    try {
-        model_.Load(control_, num_constr, num_var, Ap, Ai, Ax, rhs, constr_type,
-                    obj, lb, ub, &info_);
-        if (info_.errflag) {
-            control_.CloseLogfile();
-            return info_.status = IPX_STATUS_invalid_input;
-        }
-        InteriorPointSolve();
-        if ((info_.status_ipm == IPX_STATUS_optimal ||
-             info_.status_ipm == IPX_STATUS_imprecise) && control_.crossover())
-            RunCrossover();
-        if (basis_) {
-            info_.ftran_sparse = basis_->frac_ftran_sparse();
-            info_.btran_sparse = basis_->frac_btran_sparse();
-            info_.time_lu_invert = basis_->time_factorize();
-            info_.time_lu_update = basis_->time_update();
-            info_.time_ftran = basis_->time_ftran();
-            info_.time_btran = basis_->time_btran();
-            info_.mean_fill = basis_->mean_fill();
-            info_.max_fill = basis_->max_fill();
-        }
-        if (info_.status_ipm == IPX_STATUS_primal_infeas ||
-            info_.status_ipm == IPX_STATUS_dual_infeas ||
-            info_.status_crossover == IPX_STATUS_primal_infeas ||
-            info_.status_crossover == IPX_STATUS_dual_infeas) {
-            // When IPM or crossover detect the model to be infeasible
-            // (currently only the former is implemented), then the problem is
-            // solved.
-            info_.status = IPX_STATUS_solved;
-        } else {
-            Int method_status = control_.crossover() ?
-                info_.status_crossover : info_.status_ipm;
-            if (method_status == IPX_STATUS_optimal ||
-                method_status == IPX_STATUS_imprecise)
-                info_.status = IPX_STATUS_solved;
-            else
-                info_.status = IPX_STATUS_stopped;
-        }
-        PrintSummary();
+  ClearModel();
+  control_.ResetTimer();
+  control_.OpenLogfile();
+  control_.Log() << "IPX version 1.0\n";
+  try {
+    model_.Load(control_, num_constr, num_var, Ap, Ai, Ax, rhs, constr_type,
+                obj, lb, ub, &info_);
+    if (info_.errflag) {
+      control_.CloseLogfile();
+      return info_.status = IPX_STATUS_invalid_input;
     }
-    catch (const std::bad_alloc&) {
-        control_.Log() << " out of memory\n";
-        info_.status = IPX_STATUS_out_of_memory;
+    InteriorPointSolve();
+    if ((info_.status_ipm == IPX_STATUS_optimal ||
+         info_.status_ipm == IPX_STATUS_imprecise) &&
+        control_.crossover())
+      RunCrossover();
+    if (basis_) {
+      info_.ftran_sparse = basis_->frac_ftran_sparse();
+      info_.btran_sparse = basis_->frac_btran_sparse();
+      info_.time_lu_invert = basis_->time_factorize();
+      info_.time_lu_update = basis_->time_update();
+      info_.time_ftran = basis_->time_ftran();
+      info_.time_btran = basis_->time_btran();
+      info_.mean_fill = basis_->mean_fill();
+      info_.max_fill = basis_->max_fill();
     }
-    catch (const std::exception& e) {
-        control_.Log() << " internal error: " << e.what() << '\n';
-        info_.status = IPX_STATUS_internal_error;
+    if (info_.status_ipm == IPX_STATUS_primal_infeas ||
+        info_.status_ipm == IPX_STATUS_dual_infeas ||
+        info_.status_crossover == IPX_STATUS_primal_infeas ||
+        info_.status_crossover == IPX_STATUS_dual_infeas) {
+      // When IPM or crossover detect the model to be infeasible
+      // (currently only the former is implemented), then the problem is
+      // solved.
+      info_.status = IPX_STATUS_solved;
+    } else {
+      Int method_status =
+          control_.crossover() ? info_.status_crossover : info_.status_ipm;
+      if (method_status == IPX_STATUS_optimal ||
+          method_status == IPX_STATUS_imprecise)
+        info_.status = IPX_STATUS_solved;
+      else
+        info_.status = IPX_STATUS_stopped;
     }
-    info_.time_total = control_.Elapsed();
-    control_.Debug(2) << info_;
-    control_.CloseLogfile();
-    return info_.status;
+    PrintSummary();
+  } catch (const std::bad_alloc&) {
+    control_.Log() << " out of memory\n";
+    info_.status = IPX_STATUS_out_of_memory;
+  } catch (const std::exception& e) {
+    control_.Log() << " internal error: " << e.what() << '\n';
+    info_.status = IPX_STATUS_internal_error;
+  }
+  info_.time_total = control_.Elapsed();
+  control_.Debug(2) << info_;
+  control_.CloseLogfile();
+  return info_.status;
 }
 
-Info LpSolver::GetInfo() const {
-    return info_;
-}
+Info LpSolver::GetInfo() const { return info_; }
 
 Int LpSolver::GetInteriorSolution(double* x, double* xl, double* xu,
                                   double* slack, double* y, double* zl,
                                   double* zu) const {
-    if (!iterate_)
-        return -1;
-    model_.PostsolveInteriorSolution(
-        iterate_->x(), iterate_->xl(), iterate_->xu(),
-        iterate_->y(), iterate_->zl(), iterate_->zu(),
-        x, xl, xu, slack, y, zl, zu);
-    return 0;
+  if (!iterate_) return -1;
+  model_.PostsolveInteriorSolution(
+      iterate_->x(), iterate_->xl(), iterate_->xu(), iterate_->y(),
+      iterate_->zl(), iterate_->zu(), x, xl, xu, slack, y, zl, zu);
+  return 0;
 }
 
 Int LpSolver::GetBasicSolution(double* x, double* slack, double* y, double* z,
                                Int* cbasis, Int* vbasis) const {
-    if (basic_statuses_.empty())
-        return -1;
-    model_.PostsolveBasicSolution(x_crossover_, y_crossover_, z_crossover_,
-                                  basic_statuses_, x, slack, y, z);
-    model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
-    return 0;
+  if (basic_statuses_.empty()) return -1;
+  model_.PostsolveBasicSolution(x_crossover_, y_crossover_, z_crossover_,
+                                basic_statuses_, x, slack, y, z);
+  model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
+  return 0;
 }
 
-Parameters LpSolver::GetParameters() const {
-    return control_.parameters();
-}
+Parameters LpSolver::GetParameters() const { return control_.parameters(); }
 
 void LpSolver::SetParameters(Parameters new_parameters) {
-    control_.parameters(new_parameters);
+  control_.parameters(new_parameters);
 }
 
 void LpSolver::ClearModel() {
-    info_ = Info();
-    model_.clear();
-    iterate_.reset(nullptr);
-    basis_.reset(nullptr);
-    x_crossover_.resize(0);
-    y_crossover_.resize(0);
-    z_crossover_.resize(0);
-    basic_statuses_.clear();
-    basic_statuses_.shrink_to_fit();
+  info_ = Info();
+  model_.clear();
+  iterate_.reset(nullptr);
+  basis_.reset(nullptr);
+  x_crossover_.resize(0);
+  y_crossover_.resize(0);
+  z_crossover_.resize(0);
+  basic_statuses_.clear();
+  basic_statuses_.shrink_to_fit();
 }
 
 Int LpSolver::GetIterate(double* x, double* y, double* zl, double* zu,
                          double* xl, double* xu) {
-    if (!iterate_)
-        return -1;
-    if (x)
-        std::copy(std::begin(iterate_->x()), std::end(iterate_->x()), x);
-    if (y)
-        std::copy(std::begin(iterate_->y()), std::end(iterate_->y()), y);
-    if (zl)
-        std::copy(std::begin(iterate_->zl()), std::end(iterate_->zl()), zl);
-    if (zu)
-        std::copy(std::begin(iterate_->zu()), std::end(iterate_->zu()), zu);
-    if (xl)
-        std::copy(std::begin(iterate_->xl()), std::end(iterate_->xl()), xl);
-    if (xu)
-        std::copy(std::begin(iterate_->xu()), std::end(iterate_->xu()), xu);
-    return 0;
+  if (!iterate_) return -1;
+  if (x) std::copy(std::begin(iterate_->x()), std::end(iterate_->x()), x);
+  if (y) std::copy(std::begin(iterate_->y()), std::end(iterate_->y()), y);
+  if (zl) std::copy(std::begin(iterate_->zl()), std::end(iterate_->zl()), zl);
+  if (zu) std::copy(std::begin(iterate_->zu()), std::end(iterate_->zu()), zu);
+  if (xl) std::copy(std::begin(iterate_->xl()), std::end(iterate_->xl()), xl);
+  if (xu) std::copy(std::begin(iterate_->xu()), std::end(iterate_->xu()), xu);
+  return 0;
 }
 
 // Returns a vector of basic statuses that is consistent with the basis and
 // the bounds from the model.
 static std::vector<Int> BuildBasicStatuses(const Basis& basis) {
-    const Model& model = basis.model();
-    const Int m = model.rows();
-    const Int n = model.cols();
-    const Vector& lb = model.lb();
-    const Vector& ub = model.ub();
-    std::vector<Int> basic_statuses(n+m);
-    for (Int j = 0; j < n+m; j++) {
-        if (basis.IsBasic(j)) {
-            basic_statuses[j] = IPX_basic;
-        } else if (std::isfinite(lb[j])) {
-            basic_statuses[j] = IPX_nonbasic_lb;
-        } else if (std::isfinite(ub[j])) {
-            basic_statuses[j] = IPX_nonbasic_ub;
-        } else {
-            basic_statuses[j] = IPX_superbasic;
-        }
+  const Model& model = basis.model();
+  const Int m = model.rows();
+  const Int n = model.cols();
+  const Vector& lb = model.lb();
+  const Vector& ub = model.ub();
+  std::vector<Int> basic_statuses(n + m);
+  for (Int j = 0; j < n + m; j++) {
+    if (basis.IsBasic(j)) {
+      basic_statuses[j] = IPX_basic;
+    } else if (std::isfinite(lb[j])) {
+      basic_statuses[j] = IPX_nonbasic_lb;
+    } else if (std::isfinite(ub[j])) {
+      basic_statuses[j] = IPX_nonbasic_ub;
+    } else {
+      basic_statuses[j] = IPX_superbasic;
     }
-    return basic_statuses;
+  }
+  return basic_statuses;
 }
 
 Int LpSolver::GetBasis(Int* cbasis, Int* vbasis) {
-    if (!basis_)
-        return -1;
-    if (!basic_statuses_.empty()) {
-        // crossover provides basic statuses
-        model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
-    } else {
-        model_.PostsolveBasis(BuildBasicStatuses(*basis_), cbasis, vbasis);
-    }
-    return 0;
+  if (!basis_) return -1;
+  if (!basic_statuses_.empty()) {
+    // crossover provides basic statuses
+    model_.PostsolveBasis(basic_statuses_, cbasis, vbasis);
+  } else {
+    model_.PostsolveBasis(BuildBasicStatuses(*basis_), cbasis, vbasis);
+  }
+  return 0;
 }
 
 Int LpSolver::GetKKTMatrix(Int* AIp, Int* AIi, double* AIx, double* g) {
-    if (!iterate_)
-        return -1;
-    if (AIp && AIi && AIx) {
-        const SparseMatrix& AI = model_.AI();
-        std::copy_n(AI.colptr(), AI.cols()+1, AIp);
-        std::copy_n(AI.rowidx(), AI.entries(), AIi);
-        std::copy_n(AI.values(), AI.entries(), AIx);
+  if (!iterate_) return -1;
+  if (AIp && AIi && AIx) {
+    const SparseMatrix& AI = model_.AI();
+    std::copy_n(AI.colptr(), AI.cols() + 1, AIp);
+    std::copy_n(AI.rowidx(), AI.entries(), AIi);
+    std::copy_n(AI.values(), AI.entries(), AIx);
+  }
+  if (g) {
+    Int m = model_.rows();
+    Int n = model_.cols();
+    for (Int j = 0; j < n + m; j++) {
+      switch (iterate_->StateOf(j)) {
+        case Iterate::State::fixed:
+          g[j] = INFINITY;
+          break;
+        case Iterate::State::free:
+          g[j] = 0.0;
+          break;
+        case Iterate::State::barrier:
+          g[j] = iterate_->zl(j) / iterate_->xl(j) +
+                 iterate_->zu(j) / iterate_->xu(j);
+          assert(std::isfinite(g[j]));
+          assert(g[j] > 0.0);
+          break;
+        default:
+          assert(0);
+      }
     }
-    if (g) {
-        Int m = model_.rows();
-        Int n = model_.cols();
-        for (Int j = 0; j < n+m; j++) {
-            switch (iterate_->StateOf(j)) {
-            case Iterate::State::fixed:
-                g[j] = INFINITY;
-                break;
-            case Iterate::State::free:
-                g[j] = 0.0;
-                break;
-            case Iterate::State::barrier:
-                g[j] = iterate_->zl(j)/iterate_->xl(j) +
-                    iterate_->zu(j)/iterate_->xu(j);
-                assert(std::isfinite(g[j]));
-                assert(g[j] > 0.0);
-                break;
-            default:
-                assert(0);
-            }
-        }
-    }
-    return 0;
+  }
+  return 0;
 }
 
 Int LpSolver::SymbolicInvert(Int* rowcounts, Int* colcounts) {
-    if (!basis_)
-        return -1;
-    basis_->SymbolicInvert(rowcounts, colcounts);
-    return 0;
+  if (!basis_) return -1;
+  basis_->SymbolicInvert(rowcounts, colcounts);
+  return 0;
 }
 
 void LpSolver::InteriorPointSolve() {
-    control_.Log() << "Interior Point Solve\n";
+  control_.Log() << "Interior Point Solve\n";
 
-    // Allocate new iterate and set tolerances for IPM termination test.
-    iterate_.reset(new Iterate(model_));
-    iterate_->feasibility_tol(control_.ipm_feasibility_tol());
-    iterate_->optimality_tol(control_.ipm_optimality_tol());
-    if (control_.crossover())
-        iterate_->crossover_start(control_.crossover_start());
+  // Allocate new iterate and set tolerances for IPM termination test.
+  iterate_.reset(new Iterate(model_));
+  iterate_->feasibility_tol(control_.ipm_feasibility_tol());
+  iterate_->optimality_tol(control_.ipm_optimality_tol());
+  if (control_.crossover())
+    iterate_->crossover_start(control_.crossover_start());
 
-    RunIPM();
+  RunIPM();
 
-    iterate_->Postprocess();
-    iterate_->EvaluatePostsolved(&info_);
+  iterate_->Postprocess();
+  iterate_->EvaluatePostsolved(&info_);
 
-    // Declare status_ipm "imprecise" if the IPM terminated optimal but the
-    // solution after postprocessing/postsolve does not satisfy tolerances.
-    if (info_.status_ipm == IPX_STATUS_optimal) {
-        if (std::abs(info_.rel_objgap) > control_.ipm_optimality_tol() ||
-            info_.rel_presidual > control_.ipm_feasibility_tol() ||
-            info_.rel_dresidual > control_.ipm_feasibility_tol())
-            info_.status_ipm = IPX_STATUS_imprecise;
-    }
+  // Declare status_ipm "imprecise" if the IPM terminated optimal but the
+  // solution after postprocessing/postsolve does not satisfy tolerances.
+  if (info_.status_ipm == IPX_STATUS_optimal) {
+    if (std::abs(info_.rel_objgap) > control_.ipm_optimality_tol() ||
+        info_.rel_presidual > control_.ipm_feasibility_tol() ||
+        info_.rel_dresidual > control_.ipm_feasibility_tol())
+      info_.status_ipm = IPX_STATUS_imprecise;
+  }
 }
 
 void LpSolver::RunIPM() {
-    IPM ipm(control_);
+  IPM ipm(control_);
 
-    ComputeStartingPoint(ipm);
-    if (info_.status_ipm != IPX_STATUS_not_run)
-        return;
-    RunInitialIPM(ipm);
-    if (info_.status_ipm != IPX_STATUS_not_run)
-        return;
-    BuildStartingBasis();
-    if (info_.status_ipm != IPX_STATUS_not_run)
-        return;
-    RunMainIPM(ipm);
+  ComputeStartingPoint(ipm);
+  if (info_.status_ipm != IPX_STATUS_not_run) return;
+  RunInitialIPM(ipm);
+  if (info_.status_ipm != IPX_STATUS_not_run) return;
+  BuildStartingBasis();
+  if (info_.status_ipm != IPX_STATUS_not_run) return;
+  RunMainIPM(ipm);
 }
 
 void LpSolver::ComputeStartingPoint(IPM& ipm) {
-    Timer timer;
-    KKTSolverDiag kkt(control_, model_);
+  Timer timer;
+  KKTSolverDiag kkt(control_, model_);
 
-    // If the starting point procedure fails, then iterate_ remains as
-    // initialized by the constructor, which is a valid state for
-    // postprocessing/postsolving.
-    ipm.StartingPoint(&kkt, iterate_.get(), &info_);
-    info_.time_ipm1 += timer.Elapsed();
+  // If the starting point procedure fails, then iterate_ remains as
+  // initialized by the constructor, which is a valid state for
+  // postprocessing/postsolving.
+  ipm.StartingPoint(&kkt, iterate_.get(), &info_);
+  info_.time_ipm1 += timer.Elapsed();
 }
 
 void LpSolver::RunInitialIPM(IPM& ipm) {
-    Timer timer;
-    KKTSolverDiag kkt(control_, model_);
+  Timer timer;
+  KKTSolverDiag kkt(control_, model_);
 
-    Int switchiter = control_.switchiter();
-    if (switchiter < 0) {
-        // Switch iteration not specified by user. Run as long as KKT solver
-        // converges within min(500,10+m/20) iterations.
-        Int m = model_.rows();
-        kkt.maxiter(std::min(500l, (long) (10+m/20) ));
-        ipm.maxiter(control_.ipm_maxiter());
-    } else {
-        ipm.maxiter(std::min(switchiter, control_.ipm_maxiter()));
-    }
-    ipm.Driver(&kkt, iterate_.get(), &info_);
-    switch (info_.status_ipm) {
+  Int switchiter = control_.switchiter();
+  if (switchiter < 0) {
+    // Switch iteration not specified by user. Run as long as KKT solver
+    // converges within min(500,10+m/20) iterations.
+    Int m = model_.rows();
+    kkt.maxiter(std::min(500l, (long)(10 + m / 20)));
+    ipm.maxiter(control_.ipm_maxiter());
+  } else {
+    ipm.maxiter(std::min(switchiter, control_.ipm_maxiter()));
+  }
+  ipm.Driver(&kkt, iterate_.get(), &info_);
+  switch (info_.status_ipm) {
     case IPX_STATUS_optimal:
-        // If the IPM reached its termination criterion in the initial
-        // iterations (happens rarely), we still call the IPM again with basis
-        // preconditioning. In exact arithmetic it would terminate without an
-        // additional iteration. A starting basis is then available for
-        // crossover.
-        info_.status_ipm = IPX_STATUS_not_run;
-        break;
+      // If the IPM reached its termination criterion in the initial
+      // iterations (happens rarely), we still call the IPM again with basis
+      // preconditioning. In exact arithmetic it would terminate without an
+      // additional iteration. A starting basis is then available for
+      // crossover.
+      info_.status_ipm = IPX_STATUS_not_run;
+      break;
     case IPX_STATUS_no_progress:
-        info_.status_ipm = IPX_STATUS_not_run;
-        break;
+      info_.status_ipm = IPX_STATUS_not_run;
+      break;
     case IPX_STATUS_failed:
-        info_.status_ipm = IPX_STATUS_not_run;
-        info_.errflag = 0;
-        break;
+      info_.status_ipm = IPX_STATUS_not_run;
+      info_.errflag = 0;
+      break;
     case IPX_STATUS_iter_limit:
-        if (info_.iter < control_.ipm_maxiter()) // stopped at switchiter
-            info_.status_ipm = IPX_STATUS_not_run;
-    }
-    info_.time_ipm1 += timer.Elapsed();
+      if (info_.iter < control_.ipm_maxiter())  // stopped at switchiter
+        info_.status_ipm = IPX_STATUS_not_run;
+  }
+  info_.time_ipm1 += timer.Elapsed();
 }
 
 void LpSolver::BuildStartingBasis() {
-    if (control_.stop_at_switch() < 0) {
-        info_.status_ipm = IPX_STATUS_debug;
-        return;
-    }
-    basis_.reset(new Basis(control_, model_));
-    control_.Log() << " Constructing starting basis...\n";
-    StartingBasis(iterate_.get(), basis_.get(), &info_);
-    if (info_.errflag == IPX_ERROR_interrupt_time) {
-        info_.errflag = 0;
-        info_.status_ipm = IPX_STATUS_time_limit;
-        return;
-    } else if (info_.errflag) {
-        info_.status_ipm = IPX_STATUS_failed;
-        return;
-    }
-    if (model_.dualized()) {
-        std::swap(info_.dependent_rows, info_.dependent_cols);
-        std::swap(info_.rows_inconsistent, info_.cols_inconsistent);
-    }
-    if (control_.stop_at_switch() > 0) {
-        info_.status_ipm = IPX_STATUS_debug;
-        return;
-    }
-    if (info_.rows_inconsistent) {
-        info_.status_ipm = IPX_STATUS_primal_infeas;
-        return;
-    }
-    if (info_.cols_inconsistent) {
-        info_.status_ipm = IPX_STATUS_dual_infeas;
-        return;
-    }
+  if (control_.stop_at_switch() < 0) {
+    info_.status_ipm = IPX_STATUS_debug;
+    return;
+  }
+  basis_.reset(new Basis(control_, model_));
+  control_.Log() << " Constructing starting basis...\n";
+  StartingBasis(iterate_.get(), basis_.get(), &info_);
+  if (info_.errflag == IPX_ERROR_interrupt_time) {
+    info_.errflag = 0;
+    info_.status_ipm = IPX_STATUS_time_limit;
+    return;
+  } else if (info_.errflag) {
+    info_.status_ipm = IPX_STATUS_failed;
+    return;
+  }
+  if (model_.dualized()) {
+    std::swap(info_.dependent_rows, info_.dependent_cols);
+    std::swap(info_.rows_inconsistent, info_.cols_inconsistent);
+  }
+  if (control_.stop_at_switch() > 0) {
+    info_.status_ipm = IPX_STATUS_debug;
+    return;
+  }
+  if (info_.rows_inconsistent) {
+    info_.status_ipm = IPX_STATUS_primal_infeas;
+    return;
+  }
+  if (info_.cols_inconsistent) {
+    info_.status_ipm = IPX_STATUS_dual_infeas;
+    return;
+  }
 }
 
 void LpSolver::RunMainIPM(IPM& ipm) {
-    KKTSolverBasis kkt(control_, *basis_);
-    Timer timer;
-    ipm.maxiter(control_.ipm_maxiter());
-    ipm.Driver(&kkt, iterate_.get(), &info_);
-    info_.time_ipm2 = timer.Elapsed();
+  KKTSolverBasis kkt(control_, *basis_);
+  Timer timer;
+  ipm.maxiter(control_.ipm_maxiter());
+  ipm.Driver(&kkt, iterate_.get(), &info_);
+  info_.time_ipm2 = timer.Elapsed();
 }
 
 void LpSolver::RunCrossover() {
-    control_.Log() << "Crossover\n";
-    assert(basis_);
-    const Int m = model_.rows();
-    const Int n = model_.cols();
-    const Vector& lb = model_.lb();
-    const Vector& ub = model_.ub();
-    basic_statuses_.clear();
+  control_.Log() << "Crossover\n";
+  assert(basis_);
+  const Int m = model_.rows();
+  const Int n = model_.cols();
+  const Vector& lb = model_.lb();
+  const Vector& ub = model_.ub();
+  basic_statuses_.clear();
 
-    // Construct a complementary primal-dual point from the final IPM iterate.
-    // This usually increases the residuals to Ax=b and A'y+z=c.
-    x_crossover_.resize(n+m);
-    y_crossover_.resize(m);
-    z_crossover_.resize(n+m);
-    iterate_->DropToComplementarity(x_crossover_, y_crossover_, z_crossover_);
+  // Construct a complementary primal-dual point from the final IPM iterate.
+  // This usually increases the residuals to Ax=b and A'y+z=c.
+  x_crossover_.resize(n + m);
+  y_crossover_.resize(m);
+  z_crossover_.resize(n + m);
+  iterate_->DropToComplementarity(x_crossover_, y_crossover_, z_crossover_);
 
-    // Run crossover. Perform dual pushes in increasing order and primal pushes
-    // in decreasing order of the scaling factors from the final IPM iterate.
-    {
-        Vector weights(n+m);
-        for (Int j = 0; j < n+m; j++)
-            weights[j] = iterate_->ScalingFactor(j);
-        Crossover crossover(control_);
-        crossover.PushAll(basis_.get(), x_crossover_, y_crossover_,
-                          z_crossover_, &weights[0], &info_);
-        info_.time_crossover =
-            crossover.time_primal() + crossover.time_dual();
-        info_.updates_crossover =
-            crossover.primal_pivots() + crossover.dual_pivots();
-        if (info_.status_crossover != IPX_STATUS_optimal) {
-            // Crossover failed. Discard solution.
-            x_crossover_.resize(0);
-            y_crossover_.resize(0);
-            z_crossover_.resize(0);
-            return;
-        }
+  // Run crossover. Perform dual pushes in increasing order and primal pushes
+  // in decreasing order of the scaling factors from the final IPM iterate.
+  {
+    Vector weights(n + m);
+    for (Int j = 0; j < n + m; j++) weights[j] = iterate_->ScalingFactor(j);
+    Crossover crossover(control_);
+    crossover.PushAll(basis_.get(), x_crossover_, y_crossover_, z_crossover_,
+                      &weights[0], &info_);
+    info_.time_crossover = crossover.time_primal() + crossover.time_dual();
+    info_.updates_crossover =
+        crossover.primal_pivots() + crossover.dual_pivots();
+    info_.pushes_crossover =
+        crossover.primal_pushes() + crossover.dual_pushes();
+    if (info_.status_crossover != IPX_STATUS_optimal) {
+      // Crossover failed. Discard solution.
+      x_crossover_.resize(0);
+      y_crossover_.resize(0);
+      z_crossover_.resize(0);
+      return;
     }
+  }
 
-    // Recompute vertex solution and set basic statuses.
-    basis_->ComputeBasicSolution(x_crossover_, y_crossover_, z_crossover_);
-    basic_statuses_.resize(n+m);
-    for (Int j = 0; j < (Int) basic_statuses_.size(); j++) {
-        if (basis_->IsBasic(j)) {
-            basic_statuses_[j] = IPX_basic;
-        } else {
-            if (lb[j] == ub[j])
-                basic_statuses_[j] = z_crossover_[j] >= 0.0 ?
-                    IPX_nonbasic_lb : IPX_nonbasic_ub;
-            else if (x_crossover_[j] == lb[j])
-                basic_statuses_[j] = IPX_nonbasic_lb;
-            else if (x_crossover_[j] == ub[j])
-                basic_statuses_[j] = IPX_nonbasic_ub;
-            else
-                basic_statuses_[j] = IPX_superbasic;
-        }
+  // Recompute vertex solution and set basic statuses.
+  basis_->ComputeBasicSolution(x_crossover_, y_crossover_, z_crossover_);
+  basic_statuses_.resize(n + m);
+  for (Int j = 0; j < (Int)basic_statuses_.size(); j++) {
+    if (basis_->IsBasic(j)) {
+      basic_statuses_[j] = IPX_basic;
+    } else {
+      if (lb[j] == ub[j])
+        basic_statuses_[j] =
+            z_crossover_[j] >= 0.0 ? IPX_nonbasic_lb : IPX_nonbasic_ub;
+      else if (x_crossover_[j] == lb[j])
+        basic_statuses_[j] = IPX_nonbasic_lb;
+      else if (x_crossover_[j] == ub[j])
+        basic_statuses_[j] = IPX_nonbasic_ub;
+      else
+        basic_statuses_[j] = IPX_superbasic;
     }
-    control_.Debug()
-        << Textline("Bound violation of basic solution:")
-        << sci2(PrimalInfeasibility(model_, x_crossover_)) << '\n'
-        << Textline("Dual sign violation of basic solution:")
-        << sci2(DualInfeasibility(model_, x_crossover_, z_crossover_)) << '\n';
-    control_.Debug()
-        << Textline("Minimum singular value of basis matrix:")
-        << sci2(basis_->MinSingularValue()) << '\n';
+  }
+  control_.Debug() << Textline("Bound violation of basic solution:")
+                   << sci2(PrimalInfeasibility(model_, x_crossover_)) << '\n'
+                   << Textline("Dual sign violation of basic solution:")
+                   << sci2(
+                          DualInfeasibility(model_, x_crossover_, z_crossover_))
+                   << '\n';
+  control_.Debug() << Textline("Minimum singular value of basis matrix:")
+                   << sci2(basis_->MinSingularValue()) << '\n';
 
-    // Declare crossover status "imprecise" if the vertex solution defined by
-    // the final basis does not satisfy tolerances.
-    model_.EvaluateBasicSolution(x_crossover_, y_crossover_, z_crossover_,
-                                 basic_statuses_, &info_);
-    if (info_.primal_infeas > control_.pfeasibility_tol() ||
-        info_.dual_infeas > control_.dfeasibility_tol())
-        info_.status_crossover = IPX_STATUS_imprecise;
+  // Declare crossover status "imprecise" if the vertex solution defined by
+  // the final basis does not satisfy tolerances.
+  model_.EvaluateBasicSolution(x_crossover_, y_crossover_, z_crossover_,
+                               basic_statuses_, &info_);
+  if (info_.primal_infeas > control_.pfeasibility_tol() ||
+      info_.dual_infeas > control_.dfeasibility_tol())
+    info_.status_crossover = IPX_STATUS_imprecise;
 }
 
 void LpSolver::PrintSummary() {
-    control_.Log() << "Summary\n"
-                   << Textline("Runtime:") << fix2(control_.Elapsed()) << "s\n"
-                   << Textline("Status interior point solve:")
-                   << StatusString(info_.status_ipm) << '\n'
-                   << Textline("Status crossover:")
-                   << StatusString(info_.status_crossover) << '\n';
-    if (info_.status_ipm == IPX_STATUS_optimal ||
-        info_.status_ipm == IPX_STATUS_imprecise) {
-        control_.Log()
-            << Textline("objective value:") << sci8(info_.pobjval) << '\n'
-            << Textline("interior solution primal residual (abs/rel):")
-            << sci2(info_.abs_presidual) << " / " << sci2(info_.rel_presidual)
-            << '\n'
-            << Textline("interior solution dual residual (abs/rel):")
-            << sci2(info_.abs_dresidual) << " / " << sci2(info_.rel_dresidual)
-            << '\n'
-            << Textline("interior solution objective gap (abs/rel):")
-            << sci2(info_.pobjval-info_.dobjval) << " / "
-            << sci2(info_.rel_objgap)  << '\n';
-    }
-    if (info_.status_crossover == IPX_STATUS_optimal ||
-        info_.status_crossover == IPX_STATUS_imprecise) {
-        control_.Log()
-            << Textline("basic solution primal infeasibility:")
-            << sci2(info_.primal_infeas) << '\n'
-            << Textline("basic solution dual infeasibility:")
-            << sci2(info_.dual_infeas) << '\n';
-    }
+  control_.Log() << "Summary\n"
+                 << Textline("Runtime:") << fix2(control_.Elapsed()) << "s\n"
+                 << Textline("Status interior point solve:")
+                 << StatusString(info_.status_ipm) << '\n'
+                 << Textline("Status crossover:")
+                 << StatusString(info_.status_crossover) << '\n';
+  if (info_.status_ipm == IPX_STATUS_optimal ||
+      info_.status_ipm == IPX_STATUS_imprecise) {
+    control_.Log() << Textline("objective value:") << sci8(info_.pobjval)
+                   << '\n'
+                   << Textline("interior solution primal residual (abs/rel):")
+                   << sci2(info_.abs_presidual) << " / "
+                   << sci2(info_.rel_presidual) << '\n'
+                   << Textline("interior solution dual residual (abs/rel):")
+                   << sci2(info_.abs_dresidual) << " / "
+                   << sci2(info_.rel_dresidual) << '\n'
+                   << Textline("interior solution objective gap (abs/rel):")
+                   << sci2(info_.pobjval - info_.dobjval) << " / "
+                   << sci2(info_.rel_objgap) << '\n';
+  }
+  if (info_.status_crossover == IPX_STATUS_optimal ||
+      info_.status_crossover == IPX_STATUS_imprecise) {
+    control_.Log() << Textline("basic solution primal infeasibility:")
+                   << sci2(info_.primal_infeas) << '\n'
+                   << Textline("basic solution dual infeasibility:")
+                   << sci2(info_.dual_infeas) << '\n';
+  }
 }
 
 }  // namespace ipx

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -251,6 +251,7 @@ struct HighsOptionsStruct {
   int simplex_iteration_limit;
   int simplex_update_limit;
   int ipm_iteration_limit;
+  bool run_crossover;
   int highs_min_threads;
   int highs_max_threads;
   int message_level;
@@ -475,6 +476,11 @@ class HighsOptions : public HighsOptionsStruct {
         "ipm_iteration_limit", "Iteration limit for IPM solver", advanced,
         &ipm_iteration_limit, 0, HIGHS_CONST_I_INF, HIGHS_CONST_I_INF);
     records.push_back(record_int);
+
+    record_bool = new OptionRecordBool("run_crossover",
+                                       "Run the crossover routine for IPX",
+                                       advanced, &run_crossover, true);
+    records.push_back(record_bool);
 
     record_int = new OptionRecordInt(
         "highs_min_threads", "Minimum number of threads in parallel execution",


### PR DESCRIPTION
@jajhall had discussed that it might be useful to turn crossover on/off to actual tell the utility of it, how much it costs to run, etc.  Crossover iterations are also always reported as 0 currently, so I've tried to do my best to report a value there.

- Adds a HiGHS option for turning off/on crossover (default true)
- Adds Primal/Dual push counts to IPX info
- Reports Primal/Dual push counts as crossover iterations

Primal/Dual push counts seem to me like they should be forwarded to HiGHS as `crossover_iteration` count, so I have assigned `iteration_counts.crossover` to be the combined push counts.

One unit test is failing due to the change in the way crossover iterations are reported and I do not understand the unit test well enough to comment on how to fix it.