### PR TITLE
Add writeSolutionPretty to the C API

### DIFF
--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -72,6 +72,10 @@ int Highs_writeSolution(void* highs, const char* filename) {
   return (int)((Highs*)highs)->writeSolution(std::string(filename));
 }
 
+int Highs_writeSolutionPretty(void* highs, const char* filename) {
+  return (int)((Highs*)highs)->writeSolution(std::string(filename), true);
+}
+
 int Highs_passLp(void* highs, const int numcol, const int numrow,
                  const int numnz, const double* colcost, const double* collower,
                  const double* colupper, const double* rowlower,

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -110,6 +110,13 @@ int Highs_writeSolution(void* highs,          //!< HiGHS object reference
 );
 
 /*
+ * @brief Reports the solution and basis status in a human-readable fashion
+ */
+int Highs_writeSolutionPretty(void* highs,          //!< HiGHS object reference
+                        const char* filename  //!< filename
+);
+
+/*
  * @brief pass an LP to HiGHS
  */
 int Highs_passLp(


### PR DESCRIPTION
There was no way to get the prettily-formatted solution from the C API

This keeps backwards compatibility by creating a new function.
﻿
There is no other way to get a solution wil the column names besides writeSolutionPretty
