### PR TITLE
FIX: IPM crossover iteration

### DIFF
--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -194,7 +194,7 @@ void testSolversSetup(const std::string model,
     simplex_strategy_iteration_count[(
         int)SimplexStrategy::SIMPLEX_STRATEGY_PRIMAL] = 94;
     model_iteration_count.ipm = 18;
-    model_iteration_count.crossover = 4;
+    model_iteration_count.crossover = 18;
   }
 }
 

--- a/src/ipm/IpxWrapper.h
+++ b/src/ipm/IpxWrapper.h
@@ -596,8 +596,8 @@ HighsStatus solveLpIpx(const HighsOptions& options, HighsTimer& timer,
   ipx::Info ipx_info = lps.GetInfo();
   iteration_counts.ipm += (int)ipx_info.iter;
 
-  iteration_counts.crossover += (int)ipx_info.updates_crossover;
-  // iteration_counts.crossover += (int)ipx_info.pushes_crossover;
+  // iteration_counts.crossover += (int)ipx_info.updates_crossover;
+  iteration_counts.crossover += (int)ipx_info.pushes_crossover;
 
   // If not solved...
   if (solve_status != IPX_STATUS_solved) {

--- a/src/ipm/ipx/include/ipx_info.h
+++ b/src/ipm/ipx/include/ipx_info.h
@@ -56,6 +56,7 @@ struct ipx_info {
     ipxint updates_start;       /* # basis updates for starting basis */
     ipxint updates_ipm;         /* # basis updates in IPM */
     ipxint updates_crossover;   /* # basis updates in crossover */
+    ipxint pushes_crossover;    /* # Primal/Dual pushes in crossover */
 
     /* major computation times */
     double time_total;          /* total runtime (wallclock) */

--- a/src/ipm/ipx/src/info.cc
+++ b/src/ipm/ipx/src/info.cc
@@ -64,6 +64,7 @@ std::ostream& operator<<(std::ostream& os, const Info& info) {
     dump(os, "updates_start", info.updates_start);
     dump(os, "updates_ipm", info.updates_ipm);
     dump(os, "updates_crossover", info.updates_crossover);
+    dump(os, "pushes_crossover", info.pushes_crossover);
 
     dump(os, "time_total", fix2(info.time_total));
     dump(os, "time_ipm1", fix2(info.time_ipm1));

--- a/src/ipm/ipx/src/lp_solver.cc
+++ b/src/ipm/ipx/src/lp_solver.cc
@@ -485,6 +485,8 @@ void LpSolver::RunCrossover() {
             crossover.time_primal() + crossover.time_dual();
         info_.updates_crossover =
             crossover.primal_pivots() + crossover.dual_pivots();
+        info_.pushes_crossover =
+            crossover.primal_pushes() + crossover.dual_pushes();
         if (info_.status_crossover != IPX_STATUS_optimal) {
             // Crossover failed. Discard solution.
             x_crossover_.resize(0);


### PR DESCRIPTION
- closes #473 -- regression in crossover iteration count introduced in #439 
- uses `pushes_crossover` instead of `updates_crossover` to reckon crossover iteration count