### PR TITLE
Add an option to specify the model file extension and open /dev/stdin

### DIFF
--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -162,7 +162,7 @@ void reportSolvedLpStats(FILE* output, int message_level,
       highs.getHighsInfoValue("objective_function_value",
                               objective_function_value);
       HighsPrintMessage(output, message_level, ML_ALWAYS,
-                        "Objective value     : %13.6e\n",
+                        "Objective value     : %f\n",
                         objective_function_value);
     }
     double run_time = highs.getHighsRunTime();

--- a/src/io/Filereader.cpp
+++ b/src/io/Filereader.cpp
@@ -27,9 +27,8 @@ static const std::string getFilenameExt(const std::string filename) {
   return name;
 }
 
-Filereader* Filereader::getFilereader(const std::string filename) {
+Filereader* Filereader::getFilereaderByExtension(const std::string extension) {
   Filereader* reader;
-  const std::string extension = getFilenameExt(filename);
   if (extension.compare("mps") == 0) {
     reader = new FilereaderMps();
   } else if (extension.compare("lp") == 0) {
@@ -40,6 +39,11 @@ Filereader* Filereader::getFilereader(const std::string filename) {
     reader = NULL;
   }
   return reader;
+}
+
+Filereader* Filereader::getFilereader(const std::string filename) {
+  const std::string extension = getFilenameExt(filename);
+  return getFilereaderByExtension(extension);
 }
 
 void interpretFilereaderRetcode(FILE* logfile, const std::string filename,

--- a/src/io/Filereader.h
+++ b/src/io/Filereader.h
@@ -37,6 +37,7 @@ class Filereader {
   virtual HighsStatus writeModelToFile(const HighsOptions& options,
                                        const std::string filename,
                                        HighsLp& model) = 0;
+  static Filereader* getFilereaderByExtension(const std::string extension);
   static Filereader* getFilereader(const std::string filename);
 
   virtual ~Filereader(){};

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -272,7 +272,9 @@ HighsStatus Highs::passModel(const int num_col, const int num_row,
 
 HighsStatus Highs::readModel(const std::string filename) {
   HighsStatus return_status = HighsStatus::OK;
-  Filereader* reader = Filereader::getFilereader(filename);
+  Filereader* reader = this->options_.model_file_type.size()
+	? Filereader::getFilereaderByExtension(this->options_.model_file_type)
+	: Filereader::getFilereader(filename);
   if (reader == NULL) {
     HighsLogMessage(options_.logfile, HighsMessageType::ERROR,
                     "Model file %s not supported", filename.c_str());

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -217,6 +217,7 @@ const int KEEP_N_ROWS_KEEP_ROWS = 1;
 
 // Strings for command line options
 const string model_file_string = "model_file";
+const string model_file_type_string = "model_file_type";
 const string presolve_string = "presolve";
 const string solver_string = "solver";
 const string parallel_string = "parallel";
@@ -228,6 +229,7 @@ const string options_file_string = "options_file";
 struct HighsOptionsStruct {
   // Options read from the command line
   std::string model_file;
+  std::string model_file_type;
   std::string presolve;
   std::string solver;
   std::string parallel;
@@ -349,6 +351,10 @@ class HighsOptions : public HighsOptionsStruct {
     record_string =
         new OptionRecordString(model_file_string, "Model file", advanced,
                                &model_file, FILENAME_DEFAULT);
+    records.push_back(record_string);
+    record_string =
+        new OptionRecordString(model_file_type_string, "Model type", advanced,
+                               &model_file_type, FILENAME_DEFAULT);
     records.push_back(record_string);
     record_string = new OptionRecordString(
         presolve_string, "Presolve option: \"off\", \"choose\" or \"on\"",

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -21,10 +21,13 @@ bool loadOptions(int argc, char** argv, HighsOptions& options) {
     cxxopts::Options cxx_options(argv[0], "HiGHS options");
     cxx_options.positional_help("[file]").show_positional_help();
 
-    std::string presolve, solver, parallel;
+    std::string presolve, solver, parallel, file_type;
 
     cxx_options.add_options()(model_file_string, "File of model to solve.",
                               cxxopts::value<std::vector<std::string>>())(
+        model_file_type_string,
+        "Model type",
+        cxxopts::value<std::string>(file_type))(
         presolve_string,
         "Presolve: \"choose\" by default - \"on\"/\"off\" are alternatives.",
         cxxopts::value<std::string>(presolve))(
@@ -66,6 +69,13 @@ bool loadOptions(int argc, char** argv, HighsOptions& options) {
       } else {
         options.model_file = v[0];
       }
+    }
+
+    if (result.count(model_file_type_string)) {
+      std::string value = result[model_file_type_string].as<std::string>();
+      if (setOptionValue(options.logfile, model_file_type_string, options.records,
+                         value) != OptionStatus::OK)
+        return false;
     }
 
     if (result.count(presolve_string)) {


### PR DESCRIPTION
The motivation for this was to test several mps compressed files:
```
zcat file.mps.gz | highs --model_file_type mps /dev/stdin
```