### PR TITLE
[C API] Add getters for logfile and output

### DIFF
--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -97,6 +97,14 @@ int Highs_setHighsOutput(void* highs, void* outputfile) {
   return (int)((Highs*)highs)->setHighsOutput((FILE*)outputfile);
 }
 
+void* Highs_getHighsLogfile(void* highs) {
+  return (void*)((Highs*)highs)->getHighsOptions().logfile;
+}
+
+void* Highs_getHighsOutput(void* highs) {
+  return (void*)((Highs*)highs)->getHighsOptions().output;
+}
+
 int Highs_setHighsBoolOptionValue(void* highs, const char* option,
                                   const int value) {
   return (int)((Highs*)highs)

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -93,6 +93,18 @@ int Highs_setHighsOutput(void* highs,      //!< HiGHS object reference
 );
 
 /*
+ * @brief Gets the logfile for printing.
+ */
+void* Highs_getHighsLogfile(void* highs  //!< HiGHS object reference
+);
+
+/*
+ * @brief Gets the output for printing.
+ */
+void* Highs_getHighsOutput(void* highs  //!< HiGHS object reference
+);
+
+/*
  * @brief Runs HiGHS
  */
 int Highs_run(void* highs  //!< HiGHS object reference


### PR DESCRIPTION
I realized I needed this for the Julia interface to be able to restore the output after setting to `NULL`. (Unless @matbesancon knows how to pass `stdout` from Julia to C?)

But perhaps a better way is to remove the `setHighsOutput` and `setHighsLogfile`, rename `Highs_runQuiet` to `Highs_setQuiet`, and introduce `Highs_unsetQuiet`

```C
int Highs_setQuiet(void* highs) {
  int return_status = (int)((Highs*)highs)->setHighsLogfile(NULL);
  if (return_status) return return_status;
  return (int)((Highs*)highs)->setHighsOutput(NULL);
}

int Highs_unsetQuiet(void* highs) {
  int return_status = (int)((Highs*)highs)->setHighsLogfile(stdout);
  if (return_status) return return_status;
  return (int)((Highs*)highs)->setHighsOutput(stdout);
}
```

Thoughts?