### PR TITLE
improve MIP reporting

### DIFF
--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -264,6 +264,8 @@ restart:
                                << nTreeRestarts);
 
       if (doRestart) {
+        highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                     "\nRestarting search from the root node\n\n");
         mipdata_->performRestart();
         goto restart;
       }

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -265,7 +265,7 @@ restart:
 
       if (doRestart) {
         highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
-                     "\nRestarting search from the root node\n\n");
+                     "\nRestarting search from the root node\n");
         mipdata_->performRestart();
         goto restart;
       }

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -161,13 +161,7 @@ restart:
           options_mip_->mip_pool_soft_limit)
         mipdata_->conflictPool.performAging();
 
-      if (mipdata_->dispfreq != 0) {
-        if (mipdata_->num_leaves - mipdata_->last_displeave >=
-            std::min(mipdata_->dispfreq,
-                     3 + int64_t(0.1 * mipdata_->num_leaves)))
-          mipdata_->printDisplayLine();
-      }
-
+      mipdata_->printDisplayLine();
       // printf("continue plunging due to good esitmate\n");
     }
     search.openNodesToQueue(mipdata_->nodequeue);
@@ -176,11 +170,7 @@ restart:
 
     if (limit_reached) break;
 
-    if (mipdata_->dispfreq != 0) {
-      if (mipdata_->num_leaves - mipdata_->last_displeave >=
-          std::min(mipdata_->dispfreq, 3 + int64_t(0.1 * mipdata_->num_leaves)))
-        mipdata_->printDisplayLine();
-    }
+    mipdata_->printDisplayLine();
 
     // the search datastructure should have no installed node now
     assert(!search.hasNode());
@@ -340,12 +330,7 @@ restart:
         mipdata_->lower_bound = std::min(
             mipdata_->upper_bound, mipdata_->nodequeue.getBestLowerBound());
 
-        if (mipdata_->dispfreq != 0) {
-          if (mipdata_->num_leaves - mipdata_->last_displeave >=
-              std::min(mipdata_->dispfreq,
-                       3 + int64_t(0.1 * mipdata_->num_leaves)))
-            mipdata_->printDisplayLine();
-        }
+        mipdata_->printDisplayLine();
         continue;
       }
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -801,7 +801,7 @@ static std::array<char, 16> convertToPrintString(int64_t val) {
 
 void HighsMipSolverData::printDisplayLine(char first) {
   double time = mipsolver.timer_.read(mipsolver.timer_.solve_clock);
-  if (time - last_disptime < 5.) return;
+  if (first == ' ' && time - last_disptime < 5.) return;
 
   last_disptime = time;
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -359,6 +359,15 @@ void HighsMipSolverData::runSetup() {
                  mipsolver.numRow(), mipsolver.numCol(), numBin,
                  numintegercols - numBin, (HighsInt)implint_cols.size(),
                  mipsolver.numNonzero());
+  } else {
+    highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
+                 "Model after restart has %" HIGHSINT_FORMAT
+                 " rows, %" HIGHSINT_FORMAT " cols (%" HIGHSINT_FORMAT
+                 " bin., %" HIGHSINT_FORMAT " int., %" HIGHSINT_FORMAT
+                 " impl.), and %" HIGHSINT_FORMAT " nonzeros\n\n",
+                 mipsolver.numRow(), mipsolver.numCol(), numBin,
+                 numintegercols - numBin, (HighsInt)implint_cols.size(),
+                 mipsolver.numNonzero());
   }
 
   heuristics.setupIntCols();
@@ -1248,7 +1257,7 @@ restart:
       if (fixingRate >= 2.5 + 7.5 * mipsolver.submip ||
           (!mipsolver.submip && fixingRate > 0 && numRestarts == 0)) {
         highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
-                     "\n%.1f%% inactive integer columns, restarting\n\n",
+                     "\n%.1f%% inactive integer columns, restarting\n",
                      fixingRate);
         maxSepaRounds = std::min(maxSepaRounds, nseparounds);
         performRestart();

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -804,8 +804,8 @@ void HighsMipSolverData::printDisplayLine(char first) {
     highsLogUser(
         mipsolver.options_mip_->log_options, HighsLogType::kInfo,
         // clang-format off
-        "\n        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |      Work      \n"
-          "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters    Time\n\n"
+        "\n        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work      \n"
+          "     Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time\n\n"
         // clang-format on
     );
 
@@ -850,7 +850,7 @@ void HighsMipSolverData::printDisplayLine(char first) {
   highsLogUser(
       mipsolver.options_mip_->log_options, HighsLogType::kInfo,
       // clang-format off
-      " %c %7s %7s   %7s %6.2f%%   %-15.9g %-15.9g %7.2f%%   %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT "   %7s %6.1fs\n",
+      " %c %7s %7s   %7s %6.2f%%   %-15.9g %-15.9g %7.2f%%   %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT "   %7s %7.1fs\n",
       // clang-format on
       first, print_nodes.data(), queue_nodes.data(), print_leaves.data(),
       explored, lb, ub, gap, cutpool.getNumCuts(),

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1332,8 +1332,10 @@ void HighsMipSolverData::checkObjIntegrality() {
 
     if (currgcd != 0) objintscale /= currgcd;
 
-    highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
-                 "Objective function is integral with scale %g\n", objintscale);
+    if (numRestarts == 0)
+      highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
+                   "Objective function is integral with scale %g\n",
+                   objintscale);
   }
 }
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -383,7 +383,7 @@ void HighsMipSolverData::runSetup() {
     }
     if (haveBin) {
       highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
-                   "\n(%4.1fs) Starting symmetry computation\n",
+                   "\n(%4.1fs) Starting symmetry detection\n",
                    mipsolver.timer_.read(mipsolver.timer_.solve_clock));
       HighsSymmetryDetection symDetection;
       symDetection.loadModelAsGraph(mipsolver.mipdata_->presolvedModel,

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -175,7 +175,6 @@ void HighsMipSolverData::init() {
   sepa_lp_iterations = 0;
   sb_lp_iterations = 0;
   num_disp_lines = 0;
-  last_disptime = -kHighsInf;
   cliquesExtracted = false;
   rowMatrixSet = false;
   lower_bound = -kHighsInf;
@@ -212,6 +211,8 @@ void HighsMipSolverData::runPresolve() {
 
 void HighsMipSolverData::runSetup() {
   const HighsLp& model = *mipsolver.model_;
+
+  last_disptime = -kHighsInf;
 
   // transform the objective limit to the current model
   upper_limit -= mipsolver.model_->offset_;

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -774,9 +774,9 @@ bool HighsMipSolverData::addIncumbent(const std::vector<double>& sol,
   return true;
 }
 
-static std::array<char, 8> convertToPrintString(int64_t val) {
+static std::array<char, 16> convertToPrintString(int64_t val) {
   double l = std::log10(std::max(1.0, double(val)));
-  std::array<char, 8> printString;
+  std::array<char, 16> printString;
   switch (int(l)) {
     case 0:
     case 1:
@@ -784,15 +784,15 @@ static std::array<char, 8> convertToPrintString(int64_t val) {
     case 3:
     case 4:
     case 5:
-      std::snprintf(printString.data(), 8, "%ld", val);
+      std::snprintf(printString.data(), 16, "%ld", val);
       break;
     case 6:
     case 7:
     case 8:
-      std::snprintf(printString.data(), 8, "%ldk", val / 1000);
+      std::snprintf(printString.data(), 16, "%ldk", val / 1000);
       break;
     default:
-      std::snprintf(printString.data(), 8, "%ldm", val / 1000000);
+      std::snprintf(printString.data(), 16, "%ldm", val / 1000000);
   }
 
   return printString;
@@ -818,9 +818,9 @@ void HighsMipSolverData::printDisplayLine(char first) {
   ++num_disp_lines;
   last_displeave = num_leaves;
 
-  std::array<char, 8> print_nodes = convertToPrintString(num_nodes);
-  std::array<char, 8> queue_nodes = convertToPrintString(nodequeue.numNodes());
-  std::array<char, 8> print_leaves =
+  std::array<char, 16> print_nodes = convertToPrintString(num_nodes);
+  std::array<char, 16> queue_nodes = convertToPrintString(nodequeue.numNodes());
+  std::array<char, 16> print_leaves =
       convertToPrintString(num_leaves - num_leaves_before_run);
 
   double explored = 100 * double(pruned_treeweight);
@@ -837,7 +837,7 @@ void HighsMipSolverData::printDisplayLine(char first) {
     gap = std::min(9999., 100 * (ub - lb) / std::max(1.0, std::abs(ub)));
   }
 
-  std::array<char, 8> print_lp_iters =
+  std::array<char, 16> print_lp_iters =
       convertToPrintString(total_lp_iterations);
 
   if (upper_bound != kHighsInf) {

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -860,17 +860,26 @@ void HighsMipSolverData::printDisplayLine(char first) {
     if (std::abs(ub) <= epsilon) ub = 0;
     lb = std::min(ub, lb);
     gap = std::min(9999., 100 * (ub - lb) / std::max(1.0, std::abs(ub)));
-  }
 
-  highsLogUser(
-      mipsolver.options_mip_->log_options, HighsLogType::kInfo,
-      // clang-format off
-      " %c %7s %7s   %7s %6.2f%%   %-15.9g %-15.9g %7.2f%%   %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT "   %7s %7.1fs\n",
-      // clang-format on
-      first, print_nodes.data(), queue_nodes.data(), print_leaves.data(),
-      explored, lb, ub, gap, cutpool.getNumCuts(),
-      lp.numRows() - lp.getNumModelRows(), conflictPool.getNumConflicts(),
-      print_lp_iters.data(), time);
+    highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
+                 // clang-format off
+                 " %c %7s %7s   %7s %6.2f%%   %-15.9g %-15.9g %7.2f%%   %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT "   %7s %7.1fs\n",
+                 // clang-format on
+                 first, print_nodes.data(), queue_nodes.data(),
+                 print_leaves.data(), explored, lb, ub, gap,
+                 cutpool.getNumCuts(), lp.numRows() - lp.getNumModelRows(),
+                 conflictPool.getNumConflicts(), print_lp_iters.data(), time);
+  } else {
+    highsLogUser(
+        mipsolver.options_mip_->log_options, HighsLogType::kInfo,
+        // clang-format off
+        " %c %7s %7s   %7s %6.2f%%   %-15.9g %-15.9g %8.2f   %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT " %6" HIGHSINT_FORMAT "   %7s %7.1fs\n",
+        // clang-format on
+        first, print_nodes.data(), queue_nodes.data(), print_leaves.data(),
+        explored, lb, ub, gap, cutpool.getNumCuts(),
+        lp.numRows() - lp.getNumModelRows(), conflictPool.getNumConflicts(),
+        print_lp_iters.data(), time);
+  }
 }
 
 bool HighsMipSolverData::rootSeparationRound(

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -383,7 +383,7 @@ void HighsMipSolverData::runSetup() {
     }
     if (haveBin) {
       highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
-                   "(%4.1fs) Starting symmetry computation\n",
+                   "\n(%4.1fs) Starting symmetry computation\n",
                    mipsolver.timer_.read(mipsolver.timer_.solve_clock));
       HighsSymmetryDetection symDetection;
       symDetection.loadModelAsGraph(mipsolver.mipdata_->presolvedModel,

--- a/src/mip/HighsMipSolverData.h
+++ b/src/mip/HighsMipSolverData.h
@@ -83,9 +83,9 @@ struct HighsMipSolverData {
 
   HighsCDouble pruned_treeweight;
   double avgrootlpiters;
+  double last_disptime;
   int64_t firstrootlpiters;
   int64_t num_nodes;
-  int64_t last_displeave;
   int64_t num_leaves;
   int64_t num_leaves_before_run;
   int64_t num_nodes_before_run;

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -3475,7 +3475,7 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postSolveStack) {
   if (options->presolve != "off") {
     if (!mipsolver || mipsolver->mipdata_->numRestarts == 0)
       highsLogUser(options->log_options, HighsLogType::kInfo,
-                  "\nPresolving model\n");
+                   "\nPresolving model\n");
 
     auto report = [&]() {
       if (!mipsolver || mipsolver->mipdata_->numRestarts == 0) {

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -3473,17 +3473,20 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postSolveStack) {
   }
 
   if (options->presolve != "off") {
-    highsLogUser(options->log_options, HighsLogType::kInfo,
-                 "\nPresolving model\n");
+    if (!mipsolver || mipsolver->mipdata_->numRestarts == 0)
+      highsLogUser(options->log_options, HighsLogType::kInfo,
+                  "\nPresolving model\n");
 
     auto report = [&]() {
-      HighsInt numCol = model->numCol_ - numDeletedCols;
-      HighsInt numRow = model->numRow_ - numDeletedRows;
-      HighsInt numNonz = Avalue.size() - freeslots.size();
-      highsLogUser(options->log_options, HighsLogType::kInfo,
-                   "%" HIGHSINT_FORMAT " rows, %" HIGHSINT_FORMAT
-                   " cols, %" HIGHSINT_FORMAT " nonzeros\n",
-                   numRow, numCol, numNonz);
+      if (!mipsolver || mipsolver->mipdata_->numRestarts == 0) {
+        HighsInt numCol = model->numCol_ - numDeletedCols;
+        HighsInt numRow = model->numRow_ - numDeletedRows;
+        HighsInt numNonz = Avalue.size() - freeslots.size();
+        highsLogUser(options->log_options, HighsLogType::kInfo,
+                     "%" HIGHSINT_FORMAT " rows, %" HIGHSINT_FORMAT
+                     " cols, %" HIGHSINT_FORMAT " nonzeros\n",
+                     numRow, numCol, numNonz);
+      }
     };
 
     HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postSolveStack));


### PR DESCRIPTION
Improve reporting of the MIP solver. Uses a table without bars and lines take a bit less space. Information is more organized. Prints information about the model size after presolve and about variable types.