### PR TITLE
Tidy h factor

### DIFF
--- a/check/TestSpecialLps.cpp
+++ b/check/TestSpecialLps.cpp
@@ -448,7 +448,6 @@ void singularStartingBasis(Highs& highs) {
   status = highs.setBasis(basis);
   REQUIRE(status == HighsStatus::OK);
 
-  /*
   status = highs.run();
   REQUIRE(status == HighsStatus::OK);
 
@@ -458,6 +457,7 @@ void singularStartingBasis(Highs& highs) {
   model_status = highs.getModelStatus();
   REQUIRE(model_status == require_model_status);
 
+  /*
   if (require_model_status == HighsModelStatus::OPTIMAL) {
     REQUIRE(objectiveOk(info.objective_function_value, optimal_objective));
   }

--- a/check/TestSpecialLps.cpp
+++ b/check/TestSpecialLps.cpp
@@ -457,7 +457,6 @@ void singularStartingBasis(Highs& highs) {
   model_status = highs.getModelStatus();
   REQUIRE(model_status == require_model_status);
 
-  /*
   if (require_model_status == HighsModelStatus::OPTIMAL) {
     REQUIRE(objectiveOk(info.objective_function_value, optimal_objective));
   }
@@ -465,7 +464,6 @@ void singularStartingBasis(Highs& highs) {
   REQUIRE(status == HighsStatus::OK);
 
   reportSolution(highs);
-  */
 }
 TEST_CASE("LP-272", "[highs_test_special_lps]") {
   Highs highs;

--- a/src/lp_data/HighsSolutionDebug.cpp
+++ b/src/lp_data/HighsSolutionDebug.cpp
@@ -72,7 +72,7 @@ HighsDebugStatus debugHighsBasicSolution(const string message,
                                          const HighsSolution& solution) {
   // Non-trivially expensive analysis of a HiGHS basic solution, starting from
   // options, assuming no knowledge of solution parameters or model status
-  if (options.highs_debug_level < HIGHS_DEBUG_LEVEL_COSTLY)
+  if (options.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
     return HighsDebugStatus::NOT_CHECKED;
 
   // Check that there is a solution and valid basis to use
@@ -116,7 +116,7 @@ HighsDebugStatus debugHighsBasicSolution(
     const HighsModelStatus model_status) {
   // Non-trivially expensive analysis of a HiGHS basic solution, starting from
   // solution_params
-  if (options.highs_debug_level < HIGHS_DEBUG_LEVEL_COSTLY)
+  if (options.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
     return HighsDebugStatus::NOT_CHECKED;
 
   // Check that there is a solution and valid basis to use

--- a/src/lp_data/HighsSolutionDebug.cpp
+++ b/src/lp_data/HighsSolutionDebug.cpp
@@ -443,6 +443,7 @@ bool debugBasicSolutionVariable(
 
     if (primal_infeasibility > primal_feasibility_tolerance) {
       // Outside a bound
+      off_bound_nonbasic = primal_infeasibility;
       dual_infeasibility = 0;
       if (value < lower) {
         query = true;
@@ -455,6 +456,7 @@ bool debugBasicSolutionVariable(
       }
     } else if (primal_residual >= -primal_feasibility_tolerance) {
       // At a bound: check for dual feasibility
+      off_bound_nonbasic = std::fabs(primal_residual);
       if (lower < upper) {
         // Non-fixed variable
         if (value < middle) {

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -256,7 +256,7 @@ HighsStatus runSimplexSolver(HighsModelObject& highs_model_object) {
       }
 
       int& num_scaled_primal_infeasibilities =
-          highs_model_object.scaled_solution_params_.num_primal_infeasibilities;
+          simplex_info.num_primal_infeasibilities;
       if (highs_model_object.scaled_model_status_ ==
               HighsModelStatus::OPTIMAL &&
           num_scaled_primal_infeasibilities) {

--- a/src/simplex/HFactorDebug.cpp
+++ b/src/simplex/HFactorDebug.cpp
@@ -88,9 +88,9 @@ HighsDebugStatus debugCheckInvert(const int highs_debug_level, FILE* output,
       report_level = ML_VERBOSE;
     }
     HighsPrintMessage(
-         output, message_level, report_level,
-	 "CheckINVERT:   %-9s (%9.4g) norm for random solution solve error\n",
-	 value_adjective.c_str(), solve_error_norm);
+        output, message_level, report_level,
+        "CheckINVERT:   %-9s (%9.4g) norm for random solution solve error\n",
+        value_adjective.c_str(), solve_error_norm);
   }
 
   if (highs_debug_level < HIGHS_DEBUG_LEVEL_EXPENSIVE) return return_status;
@@ -144,7 +144,7 @@ HighsDebugStatus debugCheckInvert(const int highs_debug_level, FILE* output,
     }
     HighsPrintMessage(output, message_level, report_level,
                       "CheckINVERT:   %-9s (%9.4g) norm for inverse error\n",
-		      value_adjective.c_str(), inverse_error_norm);
+                      value_adjective.c_str(), inverse_error_norm);
   }
 
   return return_status;

--- a/src/simplex/HFactorDebug.cpp
+++ b/src/simplex/HFactorDebug.cpp
@@ -74,22 +74,24 @@ HighsDebugStatus debugCheckInvert(const int highs_debug_level, FILE* output,
   int report_level;
   return_status = HighsDebugStatus::OK;
 
-  if (solve_error_norm > solve_excessive_error) {
-    value_adjective = "Excessive";
-    report_level = ML_ALWAYS;
-    return_status = HighsDebugStatus::WARNING;
-  } else if (solve_error_norm > solve_large_error) {
-    value_adjective = "Large";
-    report_level = ML_DETAILED;
-    return_status = HighsDebugStatus::WARNING;
-  } else {
-    value_adjective = "Small";
-    report_level = ML_VERBOSE;
+  if (solve_error_norm) {
+    if (solve_error_norm > solve_excessive_error) {
+      value_adjective = "Excessive";
+      report_level = ML_ALWAYS;
+      return_status = HighsDebugStatus::WARNING;
+    } else if (solve_error_norm > solve_large_error) {
+      value_adjective = "Large";
+      report_level = ML_DETAILED;
+      return_status = HighsDebugStatus::WARNING;
+    } else {
+      value_adjective = "Small";
+      report_level = ML_VERBOSE;
+    }
+    HighsPrintMessage(
+         output, message_level, report_level,
+	 "CheckINVERT:   %-9s (%9.4g) norm for random solution solve error\n",
+	 value_adjective.c_str(), solve_error_norm);
   }
-  HighsPrintMessage(
-      output, message_level, report_level,
-      "CheckINVERT:   %-9s (%9.4g) norm for random solution solve error\n",
-      value_adjective.c_str(), solve_error_norm);
 
   if (highs_debug_level < HIGHS_DEBUG_LEVEL_EXPENSIVE) return return_status;
 
@@ -127,21 +129,23 @@ HighsDebugStatus debugCheckInvert(const int highs_debug_level, FILE* output,
     inverse_error_norm =
         std::max(inverse_column_error_norm, inverse_error_norm);
   }
-  if (inverse_error_norm > inverse_excessive_error) {
-    value_adjective = "Excessive";
-    report_level = ML_ALWAYS;
-    return_status = HighsDebugStatus::WARNING;
-  } else if (inverse_error_norm > inverse_large_error) {
-    value_adjective = "Large";
-    report_level = ML_DETAILED;
-    return_status = HighsDebugStatus::WARNING;
-  } else {
-    value_adjective = "Small";
-    report_level = ML_VERBOSE;
+  if (inverse_error_norm) {
+    if (inverse_error_norm > inverse_excessive_error) {
+      value_adjective = "Excessive";
+      report_level = ML_ALWAYS;
+      return_status = HighsDebugStatus::WARNING;
+    } else if (inverse_error_norm > inverse_large_error) {
+      value_adjective = "Large";
+      report_level = ML_DETAILED;
+      return_status = HighsDebugStatus::WARNING;
+    } else {
+      value_adjective = "Small";
+      report_level = ML_VERBOSE;
+    }
+    HighsPrintMessage(output, message_level, report_level,
+                      "CheckINVERT:   %-9s (%9.4g) norm for inverse error\n",
+		      value_adjective.c_str(), inverse_error_norm);
   }
-  HighsPrintMessage(output, message_level, report_level,
-                    "CheckINVERT:   %-9s (%9.4g) norm for inverse error\n",
-                    value_adjective.c_str(), inverse_error_norm);
 
   return return_status;
 }

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -916,8 +916,9 @@ void computeDualObjectiveValue(HighsModelObject& highs_model_object,
   simplex_lp_status.has_dual_objective_value = true;
 }
 
-int setSourceOutFmBd(const HighsModelObject& highs_model_object, const int columnOut) {
-  const HighsSimplexInfo &simplex_info = highs_model_object.simplex_info_;
+int setSourceOutFmBd(const HighsModelObject& highs_model_object,
+                     const int columnOut) {
+  const HighsSimplexInfo& simplex_info = highs_model_object.simplex_info_;
   int sourceOut = 0;
   if (simplex_info.workLower_[columnOut] !=
       simplex_info.workUpper_[columnOut]) {

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -456,10 +456,10 @@ HighsStatus transition(HighsModelObject& highs_model_object) {
         // Finite lower bound so boxed or lower
         if (!highs_isInfinity(upper)) {
           // Finite upper bound so boxed
-	  //
+          //
           // Determine the bound to set the value to according to, in order of
           // priority
-	  //
+          //
           // 1. Any valid HiGHS basis status
           if (have_highs_basis) {
             if (iVar < simplex_lp.numCol_) {
@@ -483,47 +483,49 @@ HighsStatus transition(HighsModelObject& highs_model_object) {
           }
           // 2. Any HiGHS solution value
           if (move == illegal_move_value && have_highs_solution) {
-	    // Reach here if there is no HiGHS basis or the HiGHS
-	    // nonbasic status is just NONBASIC.
+            // Reach here if there is no HiGHS basis or the HiGHS
+            // nonbasic status is just NONBASIC.
             double midpoint = 0.5 * (lower + upper);
-	    double value_from_highs_solution;
+            double value_from_highs_solution;
             if (iVar < simplex_lp.numCol_) {
-	      assert(basis.col_status[iVar] == HighsBasisStatus::NONBASIC);
-	      value_from_highs_solution = solution.col_value[iVar] / scale.col_[iVar];
+              assert(basis.col_status[iVar] == HighsBasisStatus::NONBASIC);
+              value_from_highs_solution =
+                  solution.col_value[iVar] / scale.col_[iVar];
             } else {
               int iRow = iVar - simplex_lp.numCol_;
-	      assert(basis.row_status[iRow] == HighsBasisStatus::NONBASIC);
-	      value_from_highs_solution = -solution.row_value[iRow] * scale.row_[iRow];
+              assert(basis.row_status[iRow] == HighsBasisStatus::NONBASIC);
+              value_from_highs_solution =
+                  -solution.row_value[iRow] * scale.row_[iRow];
             }
-	    if (value_from_highs_solution < midpoint) {
-	      move = NONBASIC_MOVE_UP;
-	      value = lower;
-	    } else {
-	      move = NONBASIC_MOVE_DN;
-	      value = upper;
-	    }
+            if (value_from_highs_solution < midpoint) {
+              move = NONBASIC_MOVE_UP;
+              value = lower;
+            } else {
+              move = NONBASIC_MOVE_DN;
+              value = upper;
+            }
           }
           // 3. Lower bound for original LP
           if (move == illegal_move_value) {
-	    const bool gurobi_initial_value = false;
-	    if (gurobi_initial_value) {
-	      // Set to bound that is closer to zero
-	      if (fabs(lower) < fabs(upper)) {
-		move = NONBASIC_MOVE_UP;
-		value = lower;
-	      } else {
-		move = NONBASIC_MOVE_DN;
-		value = upper;
-	      }
-	    } else {
-	      if (iVar < simplex_lp.numCol_) {
-		move = NONBASIC_MOVE_UP;
-		value = lower;
-	      } else {
-		move = NONBASIC_MOVE_DN;
-		value = upper;
-	      }
-	    }
+            const bool gurobi_initial_value = false;
+            if (gurobi_initial_value) {
+              // Set to bound that is closer to zero
+              if (fabs(lower) < fabs(upper)) {
+                move = NONBASIC_MOVE_UP;
+                value = lower;
+              } else {
+                move = NONBASIC_MOVE_DN;
+                value = upper;
+              }
+            } else {
+              if (iVar < simplex_lp.numCol_) {
+                move = NONBASIC_MOVE_UP;
+                value = lower;
+              } else {
+                move = NONBASIC_MOVE_DN;
+                value = upper;
+              }
+            }
           }
         } else {
           // Lower (since upper bound is infinite)
@@ -540,35 +542,36 @@ HighsStatus transition(HighsModelObject& highs_model_object) {
         value = 0;
       }
       assert(move != illegal_move_value);
+      /*
       if (have_highs_basis && have_highs_solution) {
-	// See how the deduced value differs from the HiGHS solution
-	double debug_solution = 0;
-	std::string debug_type;
-	int debug_index;
-	HighsBasisStatus debug_basis;
-	if (iVar < simplex_lp.numCol_) {
-	  // Column
-	  debug_type = "Col";
-	  debug_index = iVar;
-	  debug_solution = solution.col_value[iVar] / scale.col_[iVar];
-	  debug_basis = basis.col_status[iVar];
-	} else {
-	  int iRow = iVar - simplex_lp.numCol_;
-	  debug_type = "Row";
-	  debug_index = iRow;
-	  debug_solution = -solution.row_value[iRow] * scale.row_[iRow];
-	  debug_basis = basis.row_status[iRow];
-	}
-	const double debug_solution_difference = fabs(debug_solution - value);
-	if (debug_solution_difference>1e-12) {
-	  printf("%s %6d: Difference %g Solution(H%g, %g); Bounds [%g, %g]; Basis(H%2d, S%2d)\n",
-		 debug_type.c_str(), debug_index,
-		 debug_solution_difference,
-		 debug_solution, value,
-		 lower, upper,
-		 (int)debug_basis, move);
-	}
+        // See how the deduced value differs from the HiGHS solution
+        double debug_solution = 0;
+        std::string debug_type;
+        int debug_index;
+        HighsBasisStatus debug_basis;
+        if (iVar < simplex_lp.numCol_) {
+          // Column
+          debug_type = "Col";
+          debug_index = iVar;
+          debug_solution = solution.col_value[iVar] / scale.col_[iVar];
+          debug_basis = basis.col_status[iVar];
+        } else {
+          int iRow = iVar - simplex_lp.numCol_;
+          debug_type = "Row";
+          debug_index = iRow;
+          debug_solution = -solution.row_value[iRow] * scale.row_[iRow];
+          debug_basis = basis.row_status[iRow];
+        }
+        const double debug_solution_difference = fabs(debug_solution - value);
+        if (debug_solution_difference > 1e-12) {
+          printf(
+              "%s %6d: Difference %g Solution(H%g, %g); Bounds [%g, %g]; "
+              "Basis(H%2d, S%2d)\n",
+              debug_type.c_str(), debug_index, debug_solution_difference,
+              debug_solution, value, lower, upper, (int)debug_basis, move);
+        }
       }
+      */
       simplex_info.workValue_[iVar] = value;
       simplex_basis.nonbasicMove_[iVar] = move;
     } else {

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -488,12 +488,14 @@ HighsStatus transition(HighsModelObject& highs_model_object) {
             double midpoint = 0.5 * (lower + upper);
             double value_from_highs_solution;
             if (iVar < simplex_lp.numCol_) {
-              assert(basis.col_status[iVar] == HighsBasisStatus::NONBASIC);
+              assert(!have_highs_basis ||
+                     basis.col_status[iVar] == HighsBasisStatus::NONBASIC);
               value_from_highs_solution =
                   solution.col_value[iVar] / scale.col_[iVar];
             } else {
               int iRow = iVar - simplex_lp.numCol_;
-              assert(basis.row_status[iRow] == HighsBasisStatus::NONBASIC);
+              assert(!have_highs_basis ||
+                     basis.row_status[iRow] == HighsBasisStatus::NONBASIC);
               value_from_highs_solution =
                   -solution.row_value[iRow] * scale.row_[iRow];
             }

--- a/src/simplex/HSimplex.h
+++ b/src/simplex/HSimplex.h
@@ -60,6 +60,9 @@ void computeDualObjectiveValue(HighsModelObject& highs_model_object,
                                int phase = 2);
 
 void computePrimalObjectiveValue(HighsModelObject& highs_model_object);
+
+int setSourceOutFmBd(const HighsModelObject& highs_model_object, const int column_out);
+
 #ifdef HiGHSDEV
 void getPrimalValue(const HighsModelObject& highs_model_object,
                     vector<double>& primal_value);

--- a/src/simplex/HSimplex.h
+++ b/src/simplex/HSimplex.h
@@ -61,7 +61,8 @@ void computeDualObjectiveValue(HighsModelObject& highs_model_object,
 
 void computePrimalObjectiveValue(HighsModelObject& highs_model_object);
 
-int setSourceOutFmBd(const HighsModelObject& highs_model_object, const int column_out);
+int setSourceOutFmBd(const HighsModelObject& highs_model_object,
+                     const int column_out);
 
 #ifdef HiGHSDEV
 void getPrimalValue(const HighsModelObject& highs_model_object,

--- a/src/simplex/HSimplex.h
+++ b/src/simplex/HSimplex.h
@@ -181,6 +181,7 @@ void computeDual(HighsModelObject& highs_model_object);
 
 void correctDual(HighsModelObject& highs_model_object,
                  int* free_infeasibility_count);
+void correctDual(HighsModelObject& highs_model_object);
 
 // Record the shift in the cost of a particular column
 void shift_cost(HighsModelObject& highs_model_object, int iCol, double amount);

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -927,7 +927,7 @@ HighsDebugStatus debugSimplexBasicSolution(
     const string message, const HighsModelObject& highs_model_object) {
   // Non-trivially expensive analysis of a simplex basic solution, starting from
   // solution_params
-  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_COSTLY)
+  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
     return HighsDebugStatus::NOT_CHECKED;
 
   HighsDebugStatus return_status = HighsDebugStatus::NOT_CHECKED;
@@ -1137,7 +1137,7 @@ HighsDebugStatus debugSimplexInfoBasisConsistent(
 HighsDebugStatus debugSimplexHighsSolutionDifferences(
     const HighsModelObject& highs_model_object) {
   // Nontrivially expensive check of dimensions and sizes
-  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_COSTLY)
+  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_CHEAP)
     return HighsDebugStatus::NOT_CHECKED;
 
   const HighsOptions& options = highs_model_object.options_;

--- a/src/simplex/HSimplexDebug.cpp
+++ b/src/simplex/HSimplexDebug.cpp
@@ -1133,3 +1133,188 @@ HighsDebugStatus debugSimplexInfoBasisConsistent(
   }
   return return_status;
 }
+
+HighsDebugStatus debugSimplexHighsSolutionDifferences(
+    const HighsModelObject& highs_model_object) {
+  // Nontrivially expensive check of dimensions and sizes
+  if (highs_model_object.options_.highs_debug_level < HIGHS_DEBUG_LEVEL_COSTLY)
+    return HighsDebugStatus::NOT_CHECKED;
+
+  const HighsOptions& options = highs_model_object.options_;
+  const HighsSolution& solution = highs_model_object.solution_;
+  const HighsLp& simplex_lp = highs_model_object.simplex_lp_;
+  const HighsSimplexInfo& simplex_info = highs_model_object.simplex_info_;
+  const SimplexBasis& simplex_basis = highs_model_object.simplex_basis_;
+  const HighsScale& scale = highs_model_object.scale_;
+
+  HighsDebugStatus return_status = HighsDebugStatus::NOT_CHECKED;
+
+  // Go through the columns, finding the differences in nonbasic column values
+  // and duals
+  double max_nonbasic_col_value_difference = 0;
+  double max_nonbasic_col_dual_difference = 0;
+  for (int iCol = 0; iCol < simplex_lp.numCol_; iCol++) {
+    int iVar = iCol;
+    if (simplex_basis.nonbasicFlag_[iVar] == NONBASIC_FLAG_TRUE) {
+      // Consider this nonbasic column
+      double local_col_value = simplex_info.workValue_[iVar] * scale.col_[iCol];
+      double local_col_dual = (int)simplex_lp.sense_ *
+                              simplex_info.workDual_[iVar] /
+                              (scale.col_[iCol] / scale.cost_);
+      double value_difference =
+          fabs(local_col_value - solution.col_value[iCol]);
+      double dual_difference = fabs(local_col_dual - solution.col_dual[iCol]);
+      max_nonbasic_col_value_difference =
+          std::max(value_difference, max_nonbasic_col_value_difference);
+      max_nonbasic_col_dual_difference =
+          std::max(dual_difference, max_nonbasic_col_dual_difference);
+    }
+  }
+  // Go through the rows, finding the differences in nonbasic and
+  // basic row values and duals, as well as differences in basic
+  // column values and duals
+  double max_nonbasic_row_value_difference = 0;
+  double max_nonbasic_row_dual_difference = 0;
+  double max_basic_col_value_difference = 0;
+  double max_basic_col_dual_difference = 0;
+  double max_basic_row_value_difference = 0;
+  double max_basic_row_dual_difference = 0;
+
+  for (int ix = 0; ix < simplex_lp.numRow_; ix++) {
+    int iRow = ix;
+    int iVar = simplex_lp.numCol_ + iRow;
+    if (simplex_basis.nonbasicFlag_[iVar] == NONBASIC_FLAG_TRUE) {
+      // Consider this nonbasic row
+      double local_row_value =
+          -simplex_info.workValue_[iVar] / scale.row_[iRow];
+      double local_row_dual = (int)simplex_lp.sense_ *
+                              simplex_info.workDual_[iVar] *
+                              (scale.row_[iRow] * scale.cost_);
+      double value_difference =
+          fabs(local_row_value - solution.row_value[iRow]);
+      double dual_difference = fabs(local_row_dual - solution.row_dual[iRow]);
+      max_nonbasic_row_value_difference =
+          std::max(value_difference, max_nonbasic_row_value_difference);
+      max_nonbasic_row_dual_difference =
+          std::max(dual_difference, max_nonbasic_row_dual_difference);
+    }
+    // Consider the basic variable associated with this row index
+    iVar = simplex_basis.basicIndex_[ix];
+    if (iVar < simplex_lp.numCol_) {
+      // Consider this basic column
+      int iCol = iVar;
+      double local_col_value = simplex_info.baseValue_[ix] * scale.col_[iCol];
+      double local_col_dual = 0;
+      double value_difference =
+          fabs(local_col_value - solution.col_value[iCol]);
+      double dual_difference = fabs(local_col_dual - solution.col_dual[iCol]);
+      max_basic_col_value_difference =
+          std::max(value_difference, max_basic_col_value_difference);
+      max_basic_col_dual_difference =
+          std::max(dual_difference, max_basic_col_dual_difference);
+    } else {
+      // Consider this basic row
+      iRow = iVar - simplex_lp.numCol_;
+      double local_row_value = -simplex_info.baseValue_[ix] / scale.row_[iRow];
+      double local_row_dual = 0;
+      double value_difference =
+          fabs(local_row_value - solution.row_value[iRow]);
+      double dual_difference = fabs(local_row_dual - solution.row_dual[iRow]);
+      max_basic_row_value_difference =
+          std::max(value_difference, max_basic_row_value_difference);
+      max_basic_row_dual_difference =
+          std::max(dual_difference, max_basic_row_dual_difference);
+    }
+  }
+
+  HighsPrintMessage(options.output, options.message_level, ML_ALWAYS,
+                    "\nHiGHS-simplex solution differences\n");
+  std::string value_adjective;
+  int report_level;
+  return_status = HighsDebugStatus::OK;
+  if (max_nonbasic_col_value_difference > 0) {
+    value_adjective = "Excessive";
+    report_level = ML_ALWAYS;
+    return_status = debugWorseStatus(HighsDebugStatus::WARNING, return_status);
+    HighsPrintMessage(
+        options.output, options.message_level, report_level,
+        "HighsSimplexD: %-9s Nonbasic column value difference: %9.4g\n",
+        value_adjective.c_str(), max_nonbasic_col_value_difference);
+  }
+  if (max_nonbasic_row_value_difference > 0) {
+    value_adjective = "Excessive";
+    report_level = ML_ALWAYS;
+    return_status = debugWorseStatus(HighsDebugStatus::WARNING, return_status);
+    HighsPrintMessage(
+        options.output, options.message_level, report_level,
+        "HighsSimplexD: %-9s Nonbasic row    value difference: %9.4g\n",
+        value_adjective.c_str(), max_nonbasic_row_value_difference);
+  }
+
+  return_status = debugWorseStatus(
+      debugAssessSolutionNormDifference(options, "Basic   column value",
+                                        max_basic_col_value_difference),
+      return_status);
+  return_status = debugWorseStatus(
+      debugAssessSolutionNormDifference(options, "Basic      row value",
+                                        max_basic_row_value_difference),
+      return_status);
+  return_status = debugWorseStatus(
+      debugAssessSolutionNormDifference(options, "Nonbasic column dual",
+                                        max_nonbasic_col_dual_difference),
+      return_status);
+  return_status = debugWorseStatus(
+      debugAssessSolutionNormDifference(options, "Nonbasic    row dual",
+                                        max_nonbasic_row_dual_difference),
+      return_status);
+
+  if (max_basic_col_dual_difference > 0) {
+    value_adjective = "Excessive";
+    report_level = ML_ALWAYS;
+    return_status = debugWorseStatus(HighsDebugStatus::WARNING, return_status);
+    HighsPrintMessage(
+        options.output, options.message_level, report_level,
+        "HighsSimplexD: %-9s Basic    column dual difference: %9.4g\n",
+        value_adjective.c_str(), max_basic_col_dual_difference);
+  }
+  if (max_basic_row_dual_difference > 0) {
+    value_adjective = "Excessive";
+    report_level = ML_ALWAYS;
+    return_status = debugWorseStatus(HighsDebugStatus::WARNING, return_status);
+    HighsPrintMessage(
+        options.output, options.message_level, report_level,
+        "HighsSimplexD: %-9s Basic    row     dual difference: %9.4g\n",
+        value_adjective.c_str(), max_basic_row_dual_difference);
+  }
+
+  return return_status;
+}
+
+HighsDebugStatus debugAssessSolutionNormDifference(const HighsOptions& options,
+                                                   const std::string type,
+                                                   const double difference) {
+  const double small_difference = 1e-12;
+  const double large_difference = 1e-8;
+  const double excessive_difference = 1e-4;
+  HighsDebugStatus return_status = HighsDebugStatus::OK;
+  if (difference <= small_difference) return return_status;
+  std::string value_adjective;
+  int report_level;
+
+  if (difference > excessive_difference) {
+    value_adjective = "Excessive";
+    report_level = ML_ALWAYS;
+    return_status = HighsDebugStatus::WARNING;
+  } else if (difference > large_difference) {
+    value_adjective = "Large";
+    report_level = ML_DETAILED;
+    return_status = HighsDebugStatus::WARNING;
+  } else {
+    value_adjective = "OK";
+    report_level = ML_VERBOSE;
+  }
+  HighsPrintMessage(options.output, options.message_level, report_level,
+                    "HighsSimplexD: %-9s %s difference: %9.4g\n",
+                    value_adjective.c_str(), type.c_str(), difference);
+  return return_status;
+}

--- a/src/simplex/HSimplexDebug.h
+++ b/src/simplex/HSimplexDebug.h
@@ -70,4 +70,11 @@ HighsDebugStatus debugSimplexBasicSolution(
 
 HighsDebugStatus debugSimplexInfoBasisConsistent(
     const HighsModelObject& highs_model_object);
+
+HighsDebugStatus debugSimplexHighsSolutionDifferences(
+    const HighsModelObject& highs_model_object);
+
+HighsDebugStatus debugAssessSolutionNormDifference(const HighsOptions& options,
+                                                   const std::string type,
+                                                   const double difference);
 #endif  // SIMPLEX_HSIMPLEXDEBUG_H_

--- a/src/simplex/HighsSimplexAnalysis.cpp
+++ b/src/simplex/HighsSimplexAnalysis.cpp
@@ -34,7 +34,7 @@ void HighsSimplexAnalysis::setup(const HighsLp& lp, const HighsOptions& options,
   //
   AnIterIt0 = simplex_iteration_count_;
   AnIterCostlyDseFq = 0;
-  AnIterPrevRpNumCostlyDseIt = 0;
+  AnIterNumCostlyDseIt = 0;
   // Copy messaging parameter from options
   messaging(options.logfile, options.output, options.message_level);
   // Initialise the densities
@@ -180,7 +180,6 @@ void HighsSimplexAnalysis::setup(const HighsLp& lp, const HighsOptions& options,
   num_row_price_with_switch = 0;
   int last_dual_edge_weight_mode = (int)DualEdgeWeightMode::STEEPEST_EDGE;
   for (int k = 0; k <= last_dual_edge_weight_mode; k++) AnIterNumEdWtIt[k] = 0;
-  AnIterNumCostlyDseIt = 0;
   AnIterTraceNumRec = 0;
   AnIterTraceIterDl = 1;
   AnIterTraceRec* lcAnIter = &AnIterTrace[0];

--- a/src/simplex/HighsSimplexAnalysis.h
+++ b/src/simplex/HighsSimplexAnalysis.h
@@ -251,8 +251,6 @@ class HighsSimplexAnalysis {
   const double AnIterFracNumTot_ItBfSw = 0.1;         //!<
   const double AnIterFracNumCostlyDseItbfSw = 0.05;   //!<
   double AnIterCostlyDseMeasure;
-  int AnIterPrevRpNumCostlyDseIt;  //!< Number of costly DSE iterations when
-                                   //!< previously reported
 
   const double accept_weight_threshhold = 0.25;
   const double weight_error_threshhold = 4.0;


### PR DESCRIPTION
Reinstated code to handle rank deficiency. Fixed a couple of bugs (unassigned value +. now runs faster and deterministically for stocfor3 and watson_*) and handles case where phase 2 primal simplex clean-up yields primal infeasibilities (we solve stat96v1!)