### PR TITLE
ENH: minor modifications to parse basic SIF format

### DIFF
--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -168,7 +168,9 @@ HMpsFF::parsekey HMpsFF::checkFirstWord(std::string& strline, int& start,
 
   word = strline.substr(start, end - start);
 
-  if (word == "OBJSENSE")
+  if (word == "NAME") {
+    return HMpsFF::parsekey::NAME;
+  } else if (word == "OBJSENSE")
     return HMpsFF::parsekey::OBJSENSE;
   else if (word.front() == 'M') {
     if (word == "MAX")
@@ -196,13 +198,19 @@ HMpsFF::parsekey HMpsFF::checkFirstWord(std::string& strline, int& start,
     return HMpsFF::parsekey::NONE;
 }
 
-HMpsFF::parsekey HMpsFF::parseDefault(std::ifstream& file) const {
+HMpsFF::parsekey HMpsFF::parseDefault(std::ifstream& file) {
   std::string strline, word;
   if (getline(file, strline)) {
     strline = trim(strline);
     if (strline.empty()) return HMpsFF::parsekey::COMMENT;
     int s, e;
-    return checkFirstWord(strline, s, e, word);
+    HMpsFF::parsekey key = checkFirstWord(strline, s, e, word);
+    if (key == HMpsFF::parsekey::NAME) {
+      // Save name of the MPS file
+      mpsName = first_word(strline, e);
+      return HMpsFF::parsekey::NONE;
+    }
+    return key;
   }
   return HMpsFF::parsekey::FAIL;
 }
@@ -566,6 +574,14 @@ HMpsFF::parsekey HMpsFF::parseRhs(FILE* logfile, std::ifstream& file) {
     // start of new section?
     if (key != parsekey::NONE && key != parsekey::RHS) return key;
 
+    // Ignore lack of name for SIF format;
+    // we know we have this case when "word" is a row name
+    if ((key == parsekey::NONE) &&
+        (key != parsekey::RHS) &&
+        (rowname2idx.find(word) != rowname2idx.end())) {
+      end = begin;
+    }
+
     int rowidx;
 
     std::string marker = first_word(strline, end);
@@ -583,6 +599,27 @@ HMpsFF::parsekey HMpsFF::parseRhs(FILE* logfile, std::ifstream& file) {
     }
 
     auto mit = rowname2idx.find(marker);
+
+    // SIF format sometimes has the name of the MPS file
+    // prepended to the RHS entry; remove it here if
+    // that's the case. "word" will then hold the marker,
+    // so also get new "word" and "end" values
+    if (mit == rowname2idx.end()) {
+      if (marker == mpsName) {
+        marker = word;
+        end_marker = end;
+        word = "";
+        word = first_word(strline, end_marker);
+        end = first_word_end(strline, end_marker);
+        if (word == "") {
+          HighsLogMessage(logfile, HighsMessageType::ERROR,
+                          "No bound given for SIF row %s", marker.c_str());
+          return HMpsFF::parsekey::FAIL;
+        }
+        mit = rowname2idx.find(marker);
+      }
+    }
+
     if (mit == rowname2idx.end()) {
       HighsLogMessage(
           logfile, HighsMessageType::WARNING,
@@ -748,10 +785,22 @@ HMpsFF::parsekey HMpsFF::parseBounds(FILE* logfile, std::ifstream& file) {
       exit(1);
     }
 
-    // The first word is the bound name, which should be ignored.
+    std::string bound_name = first_word(strline, end);
     int end_bound_name = first_word_end(strline, end);
-    std::string marker = first_word(strline, end_bound_name);
-    int end_marker = first_word_end(strline, end_bound_name);
+
+    std::string marker;
+    int end_marker;
+    if (colname2idx.find(bound_name) != colname2idx.end()) {
+      // SIF format might not have the bound name, so skip
+      // it here if we found the marker instead
+      marker = bound_name;
+      end_marker = end_bound_name;
+    }
+    else {
+      // The first word is the bound name, which should be ignored.
+      marker = first_word(strline, end_bound_name);
+      end_marker = first_word_end(strline, end_bound_name);
+    }
 
     auto mit = colname2idx.find(marker);
     if (mit == colname2idx.end()) {

--- a/src/io/HMpsFF.h
+++ b/src/io/HMpsFF.h
@@ -68,6 +68,7 @@ class HMpsFF {
   int numRow;
   int numCol;
   int nnz;
+  std::string mpsName;
 
   ObjSense objSense = ObjSense::MINIMIZE;  // Minimization by default
   double objOffset = 0;
@@ -100,6 +101,7 @@ class HMpsFF {
   const bool handle_bv_in_bounds = false;
 
   enum class parsekey {
+    NAME,
     OBJSENSE,
     MAX,
     MIN,
@@ -131,7 +133,7 @@ class HMpsFF {
   HMpsFF::parsekey checkFirstWord(std::string& strline, int& start, int& end,
                                   std::string& word) const;
 
-  HMpsFF::parsekey parseDefault(std::ifstream& file) const;
+  HMpsFF::parsekey parseDefault(std::ifstream& file);
   HMpsFF::parsekey parseObjsense(FILE* logfile, std::ifstream& file);
   HMpsFF::parsekey parseRows(FILE* logfile, std::ifstream& file);
   HMpsFF::parsekey parseCols(FILE* logfile, std::ifstream& file);


### PR DESCRIPTION
closes #442 

Implements basic SIF compatibility for the MPS reader:
- read and save the MPS `NAME` field (needed to remove from `RHS` entry when present)
- handle case of unnamed `RHS` entry
- handle case of unnamed `BOUND` entry
- all examples in #442 are now parsed as expected

## Notes
The SIF file format appears to be a superset of the MPS file format (see http://www.numerical.rl.ac.uk/lancelot/sif/node9.html).  The examples in #442 should be completely MPS-compatible, but the HiGHS MPS reader fails on some sections.  This PR addresses those failure cases.

Cross referencing SciPy issue where these failures were discovered: https://github.com/scipy/scipy/issues/13372#issuecomment-763334138