### PR TITLE
add command line options for random seed and solution file

### DIFF
--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -198,6 +198,11 @@ set(mipInstances
 set(settings
     "--presolve=off"
     "--presolve=on"
+    "--random_seed=1"
+    "--random_seed=2"
+    "--random_seed=3"
+    "--random_seed=4"
+    "--random_seed=5"
 #    "--parallel=on"
     )
 

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -1808,16 +1808,16 @@ void writeSolutionToFile(FILE* file, const HighsLp& lp, const HighsBasis& basis,
     fprintf(file, " Basis\n");
     fprintf(file, "Columns\n");
     for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
-      if (have_value) fprintf(file, "%g", use_col_value[iCol]);
-      if (have_dual) fprintf(file, "%g", use_col_dual[iCol]);
+      if (have_value) fprintf(file, "%.15g", use_col_value[iCol]);
+      if (have_dual) fprintf(file, "%.15g", use_col_dual[iCol]);
       if (have_basis)
         fprintf(file, " %" HIGHSINT_FORMAT "", (HighsInt)use_col_status[iCol]);
       fprintf(file, " \n");
     }
     fprintf(file, "Rows\n");
     for (HighsInt iRow = 0; iRow < lp.num_row_; iRow++) {
-      if (have_value) fprintf(file, "%g", use_row_value[iRow]);
-      if (have_dual) fprintf(file, "%g", use_row_dual[iRow]);
+      if (have_value) fprintf(file, "%.15g", use_row_value[iRow]);
+      if (have_dual) fprintf(file, "%.15g", use_row_dual[iRow]);
       if (have_basis)
         fprintf(file, " %" HIGHSINT_FORMAT "", (HighsInt)use_row_status[iRow]);
       fprintf(file, " \n");

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -250,6 +250,8 @@ const string kSolverString = "solver";
 const string kParallelString = "parallel";
 const string kTimeLimitString = "time_limit";
 const string kOptionsFileString = "options_file";
+const string kRandomSeedString = "random_seed";
+const string kSolutionFileString = "solution_file";
 
 // String for HiGHS log file option
 const string kLogFileString = "log_file";
@@ -271,7 +273,7 @@ struct HighsOptionsStruct {
   double ipm_optimality_tolerance;
   double objective_bound;
   double objective_target;
-  HighsInt highs_random_seed;
+  HighsInt random_seed;
   HighsInt highs_debug_level;
   HighsInt highs_analysis_level;
   HighsInt simplex_strategy;
@@ -472,8 +474,8 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_double);
 
     record_int =
-        new OptionRecordInt("highs_random_seed", "random seed used in HiGHS",
-                            advanced, &highs_random_seed, 0, 0, kHighsIInf);
+        new OptionRecordInt(kRandomSeedString, "random seed used in HiGHS",
+                            advanced, &random_seed, 0, 0, kHighsIInf);
     records.push_back(record_int);
 
     record_int =
@@ -565,7 +567,7 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_bool);
 
     record_string =
-        new OptionRecordString("solution_file", "Solution file", advanced,
+        new OptionRecordString(kSolutionFileString, "Solution file", advanced,
                                &solution_file, kHighsFilenameDefault);
     records.push_back(record_string);
 

--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -21,7 +21,7 @@ HighsCutGeneration::HighsCutGeneration(const HighsLpRelaxation& lpRelaxation,
                                        HighsCutPool& cutpool)
     : lpRelaxation(lpRelaxation),
       cutpool(cutpool),
-      randgen(lpRelaxation.getMipSolver().options_mip_->highs_random_seed +
+      randgen(lpRelaxation.getMipSolver().options_mip_->random_seed +
               lpRelaxation.getNumLpIterations() + cutpool.getNumCuts()),
       feastol(lpRelaxation.getMipSolver().mipdata_->feastol),
       epsilon(lpRelaxation.getMipSolver().mipdata_->epsilon) {}

--- a/src/mip/HighsDomain.cpp
+++ b/src/mip/HighsDomain.cpp
@@ -1394,8 +1394,6 @@ void HighsDomain::changeBound(HighsDomainChange boundchg, Reason reason) {
   assert(boundchg.column >= 0);
   assert(boundchg.column < (HighsInt)col_upper_.size());
   // assert(infeasible_ == 0);
-  mipsolver->mipdata_->debugSolution.boundChangeAdded(
-      *this, boundchg, reason.type == Reason::kBranching);
   HighsInt prevPos;
   if (boundchg.boundtype == HighsBoundType::kLower) {
     if (boundchg.boundval <= col_lower_[boundchg.column]) {
@@ -1442,6 +1440,9 @@ void HighsDomain::changeBound(HighsDomainChange boundchg, Reason reason) {
     prevPos = colUpperPos_[boundchg.column];
     colUpperPos_[boundchg.column] = domchgstack_.size();
   }
+
+  mipsolver->mipdata_->debugSolution.boundChangeAdded(
+      *this, boundchg, reason.type == Reason::kBranching);
 
   if (reason.type == Reason::kBranching)
     branchPos_.push_back(domchgstack_.size());

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -106,8 +106,7 @@ double HighsLpRelaxation::slackUpper(HighsInt row) const {
 HighsLpRelaxation::HighsLpRelaxation(const HighsMipSolver& mipsolver)
     : mipsolver(mipsolver) {
   lpsolver.setOptionValue("output_flag", false);
-  lpsolver.setOptionValue("highs_random_seed",
-                          mipsolver.options_mip_->highs_random_seed);
+  lpsolver.setOptionValue("random_seed", mipsolver.options_mip_->random_seed);
   lpsolver.setOptionValue("primal_feasibility_tolerance",
                           mipsolver.options_mip_->mip_feasibility_tolerance);
   lpsolver.setOptionValue(

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -36,7 +36,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
   const HighsLp& lp = lpRelaxation.getLp();
   const HighsSolution& lpSolution = lpRelaxation.getSolution();
 
-  randgen.initialise(mip.options_mip_->highs_random_seed +
+  randgen.initialise(mip.options_mip_->random_seed +
                      lpRelaxation.getNumLpIterations());
   std::vector<RowType> rowtype;
   rowtype.resize(lp.num_row_);

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -28,7 +28,7 @@
 HighsPrimalHeuristics::HighsPrimalHeuristics(HighsMipSolver& mipsolver)
     : mipsolver(mipsolver),
       lp_iterations(0),
-      randgen(mipsolver.options_mip_->highs_random_seed) {
+      randgen(mipsolver.options_mip_->random_seed) {
   successObservations = 0;
   numSuccessObservations = 0;
   infeasObservations = 0;

--- a/src/mip/HighsSearch.cpp
+++ b/src/mip/HighsSearch.cpp
@@ -422,9 +422,11 @@ HighsInt HighsSearch::selectBranchingCandidate(int64_t maxSbIters) {
             if (!solutionValid) continue;
           }
 
-          if (objdelta <= mipsolver.mipdata_->feastol)
+          if (objdelta <= mipsolver.mipdata_->feastol) {
             pseudocost.addObservation(fracints[k].first,
                                       otherdownval - otherfracval, objdelta);
+            markBranchingVarDownReliableAtNode(fracints[k].first);
+          }
 
           downscore[k] = std::min(downscore[k], objdelta);
         } else if (sol[fracints[k].first] >=
@@ -473,9 +475,11 @@ HighsInt HighsSearch::selectBranchingCandidate(int64_t maxSbIters) {
             if (!solutionValid) continue;
           }
 
-          if (objdelta <= mipsolver.mipdata_->feastol)
+          if (objdelta <= mipsolver.mipdata_->feastol) {
             pseudocost.addObservation(fracints[k].first,
                                       otherupval - otherfracval, objdelta);
+            markBranchingVarUpReliableAtNode(fracints[k].first);
+          }
 
           upscore[k] = std::min(upscore[k], objdelta);
         }
@@ -484,7 +488,10 @@ HighsInt HighsSearch::selectBranchingCandidate(int64_t maxSbIters) {
 
     if (!downscorereliable[candidate] &&
         (upscorereliable[candidate] ||
-         downscore[candidate] >= upscore[candidate])) {
+         std::make_pair(downscore[candidate],
+                        pseudocost.getAvgInferencesDown(col)) >=
+             std::make_pair(upscore[candidate],
+                            pseudocost.getAvgInferencesUp(col)))) {
       // evaluate down branch
       int64_t inferences = -(int64_t)localdom.getDomainChangeStack().size() - 1;
 

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -1311,7 +1311,7 @@ HPresolve::Result HPresolve::runProbing(HighsPostsolveStack& postSolveStack) {
   // other binaries
   std::vector<std::tuple<int64_t, HighsInt, HighsInt, HighsInt>> binaries;
   binaries.reserve(model->num_col_);
-  HighsRandom random(options->highs_random_seed);
+  HighsRandom random(options->random_seed);
   for (HighsInt i = 0; i != model->num_col_; ++i) {
     if (domain.isBinary(i)) {
       HighsInt implicsUp = cliquetable.getNumImplications(i, 1);

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4068,7 +4068,7 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postSolveStack) {
             model->row_upper_[i],
             rowsizeInteger[i] + rowsizeImplInt[i] == rowsize[i] &&
                 rowCoefficientsIntegral(i, 1.0),
-            false);
+            true, false, false);
 
         markRowDeleted(i);
         for (HighsInt j : rowpositions) unlink(j);

--- a/src/presolve/HighsSymmetry.cpp
+++ b/src/presolve/HighsSymmetry.cpp
@@ -230,7 +230,7 @@ HighsSymmetries::computeStabilizerOrbits(const HighsDomain& localdom) {
     HighsInt orbit = getOrbit(permutationColumns[i]);
     if (orbitSize[orbit] == 1)
       stabilizerOrbits.stabilizedCols.push_back(permutationColumns[i]);
-    else
+    else if (localdom.isGlobalBinary(permutationColumns[i]))
       stabilizerOrbits.orbitCols.push_back(permutationColumns[i]);
   }
   stabilizerOrbits.symmetries = this;

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -534,7 +534,7 @@ void HEkk::setSimplexOptions() {
       options_.primal_simplex_bound_perturbation_multiplier;
   info_.factor_pivot_threshold = options_.factor_pivot_threshold;
   info_.update_limit = options_.simplex_update_limit;
-  random_.initialise(options_.highs_random_seed);
+  random_.initialise(options_.random_seed);
 
   // Set values of internal options
   info_.store_squared_primal_infeasibility = true;


### PR DESCRIPTION
I added command line options for specifying a solution file and specifying a random seed. The latter is now used for additional testing in the ctest by running all instances with seeds 1 to 5 in addition to the default seed of 0. This increases the probability of catching bugs a little and the instances solve quickly enough so that it is not an issue to run them a bit more often.