### PR TITLE
Modify CMakeLists for Julia cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(FAST_BUILD "Fast build: only build static lib and exe and quick test." OF
 # set the correct rpath for OS X
 set(CMAKE_MACOSX_RPATH ON)
 
+option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols into the DLL" ON)
+
 if (NOT FAST_BUILD)
 
 set(HIGHS_VERSION_PATCH 0)
@@ -60,7 +62,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/lib)
 
-option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols into the DLL" ON)
 
 find_program(GIT git)
 if((GIT) AND (EXISTS ${HIGHS_SOURCE_DIR}/.git))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,10 +466,16 @@ endif()
 # Dashboards later on.
 # include(CTest)
 
-install(TARGETS libhighs EXPORT highs-targets
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include)
+if (UNIX)
+    install(TARGETS libhighs EXPORT highs-targets
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib
+            PUBLIC_HEADER DESTINATION include)
+elseif (WIN32)
+    install(TARGETS libhighs EXPORT highs-targets
+            LIBRARY DESTINATION bin
+            PUBLIC_HEADER DESTINATION include)
+endif()
 
 # if (IPX_ON)
 #     install(TARGETS ipx EXPORT highs-targets


### PR DESCRIPTION
We're trying to build a new version of HiGHS for Julia [[Yggdrasil PR]](https://github.com/JuliaPackaging/Yggdrasil/pull/2508).  But it needs these commits which are not on `master`. Without them, it can't find the `dll` on windows [[log]](https://dev.azure.com/JuliaPackaging/Yggdrasil/_build/results?buildId=8957&view=logs&jobId=d91d37a3-1c8a-51b4-f84d-7891b16cbc7f&j=d91d37a3-1c8a-51b4-f84d-7891b16cbc7f&t=7b336dbb-6fc8-5646-89a9-84d0b3ceb623). (Although we don't necessarily need the change to `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` because we can run with `FAST=OFF`.)

@galabovaa, not sure if you want what you have, or something like:
```make
if (JULIA AND WIN32)
    install(TARGETS libhighs EXPORT highs-targets
    LIBRARY DESTINATION bin
    PUBLIC_HEADER DESTINATION include)
else
    install(TARGETS libhighs EXPORT highs-targets
            LIBRARY DESTINATION lib
            ARCHIVE DESTINATION lib
            PUBLIC_HEADER DESTINATION include)
endif()
```

cc @matbesancon 