### PR TITLE
fix performance issue with counting number of binary implications

### DIFF
--- a/src/mip/HighsCliqueTable.cpp
+++ b/src/mip/HighsCliqueTable.cpp
@@ -1720,16 +1720,18 @@ void HighsCliqueTable::cleanupFixed(HighsDomain& globaldom) {
 
 HighsInt HighsCliqueTable::getNumImplications(HighsInt col) {
   assert(stack.empty());
-  HighsInt numimplics = 0;
+  // first count all cliques as one implication, so that cliques of size two
+  // are accounted for already
+  HighsInt numimplics = numcliquesvar[CliqueVar(col, 0).index()] +
+                        numcliquesvar[CliqueVar(col, 1).index()];
 
+  // now loop over cliques larger than size two and add the cliquelength - 1 as
+  // implication but subtract 1 more as each clique is already counted as one
+  // implication
   if (cliquesetroot[CliqueVar(col, 1).index()] != -1)
     stack.emplace_back(cliquesetroot[CliqueVar(col, 1).index()]);
   if (cliquesetroot[CliqueVar(col, 0).index()] != -1)
     stack.emplace_back(cliquesetroot[CliqueVar(col, 0).index()]);
-  if (sizeTwoCliquesetRoot[CliqueVar(col, 1).index()] != -1)
-    stack.emplace_back(sizeTwoCliquesetRoot[CliqueVar(col, 1).index()]);
-  if (sizeTwoCliquesetRoot[CliqueVar(col, 0).index()] != -1)
-    stack.emplace_back(sizeTwoCliquesetRoot[CliqueVar(col, 0).index()]);
 
   while (!stack.empty()) {
     HighsInt node = stack.back();
@@ -1740,9 +1742,7 @@ HighsInt HighsCliqueTable::getNumImplications(HighsInt col) {
       stack.emplace_back(cliquesets[node].right);
 
     HighsInt nimplics = cliques[cliquesets[node].cliqueid].end -
-                        cliques[cliquesets[node].cliqueid].start - 1;
-    nimplics *= (1 + cliques[cliquesets[node].cliqueid].equality);
-
+                        cliques[cliquesets[node].cliqueid].start - 2;
     numimplics += nimplics;
   }
 
@@ -1751,26 +1751,24 @@ HighsInt HighsCliqueTable::getNumImplications(HighsInt col) {
 
 HighsInt HighsCliqueTable::getNumImplications(HighsInt col, bool val) {
   assert(stack.empty());
-  HighsInt numimplics = 0;
+  HighsInt numimplics = numcliquesvar[CliqueVar(col, val).index()];
 
-  if (cliquesetroot[CliqueVar(col, val).index()] != -1)
+  if (cliquesetroot[CliqueVar(col, val).index()] != -1) {
     stack.emplace_back(cliquesetroot[CliqueVar(col, val).index()]);
-  if (sizeTwoCliquesetRoot[CliqueVar(col, val).index()] != -1)
-    stack.emplace_back(sizeTwoCliquesetRoot[CliqueVar(col, val).index()]);
 
-  while (!stack.empty()) {
-    HighsInt node = stack.back();
-    stack.pop_back();
+    while (!stack.empty()) {
+      HighsInt node = stack.back();
+      stack.pop_back();
 
-    if (cliquesets[node].left != -1) stack.emplace_back(cliquesets[node].left);
-    if (cliquesets[node].right != -1)
-      stack.emplace_back(cliquesets[node].right);
+      if (cliquesets[node].left != -1)
+        stack.emplace_back(cliquesets[node].left);
+      if (cliquesets[node].right != -1)
+        stack.emplace_back(cliquesets[node].right);
 
-    HighsInt nimplics = cliques[cliquesets[node].cliqueid].end -
-                        cliques[cliquesets[node].cliqueid].start - 1;
-    nimplics *= (1 + cliques[cliquesets[node].cliqueid].equality);
-
-    numimplics += nimplics;
+      HighsInt nimplics = cliques[cliquesets[node].cliqueid].end -
+                          cliques[cliquesets[node].cliqueid].start - 2;
+      numimplics += nimplics;
+    }
   }
 
   return numimplics;

--- a/src/mip/HighsCliqueTable.cpp
+++ b/src/mip/HighsCliqueTable.cpp
@@ -1742,8 +1742,9 @@ HighsInt HighsCliqueTable::getNumImplications(HighsInt col) {
       stack.emplace_back(cliquesets[node].right);
 
     HighsInt nimplics = cliques[cliquesets[node].cliqueid].end -
-                        cliques[cliquesets[node].cliqueid].start - 2;
-    numimplics += nimplics;
+                        cliques[cliquesets[node].cliqueid].start - 1;
+    nimplics *= (1 + cliques[cliquesets[node].cliqueid].equality);
+    numimplics += nimplics - 1;
   }
 
   return numimplics;
@@ -1766,8 +1767,9 @@ HighsInt HighsCliqueTable::getNumImplications(HighsInt col, bool val) {
         stack.emplace_back(cliquesets[node].right);
 
       HighsInt nimplics = cliques[cliquesets[node].cliqueid].end -
-                          cliques[cliquesets[node].cliqueid].start - 2;
-      numimplics += nimplics;
+                          cliques[cliquesets[node].cliqueid].start - 1;
+      nimplics *= (1 + cliques[cliquesets[node].cliqueid].equality);
+      numimplics += nimplics - 1;
     }
   }
 

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -38,28 +38,33 @@ void HighsPrimalHeuristics::setupIntCols() {
   intcols = mipsolver.mipdata_->integer_cols;
 
   std::sort(intcols.begin(), intcols.end(), [&](HighsInt c1, HighsInt c2) {
-    HighsInt uplocks1 = mipsolver.mipdata_->uplocks[c1];
-    HighsInt downlocks1 = mipsolver.mipdata_->downlocks[c1];
+    double lockScore1 =
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->uplocks[c1]) *
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->downlocks[c1]);
 
-    HighsInt cliqueImplicsUp1 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c1, 1);
-    HighsInt cliqueImplicsDown1 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c1, 0);
+    double lockScore2 =
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->uplocks[c2]) *
+        (mipsolver.mipdata_->feastol + mipsolver.mipdata_->downlocks[c2]);
 
-    HighsInt uplocks2 = mipsolver.mipdata_->uplocks[c2];
-    HighsInt downlocks2 = mipsolver.mipdata_->downlocks[c2];
+    if (lockScore1 > lockScore2) return true;
+    if (lockScore2 > lockScore1) return false;
 
-    HighsInt cliqueImplicsUp2 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c2, 1);
-    HighsInt cliqueImplicsDown2 =
-        mipsolver.mipdata_->cliquetable.getNumImplications(c2, 0);
+    double cliqueScore1 =
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c1, 1)) *
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c1, 0));
 
-    return std::make_tuple(uplocks1 * downlocks1,
-                           cliqueImplicsUp1 * cliqueImplicsDown1,
-                           HighsHashHelpers::hash(uint64_t(c1)), c1) >
-           std::make_tuple(uplocks2 * downlocks2,
-                           cliqueImplicsUp2 * cliqueImplicsDown2,
-                           HighsHashHelpers::hash(uint64_t(c2)), c2);
+    double cliqueScore2 =
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c2, 1)) *
+        (mipsolver.mipdata_->feastol +
+         mipsolver.mipdata_->cliquetable.getNumImplications(c2, 0));
+
+    return std::make_tuple(cliqueScore1, HighsHashHelpers::hash(uint64_t(c1)),
+                           c1) >
+           std::make_tuple(cliqueScore2, HighsHashHelpers::hash(uint64_t(c2)),
+                           c2);
   });
 }
 

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4310,7 +4310,8 @@ HighsInt HPresolve::strengthenInequalities() {
       for (HighsInt i = indices.size() - 1; i >= 0; --i) {
         double delta = upper[indices[i]] * reducedcost[indices[i]];
 
-        if (reducedcost[indices[i]] > smallVal && lambda - delta <= smallVal)
+        if (upper[indices[i]] <= 1000.0 && reducedcost[indices[i]] > smallVal &&
+            lambda - delta <= smallVal)
           cover.push_back(indices[i]);
         else
           lambda -= delta;


### PR DESCRIPTION
Small change that showed up as performance issue in some benchmark instance. The counting of binary implications in cliques of size two took very long when there where many cliques of size two. Now the implications are counted more efficiently and do not need top loop over cliques of size two. Also some calls to counting the implications are avoided by writing the comparison function that made the calls during sorting in a way that first evaluates the first sorting criterion and only counts the implications when the first criterion is equal.