### PR TITLE
Mention JS in the list of available interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ Rust
 
 - HiGHS can be used from rust through the [`highs` crate](https://crates.io/crates/highs). The rust linear programming modeler [**good_lp**](https://crates.io/crates/good_lp) supports HiGHS. 
 
+Javascript
+----------
+
+HiGHS can be used from javascript directly inside a web browser thanks to [highs-js](https://github.com/lovasoa/highs-js). See the [demo](https://lovasoa.github.io/highs-js/) and the [npm package](https://www.npmjs.com/package/highs).
+
 OSI
 ---
 - `OSI_ROOT`:


### PR DESCRIPTION
I compiled HiGHS to WASM in order to be able to use it from a web browser.