### PR TITLE
C API and static analysis fixes

### DIFF
--- a/examples/call_highs_from_c.c
+++ b/examples/call_highs_from_c.c
@@ -61,9 +61,9 @@ void minimal_api() {
   //        8 <= 2x_0 +  x_1
   // 0 <= x_0 <= 3; 1 <= x_1
 
-  int numcol = 2;
-  int numrow = 3;
-  int nnz = 5;
+  const int numcol = 2;
+  const int numrow = 3;
+  const int nnz = 5;
 
   // Define the column costs, lower bounds and upper bounds
   double colcost[numcol] = {2.0, 3.0};
@@ -131,9 +131,9 @@ void full_api() {
 
   highs = Highs_create();
 
-  int numcol = 2;
-  int numrow = 3;
-  int nnz = 5;
+  const int numcol = 2;
+  const int numrow = 3;
+  const int nnz = 5;
   int i;
 
   // Define the column costs, lower bounds and upper bounds

--- a/src/ipm/ipx/src/basis.h
+++ b/src/ipm/ipx/src/basis.h
@@ -30,9 +30,9 @@ public:
     Basis(const Basis&) = delete;
     Basis& operator=(const Basis&) = delete;
 
-    // Move is OK.
+    // Move
     Basis(Basis&&) = default;
-    Basis& operator=(Basis&&) = default;
+    Basis& operator=(Basis&&) = delete; // delete: control_ cannot be moved!
 
     ~Basis() = default;
 

--- a/src/lp_data/HighsSolutionDebug.cpp
+++ b/src/lp_data/HighsSolutionDebug.cpp
@@ -762,7 +762,7 @@ HighsDebugStatus debugCompareSolutionParamValue(const string name,
     value_adjective = "Large";
     report_level = ML_DETAILED;
     return_status = HighsDebugStatus::WARNING;
-  } else if (v0 != v1) {
+  } else { // v0 != v1
     value_adjective = "OK";
     report_level = ML_VERBOSE;
   }


### PR DESCRIPTION
Small fixes

- C API example in master not compiling in master using gcc 7.5 or clang-10
    - Fix: add `const` qualifiers to array sizes
- IPX Basis class was trying to declare as default an implicitly deleted move constructor -- explicitly delete and make note
- Clang static analysis notes that control flow can be simplified by removing last `else if` (if I understood the control flow correctly)