### PR TITLE
BUG: comment out lines that cause presolve to miss infeasible problem

### DIFF
--- a/src/presolve/Presolve.cpp
+++ b/src/presolve/Presolve.cpp
@@ -2399,10 +2399,13 @@ void Presolve::setPrimalValue(int j, double value) {
 
       // update singleton row list
       if (nzRow.at(row) == 1) singRow.push_back(row);
-      if (nzRow.at(row) == 0) {
-        flagRow[row] = 0;
-        addChange(PresolveRule::EMPTY_ROW, row, j);
-      }
+
+      // TODO: the following causes presolve to miss some infeasible problems;
+      //       see https://github.com/ERGO-Code/HiGHS/issues/425
+      // if (nzRow.at(row) == 0) {
+      //   flagRow[row] = 0;
+      //   addChange(PresolveRule::EMPTY_ROW, row, j);
+      // }
     }
   }
 


### PR DESCRIPTION
@jajhall @galabovaa 

Closes https://github.com/ERGO-Code/HiGHS/issues/425

- comment out lines introduced in commit f5f4d432e70ec38f0c927e44f5ae8a3dcf70803c