### PR TITLE
Small improvements

### DIFF
--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -338,6 +338,14 @@ restart:
       // the node is still not fathomed, so perform separation
       sepa.separate(search.getLocalDomain());
 
+      if (mipdata_->domain.infeasible()) {
+        search.cutoffNode();
+        mipdata_->nodequeue.clear();
+        mipdata_->pruned_treeweight = 1.0;
+        mipdata_->lower_bound = std::min(kHighsInf, mipdata_->upper_bound);
+        break;
+      }
+
       // after separation we store the new basis and proceed with the outer loop
       // to perform a dive from this node
       if (mipdata_->lp.getStatus() != HighsLpRelaxation::Status::kError &&

--- a/src/mip/HighsSeparator.cpp
+++ b/src/mip/HighsSeparator.cpp
@@ -19,7 +19,8 @@
 #include "mip/HighsMipSolver.h"
 
 HighsSeparator::HighsSeparator(const HighsMipSolver& mipsolver,
-                               const char* name, const char* ch3_name) {
+                               const char* name, const char* ch3_name)
+    : numCutsFound(0), numCalls(0) {
   clockIndex = mipsolver.timer_.clock_def(name, ch3_name);
 }
 

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -358,7 +358,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
     };
 
     vectorsum.cleanup(IsZero);
-    if (maxError > mip.mipdata_->feastol){
+    if (maxError > mip.mipdata_->feastol) {
       vectorsum.clear();
       return false;
     }

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -261,7 +261,10 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
       continue;
     }
 
-    if (lb == -kHighsInf && ub == kHighsInf) return false;
+    if (lb == -kHighsInf && ub == kHighsInf) {
+      vectorsum.clear();
+      return false;
+    }
 
     if (lprelaxation.isColIntegral(col)) {
       if (lb == -kHighsInf || ub == kHighsInf) integersPositive = false;
@@ -355,7 +358,10 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
     };
 
     vectorsum.cleanup(IsZero);
-    if (maxError > mip.mipdata_->feastol) return false;
+    if (maxError > mip.mipdata_->feastol){
+      vectorsum.clear();
+      return false;
+    }
 
     inds = vectorsum.getNonzeros();
     numNz = inds.size();


### PR DESCRIPTION
Stricter limit on the number of tableau rows used for cut generation. Previously only the number of cuts was limited to 1000. This could lead to all tableau rows of fractional basis variables being tested for cut generation if the cut generation always failed, e.g. due to numeric safe-guards or other limits imposed on the cuts. Now the cut generation for tableau based cuts is limited to only try the tableau rows of the 200 most fractional basis indices for cut generation. While leading to slightly more nodes on average runtime and number of solved instances improves.