### PR TITLE
Fix getModelStatus in Fortran interface

### DIFF
--- a/src/interfaces/highs_lp_solver.f90
+++ b/src/interfaces/highs_lp_solver.f90
@@ -203,7 +203,7 @@ module highs_lp_solver
       use iso_c_binding
       type(c_ptr), VALUE :: h
       integer ( c_int ) :: model_status
-      integer ( c_int ) :: scaled_model
+      integer ( c_int ), VALUE :: scaled_model
     end function Highs_getModelStatus
 
     function Highs_getObjectiveValue (h) result(ov) bind(c, name='Highs_getObjectiveValue')


### PR DESCRIPTION
The VALUE parameter must be added to the scaled_model argument so it gest passed correctly to Highs_getModelStatus (otherwise a 0 gets passed by reference which will be a nonzero value which will be interpreted as true)