### PR TITLE
FIX: don't read name if it doesn't exist

### DIFF
--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -207,7 +207,9 @@ HMpsFF::parsekey HMpsFF::parseDefault(std::ifstream& file) {
     HMpsFF::parsekey key = checkFirstWord(strline, s, e, word);
     if (key == HMpsFF::parsekey::NAME) {
       // Save name of the MPS file
-      mpsName = first_word(strline, e);
+      if (e < strline.length()) {
+        mpsName = first_word(strline, e);
+      }
       return HMpsFF::parsekey::NONE;
     }
     return key;


### PR DESCRIPTION
- don't read `NAME` field if empty
- closes #467