### PR TITLE
fix missing virtual dtor

### DIFF
--- a/src/qpsolver/pricing.hpp
+++ b/src/qpsolver/pricing.hpp
@@ -9,6 +9,7 @@ class Pricing {
   virtual HighsInt price(const Vector& x, const Vector& gradient) = 0;
   virtual void update_weights(const Vector& aq, const Vector& ep, HighsInt p,
                               HighsInt q) = 0;
+  virtual ~Pricing() {}
 };
 
 #endif


### PR DESCRIPTION
I get a warning since delete is called on a sublass of type `Pricing` via a pointer of type `Pricing`, but the class does not have a virtual destrucutor. So I think the warning of the compiler is justified and this is a bug which is fixed here.

```
usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:81:2: warning: delete called on 'Pricing' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/unique_ptr.h:292:4: note: in instantiation of member function 'std::default_delete<Pricing>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/leona/projects/highs/src/qpsolver/solver.cpp:138:7: note: in instantiation of member function 'std::unique_ptr<Pricing, std::default_delete<Pricing> >::~unique_ptr' requested here
      std::unique_ptr<Pricing>(new DevexPricing(runtime, basis, redcosts));
```