### PR TITLE
Update highs_lp_solver.f90

### DIFF
--- a/src/interfaces/highs_lp_solver.f90
+++ b/src/interfaces/highs_lp_solver.f90
@@ -88,7 +88,7 @@ module highs_lp_solver
       use iso_c_binding
       type(c_ptr), VALUE :: h
       character( c_char ) :: o(*)
-      integer ( c_int ) :: v
+      integer ( c_int ), VALUE :: v
       integer ( c_int ) :: s
     end function Highs_setIntOptionValue
 


### PR DESCRIPTION
Fix to correctly pass integer option from Fortran to HiGHS