### PR TITLE
Mip changes based on ekk_simplify

### DIFF
--- a/.github/workflows/build-clang.yml
+++ b/.github/workflows/build-clang.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --output-on-failure
 
   release:
     runs-on: ${{ matrix.os }}
@@ -70,4 +70,4 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C RELEASE
+      run: ctest -C RELEASE --output-on-failure

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -69,7 +69,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C DEBUG
+      run: ctest -C DEBUG --out-on-failure
 
 
   fast_build_release:
@@ -104,4 +104,4 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C DEBUG
+      run: ctest -C DEBUG --out-on-failure

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,7 +35,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C RELEASE
+      run: ctest -C RELEASE --output-on-failure
 
   fast_build_debug:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --output-on-failure
 
   release:
     runs-on: ${{ matrix.os }}
@@ -66,4 +66,4 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C RELEASE
+      run: ctest -C RELEASE --output-on-failure

--- a/.github/workflows/fast-build.yml
+++ b/.github/workflows/fast-build.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C $BUILD_TYPE
+      run: ctest -C $BUILD_TYPE --output-on-failure
 
   release:
     runs-on: ${{ matrix.os }}
@@ -63,4 +63,4 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ctest
+      run: ctest --output-on-failure

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,6 +104,7 @@ set(sources
     mip/HighsCutPool.cpp
     mip/HighsCliqueTable.cpp
     mip/HighsImplications.cpp
+    mip/HighsPrimalHeuristics.cpp
     mip/HighsNodeQueue.cpp
     presolve/Presolve.cpp
     presolve/PresolveComponent.cpp
@@ -419,6 +420,7 @@ target_sources(libhighs PRIVATE
     mip/HighsCutPool.cpp
     mip/HighsCliqueTable.cpp
     mip/HighsImplications.cpp
+    mip/HighsPrimalHeuristics.cpp
     mip/HighsNodeQueue.cpp
     presolve/Presolve.cpp
     presolve/PresolveComponent.cpp

--- a/src/mip/HighsCliqueTable.cpp
+++ b/src/mip/HighsCliqueTable.cpp
@@ -116,6 +116,88 @@ void HighsCliqueTable::resolveSubstitution(CliqueVar& v) const {
   }
 }
 
+void HighsCliqueTable::resolveSubstitution(int& col, double& val,
+                                           double& offset) const {
+  while (colsubstituted[col]) {
+    Substitution subst = substitutions[colsubstituted[col] - 1];
+    if (subst.replace.val == 0) {
+      offset += val;
+      val = -val;
+    }
+    col = subst.replace.col;
+  }
+}
+
+int HighsCliqueTable::runCliqueSubsumption(HighsDomain& globaldom,
+                                           std::vector<CliqueVar>& clique) {
+  if (clique.size() == 2) return 0;
+  int nremoved = 0;
+  bool redundant = false;
+  cliquehits.resize(cliques.size());
+  for (CliqueVar v : clique) {
+    if (cliquesetroot[v.index()] != -1)
+      stack.emplace_back(cliquesetroot[v.index()]);
+
+    while (!stack.empty()) {
+      int node = stack.back();
+      stack.pop_back();
+
+      if (cliquesets[node].left != -1)
+        stack.emplace_back(cliquesets[node].left);
+      if (cliquesets[node].right != -1)
+        stack.emplace_back(cliquesets[node].right);
+
+      int cliqueid = cliquesets[node].cliqueid;
+      if (cliquehits[cliqueid] == 0) cliquehitinds.push_back(cliqueid);
+
+      ++cliquehits[cliqueid];
+    }
+  }
+
+  if (cliquehitinds.size() == 1) {
+    int hits = cliquehits[cliquehitinds[0]];
+    cliquehits[cliquehitinds[0]] = 0;
+    if (hits == (int)clique.size()) redundant = true;
+  } else {
+    int firstremovable = -1;
+    for (int cliqueid : cliquehitinds) {
+      int hits = cliquehits[cliqueid];
+      cliquehits[cliqueid] = 0;
+
+      if (cliques[cliqueid].end - cliques[cliqueid].start == hits) {
+        if (cliques[cliqueid].equality) {
+          for (CliqueVar v : clique) {
+            cliquesetroot[v.index()] =
+                splay(cliqueid, cliquesetroot[v.index()]);
+            int node = cliquesetroot[v.index()];
+            if (node == -1 || cliquesets[node].cliqueid != cliqueid)
+              infeasvertexstack.push_back(v);
+          }
+        } else if (firstremovable == -1) {
+          firstremovable = cliqueid;
+        } else {
+          ++nremoved;
+          removeClique(cliqueid);
+        }
+      } else if (hits == (int)clique.size())
+        redundant = true;
+    }
+
+    if (nremoved != 0) {
+      removeClique(firstremovable);
+      clique.erase(
+          std::remove_if(clique.begin(), clique.end(),
+                         [&](CliqueVar v) { return globaldom.isFixed(v.col); }),
+          clique.end());
+    }
+  }
+  cliquehitinds.clear();
+
+  if (redundant) clique.clear();
+
+  return nremoved;
+}
+
 void HighsCliqueTable::bronKerboschRecurse(BronKerboschData& data, int Plen,
                                            const CliqueVar* X, int Xlen) {
   double w = data.wR;
@@ -493,7 +575,9 @@ void HighsCliqueTable::addClique(HighsDomain& globaldom, CliqueVar* cliquevars,
 
     for (int i = 0; i < numcliquevars - 1; ++i) {
       if (globaldom.isFixed(cliquevars[i].col)) continue;
-      if (cliquesetroot[cliquevars[i].complement().index()] == -1) continue;
+      if (cliquesetroot[cliquevars[i].index()] == -1 &&
+          cliquesetroot[cliquevars[i].complement().index()])
+        continue;
 
       for (int j = i + 1; j < numcliquevars; ++j) {
         if (globaldom.isFixed(cliquevars[j].col)) continue;
@@ -556,10 +640,11 @@ void HighsCliqueTable::extractCliques(
   auto binaryend = std::partition(perm.begin(), perm.end(), [&](int pos) {
     return globaldom.isBinary(inds[pos]);
   });
+  nbin = binaryend - perm.begin();
+  if (nbin <= 1) return;
 
   std::sort(perm.begin(), binaryend,
             [&](int p1, int p2) { return vals[p1] > vals[p2]; });
-
   // check if any cliques exists
   if (vals[perm[0]] + vals[perm[1]] <= rhs + feastol) return;
 
@@ -616,8 +701,12 @@ void HighsCliqueTable::extractCliques(
 
     // printf("extracted this clique:\n");
     // printClique(clique);
-    addClique(globaldom, clique.data(), clique.size());
-    if (globaldom.infeasible()) return;
+    runCliqueSubsumption(globaldom, clique);
+
+    if (clique.size() >= 2) {
+      addClique(globaldom, clique.data(), clique.size());
+      if (globaldom.infeasible()) return;
+    }
 
     // further cliques are just subsets of this clique
     if (cliqueend == perm.begin() + k) return;
@@ -663,6 +752,9 @@ void HighsCliqueTable::extractCliques(HighsMipSolver& mipsolver) {
   std::vector<int> perm;
   std::vector<int8_t> complementation;
   std::vector<CliqueVar> clique;
+  std::unordered_map<int, double> entries;
+  double offset;
+
   double rhs;
 
   HighsDomain& globaldom = mipsolver.mipdata_->domain;
@@ -704,63 +796,31 @@ void HighsCliqueTable::extractCliques(HighsMipSolver& mipsolver) {
       }
     }
 
-    if (mipsolver.rowUpper(i) != HIGHS_CONST_INF) {
-      rhs = mipsolver.rowUpper(i);
-      inds.clear();
-      vals.clear();
-      complementation.clear();
-      bool freevar = false;
-      int nbin = 0;
+    offset = 0;
+    for (int j = start; j != end; ++j) {
+      int col = mipsolver.mipdata_->ARindex_[j];
+      double val = mipsolver.mipdata_->ARvalue_[j];
 
-      for (int j = start; j != end; ++j) {
-        int col = mipsolver.mipdata_->ARindex_[j];
-        if (globaldom.isBinary(col)) ++nbin;
-        if (mipsolver.mipdata_->ARvalue_[j] < 0) {
-          if (globaldom.colUpper_[col] == HIGHS_CONST_INF) {
-            freevar = true;
-            break;
-          }
-
-          vals.push_back(-mipsolver.mipdata_->ARvalue_[j]);
-          inds.push_back(col);
-          complementation.push_back(-1);
-          rhs -= mipsolver.mipdata_->ARvalue_[j] * globaldom.colUpper_[col];
-        } else {
-          if (globaldom.colLower_[col] == -HIGHS_CONST_INF) {
-            freevar = true;
-            break;
-          }
-
-          vals.push_back(mipsolver.mipdata_->ARvalue_[j]);
-          inds.push_back(col);
-          complementation.push_back(1);
-          rhs -= mipsolver.mipdata_->ARvalue_[j] * globaldom.colLower_[col];
-        }
-      }
-
-      if (!freevar && nbin > 1) {
-        // printf("extracing cliques from this row:\n");
-        // printRow(globaldom, inds.data(), vals.data(), inds.size(),
-        //         -HIGHS_CONST_INF, rhs);
-        extractCliques(globaldom, inds, vals, complementation, rhs, nbin, perm,
-                       clique, mipsolver.mipdata_->feastol);
-        if (globaldom.infeasible()) return;
-      }
+      resolveSubstitution(col, val, offset);
+      entries[col] += val;
     }
 
-    if (mipsolver.rowLower(i) != -HIGHS_CONST_INF) {
-      rhs = -mipsolver.rowLower(i);
+    if (mipsolver.rowUpper(i) != HIGHS_CONST_INF) {
+      rhs = mipsolver.rowUpper(i) - offset;
       inds.clear();
       vals.clear();
       complementation.clear();
       bool freevar = false;
       int nbin = 0;
 
-      for (int j = start; j != end; ++j) {
-        int col = mipsolver.mipdata_->ARindex_[j];
+      for (const std::pair<int, double>& entry : entries) {
+        int col = entry.first;
+        double val = entry.second;
+
+        if (std::abs(val) < mipsolver.mipdata_->epsilon) continue;
+
         if (globaldom.isBinary(col)) ++nbin;
 
-        double val = -mipsolver.mipdata_->ARvalue_[j];
         if (val < 0) {
           if (globaldom.colUpper_[col] == HIGHS_CONST_INF) {
             freevar = true;
@@ -793,6 +853,142 @@ void HighsCliqueTable::extractCliques(HighsMipSolver& mipsolver) {
         if (globaldom.infeasible()) return;
       }
     }
+
+    if (mipsolver.rowLower(i) != -HIGHS_CONST_INF) {
+      rhs = -mipsolver.rowLower(i) + offset;
+      inds.clear();
+      vals.clear();
+      complementation.clear();
+      bool freevar = false;
+      int nbin = 0;
+
+      for (const std::pair<int, double>& entry : entries) {
+        int col = entry.first;
+        double val = -entry.second;
+        if (std::abs(val) < mipsolver.mipdata_->epsilon) continue;
+
+        if (globaldom.isBinary(col)) ++nbin;
+
+        if (val < 0) {
+          if (globaldom.colUpper_[col] == HIGHS_CONST_INF) {
+            freevar = true;
+            break;
+          }
+
+          vals.push_back(-val);
+          inds.push_back(col);
+          complementation.push_back(-1);
+          rhs -= val * globaldom.colUpper_[col];
+        } else {
+          if (globaldom.colLower_[col] == -HIGHS_CONST_INF) {
+            freevar = true;
+            break;
+          }
+
+          vals.push_back(val);
+          inds.push_back(col);
+          complementation.push_back(1);
+          rhs -= val * globaldom.colLower_[col];
+        }
+      }
+
+      if (!freevar && nbin > 1) {
+        // printf("extracing cliques from this row:\n");
+        // printRow(globaldom, inds.data(), vals.data(), inds.size(),
+        //         -HIGHS_CONST_INF, rhs);
+        extractCliques(globaldom, inds, vals, complementation, rhs, nbin, perm,
+                       clique, mipsolver.mipdata_->feastol);
+        if (globaldom.infeasible()) return;
+      }
+    }
+
+    entries.clear();
+  }
+}
+
+void HighsCliqueTable::extractObjCliques(HighsMipSolver& mipsolver) {
+  std::vector<int> inds;
+  std::vector<double> vals;
+  std::vector<int> perm;
+  std::vector<int8_t> complementation;
+  std::vector<CliqueVar> clique;
+  std::unordered_map<int, double> entries;
+  double offset = 0.0;
+
+  HighsDomain& globaldom = mipsolver.mipdata_->domain;
+  for (int j = 0; j != mipsolver.numCol(); ++j) {
+    int col = j;
+    double val = mipsolver.colCost(col);
+    if (val == 0.0) continue;
+
+    if (globaldom.isFixed(col)) {
+      offset += val * globaldom.colLower_[col];
+      continue;
+    }
+
+    resolveSubstitution(col, val, offset);
+    entries[col] += val;
+  }
+
+  double rhs = mipsolver.mipdata_->upper_limit - offset;
+
+  bool freevar = false;
+  int nbin = 0;
+
+  for (const std::pair<int, double>& entry : entries) {
+    int col = entry.first;
+    double val = entry.second;
+
+    if (std::abs(val) <= mipsolver.mipdata_->epsilon) continue;
+
+    if (globaldom.isBinary(col)) ++nbin;
+
+    if (val < 0) {
+      if (globaldom.colUpper_[col] == HIGHS_CONST_INF) {
+        freevar = true;
+        break;
+      }
+
+      vals.push_back(-val);
+      inds.push_back(col);
+      complementation.push_back(-1);
+      rhs -= val * globaldom.colUpper_[col];
+    } else {
+      if (globaldom.colLower_[col] == -HIGHS_CONST_INF) {
+        freevar = true;
+        break;
+      }
+
+      vals.push_back(val);
+      inds.push_back(col);
+      complementation.push_back(1);
+      rhs -= val * globaldom.colLower_[col];
+    }
+  }
+
+  if (!freevar && nbin > 1) {
+    int len = (int)inds.size();
+
+    int nfixed = 0;
+    for (int i = 0; i != len; ++i) {
+      if (mipsolver.variableType(inds[i]) != HighsVarType::INTEGER) continue;
+      if (vals[i] <= rhs + mipsolver.mipdata_->feastol) continue;
+      if (globaldom.isFixed(inds[i])) continue;
+
+      ++nfixed;
+      if (complementation[i] == -1)
+        globaldom.fixCol(inds[i], globaldom.colUpper_[inds[i]]);
+      else
+        globaldom.fixCol(inds[i], globaldom.colLower_[inds[i]]);
+      if (globaldom.infeasible()) return;
+    }
+
+    // printf("extracing cliques from this row:\n");
+    // printRow(globaldom, inds.data(), vals.data(), inds.size(),
+    //         -HIGHS_CONST_INF, rhs);
+    extractCliques(globaldom, inds, vals, complementation, rhs, nbin, perm,
+                   clique, mipsolver.mipdata_->feastol);
+    if (globaldom.infeasible()) return;
   }
 }
 
@@ -922,8 +1118,7 @@ void HighsCliqueTable::separateCliques(const std::vector<double>& sol,
 
     assert(debugactivity <= rhs + 1e-9);
 #endif
-    int cut = cutpool.addCut(inds.data(), vals.data(), inds.size(), rhs);
-    localdom.cutAdded(cut);
+    cutpool.addCut(inds.data(), vals.data(), inds.size(), rhs);
   }
 
   if (runcliquesubsumption) {
@@ -992,8 +1187,6 @@ void HighsCliqueTable::separateCliques(const std::vector<double>& sol,
             origin = -1;
           }
           removeClique(firstremovable);
-          printf("removed %d cliques in favor of clique cut of size %d\n",
-                 nremoved + 1, (int)clique.size());
           clique.erase(std::remove_if(clique.begin(), clique.end(),
                                       [&](CliqueVar v) {
                                         return globaldom.isFixed(v.col);
@@ -1005,6 +1198,31 @@ void HighsCliqueTable::separateCliques(const std::vector<double>& sol,
       cliquehitinds.clear();
     }
   }
+}
+
+std::vector<std::vector<HighsCliqueTable::CliqueVar>>
+HighsCliqueTable::separateCliques(const std::vector<double>& sol,
+                                  const HighsDomain& globaldom,
+                                  double feastol) {
+  BronKerboschData data(sol);
+  data.feastol = feastol;
+
+  int numcols = globaldom.colLower_.size();
+  assert(int(numcliquesvar.size()) == 2 * numcols);
+  for (int i = 0; i != numcols; ++i) {
+    if (colsubstituted[i]) continue;
+
+    if (numcliquesvar[CliqueVar(i, 0).index()] != 0 &&
+        CliqueVar(i, 0).weight(sol) > feastol)
+      data.P.emplace_back(i, 0);
+    if (numcliquesvar[CliqueVar(i, 1).index()] != 0 &&
+        CliqueVar(i, 1).weight(sol) > feastol)
+      data.P.emplace_back(i, 1);
+  }
+
+  bronKerboschRecurse(data, data.P.size(), nullptr, 0);
+
+  return std::move(data.cliques);
 }
 
 void HighsCliqueTable::addImplications(HighsDomain& domain, int col, int val) {
@@ -1035,13 +1253,13 @@ void HighsCliqueTable::addImplications(HighsDomain& domain, int col, int val) {
         if (domain.colUpper_[cliqueentries[i].col] == 0.0) continue;
 
         domain.changeBound(HighsBoundType::Upper, cliqueentries[i].col, 0.0,
-                           -2);
+                           HighsDomain::Reason::unspecified());
         if (domain.infeasible()) return;
       } else {
         if (domain.colLower_[cliqueentries[i].col] == 1.0) continue;
 
         domain.changeBound(HighsBoundType::Lower, cliqueentries[i].col, 1.0,
-                           -2);
+                           HighsDomain::Reason::unspecified());
         if (domain.infeasible()) return;
       }
     }
@@ -1072,13 +1290,13 @@ void HighsCliqueTable::addImplications(HighsDomain& domain, int col, int val) {
         if (domain.colUpper_[cliqueentries[i].col] == 0.0) continue;
 
         domain.changeBound(HighsBoundType::Upper, cliqueentries[i].col, 0.0,
-                           -2);
+                           HighsDomain::Reason::unspecified());
         if (domain.infeasible()) return;
       } else {
         if (domain.colLower_[cliqueentries[i].col] == 1.0) continue;
 
         domain.changeBound(HighsBoundType::Lower, cliqueentries[i].col, 1.0,
-                           -2);
+                           HighsDomain::Reason::unspecified());
         if (domain.infeasible()) return;
       }
     }

--- a/src/mip/HighsCliqueTable.h
+++ b/src/mip/HighsCliqueTable.h
@@ -72,6 +72,9 @@ class HighsCliqueTable {
   std::vector<Substitution> substitutions;
   std::vector<int> deletedrows;
   std::vector<std::pair<int, CliqueVar>> cliqueextensions;
+  std::vector<uint16_t> cliquehits;
+  std::vector<int> cliquehitinds;
+  std::vector<int> stack;
   int nfixings;
 
   int splay(int cliqueid, int root);
@@ -82,8 +85,8 @@ class HighsCliqueTable {
 
   int findCommonCliqueRecurse(int& r1, int& r2);
 
-  void resolveSubstitution(CliqueVar& v) const;
-
+  int runCliqueSubsumption(HighsDomain& globaldom,
+                           std::vector<CliqueVar>& clique);
   struct BronKerboschData {
     const std::vector<double>& sol;
     std::vector<CliqueVar> P;
@@ -135,6 +138,10 @@ class HighsCliqueTable {
 
   void removeClique(int cliqueid);
 
+  void resolveSubstitution(CliqueVar& v) const;
+
+  void resolveSubstitution(int& col, double& val, double& rhs) const;
+
   std::vector<int>& getDeletedRows() { return deletedrows; }
 
   const std::vector<int>& getDeletedRows() const { return deletedrows; }
@@ -164,6 +171,8 @@ class HighsCliqueTable {
 
   void extractCliques(HighsMipSolver& mipsolver);
 
+  void extractObjCliques(HighsMipSolver& mipsolver);
+
   void vertexInfeasible(HighsDomain& globaldom, int col, int val);
 
   bool haveCommonClique(CliqueVar v1, CliqueVar v2) {
@@ -182,6 +191,10 @@ class HighsCliqueTable {
   void separateCliques(const std::vector<double>& sol,
                        const HighsDomain& globaldom, HighsDomain& localdom,
                        HighsCutPool& cutpool, double feastol);
+
+  std::vector<std::vector<CliqueVar>> separateCliques(
+      const std::vector<double>& sol, const HighsDomain& globaldom,
+      double feastol);
 
   void cleanupFixed(HighsDomain& globaldom);
 

--- a/src/mip/HighsCliqueTable.h
+++ b/src/mip/HighsCliqueTable.h
@@ -59,7 +59,7 @@ class HighsCliqueTable {
   std::vector<CliqueVar> cliqueentries;
   std::vector<CliqueSetNode> cliquesets;
 
-  std::vector<std::pair<int*,int*>> commoncliquestack;
+  std::vector<std::pair<int*, int*>> commoncliquestack;
   std::set<std::pair<int, int>> freespaces;
   std::vector<int> freeslots;
   std::vector<Clique> cliques;

--- a/src/mip/HighsCliqueTable.h
+++ b/src/mip/HighsCliqueTable.h
@@ -59,7 +59,7 @@ class HighsCliqueTable {
   std::vector<CliqueVar> cliqueentries;
   std::vector<CliqueSetNode> cliquesets;
 
-  std::vector<int*> commoncliquestack;
+  std::vector<std::pair<int*,int*>> commoncliquestack;
   std::set<std::pair<int, int>> freespaces;
   std::vector<int> freeslots;
   std::vector<Clique> cliques;
@@ -143,6 +143,11 @@ class HighsCliqueTable {
 
   const std::vector<Substitution>& getSubstitutions() const {
     return substitutions;
+  }
+
+  const Substitution* getSubstitution(int col) const {
+    return colsubstituted[col] ? &substitutions[colsubstituted[col] - 1]
+                               : nullptr;
   }
 
   std::vector<std::pair<int, CliqueVar>>& getCliqueExtensions() {

--- a/src/mip/HighsCutPool.cpp
+++ b/src/mip/HighsCutPool.cpp
@@ -315,5 +315,8 @@ int HighsCutPool::addCut(int* Rindex, double* Rvalue, int Rlen, double rhs,
   rownormalization_[rowindex] = 1.0 / double(sqrt(norm));
   maxabscoef_[rowindex] = maxabscoef;
 
+  for (HighsDomain::CutpoolPropagation* propagationdomain : propagationDomains)
+    propagationdomain->cutAdded(rowindex);
+
   return rowindex;
 }

--- a/src/mip/HighsCutPool.h
+++ b/src/mip/HighsCutPool.h
@@ -51,6 +51,7 @@ class HighsCutPool {
   std::vector<double> maxabscoef_;
   std::vector<uint8_t> rowintegral;
   std::unordered_multimap<size_t, int> supportmap;
+  std::vector<HighsDomain::CutpoolPropagation*> propagationDomains;
 
   int agelim_;
   int nrounds_;
@@ -77,6 +78,19 @@ class HighsCutPool {
   void ageLPRows(HighsLpRelaxation& lprelaxation);
 
   void ageNonLPRows();
+
+  void addPropagationDomain(HighsDomain::CutpoolPropagation* domain) {
+    propagationDomains.push_back(domain);
+  }
+
+  void removePropagationDomain(HighsDomain::CutpoolPropagation* domain) {
+    for (int k = propagationDomains.size() - 1; k >= 0; --k) {
+      if (propagationDomains[k] == domain) {
+        propagationDomains.erase(propagationDomains.begin() + k);
+        return;
+      }
+    }
+  }
 
   void setAgeLimit(int agelim) { agelim_ = agelim; }
 

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -90,7 +90,8 @@ bool HighsImplications::computeImplications(int col, bool val) {
 
 bool HighsImplications::runProbing(int col, int& numboundchgs) {
   if (globaldomain.isBinary(col) && !implicationsCached(col, 1) &&
-      !implicationsCached(col, 0)) {
+      !implicationsCached(col, 0) &&
+      cliquetable.getSubstitution(col) == nullptr) {
     bool infeasible;
 
     infeasible = computeImplications(col, 1);

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -9,8 +9,6 @@ bool HighsImplications::computeImplications(int col, bool val) {
   const auto& domchgstack = globaldomain.getDomainChangeStack();
 
   int changedend = globaldomain.getChangedCols().size();
-  int proprowend = globaldomain.getPropagateRows().size();
-  int propcutend = globaldomain.getPropagateCuts().size();
 
   if (val)
     globaldomain.changeBound(HighsBoundType::Lower, col, 1);
@@ -20,9 +18,6 @@ bool HighsImplications::computeImplications(int col, bool val) {
   if (globaldomain.infeasible()) {
     globaldomain.backtrack();
     globaldomain.clearChangedCols(changedend);
-    globaldomain.clearPropagateRows(proprowend);
-    globaldomain.clearPropagateCuts(propcutend);
-
     cliquetable.vertexInfeasible(globaldomain, col, val);
 
     return true;
@@ -37,8 +32,6 @@ bool HighsImplications::computeImplications(int col, bool val) {
   if (globaldomain.infeasible()) {
     globaldomain.backtrack();
     globaldomain.clearChangedCols(changedend);
-    globaldomain.clearPropagateRows(proprowend);
-    globaldomain.clearPropagateCuts(propcutend);
 
     cliquetable.vertexInfeasible(globaldomain, col, val);
 
@@ -55,8 +48,6 @@ bool HighsImplications::computeImplications(int col, bool val) {
 
   globaldomain.backtrack();
   globaldomain.clearChangedCols(changedend);
-  globaldomain.clearPropagateRows(proprowend);
-  globaldomain.clearPropagateCuts(propcutend);
 
   // add the implications of binary variables to the clique table
   auto binstart =
@@ -125,9 +116,11 @@ bool HighsImplications::runProbing(int col, int& numboundchgs) {
                implicsdown[d].boundval < implicsup[u].boundval) ||
               (implicsup[u].boundtype == HighsBoundType::Upper &&
                implicsdown[d].boundval > implicsup[u].boundval))
-            globaldomain.changeBound(implicsdown[d], -2);
+            globaldomain.changeBound(implicsdown[d],
+                                     HighsDomain::Reason::unspecified());
           else
-            globaldomain.changeBound(implicsup[u], -2);
+            globaldomain.changeBound(implicsup[u],
+                                     HighsDomain::Reason::unspecified());
           assert(!globaldomain.infeasible());
           ++numboundchgs;
           globaldomain.propagate();

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -565,6 +565,19 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
       }
 
       return Status::UnscaledInfeasible;
+    case HighsModelStatus::REACHED_ITERATION_LIMIT: {
+      if (resolve_on_error) {
+        Highs ipm;
+        ipm.passModel(lpsolver.getLp());
+        ipm.setHighsOptionValue("solver", "ipm");
+        ipm.setHighsOutput();
+        ipm.setHighsLogfile();
+        ipm.run();
+        lpsolver.setBasis(ipm.getBasis());
+        return run(false);
+      }
+      return Status::Error;
+    }
     case HighsModelStatus::PRIMAL_DUAL_INFEASIBLE:
     // case HighsModelStatus::PRIMAL_INFEASIBLE:
     //  if (lpsolver.getModelStatus(false) == scaledmodelstatus)

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -496,6 +496,7 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
       if (checkDualProof()) return Status::Infeasible;
 
       return Status::Error;
+    case HighsModelStatus::PRIMAL_DUAL_INFEASIBLE:
     case HighsModelStatus::PRIMAL_INFEASIBLE:
       storeDualInfProof();
       if (checkDualProof()) {
@@ -578,7 +579,7 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
       }
       return Status::Error;
     }
-    case HighsModelStatus::PRIMAL_DUAL_INFEASIBLE:
+    //case HighsModelStatus::PRIMAL_DUAL_INFEASIBLE:
     // case HighsModelStatus::PRIMAL_INFEASIBLE:
     //  if (lpsolver.getModelStatus(false) == scaledmodelstatus)
     //    return Status::Infeasible;
@@ -670,7 +671,7 @@ HighsLpRelaxation::Status HighsLpRelaxation::resolveLp() {
         for (int i = 0; i != mipsolver.numCol(); ++i)
           objsum += roundsol[i] * mipsolver.colCost(i);
 
-        mipsolver.mipdata_->addIncumbent(roundsol, double(objsum), 'R');
+        mipsolver.mipdata_->addIncumbent(roundsol, double(objsum), 'S');
         objsum = 0;
       }
 

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -579,7 +579,7 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
       }
       return Status::Error;
     }
-    //case HighsModelStatus::PRIMAL_DUAL_INFEASIBLE:
+    // case HighsModelStatus::PRIMAL_DUAL_INFEASIBLE:
     // case HighsModelStatus::PRIMAL_INFEASIBLE:
     //  if (lpsolver.getModelStatus(false) == scaledmodelstatus)
     //    return Status::Infeasible;

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -613,12 +613,6 @@ HighsLpRelaxation::Status HighsLpRelaxation::resolveLp() {
           const HighsCliqueTable::Substitution* subst =
               mipsolver.mipdata_->cliquetable.getSubstitution(col);
           while (subst != nullptr) {
-            if (!mipsolver.submip)
-              printf(
-                  "happened: col %d with val %g replaced with col %d with val "
-                  "%g\n",
-                  col, val, subst->replace.col,
-                  (subst->replace.val == 0) ? 1.0 - val : val);
             col = subst->replace.col;
             if (subst->replace.val == 0) val = 1.0 - val;
 
@@ -631,9 +625,6 @@ HighsLpRelaxation::Status HighsLpRelaxation::resolveLp() {
       }
 
       for (const auto& it : fracints) {
-        if (it.second.second != 1 && !mipsolver.submip)
-          printf("col %d: %d values averaged to %g\n", it.first,
-                 it.second.second, it.second.first / (double)it.second.second);
         fractionalints.emplace_back(it.first,
                                     it.second.first / (double)it.second.second);
       }

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -279,7 +279,9 @@ void HighsMipSolver::run() {
 
       if (!search.backtrack()) break;
 
-      if (search.getCurrentEstimate() >= mipdata_->upper_limit) break;
+      if (mipdata_->upper_limit == HIGHS_CONST_INF ||
+          search.getCurrentEstimate() >= mipdata_->upper_limit)
+        break;
 
       if (mipdata_->num_nodes - plungestart >=
           std::min(size_t{1000}, mipdata_->num_nodes / 10))

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -252,9 +252,9 @@ void HighsMipSolver::run() {
     // set iteration limit for each lp solve during the dive to 10 times the
     // average nodes
 
-    int iterlimit = 100 * int(mipdata_->lp.getNumLpIterations() /
+    int iterlimit = 100 * int(mipdata_->total_lp_iterations /
                               (double)std::max(size_t{1}, mipdata_->num_nodes));
-    iterlimit = std::max(1000, iterlimit);
+    iterlimit = std::max(10000, iterlimit);
 
     mipdata_->lp.setIterationLimit(iterlimit);
 

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -274,8 +274,9 @@ void HighsMipSolver::run() {
           break;
         }
 
-        mipdata_->heuristics.randomizedRounding(
-            mipdata_->lp.getLpSolver().getSolution().col_value);
+        if (mipdata_->incumbent.empty())
+          mipdata_->heuristics.randomizedRounding(
+              mipdata_->lp.getLpSolver().getSolution().col_value);
 
         if (mipdata_->incumbent.empty())
           mipdata_->heuristics.RENS(

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -252,8 +252,11 @@ void HighsMipSolver::run() {
     // set iteration limit for each lp solve during the dive to 10 times the
     // average nodes
 
-    int iterlimit = 100 * int(mipdata_->total_lp_iterations /
-                              (double)std::max(size_t{1}, mipdata_->num_nodes));
+    int iterlimit =
+        10 *
+        int(mipdata_->total_lp_iterations - mipdata_->sb_lp_iterations -
+            mipdata_->sepa_lp_iterations) /
+        (double)std::max(size_t{1}, mipdata_->num_nodes);
     iterlimit = std::max(10000, iterlimit);
 
     mipdata_->lp.setIterationLimit(iterlimit);
@@ -342,7 +345,7 @@ void HighsMipSolver::run() {
     }
 
     // remove the iteration limit when installing a new node
-    mipdata_->lp.setIterationLimit();
+    // mipdata_->lp.setIterationLimit();
 
     // loop to install the next node for the search
     while (!mipdata_->nodequeue.empty()) {

--- a/src/mip/HighsMipSolver.h
+++ b/src/mip/HighsMipSolver.h
@@ -46,6 +46,8 @@ class HighsMipSolver {
 
   double rowUpper(int col) const { return model_->rowUpper_[col]; }
 
+  bool isSolutionFeasible(const std::vector<double>& solution) const;
+
   const HighsVarType* variableType() const {
     return model_->integrality_.data();
   }

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -991,6 +991,6 @@ void HighsMipSolverData::runProbing() {
                       int(domain.getChangedCols().size()) - nfixed);
 
     cliquetable.cleanupFixed(domain);
-    cliquetable.runCliqueMerging(domain);
+    if (!mipsolver.mipdata_->modelcleanup) cliquetable.runCliqueMerging(domain);
   }
 }

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1,5 +1,7 @@
 #include "mip/HighsMipSolverData.h"
 
+#include <random>
+
 #include "lp_data/HighsLpUtils.h"
 #include "presolve/HAggregator.h"
 
@@ -18,6 +20,39 @@ static int64_t gcd(int64_t a, int64_t b) {
   } while (b != 0);
 
   return a;
+}
+
+bool HighsMipSolverData::trySolution(const std::vector<double>& solution,
+                                     char source) {
+  if (int(solution.size()) != mipsolver.model_->numCol_) return false;
+
+  HighsCDouble obj = 0;
+
+  for (int i = 0; i != mipsolver.model_->numCol_; ++i) {
+    if (solution[i] < mipsolver.model_->colLower_[i] - feastol) return false;
+    if (solution[i] > mipsolver.model_->colUpper_[i] + feastol) return false;
+    if (mipsolver.variableType(i) == HighsVarType::INTEGER &&
+        std::abs(solution[i] - std::floor(solution[i] + 0.5)) > feastol)
+      return false;
+
+    obj += mipsolver.colCost(i) * solution[i];
+  }
+
+  for (int i = 0; i != mipsolver.model_->numRow_; ++i) {
+    double rowactivity = 0.0;
+
+    int start = ARstart_[i];
+    int end = ARstart_[i + 1];
+
+    for (int j = start; j != end; ++j)
+      rowactivity += solution[ARindex_[j]] * ARvalue_[j];
+
+    if (rowactivity > mipsolver.rowUpper(i) + feastol) return false;
+    if (rowactivity < mipsolver.rowLower(i) - feastol) return false;
+  }
+
+  addIncumbent(solution, double(obj), source);
+  return true;
 }
 
 HighsMipSolverData::ModelCleanup::ModelCleanup(HighsMipSolver& mipsolver) {
@@ -124,7 +159,9 @@ HighsMipSolverData::ModelCleanup::ModelCleanup(HighsMipSolver& mipsolver) {
   // clean up fixings
   mipsolver.mipdata_->cliquetable.cleanupFixed(mipsolver.mipdata_->domain);
   for (int i = 0; i != model.numCol_; ++i) {
-    if (coldeleted[i] != 0 || colLower[i] != colUpper[i]) continue;
+    if (coldeleted[i] != 0 ||
+        std::abs(colLower[i] - colUpper[i]) > HIGHS_CONST_TINY)
+      continue;
     aggregator.removeFixedCol(i);
 
     ++nfixed;
@@ -251,8 +288,8 @@ HighsMipSolverData::ModelCleanup::ModelCleanup(HighsMipSolver& mipsolver) {
 
   mipsolver.mipdata_->rowMatrixSet = false;
   mipsolver.mipdata_->cutpool = HighsCutPool(cleanedUpModel.numCol_, 10);
-  mipsolver.mipdata_->domain =
-      HighsDomain(mipsolver, mipsolver.mipdata_->cutpool);
+  mipsolver.mipdata_->domain = HighsDomain(mipsolver);
+  mipsolver.mipdata_->domain.addCutpool(mipsolver.mipdata_->cutpool);
   mipsolver.mipdata_->pseudocost = HighsPseudocost(cleanedUpModel.numCol_);
   mipsolver.mipdata_->cliquetable.rebuild(cleanedUpModel.numCol_, cIndex,
                                           rIndex);
@@ -418,7 +455,6 @@ void HighsMipSolverData::runSetup() {
     maxAbsRowCoef[i] = maxabsval;
   }
 
-  if (model.numCol_ == 0) return;
   // compute row activities and propagate all rows once
   domain.computeRowActivities();
   domain.propagate();
@@ -429,11 +465,18 @@ void HighsMipSolverData::runSetup() {
     return;
   }
 
+  if (model.numCol_ == 0) {
+    mipsolver.modelstatus_ = HighsModelStatus::OPTIMAL;
+    return;
+  }
+
   if (checkLimits()) return;
   // extract cliques if they have not been extracted before
   if (!cliquesExtracted) {
     cliquesExtracted = true;
     cliquetable.extractCliques(mipsolver);
+    if (!domain.infeasible() && upper_limit != HIGHS_CONST_INF)
+      cliquetable.extractObjCliques(mipsolver);
     if (domain.infeasible()) {
       mipsolver.modelstatus_ = HighsModelStatus::PRIMAL_INFEASIBLE;
       lower_bound = HIGHS_CONST_INF;
@@ -484,6 +527,22 @@ void HighsMipSolverData::runSetup() {
 
   checkObjIntegrality();
   basisTransfer();
+
+  continuous_cols.clear();
+  integer_cols.clear();
+  implint_cols.clear();
+  for (int i = 0; i != mipsolver.numCol(); ++i) {
+    switch (mipsolver.variableType(i)) {
+      case HighsVarType::CONTINUOUS:
+        continuous_cols.push_back(i);
+        break;
+      case HighsVarType::IMPLICIT_INTEGER:
+        implint_cols.push_back(i);
+        break;
+      case HighsVarType::INTEGER:
+        integer_cols.push_back(i);
+    }
+  }
 }
 
 void HighsMipSolverData::basisTransfer() {
@@ -664,6 +723,7 @@ void HighsMipSolverData::addIncumbent(const std::vector<double>& sol,
     }
     if (new_upper_limit < upper_limit) {
       upper_limit = new_upper_limit;
+      cliquetable.extractObjCliques(mipsolver);
       pruned_treeweight += nodequeue.performBounding(upper_limit);
       printDisplayLine(source);
     }
@@ -720,7 +780,6 @@ void HighsMipSolverData::printDisplayLine(char first) {
 
 void HighsMipSolverData::evaluateRootNode() {
   // solve the first root lp
-
   HighsPrintMessage(mipsolver.options_mip_->output,
                     mipsolver.options_mip_->message_level, ML_MINIMAL,
                     "\nsolving root node LP relaxation\n");
@@ -744,6 +803,20 @@ void HighsMipSolverData::evaluateRootNode() {
   if (lp.unscaledDualFeasible(lp.getStatus()))
     mipsolver.mipdata_->lower_bound = lp.getObjective();
 
+  heuristics.randomizedRounding(firstlpsol);
+  heuristics.flushStatistics();
+
+  if (mipsolver.mipdata_->domain.infeasible() ||
+      mipsolver.mipdata_->lower_bound > mipsolver.mipdata_->upper_limit) {
+    mipsolver.modelstatus_ = HighsModelStatus::PRIMAL_INFEASIBLE;
+    lower_bound = std::min(HIGHS_CONST_INF, upper_bound);
+    total_lp_iterations = lp.getNumLpIterations();
+    pruned_treeweight = 1.0;
+    num_nodes = 1;
+    num_leaves = 1;
+    return;
+  }
+
   // begin separation
   std::vector<double> avgdirection;
   std::vector<double> curdirection;
@@ -766,6 +839,7 @@ void HighsMipSolverData::evaluateRootNode() {
     if (checkLimits()) return;
     ++nseparounds;
     printDisplayLine();
+
     size_t tmpilpiters = lp.getNumLpIterations();
     maxrootlpiters =
         std::max(maxrootlpiters, lp.getNumLpIterations() - tmpilpiters);
@@ -780,8 +854,19 @@ void HighsMipSolverData::evaluateRootNode() {
       return;
     }
 
+    // if( nseparounds == 5 )
+    //{
+    //  feasibilityPump();
+    //  lp.resolveLp();
+    //}
+
     const std::vector<double>& solvals =
         lp.getLpSolver().getSolution().col_value;
+
+    if (incumbent.empty()) {
+      heuristics.randomizedRounding(solvals);
+      heuristics.flushStatistics();
+    }
 
     HighsCDouble sqrnorm = 0.0;
     for (int i = 0; i != mipsolver.numCol(); ++i) {
@@ -867,6 +952,23 @@ void HighsMipSolverData::evaluateRootNode() {
     // add the root node to the nodequeue to initialize the search
     nodequeue.emplaceNode(std::vector<HighsDomainChange>(), lp.getObjective(),
                           lp.getObjective(), 1);
+    heuristics.RENS(rootlpsol);
+    heuristics.flushStatistics();
+    if (upper_limit == HIGHS_CONST_INF && !mipsolver.submip) {
+      heuristics.centralRounding();
+      heuristics.flushStatistics();
+      if (upper_limit == HIGHS_CONST_INF) {
+        heuristics.feasibilityPump();
+        heuristics.flushStatistics();
+      }
+    }
+
+    if (nodequeue.empty()) {
+      mipsolver.modelstatus_ = HighsModelStatus::OPTIMAL;
+      pruned_treeweight = 1.0;
+      num_nodes = 1;
+      num_leaves = 1;
+    }
   }
 }
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -364,6 +364,28 @@ void HighsMipSolverData::runSetup() {
     highsSparseTranspose(model.numRow_, model.numCol_, model.Astart_,
                          model.Aindex_, model.Avalue_, ARstart_, ARindex_,
                          ARvalue_);
+    uplocks.resize(model.numCol_);
+    downlocks.resize(model.numCol_);
+    for (int i = 0; i != model.numCol_; ++i) {
+      int start = model.Astart_[i];
+      int end = model.Astart_[i + 1];
+      for (int j = start; j != end; ++j) {
+        int row = model.Aindex_[j];
+
+        if (model.rowLower_[row] != -HIGHS_CONST_INF) {
+          if (model.Avalue_[j] < 0)
+            ++uplocks[i];
+          else
+            ++downlocks[i];
+        }
+        if (model.rowUpper_[row] != HIGHS_CONST_INF) {
+          if (model.Avalue_[j] < 0)
+            ++downlocks[i];
+          else
+            ++uplocks[i];
+        }
+      }
+    }
   }
 
   if (mipsolver.submip) pseudocost.setMinReliable(0);

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -709,7 +709,7 @@ void HighsMipSolverData::evaluateRootNode() {
   lp.getLpSolver().setHighsOptionValue("presolve", "off");
   maxrootlpiters = lp.getNumLpIterations();
 
-  lp.setIterationLimit(std::max(1000, int(50 * maxrootlpiters)));
+  lp.setIterationLimit(std::max(10000, int(50 * maxrootlpiters)));
   lp.getLpSolver().setHighsLogfile();
   lp.getLpSolver().setHighsOutput();
   lp.getLpSolver().setHighsOptionValue("parallel", "off");
@@ -807,7 +807,7 @@ void HighsMipSolverData::evaluateRootNode() {
       mipsolver.mipdata_->lower_bound = lp.getObjective();
     total_lp_iterations = lp.getNumLpIterations();
 
-    lp.setIterationLimit(int(50 * maxrootlpiters));
+    lp.setIterationLimit(std::max(10000, int(50 * maxrootlpiters)));
 
     if (mipsolver.mipdata_->lower_bound > mipsolver.mipdata_->upper_limit) {
       mipsolver.modelstatus_ = HighsModelStatus::PRIMAL_INFEASIBLE;
@@ -840,7 +840,7 @@ void HighsMipSolverData::evaluateRootNode() {
   } else {
     rootlpsol = lp.getLpSolver().getSolution().col_value;
     rootlpsolobj = lp.getObjective();
-    lp.setIterationLimit(int(50 * maxrootlpiters));
+    lp.setIterationLimit(std::max(10000, int(50 * maxrootlpiters)));
 
     // add the root node to the nodequeue to initialize the search
     nodequeue.emplaceNode(std::vector<HighsDomainChange>(), lp.getObjective(),
@@ -937,6 +937,8 @@ void HighsMipSolverData::runProbing() {
     int nprobed = 0;
     for (std::tuple<int, int, int> binvar : binaries) {
       int i = std::get<2>(binvar);
+
+      if (cliquetable.getSubstitution(i) != nullptr) continue;
 
       if (domain.isBinary(i)) {
         if (nprobed % 16 == 1 && checkLimits()) return;

--- a/src/mip/HighsMipSolverData.h
+++ b/src/mip/HighsMipSolverData.h
@@ -10,6 +10,7 @@
 #include "mip/HighsImplications.h"
 #include "mip/HighsLpRelaxation.h"
 #include "mip/HighsNodeQueue.h"
+#include "mip/HighsPrimalHeuristics.h"
 #include "mip/HighsPseudocost.h"
 #include "mip/HighsSearch.h"
 #include "mip/HighsSeparation.h"
@@ -27,6 +28,7 @@ struct HighsMipSolverData {
   HighsPseudocost pseudocost;
   HighsCliqueTable cliquetable;
   HighsImplications implications;
+  HighsPrimalHeuristics heuristics;
   struct Substitution {
     int substcol;
     int staycol;
@@ -62,6 +64,9 @@ struct HighsMipSolverData {
   std::vector<uint8_t> rowintegral;
   std::vector<int> uplocks;
   std::vector<int> downlocks;
+  std::vector<int> integer_cols;
+  std::vector<int> implint_cols;
+  std::vector<int> continuous_cols;
   double objintscale;
 
   double feastol;
@@ -95,11 +100,14 @@ struct HighsMipSolverData {
   HighsMipSolverData(HighsMipSolver& mipsolver)
       : mipsolver(mipsolver),
         cutpool(mipsolver.numCol(), 10),
-        domain(mipsolver, cutpool),
+        domain(mipsolver),
         lp(mipsolver),
         pseudocost(mipsolver.numCol()),
         cliquetable(mipsolver.numCol()),
-        implications(domain, cliquetable) {}
+        implications(domain, cliquetable),
+        heuristics(mipsolver) {
+    domain.addCutpool(cutpool);
+  }
 
   void init();
   void basisTransfer();
@@ -107,6 +115,7 @@ struct HighsMipSolverData {
   void cliqueExtraction();
   void runSetup();
   void runProbing();
+  bool trySolution(const std::vector<double>& solution, char source = ' ');
   void evaluateRootNode();
   void addIncumbent(const std::vector<double>& sol, double solobj, char source);
 

--- a/src/mip/HighsMipSolverData.h
+++ b/src/mip/HighsMipSolverData.h
@@ -60,6 +60,8 @@ struct HighsMipSolverData {
   std::vector<double> ARvalue_;
   std::vector<double> maxAbsRowCoef;
   std::vector<uint8_t> rowintegral;
+  std::vector<int> uplocks;
+  std::vector<int> downlocks;
   double objintscale;
 
   double feastol;

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -1,0 +1,681 @@
+#include "mip/HighsPrimalHeuristics.h"
+
+#include <numeric>
+#include <unordered_set>
+
+#include "lp_data/HighsLpUtils.h"
+#include "mip/HighsMipSolverData.h"
+#include "util/HighsHash.h"
+
+HighsPrimalHeuristics::HighsPrimalHeuristics(HighsMipSolver& mipsolver)
+    : mipsolver(mipsolver), lp_iterations(0), randgen(0) {}
+
+void HighsPrimalHeuristics::solveSubMip(std::vector<double> colLower,
+                                        std::vector<double> colUpper,
+                                        int maxleaves, int maxnodes) {
+  HighsOptions submipoptions = *mipsolver.options_mip_;
+  HighsLp submip = *mipsolver.model_;
+
+  // set bounds and restore integrality of the lp relaxation copy
+  submip.colLower_ = std::move(colLower);
+  submip.colUpper_ = std::move(colUpper);
+  submip.integrality_ = mipsolver.model_->integrality_;
+  submip.offset_ = 0;
+
+  // set limits
+  submipoptions.mip_max_leaves = maxleaves;
+  submipoptions.logfile = nullptr;
+  submipoptions.output = nullptr;
+  submipoptions.mip_max_nodes = maxnodes;
+  submipoptions.time_limit -=
+      mipsolver.timer_.read(mipsolver.timer_.solve_clock);
+  submipoptions.dual_objective_value_upper_bound =
+      mipsolver.mipdata_->upper_limit;
+  // setup solver and run it
+  HighsMipSolver submipsolver(submipoptions, submip, true);
+  submipsolver.rootbasis = &mipsolver.mipdata_->firstrootbasis;
+  submipsolver.run();
+
+  if (submipsolver.modelstatus_ != HighsModelStatus::PRIMAL_INFEASIBLE &&
+      !submipsolver.presolve_.data_.recovered_solution_.col_value.empty()) {
+    mipsolver.mipdata_->trySolution(
+        submipsolver.presolve_.data_.recovered_solution_.col_value, 'L');
+  }
+
+  if (submipsolver.mipdata_) {
+    double adjustmentfactor =
+        submipsolver.numNonzero() / (double)mipsolver.numNonzero();
+    size_t adjusted_lp_iterations =
+        (size_t)(adjustmentfactor * adjustmentfactor *
+                 submipsolver.mipdata_->total_lp_iterations);
+    lp_iterations += adjusted_lp_iterations;
+  }
+}
+
+void HighsPrimalHeuristics::RINS(const std::vector<double>& relaxationsol) {
+  if (int(relaxationsol.size()) != mipsolver.numCol()) return;
+
+  HighsSearch heur(mipsolver, mipsolver.mipdata_->pseudocost);
+  HighsDomain& localdom = heur.getLocalDomain();
+  heur.setHeuristic(true);
+
+  HighsLpRelaxation heurlp(mipsolver.mipdata_->lp);
+  // only use the global upper limit as LP limit so that dual proofs are valid
+  heurlp.setObjectiveLimit(mipsolver.mipdata_->upper_limit);
+  heur.setLpRelaxation(&heurlp);
+
+  heurlp.getLpSolver().changeColsBounds(0, mipsolver.numCol() - 1,
+                                        localdom.colLower_.data(),
+                                        localdom.colUpper_.data());
+  localdom.clearChangedCols();
+  heur.createNewNode();
+  int nbacktracks = 0;
+
+  // determine the initial number of unfixed variables fixing rate to decide if
+  // the problem is restricted enough to be considered for solving a submip
+  static constexpr double minfixingrate = 0.25;
+  int ntotal = 0;
+  int nfixed = 0;
+  double fixingrate = 0.0;
+  bool stop = false;
+
+  while (true) {
+    heur.evaluateNode();
+    if (heur.currentNodePruned()) {
+      ++nbacktracks;
+      // printf("backtrack1\n");
+      if (!heur.backtrack()) break;
+      continue;
+    }
+
+    // if we estimate that there is no improving solution in this subtree, we
+    // stop fixing variables but still backtrack to a node that has a good
+    // estimate and is not pruned as the stop flag is checked after the
+    // acktracking
+    if (heur.getCurrentEstimate() > mipsolver.mipdata_->upper_limit) {
+      heur.cutoffNode();
+      ++nbacktracks;
+      // printf("backtrack2\n");
+      if (!heur.backtrack()) break;
+      stop = true;
+      continue;
+    }
+
+    nfixed = 0;
+    ntotal = 0;
+    for (int i = 0; i != mipsolver.numCol(); ++i) {
+      // skip fixed and continuous variables
+      if (mipsolver.variableType(i) == HighsVarType::CONTINUOUS) continue;
+      if (mipsolver.mipdata_->domain.colLower_[i] ==
+          mipsolver.mipdata_->domain.colUpper_[i])
+        continue;
+
+      ++ntotal;
+      // count locally fixed variable
+      if (localdom.colLower_[i] == localdom.colUpper_[i]) ++nfixed;
+    }
+    fixingrate = nfixed / (double)ntotal;
+
+    if (stop) break;
+    if (nbacktracks >= 10) break;
+
+    std::vector<std::pair<int, double>>::iterator fixcandend;
+
+    // partition the fractional variables to consider which ones should we fix
+    // in this dive first if there is an incumbent, we dive towards the RINS
+    // neighborhood
+    fixcandend = std::partition(
+        heurlp.getFractionalIntegers().begin(),
+        heurlp.getFractionalIntegers().end(),
+        [&](const std::pair<int, double>& fracvar) {
+          return std::abs(relaxationsol[fracvar.first] -
+                          mipsolver.mipdata_->incumbent[fracvar.first]) <=
+                 mipsolver.mipdata_->feastol;
+        });
+
+    bool fixtolpsol = true;
+
+    auto getFixVal = [&](int col, double fracval) {
+      double fixval;
+      if (fixtolpsol) {
+        // RINS neighborhood (with extension)
+        fixval = std::floor(relaxationsol[col] + 0.5);
+      } else {
+        // reinforce direction of this solution away from root
+        // solution if the change is at least 0.4
+        // otherwise take the direction where the objective gets worse
+        // if objcetive is zero round to nearest integer
+        double rootchange = fracval - mipsolver.mipdata_->rootlpsol[col];
+        if (rootchange >= 0.4)
+          fixval = std::ceil(fracval);
+        else if (rootchange <= -0.4)
+          fixval = std::floor(fracval);
+        if (mipsolver.model_->colCost_[col] > 0.0)
+          fixval = std::ceil(fracval);
+        else if (mipsolver.model_->colCost_[col] < 0.0)
+          fixval = std::floor(fracval);
+        else
+          fixval = std::floor(fracval + 0.5);
+      }
+      // make sure we do not set an infeasible domain
+      fixval = std::min(localdom.colUpper_[col], fixval);
+      fixval = std::max(localdom.colLower_[col], fixval);
+      return fixval;
+    };
+
+    // no candidates left to fix for getting to the neighborhood, therefore we
+    // switch to a different diving strategy until the minimal fixing rate is
+    // reached
+    if (heurlp.getFractionalIntegers().begin() == fixcandend) {
+      if (fixingrate >= minfixingrate)
+        break;  // if the RINS neigborhood achieved a high enough fixing rate by
+                // itself we stop here
+      fixcandend = heurlp.getFractionalIntegers().end();
+      // now sort the variables by their distance towards the value they will be
+      // fixed to
+      fixtolpsol = false;
+    }
+
+    // now sort the variables by their distance towards the value they will be
+    // fixed to
+    std::sort(
+        heurlp.getFractionalIntegers().begin(), fixcandend,
+        [&](const std::pair<int, double>& a, const std::pair<int, double>& b) {
+          return std::abs(getFixVal(a.first, a.second) - a.second) <
+                 std::abs(getFixVal(b.first, b.second) - b.second);
+        });
+
+    double change = 0.0;
+    // select a set of fractional variables to fix
+    for (auto fracint : heurlp.getFractionalIntegers()) {
+      double fixval = getFixVal(fracint.first, fracint.second);
+
+      if (localdom.colLower_[fracint.first] < fixval) {
+        heur.branchUpwards(fracint.first, fixval, fracint.second);
+        if (localdom.infeasible()) break;
+      }
+
+      if (localdom.colUpper_[fracint.first] > fixval) {
+        heur.branchDownwards(fracint.first, fixval, fracint.second);
+        if (localdom.infeasible()) break;
+      }
+
+      ++nfixed;
+      fixingrate = nfixed / (double)ntotal;
+      //  if (fixingrate >= maxfixingrate) break;
+      change += std::abs(fixval - fracint.second);
+      if (change >= 1.0) break;
+    }
+
+    heurlp.flushDomain(localdom);
+
+    // printf("%d/%d fixed, fixingrate is %g\n", nfixed, ntotal, fixingrate);
+  }
+
+  // if there is no node left it means we backtracked to the global domain and
+  // the subproblem was solved with the dive
+  if (!heur.hasNode()) {
+    lp_iterations += heur.getLocalLpIterations();
+    return;
+  }
+  // determine the fixing rate to decide if the problem is restricted enough to
+  // be considered for solving a submip
+
+  // printf("fixing rate is %g\n", fixingrate);
+  if (fixingrate < 0.1) {
+    // heur.childselrule = ChildSelectionRule::BestCost;
+    heur.setMinReliable(0);
+    heur.solveDepthFirst(10);
+    lp_iterations += heur.getLocalLpIterations();
+    // lpiterations += heur.lpiterations;
+    // pseudocost = heur.pseudocost;
+    return;
+  }
+
+  solveSubMip(std::move(localdom.colLower_), std::move(localdom.colUpper_),
+              500,  // std::max(50, int(0.05 *
+                    // (mipsolver.mipdata_->num_leaves))),
+              200 + int(0.05 * (mipsolver.mipdata_->num_nodes)));
+}
+
+bool HighsPrimalHeuristics::tryRoundedPoint(const std::vector<double>& point,
+                                            char source) {
+  auto localdom = mipsolver.mipdata_->domain;
+
+  int numintcols = mipsolver.mipdata_->integer_cols.size();
+  for (int i = 0; i != numintcols; ++i) {
+    int col = mipsolver.mipdata_->integer_cols[i];
+    double intval = point[col];
+    intval = std::min(localdom.colUpper_[col], intval);
+    intval = std::max(localdom.colLower_[col], intval);
+
+    localdom.fixCol(col, intval);
+    if (localdom.infeasible()) return false;
+    localdom.propagate();
+    if (localdom.infeasible()) return false;
+  }
+
+  if (numintcols != mipsolver.numCol()) {
+    HighsLpRelaxation lprelax(mipsolver);
+    lprelax.getLpSolver().changeColsBounds(0, mipsolver.numCol() - 1,
+                                           localdom.colLower_.data(),
+                                           localdom.colUpper_.data());
+
+    if (numintcols / (double)mipsolver.numCol() >= 0.2)
+      lprelax.getLpSolver().setHighsOptionValue("presolve", "on");
+    else
+      lprelax.getLpSolver().setBasis(mipsolver.mipdata_->firstrootbasis);
+
+    HighsLpRelaxation::Status st = lprelax.resolveLp();
+
+    if (st == HighsLpRelaxation::Status::Infeasible) {
+      std::vector<int> inds;
+      std::vector<double> vals;
+      double rhs;
+      if (lprelax.computeDualInfProof(mipsolver.mipdata_->domain, inds, vals,
+                                      rhs)) {
+        HighsSeparation::computeAndAddConflictCut(mipsolver, localdom, inds,
+                                                  vals, rhs);
+      }
+      return false;
+    } else if (lprelax.unscaledPrimalFeasible(st)) {
+      mipsolver.mipdata_->addIncumbent(
+          lprelax.getLpSolver().getSolution().col_value, lprelax.getObjective(),
+          source);
+      return true;
+    }
+  }
+
+  return mipsolver.mipdata_->trySolution(localdom.colLower_, source);
+}
+
+bool HighsPrimalHeuristics::linesearchRounding(
+    const std::vector<double>& point1, const std::vector<double>& point2,
+    char source) {
+  std::vector<double> roundedpoint;
+
+  int numintcols = mipsolver.mipdata_->integer_cols.size();
+  roundedpoint.resize(mipsolver.numCol());
+
+  double alpha = 0.0;
+
+  while (alpha < 1.0) {
+    double nextalpha = 1.0;
+    bool reachedpoint2 = true;
+    printf("trying alpha = %g\n", alpha);
+    for (int i = 0; i != numintcols; ++i) {
+      int col = mipsolver.mipdata_->integer_cols[i];
+      if (mipsolver.mipdata_->uplocks[col] == 0) {
+        roundedpoint[col] = std::ceil(std::max(point1[col], point2[col]) -
+                                      mipsolver.mipdata_->feastol);
+        continue;
+      }
+
+      if (mipsolver.mipdata_->downlocks[col] == 0) {
+        roundedpoint[col] = std::floor(std::min(point1[col], point2[col]) +
+                                       mipsolver.mipdata_->feastol);
+        continue;
+      }
+
+      double convexcomb = (1.0 - alpha) * point1[col] + alpha * point2[col];
+      double intpoint2 = std::floor(point2[col] + 0.5);
+      roundedpoint[col] = std::floor(convexcomb + 0.5);
+
+      if (roundedpoint[col] == intpoint2) continue;
+
+      reachedpoint2 = false;
+      double tmpalpha = (roundedpoint[col] + 0.5 + mipsolver.mipdata_->feastol -
+                         point1[col]) /
+                        std::abs(point2[col] - point1[col]);
+      if (tmpalpha < nextalpha && tmpalpha > alpha + 1e-2) nextalpha = tmpalpha;
+    }
+
+    if (tryRoundedPoint(roundedpoint, source)) return true;
+
+    if (reachedpoint2) return false;
+
+    alpha = nextalpha;
+  }
+
+  return false;
+}
+
+void HighsPrimalHeuristics::randomizedRounding(
+    const std::vector<double>& relaxationsol) {
+  if (int(relaxationsol.size()) != mipsolver.numCol()) return;
+
+  auto localdom = mipsolver.mipdata_->domain;
+
+  std::uniform_real_distribution<double> dist(0.1, 0.9);
+
+  for (int i : mipsolver.mipdata_->integer_cols) {
+    double intval;
+    if (mipsolver.mipdata_->uplocks[i] == 0)
+      intval = std::ceil(relaxationsol[i] - mipsolver.mipdata_->feastol);
+    else if (mipsolver.mipdata_->downlocks[i] == 0)
+      intval = std::floor(relaxationsol[i] + mipsolver.mipdata_->feastol);
+    else
+      intval = std::floor(relaxationsol[i] + dist(randgen));
+
+    intval = std::min(localdom.colUpper_[i], intval);
+    intval = std::max(localdom.colLower_[i], intval);
+
+    localdom.fixCol(i, intval);
+    if (localdom.infeasible()) return;
+    localdom.propagate();
+    if (localdom.infeasible()) return;
+  }
+
+  if (int(mipsolver.mipdata_->integer_cols.size()) != mipsolver.numCol()) {
+    HighsLpRelaxation lprelax(mipsolver.mipdata_->lp);
+    lprelax.getLpSolver().changeColsBounds(0, mipsolver.numCol() - 1,
+                                           localdom.colLower_.data(),
+                                           localdom.colUpper_.data());
+    HighsLpRelaxation::Status st = lprelax.resolveLp();
+
+    if (st == HighsLpRelaxation::Status::Infeasible) {
+      std::vector<int> inds;
+      std::vector<double> vals;
+      double rhs;
+      if (lprelax.computeDualInfProof(mipsolver.mipdata_->domain, inds, vals,
+                                      rhs)) {
+        HighsSeparation::computeAndAddConflictCut(mipsolver, localdom, inds,
+                                                  vals, rhs);
+      }
+
+    } else if (lprelax.unscaledPrimalFeasible(st))
+      mipsolver.mipdata_->addIncumbent(
+          lprelax.getLpSolver().getSolution().col_value, lprelax.getObjective(),
+          'R');
+  } else {
+    mipsolver.mipdata_->trySolution(localdom.colLower_, 'R');
+  }
+}
+
+void HighsPrimalHeuristics::RENS(const std::vector<double>& relaxationsol) {
+  if (int(relaxationsol.size()) != mipsolver.numCol()) return;
+
+  HighsSearch heur(mipsolver, mipsolver.mipdata_->pseudocost);
+  HighsDomain& localdom = heur.getLocalDomain();
+  heur.setHeuristic(true);
+
+  for (int i = 0; i != mipsolver.numCol(); ++i) {
+    if (mipsolver.variableType(i) != HighsVarType::INTEGER) continue;
+    if (localdom.colLower_[i] == localdom.colUpper_[i]) continue;
+
+    double downval = std::floor(relaxationsol[i] + mipsolver.mipdata_->feastol);
+    double upval = std::ceil(relaxationsol[i] - mipsolver.mipdata_->feastol);
+
+    if (localdom.colLower_[i] < downval) {
+      localdom.changeBound(HighsBoundType::Lower, i,
+                           std::min(downval, localdom.colUpper_[i]));
+      if (!localdom.infeasible()) localdom.propagate();
+      if (localdom.infeasible()) localdom.backtrack();
+    }
+    if (localdom.colUpper_[i] > upval) {
+      localdom.changeBound(HighsBoundType::Upper, i,
+                           std::max(upval, localdom.colLower_[i]));
+      if (!localdom.infeasible()) localdom.propagate();
+      if (localdom.infeasible()) localdom.backtrack();
+    }
+  }
+  if (localdom.infeasible() || localdom.getChangedCols().empty()) return;
+
+  int nfixed = 0;
+  int ntotal = 0;
+  for (int i = 0; i != mipsolver.numCol(); ++i) {
+    // skip fixed and continuous variables
+    if (mipsolver.variableType(i) == HighsVarType::CONTINUOUS) continue;
+    if (mipsolver.mipdata_->domain.colLower_[i] ==
+        mipsolver.mipdata_->domain.colUpper_[i])
+      continue;
+
+    ++ntotal;
+    // count locally fixed variable
+    if (localdom.colLower_[i] == localdom.colUpper_[i]) ++nfixed;
+  }
+  double fixingrate = nfixed / (double)ntotal;
+  // printf("RENS fixing rate: %.2f\n", fixingrate);
+  if (fixingrate < 0.1) {
+    // if the fixing rate is too small we just perform a dive with some
+    // backtracks in this neighborhood and do not create a submip
+    HighsLpRelaxation heurlp(mipsolver.mipdata_->lp);
+    // only use the global upper limit as LP limit so that dual proofs are
+    // valid
+    heurlp.setObjectiveLimit(mipsolver.mipdata_->upper_limit);
+    heur.setLpRelaxation(&heurlp);
+
+    heurlp.getLpSolver().changeColsBounds(0, mipsolver.numCol() - 1,
+                                          localdom.colLower_.data(),
+                                          localdom.colUpper_.data());
+    localdom.clearChangedCols();
+    heur.createNewNode();
+    heur.setMinReliable(0);
+    heur.solveDepthFirst(10);
+    lp_iterations += heur.getLocalLpIterations();
+    // pseudocost = std::move(heur.getPseudoCost();
+    return;
+  }
+
+  solveSubMip(std::move(localdom.colLower_), std::move(localdom.colUpper_),
+              500,  // std::max(50, int(0.05 *
+                    // (mipsolver.mipdata_->num_leaves))),
+              200 + int(0.05 * mipsolver.mipdata_->num_nodes));
+}
+
+void HighsPrimalHeuristics::feasibilityPump() {
+  HighsLpRelaxation lprelax(mipsolver.mipdata_->lp);
+  std::unordered_set<std::vector<int>, HighsVectorHasher, HighsVectorEqual>
+      referencepoints;
+  std::vector<double> roundedsol;
+  HighsLpRelaxation::Status status = lprelax.resolveLp();
+  lp_iterations += lprelax.getNumLpIterations();
+
+  std::uniform_real_distribution<double> roundingdist(0.4, 0.6);
+  std::uniform_real_distribution<double> perturbdist(-1e-4, 1e-4);
+  std::vector<double> fracintcost;
+  std::vector<int> fracintset;
+
+  std::vector<int> mask(mipsolver.model_->numCol_, 1);
+  std::vector<double> cost(mipsolver.model_->numCol_, 0.0);
+  if (mipsolver.mipdata_->upper_limit != HIGHS_CONST_INF) {
+    std::vector<int> objinds;
+    std::vector<double> objval;
+    for (int i = 0; i != mipsolver.numCol(); ++i) {
+      if (mipsolver.colCost(i) != 0) {
+        objinds.push_back(i);
+        objval.push_back(mipsolver.colCost(i));
+      }
+    }
+
+    lprelax.getLpSolver().addRow(-HIGHS_CONST_INF,
+                                 mipsolver.mipdata_->upper_limit,
+                                 objinds.size(), objinds.data(), objval.data());
+  }
+
+  lprelax.getLpSolver().setHighsLogfile(mipsolver.options_mip_->logfile);
+  lprelax.getLpSolver().setHighsOutput(mipsolver.options_mip_->output);
+
+  lprelax.getLpSolver().setHighsOptionValue("simplex_strategy",
+                                            SIMPLEX_STRATEGY_PRIMAL);
+  lprelax.getLpSolver().setHighsOptionValue(
+      "primal_simplex_bound_perturbation_multiplier", 0.0);
+
+  lprelax.setIterationLimit(mipsolver.mipdata_->maxrootlpiters);
+
+  while (!lprelax.getFractionalIntegers().empty()) {
+    const auto& lpsol = lprelax.getLpSolver().getSolution().col_value;
+    roundedsol = lprelax.getLpSolver().getSolution().col_value;
+
+    std::vector<int> referencepoint;
+    referencepoint.reserve(mipsolver.mipdata_->integer_cols.size());
+
+    auto localdom = mipsolver.mipdata_->domain;
+    for (int i : mipsolver.mipdata_->integer_cols) {
+      assert(mipsolver.variableType(i) == HighsVarType::INTEGER);
+      double intval = std::floor(roundedsol[i] + roundingdist(randgen));
+      intval = std::max(intval, localdom.colLower_[i]);
+      intval = std::min(intval, localdom.colUpper_[i]);
+      roundedsol[i] = intval;
+      referencepoint.push_back((int)intval);
+      if (!localdom.infeasible()) {
+        localdom.fixCol(i, intval);
+        if (localdom.infeasible()) continue;
+        localdom.propagate();
+        if (localdom.infeasible()) continue;
+      }
+    }
+
+    bool havecycle = !referencepoints.emplace(referencepoint).second;
+
+    while (havecycle) {
+      std::uniform_int_distribution<int> dist(
+          0, mipsolver.mipdata_->integer_cols.size() - 1);
+      for (int i = 0; i != 10; ++i) {
+        int flippos = dist(randgen);
+        int col = mipsolver.mipdata_->integer_cols[flippos];
+        if (roundedsol[col] > lpsol[col])
+          roundedsol[col] = (int)std::floor(lpsol[col]);
+        else if (roundedsol[col] < lpsol[col])
+          roundedsol[col] = (int)std::ceil(lpsol[col]);
+        else if (roundedsol[col] < mipsolver.mipdata_->domain.colUpper_[col])
+          roundedsol[col] = mipsolver.mipdata_->domain.colUpper_[col];
+        else
+          roundedsol[col] = mipsolver.mipdata_->domain.colLower_[col];
+
+        referencepoint[flippos] = (int)roundedsol[col];
+      }
+      havecycle = !referencepoints.emplace(referencepoint).second;
+    }
+
+    if (linesearchRounding(lpsol, roundedsol, 'F')) return;
+
+    if (lprelax.getNumLpIterations() >=
+        1000 + mipsolver.mipdata_->maxrootlpiters * 3)
+      break;
+
+    for (int i : mipsolver.mipdata_->integer_cols) {
+      assert(mipsolver.variableType(i) == HighsVarType::INTEGER);
+
+      if (lpsol[i] > roundedsol[i] - mipsolver.mipdata_->feastol)
+        cost[i] = -1.0 + perturbdist(randgen);
+      else
+        cost[i] = 1.0 + perturbdist(randgen);
+    }
+
+    lprelax.getLpSolver().changeColsCost(mask.data(), cost.data());
+    size_t oldnumiters = lprelax.getNumLpIterations();
+    status = lprelax.resolveLp();
+    lp_iterations += lprelax.getNumLpIterations() - oldnumiters;
+  }
+
+  if (lprelax.getFractionalIntegers().empty() &&
+      lprelax.unscaledPrimalFeasible(status))
+    mipsolver.mipdata_->addIncumbent(
+        lprelax.getLpSolver().getSolution().col_value, lprelax.getObjective(),
+        'F');
+}
+
+void HighsPrimalHeuristics::centralRounding() {
+  Highs ipm;
+  ipm.setHighsOptionValue("solver", "ipm");
+  ipm.setHighsOptionValue("run_crossover", false);
+  ipm.setHighsOptionValue("presolve", "off");
+  HighsLp lpmodel(
+      *mipsolver.model_);  // mipsolver.mipdata_->lp.getLpSolver().getLp());
+  lpmodel.colCost_.assign(lpmodel.numCol_, 0.0);
+  ipm.passModel(std::move(lpmodel));
+
+  if (mipsolver.mipdata_->upper_limit != HIGHS_CONST_INF) {
+    std::vector<int> objinds;
+    std::vector<double> objval;
+    for (int i = 0; i != mipsolver.numCol(); ++i) {
+      if (mipsolver.colCost(i) != 0) {
+        objinds.push_back(i);
+        objval.push_back(mipsolver.colCost(i));
+      }
+    }
+
+    ipm.addRow(-HIGHS_CONST_INF, mipsolver.mipdata_->upper_limit,
+               objinds.size(), objinds.data(), objval.data());
+  }
+  ipm.run();
+
+  const std::vector<double>& sol = ipm.getSolution().col_value;
+
+  linesearchRounding(mipsolver.mipdata_->firstlpsol, sol, 'C');
+}
+
+void HighsPrimalHeuristics::clique() {
+  std::unordered_map<int, double> entries;
+  double offset = 0.0;
+
+  HighsDomain& globaldom = mipsolver.mipdata_->domain;
+  for (int j = 0; j != mipsolver.numCol(); ++j) {
+    int col = j;
+    double val = mipsolver.colCost(col);
+    if (val == 0.0) continue;
+
+    if (!globaldom.isBinary(col)) {
+      offset += val * globaldom.colLower_[col];
+      continue;
+    }
+
+    mipsolver.mipdata_->cliquetable.resolveSubstitution(col, val, offset);
+    entries[col] += val;
+  }
+
+  std::vector<double> profits;
+  std::vector<HighsCliqueTable::CliqueVar> objvars;
+
+  for (const std::pair<int, double>& entry : entries) {
+    double objprofit = -entry.second;
+    if (objprofit < 0) {
+      offset += objprofit;
+      profits.push_back(-objprofit);
+      objvars.emplace_back(entry.first, 0);
+    } else {
+      profits.push_back(objprofit);
+      objvars.emplace_back(entry.first, 1);
+    }
+  }
+
+  std::vector<double> solution(mipsolver.numCol());
+
+  int nobjvars = profits.size();
+  for (int i = 0; i != nobjvars; ++i) solution[objvars[i].col] = objvars[i].val;
+
+  std::vector<std::vector<HighsCliqueTable::CliqueVar>> cliques;
+  double bestviol;
+  int bestviolpos;
+  int numcliques;
+
+  cliques = mipsolver.mipdata_->cliquetable.separateCliques(
+      solution, mipsolver.mipdata_->domain, mipsolver.mipdata_->feastol);
+  numcliques = cliques.size();
+  while (numcliques != 0) {
+    bestviol = 0.5;
+    bestviolpos = -1;
+
+    for (int c = 0; c != numcliques; ++c) {
+      double viol = -1.0;
+      for (HighsCliqueTable::CliqueVar clqvar : cliques[c])
+        viol += clqvar.weight(solution);
+
+      if (viol > bestviolpos) {
+        bestviolpos = c;
+        bestviol = viol;
+      }
+    }
+
+    cliques = mipsolver.mipdata_->cliquetable.separateCliques(
+        solution, mipsolver.mipdata_->domain, mipsolver.mipdata_->feastol);
+    numcliques = cliques.size();
+  }
+}
+
+void HighsPrimalHeuristics::flushStatistics() {
+  mipsolver.mipdata_->heuristic_lp_iterations += lp_iterations;
+  mipsolver.mipdata_->total_lp_iterations += lp_iterations;
+  lp_iterations = 0;
+}

--- a/src/mip/HighsPrimalHeuristics.h
+++ b/src/mip/HighsPrimalHeuristics.h
@@ -1,0 +1,41 @@
+#ifndef HIGHS_PRIMAL_HEURISTICS_H_
+#define HIGHS_PRIMAL_HEURISTICS_H_
+
+#include <random>
+#include <vector>
+
+class HighsMipSolver;
+
+class HighsPrimalHeuristics {
+ private:
+  HighsMipSolver& mipsolver;
+  size_t lp_iterations;
+  std::mt19937 randgen;
+
+ public:
+  HighsPrimalHeuristics(HighsMipSolver& mipsolver);
+
+  void solveSubMip(std::vector<double> colLower, std::vector<double> colUpper,
+                   int maxleaves, int maxnodes);
+
+  void RENS(const std::vector<double>& relaxationsol);
+
+  void RINS(const std::vector<double>& relaxationsol);
+
+  void feasibilityPump();
+
+  void centralRounding();
+
+  void flushStatistics();
+
+  void clique();
+
+  bool tryRoundedPoint(const std::vector<double>& point, char source);
+
+  bool linesearchRounding(const std::vector<double>& point1,
+                          const std::vector<double>& point2, char source);
+
+  void randomizedRounding(const std::vector<double>& relaxationsol);
+};
+
+#endif

--- a/src/mip/HighsSearch.cpp
+++ b/src/mip/HighsSearch.cpp
@@ -579,10 +579,11 @@ int HighsSearch::selectBranchingCandidate() {
   // reliable pseudocost so that they do not get evaluated
   for (int k = 0; k != numfrac; ++k) {
     int col = fracints[k].first;
+    double fracval = fracints[k].second;
 
     if (pseudocost.isReliable(col) || branchingVarReliableAtNode(col)) {
-      upscore[k] = pseudocost.getPseudocostUp(col, fracints[k].second);
-      downscore[k] = pseudocost.getPseudocostDown(col, fracints[k].second);
+      upscore[k] = pseudocost.getPseudocostUp(col, fracval);
+      downscore[k] = pseudocost.getPseudocostDown(col, fracval);
       upscorereliable[k] = true;
       downscorereliable[k] = true;
     }

--- a/src/mip/HighsSearch.h
+++ b/src/mip/HighsSearch.h
@@ -89,8 +89,6 @@ class HighsSearch {
 
   double getCutoffBound() const;
 
-  HighsDomain& getLocalDomain() { return localdom; }
-
   void setLpRelaxation(HighsLpRelaxation* lp) { this->lp = lp; }
 
   double checkSol(const std::vector<double>& sol, bool& integerfeasible) const;
@@ -99,7 +97,21 @@ class HighsSearch {
 
   void heuristicSearchNew();
 
+  void createNewNode();
+
+  void cutoffNode();
+
+  void branchDownwards(int col, double newub, double branchpoint);
+
+  void branchUpwards(int col, double newlb, double branchpoint);
+
+  void setMinReliable(int minreliable);
+
+  void setHeuristic(bool inheuristic) { this->inheuristic = inheuristic; }
+
   void addBoundExceedingConflict();
+
+  void reducedCostFixing();
 
   void resetLocalDomain();
 
@@ -109,6 +121,8 @@ class HighsSearch {
   size_t getHeuristicLpIterations() const;
 
   size_t getTotalLpIterations() const;
+
+  size_t getLocalLpIterations() const;
 
   size_t getStrongBranchingLpIterations() const;
 
@@ -149,6 +163,14 @@ class HighsSearch {
   void printDisplayLine(char first, bool header = false);
 
   void dive();
+
+  HighsDomain& getLocalDomain() { return localdom; }
+
+  const HighsDomain& getLocalDomain() const { return localdom; }
+
+  HighsPseudocost& getPseudoCost() { return pseudocost; }
+
+  const HighsPseudocost& getPseudoCost() const { return pseudocost; }
 
   void solveDepthFirst(size_t maxbacktracks = 1);
 };

--- a/src/mip/HighsSeparation.cpp
+++ b/src/mip/HighsSeparation.cpp
@@ -2414,6 +2414,7 @@ void HighsSeparation::separate(HighsDomain& propdomain) {
       int ncuts = separationRound(propdomain, status);
       nlpiters += lp->getNumLpIterations();
       mipsolver.mipdata_->sepa_lp_iterations += nlpiters;
+      mipsolver.mipdata_->total_lp_iterations += nlpiters;
       // printf("separated %d cuts\n", ncuts);
 
       // printf(

--- a/src/mip/HighsSeparation.cpp
+++ b/src/mip/HighsSeparation.cpp
@@ -950,8 +950,7 @@ class ImpliedBounds {
 #endif
         vals[0] = 1.0;
         inds[0] = col;
-        int cut = cutpool.addCut(inds, vals, 1, 0.0);
-        propdomain.cutAdded(cut);
+        cutpool.addCut(inds, vals, 1, 0.0);
         continue;
       }
 
@@ -992,8 +991,7 @@ class ImpliedBounds {
 
           assert(debugactivity <= rhs + 1e-9);
 #endif
-          int cut = cutpool.addCut(inds, vals, 2, rhs);
-          propdomain.cutAdded(cut);
+          cutpool.addCut(inds, vals, 2, rhs);
         }
       }
 
@@ -1005,8 +1003,7 @@ class ImpliedBounds {
 #endif
         vals[0] = -1.0;
         inds[0] = col;
-        int cut = cutpool.addCut(inds, vals, 1, -1.0);
-        propdomain.cutAdded(cut);
+        cutpool.addCut(inds, vals, 1, -1.0);
         continue;
       }
 
@@ -1046,8 +1043,7 @@ class ImpliedBounds {
 
           assert(debugactivity <= rhs + feastol);
 #endif
-          int cut = cutpool.addCut(inds, vals, 2, rhs);
-          propdomain.cutAdded(cut);
+          cutpool.addCut(inds, vals, 2, rhs);
         }
       }
     }
@@ -1749,9 +1745,7 @@ class AggregationHeuristic {
       assert(debugactivity <= upper + feastol);
 #endif
 
-      int cutindex = cutpool.addCut(inds.data(), vals.data(), inds.size(),
-                                    upper, cutintegral);
-      propdomain.cutAdded(cutindex);
+      cutpool.addCut(inds.data(), vals.data(), inds.size(), upper, cutintegral);
 
       ++numcuts;
     }
@@ -2221,9 +2215,7 @@ void HighsSeparation::BaseRows::retransformAndAddCut(
   double upper = double(rhs);
   // domain.tightenCoefficients(inds.data(), vals.data(), inds.size(),
   // upper);
-  int cutindex =
-      cutpool.addCut(inds.data(), vals.data(), inds.size(), upper, cutintegral);
-  propdomain.cutAdded(cutindex);
+  cutpool.addCut(inds.data(), vals.data(), inds.size(), upper, cutintegral);
 }
 
 int HighsSeparation::separationRound(HighsDomain& propdomain,
@@ -2393,10 +2385,8 @@ void HighsSeparation::computeAndAddConflictCut(HighsMipSolver& mipsolver,
 
     assert(debugactivity <= rhs + mipsolver.mipdata_->epsilon);
 #endif
-
-    int cutind = mipsolver.mipdata_->cutpool.addCut(
-        inds.data(), vals.data(), offset, double(rhs), cutintegral);
-    localdomain.cutAdded(cutind);
+    mipsolver.mipdata_->cutpool.addCut(inds.data(), vals.data(), offset,
+                                       double(rhs), cutintegral);
   }
 }
 

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -412,8 +412,8 @@ void getUnscaledInfeasibilitiesAndNewTolerances(
     int iRow = 0;
     if (col) {
       iCol = iVar;
-      // todo @ Julian the asserts can fail with simplex_scale_strategy=0 and presolve=on
-      // scale.col_.size() is 0 in that case
+      // todo @ Julian the asserts can fail with simplex_scale_strategy=0 and
+      // presolve=on scale.col_.size() is 0 in that case
       assert(int(scale.col_.size()) > iCol);
       scale_mu = 1 / (scale.col_[iCol] / scale.cost_);
     } else {

--- a/src/simplex/HSimplex.cpp
+++ b/src/simplex/HSimplex.cpp
@@ -412,9 +412,13 @@ void getUnscaledInfeasibilitiesAndNewTolerances(
     int iRow = 0;
     if (col) {
       iCol = iVar;
+      // todo @ Julian the asserts can fail with simplex_scale_strategy=0 and presolve=on
+      // scale.col_.size() is 0 in that case
+      assert(int(scale.col_.size()) > iCol);
       scale_mu = 1 / (scale.col_[iCol] / scale.cost_);
     } else {
       iRow = iVar - lp.numCol_;
+      assert(int(scale.row_.size()) > iRow);
       scale_mu = scale.row_[iRow] * scale.cost_;
     }
     const double scaled_dual = simplex_info.workDual_[iVar];

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -28,4 +28,23 @@ struct HighsPairHasher {
   }
 };
 
+struct HighsVectorHasher {
+  template <typename T>
+  size_t operator()(const std::vector<T>& vec) const {
+    size_t hash = vec.size();
+
+    for (const T& x : vec) hash_combine(hash, std::hash<T>()(x));
+    return hash;
+  }
+};
+
+struct HighsVectorEqual {
+  template <typename T>
+  bool operator()(const std::vector<T>& vec1,
+                  const std::vector<T>& vec2) const {
+    if (vec1.size() != vec2.size()) return false;
+    return std::equal(vec1.begin(), vec1.end(), vec2.begin());
+  }
+};
+
 #endif


### PR DESCRIPTION
These are changes for the MIP solver that are based on the ekk_simplify branch. The changes are explained in the long commit message. This includes the feasibility pump heuristic which uses primal simplex calls as it changes the objective function between LP solves and therefore gives some additional test coverage for the ekk primal simplex.