### PR TITLE
Add functionality to programmatically return the type of an option.

### DIFF
--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -291,11 +291,18 @@ TEST_CASE("highs-options", "[highs_options]") {
   return_status = highs.writeHighsOptions("Highs.set");
   REQUIRE(return_status == HighsStatus::OK);
 
+  HighsOptionType highs_option_type;
+
   bool get_mps_parser_type_free;
   return_status = highs.getHighsOptionValue("mps_parser_type_free",
                                             get_mps_parser_type_free);
   REQUIRE(return_status == HighsStatus::OK);
   REQUIRE(get_mps_parser_type_free == false);
+
+  return_status =
+      highs.getHighsOptionType("mps_parser_type_free", highs_option_type);
+  REQUIRE(return_status == HighsStatus::OK);
+  REQUIRE(highs_option_type == HighsOptionType::BOOL);
 
   int get_allowed_simplex_matrix_scale_factor;
   return_status =
@@ -305,16 +312,30 @@ TEST_CASE("highs-options", "[highs_options]") {
   REQUIRE(get_allowed_simplex_matrix_scale_factor ==
           allowed_simplex_matrix_scale_factor);
 
+  return_status = highs.getHighsOptionType(
+      "allowed_simplex_matrix_scale_factor", highs_option_type);
+  REQUIRE(return_status == HighsStatus::OK);
+  REQUIRE(highs_option_type == HighsOptionType::INT);
+
   double get_small_matrix_value;
   return_status =
       highs.getHighsOptionValue("small_matrix_value", get_small_matrix_value);
   REQUIRE(return_status == HighsStatus::OK);
   REQUIRE(get_small_matrix_value == small_matrix_value);
 
+  return_status =
+      highs.getHighsOptionType("small_matrix_value", highs_option_type);
+  REQUIRE(return_status == HighsStatus::OK);
+  REQUIRE(highs_option_type == HighsOptionType::DOUBLE);
+
   std::string get_model_file;
   return_status = highs.getHighsOptionValue("model_file", get_model_file);
   REQUIRE(return_status == HighsStatus::OK);
   REQUIRE(get_model_file == model_file);
+
+  return_status = highs.getHighsOptionType("model_file", highs_option_type);
+  REQUIRE(return_status == HighsStatus::OK);
+  REQUIRE(highs_option_type == HighsOptionType::STRING);
 
   HighsOptions options = highs.getHighsOptions();
   REQUIRE(options.model_file == model_file);

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -151,6 +151,14 @@ class Highs {
       std::string& value          //!< The option value
   );
 
+  /**
+   * @brief Get the type expected by an option
+   */
+  HighsStatus getHighsOptionType(
+      const std::string& option,  //!< The option name
+      HighsOptionType& type       //!< The option type
+  );
+
   const HighsOptions& getHighsOptions() const;
 
   HighsStatus resetHighsOptions();

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -151,6 +151,14 @@ int Highs_getHighsStringOptionValue(void* highs, const char* option,
   return retcode;
 }
 
+int Highs_getHighsOptionType(void* highs, const char* option, int* type) {
+  HighsOptionType t;
+  int retcode =
+      (int)((Highs*)highs)->getHighsOptionType(std::string(option), t);
+  *type = (int)t;
+  return retcode;
+}
+
 int Highs_resetHighsOptions(void* highs) {
   return (int)((Highs*)highs)->resetHighsOptions();
 }

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -202,6 +202,14 @@ int Highs_getHighsStringOptionValue(
 );
 
 /*
+ * @brief Get the type expected by an option
+ */
+int Highs_getHighsOptionType(void* highs,         //!< HiGHS object reference
+                             const char* option,  //!< The name of the option
+                             int* type            //!< The type of the option.
+);
+
+/*
  * @brief
  */
 int Highs_resetHighsOptions(void* highs  //!< HiGHS object reference

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -138,6 +138,14 @@ HighsStatus Highs::getHighsOptionValue(const std::string& option,
   return HighsStatus::Error;
 }
 
+HighsStatus Highs::getHighsOptionType(const std::string& option,
+                                      HighsOptionType& type) {
+  if (getOptionType(options_.logfile, option, options_.records, type) ==
+      OptionStatus::OK)
+    return HighsStatus::OK;
+  return HighsStatus::Error;
+}
+
 HighsStatus Highs::resetHighsOptions() {
   resetOptions(options_.records);
   return HighsStatus::OK;

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -589,6 +589,16 @@ OptionStatus getOptionValue(FILE* logfile, const std::string& name,
   return OptionStatus::OK;
 }
 
+OptionStatus getOptionType(FILE* logfile, const std::string& name,
+                           const std::vector<OptionRecord*>& option_records,
+                           HighsOptionType& type) {
+  int index;
+  OptionStatus status = getOptionIndex(logfile, name, option_records, index);
+  if (status != OptionStatus::OK) return status;
+  type = option_records[index]->type;
+  return OptionStatus::OK;
+}
+
 void resetOptions(std::vector<OptionRecord*>& option_records) {
   int num_options = option_records.size();
   for (int index = 0; index < num_options; index++) {

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -192,6 +192,10 @@ OptionStatus getOptionValue(FILE* logfile, const std::string& name,
                             const std::vector<OptionRecord*>& option_records,
                             std::string& value);
 
+OptionStatus getOptionType(FILE* logfile, const std::string& name,
+                           const std::vector<OptionRecord*>& option_records,
+                           HighsOptionType& type);
+
 void resetOptions(std::vector<OptionRecord*>& option_records);
 
 HighsStatus writeOptionsToFile(FILE* file,


### PR DESCRIPTION
Suggested by point 6 in #449. This is useful for wrappers who do not want to store the string-to-type mapping (like [HiGHS.jl does](https://github.com/jump-dev/HiGHS.jl/blob/edc8bc310d43411348130c49cceb702979e9fd57/src/MOI_wrapper.jl#L325-L340)).

* I don't really know my way around the code, so hopefully I haven't missed anything obvious. 

* I've tested the C by calling the new function from `call_highs_from_c.c`. I had to make some other changes to get it to compile; I can split the second commit into a separate PR if you'd prefer. Seems like https://github.com/ERGO-Code/HiGHS/issues/389 is worthwhile.

* I ran the formatter on the source, but not on `call_highs_from_c`, because the diff was very large.