### PR TITLE
Fix multiply_modM61 and  Merge branch 'fix-performance-issue' 

### DIFF
--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -38,28 +38,33 @@ void HighsPrimalHeuristics::setupIntCols() {
   intcols = mipsolver.mipdata_->integer_cols;
 
   std::sort(intcols.begin(), intcols.end(), [&](HighsInt c1, HighsInt c2) {
-    HighsInt uplocks1 = mipsolver.mipdata_->uplocks[c1];
-    HighsInt downlocks1 = mipsolver.mipdata_->downlocks[c1];
+    double lockScore1 =
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->uplocks[c1]) *
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->downlocks[c1]);
 
-    HighsInt cliqueImplicsUp1 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c1, 1);
-    HighsInt cliqueImplicsDown1 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c1, 0);
+    double lockScore2 =
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->uplocks[c2]) *
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->downlocks[c2]);
 
-    HighsInt uplocks2 = mipsolver.mipdata_->uplocks[c2];
-    HighsInt downlocks2 = mipsolver.mipdata_->downlocks[c2];
+    if (lockScore1 > lockScore2) return true;
+    if (lockScore2 > lockScore1) return false;
 
-    HighsInt cliqueImplicsUp2 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c2, 1);
-    HighsInt cliqueImplicsDown2 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c2, 0);
+    double cliqueScore1 =
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c1, 1)) *
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c1, 0));
 
-    return std::make_tuple(uplocks1 * downlocks1,
-                           cliqueImplicsUp1 * cliqueImplicsDown1,
-                           HighsHashHelpers::hash(uint64_t(c1)), c1) >
-           std::make_tuple(uplocks2 * downlocks2,
-                           cliqueImplicsUp2 * cliqueImplicsDown2,
-                           HighsHashHelpers::hash(uint64_t(c2)), c2);
+    double cliqueScore2 =
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c2, 1)) *
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c2, 0));
+
+    return std::make_tuple(cliqueScore1, HighsHashHelpers::hash(uint64_t(c1)),
+                           c1) >
+           std::make_tuple(cliqueScore2, HighsHashHelpers::hash(uint64_t(c2)),
+                           c2);
   });
 }
 

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4310,7 +4310,8 @@ HighsInt HPresolve::strengthenInequalities() {
       for (HighsInt i = indices.size() - 1; i >= 0; --i) {
         double delta = upper[indices[i]] * reducedcost[indices[i]];
 
-        if (reducedcost[indices[i]] > smallVal && lambda - delta <= smallVal)
+        if (upper[indices[i]] <= 1000.0 && reducedcost[indices[i]] > smallVal &&
+            lambda - delta <= smallVal)
           cover.push_back(indices[i]);
         else
           lambda -= delta;

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -84,6 +84,7 @@ struct HighsHashHelpers {
     u64 blo = b & 0xffffffffu;  // < 2^32
 
     // compute the different order terms with adicities 2^64, 2^32, 2^0
+
     u64 term_64 = ahi * bhi;              // < 2^58
     u64 term_32 = ahi * blo + bhi * alo;  // < 2^62
     u64 term_0 = alo * blo;               // < 2^64
@@ -98,7 +99,9 @@ struct HighsHashHelpers {
     // finally take the result modulo M61 which is computed by exploiting
     // that M61 is a mersenne prime, particularly, if a * b = q * 2^61 + r
     // then a * b = (q + r) (mod 2^61 - 1)
+
     u64 result = (ab0 & M61()) + ab61;
+
     if (result >= M61()) result -= M61();
     return result;
   }

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -89,18 +89,16 @@ struct HighsHashHelpers {
     u64 term_0 = alo * blo;               // < 2^64
 
     // now extract the upper 61 and the lower 61 bits of the result a * b
-    u64 ab61 = (term_64 << 3) + (term_32 >> 29) + (term_0 >> 61);
     u64 ab0 = ((term_0 & M61()) + ((term_32 & M29()) << 32));
+    u64 ab61 = (term_64 << 3) + (term_32 >> 29) + (term_0 >> 61) + (ab0 >> 61);
 
-    // ab0 may be greater than 2^61
-    if (ab0 > M61()) ab61++;
-    ab0 &= M61();
     // ab61 may be greater than (2^61 - 1)
     if (ab61 >= M61()) ab61 -= M61();
+
     // finally take the result modulo M61 which is computed by exploiting
     // that M61 is a mersenne prime, particularly, if a * b = q * 2^61 + r
     // then a * b = (q + r) (mod 2^61 - 1)
-    u64 result = ab0 + ab61;
+    u64 result = (ab0 & M61()) + ab61;
     if (result >= M61()) result -= M61();
     return result;
   }


### PR DESCRIPTION
I find a mistake in HighsHash.h

multiply_modM61 result is wrong 

The specific derivation process and the details of the modification , you can see the pdf .(PS: I dont know how put Mathematical formula on here )
[README.pdf](https://github.com/ERGO-Code/HiGHS/files/6872524/README.pdf)


beause Linux can use **__int128_t**,so I make a test.cpp for test **multiply_modM61** (this functional)
PS: I dont know how to write your test ,so used a simple method to test .
```c++
#include <iostream>
#include <random>
#include <cassert>
using u32 = unsigned int;
using u64 = unsigned int64_t;

void write128(__int128_t x)
{
    if (x > 9)
        write128(x / 10);
    putchar(x % 10 + '0');
}
void write64(u64 x)
{
    if (x > 9)
        write64(x / 10);
    putchar(x % 10 + '0');
}

static constexpr u64 M61() { return u64{0x1fffffffffffffff}; };
static constexpr u64 M29() { return u64{0x1fffffff}; };
/// compute a * b mod 2^61-1
static u64 multiply_modM61(u64 a, u64 b)
{
    u64 ahi = a >> 32;         // < 2^29
    u64 bhi = b >> 32;         // < 2^29
    u64 alo = a & 0xffffffffu; // < 2^32
    u64 blo = b & 0xffffffffu; // < 2^32

    // compute the different order terms with adicities 2^64, 2^32, 2^0
    u64 term_64 = ahi * bhi;             // < 2^58
    u64 term_32 = ahi * blo + bhi * alo; // < 2^62
    u64 term_0 = alo * blo;              // < 2^64

    // now extract the upper 61 and the lower 61 bits of the result a * b
    u64 ab61 = (term_64 << 3) + (term_32 >> 29) + (term_0 >> 61);
    u64 ab0 = ((term_0 & M61()) + ((term_32 & M29()) << 32));

    // ab0 may be greater than 2^61
    if (ab0 > M61())
        ab61++;
    ab0 &= M61();
    // ab61 may be greater than (2^61 - 1)
    if (ab61 >= M61())
        ab61 -= M61();
    // finally take the result modulo M61 which is computed by exploiting
    // that M61 is a mersenne prime, particularly, if a * b = q * 2^61 + r
    // then a * b = (q + r) (mod 2^61 - 1)
    u64 result = ab0 + ab61;
    if (result >= M61())
        result -= M61();
    return result;
}
static u64 wrong_multiply_modM61(u64 a, u64 b)
{
    u64 ahi = a >> 32;
    u64 bhi = b >> 32;
    u64 alo = a & 0xffffffffu;
    u64 blo = b & 0xffffffffu;

    // compute the different order terms with adicities 2^64, 2^32, 2^0
    u64 term_64 = ahi * bhi;
    u64 term_32 = ahi * blo + bhi * alo;
    u64 term_0 = alo * blo;

    // now extract the upper 61 and the lower 61 bits of the result a * b
    u64 ab61 = term_64 << 3 | (term_32 + (term_0 >> 32)) >> 61;
    u64 ab0 = (term_0 + term_32) & M61();

    // finally take the result modulo M61 which is computed by exploiting
    // that M61 is a mersenne prime, particularly, if a * b = q * 2^61 + r
    // then a * b = (q + r) (mod 2^61 - 1)
    u64 result = ab0 + ab61;
    if (result >= M61())
        result -= M61();
    return result;
}
int main()
{
    int64_t MAX = (1ll << 61) - 2;
    const int T = 1000000;
    std::random_device r;
    std::default_random_engine e(r());
    std::uniform_int_distribution<int64_t> f(1, MAX);
    for (int i = 0; i < T; i++)
    {
        __int128_t MOD = M61();
        u64 AA = f(e);
        u64 BB = f(e);
        __int128_t A = AA;
        __int128_t B = BB;
        __int128_t P = A * B % MOD;
        u64 K = multiply_modM61(AA, BB);
        assert(K == P);
    }
}
```
