### PR TITLE
Mip path mixing sepa

### DIFF
--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -338,6 +338,14 @@ restart:
       // the node is still not fathomed, so perform separation
       sepa.separate(search.getLocalDomain());
 
+      if (mipdata_->domain.infeasible()) {
+        search.cutoffNode();
+        mipdata_->nodequeue.clear();
+        mipdata_->pruned_treeweight = 1.0;
+        mipdata_->lower_bound = std::min(kHighsInf, mipdata_->upper_bound);
+        break;
+      }
+
       // after separation we store the new basis and proceed with the outer loop
       // to perform a dive from this node
       if (mipdata_->lp.getStatus() != HighsLpRelaxation::Status::kError &&

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -360,7 +360,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
           break;
         }
         rhs[k] = std::min(0., rhs[k]);
-        delta = std::max(std::abs(rhs[k]) + 1.0, delta);
+        delta = std::max(std::abs(rhs[k]), delta);
 
         HighsInt len = aggregatedPath[k].first.size();
         for (HighsInt j = 0; j < len; ++j) {
@@ -385,7 +385,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       }
 
       if (pathLen > 1) {
-        delta = std::exp2(std::ceil(std::log2(delta)));
+        delta = std::exp2(std::ceil(std::log2(delta + 1.0)));
 
         HighsInt numInds = inds.size();
 

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -378,6 +378,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
             assert(inds[*pos - 1] == index);
             assert(solval[*pos - 1] == tmpSolval[j]);
             assert(upper[*pos - 1] == tmpUpper[j]);
+            if (isIntegral[*pos - 1])
+              delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
           }
         }
       }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -165,7 +165,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
   std::vector<HighsInt> baseRowInds;
   std::vector<double> baseRowVals;
   const HighsInt maxPathLen = 6;
-
+  std::vector<std::pair<std::vector<HighsInt>, std::vector<double>>>
+      aggregatedPath;
   for (HighsInt i = 0; i != lp.num_row_; ++i) {
     switch (rowtype[i]) {
       case RowType::kUnusuable:
@@ -185,6 +186,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       w = std::abs(w);
       return w <= maxWeight && w >= minWeight;
     };
+
+    aggregatedPath.clear();
 
     while (currPathLen != maxPathLen) {
       lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, false);
@@ -240,6 +243,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       bool success = cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
 
       lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, true);
+      aggregatedPath.emplace_back(baseRowInds, baseRowVals);
       rhs = 0;
 
       success =
@@ -316,6 +320,182 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
         }
 
         lpAggregator.addRow(row, weight);
+      }
+    }
+
+    // if the path has length at least 2 try to separate a path mixing cut
+    HighsInt pathLen = aggregatedPath.size();
+    if (pathLen > 1) {
+      // generate path mixing cut
+      HighsHashTable<HighsInt, HighsInt> indexPos;
+
+      std::vector<HighsInt> inds;
+      std::vector<double> solval;
+      std::vector<double> upper;
+      std::vector<uint8_t> isIntegral;
+      inds.reserve(lp.num_col_ + lp.num_row_);
+      solval.reserve(lp.num_col_ + lp.num_row_);
+      upper.reserve(lp.num_col_ + lp.num_row_);
+      isIntegral.reserve(lp.num_col_ + lp.num_row_);
+
+      std::vector<double> rhs(pathLen);
+      std::vector<double> tmpUpper;
+      std::vector<double> tmpSolval;
+
+      double delta = 1.0;
+
+      for (HighsInt k = 0; k < pathLen; ++k) {
+        bool integralPositive = false;
+
+        if (!transLp.transform(aggregatedPath[k].second, tmpUpper, tmpSolval,
+                               aggregatedPath[k].first, rhs[k],
+                               integralPositive)) {
+          pathLen = k;
+          break;
+        }
+
+        if (rhs[k] > kHighsTiny ||
+            (k > 0 && rhs[k - 1] <= rhs[k] + mip.mipdata_->feastol)) {
+          pathLen = k;
+          break;
+        }
+        rhs[k] = std::min(0., rhs[k]);
+        delta = std::max(std::abs(rhs[k]) + 1.0, delta);
+
+        HighsInt len = aggregatedPath[k].first.size();
+        for (HighsInt j = 0; j < len; ++j) {
+          HighsInt index = aggregatedPath[k].first[j];
+          HighsInt* pos = &indexPos[index];
+          if (*pos == 0) {
+            inds.push_back(index);
+            solval.push_back(tmpSolval[j]);
+            upper.push_back(tmpUpper[j]);
+            isIntegral.push_back(lpRelaxation.isColIntegral(index));
+            if (isIntegral.back())
+              delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
+            *pos = inds.size();
+          } else {
+            assert(inds[*pos - 1] == index);
+            assert(solval[*pos - 1] == tmpSolval[j]);
+            assert(upper[*pos - 1] == tmpUpper[j]);
+          }
+        }
+      }
+
+      if (pathLen > 1) {
+        delta = std::exp2(std::ceil(std::log2(delta)));
+
+        HighsInt numInds = inds.size();
+
+        std::vector<double> valueMatrix;
+        valueMatrix.resize(pathLen * numInds, 0.0);
+
+        HighsCDouble cutRhs = 0.0;
+        std::vector<double> cutVals(numInds);
+        std::vector<double> maxFrac(numInds);
+
+        double fLast = 0;
+        double scale = -1.0 / delta;
+
+        for (HighsInt k = 0; k < pathLen; ++k) {
+          double f = rhs[k] * scale;
+          HighsCDouble fDiff = HighsCDouble(f) - fLast;
+          HighsInt len = aggregatedPath[k].first.size();
+          cutRhs += fDiff;
+          for (HighsInt j = 0; j < len; ++j) {
+            HighsInt i = indexPos[aggregatedPath[k].first[j]] - 1;
+            assert(i >= 0);
+
+            double gj = aggregatedPath[k].second[j] * scale;
+
+            switch (isIntegral[i]) {
+              case 0:
+                cutVals[i] = std::max(cutVals[i], gj);
+                break;
+              case 1:
+                if (gj < fDiff) {
+                  isIntegral[i] = 2;
+
+                  double gjdown = std::floor(gj);
+                  double hj = gj - gjdown;
+                  maxFrac[i] = std::max(maxFrac[i], hj);
+
+                  cutVals[i] = double(maxFrac[i] + fDiff * gjdown);
+                } else {
+                  isIntegral[i] = 3;
+
+                  double gjup = std::ceil(gj - mip.mipdata_->epsilon);
+
+                  cutVals[i] = double(cutVals[i] + fDiff * gjup);
+                }
+                break;
+              case 2: {
+                double gjdown = std::floor(gj);
+                double hj = gj - gjdown;
+                maxFrac[i] = std::max(maxFrac[i], hj);
+
+                cutVals[i] = double(maxFrac[i] + fDiff * gjdown);
+
+                break;
+              }
+              case 3: {
+                double gjup = std::ceil(gj - mip.mipdata_->epsilon);
+
+                cutVals[i] = double(cutVals[i] + fDiff * gjup);
+              }
+            }
+          }
+
+          if (k > 0) {
+            double viol = double(cutRhs);
+            for (HighsInt j = 0; j < numInds; ++j) {
+              viol -= solval[j] * cutVals[j];
+            }
+
+            viol *= delta;
+
+            if (viol > 10 * mip.mipdata_->feastol) {
+              scale = -delta;
+              double rhs = double(cutRhs) * scale;
+              for (HighsInt j = 0; j < numInds; ++j) {
+                cutVals[j] *= scale;
+              }
+
+              for (HighsInt j = numInds - 1; j >= 0; --j) {
+                if (std::abs(cutVals[j]) <= mip.mipdata_->epsilon) {
+                  --numInds;
+                  std::swap(cutVals[j], cutVals[numInds]);
+                  std::swap(inds[j], inds[numInds]);
+                }
+              }
+
+              cutVals.resize(numInds);
+              inds.resize(numInds);
+
+              if (transLp.untransform(cutVals, inds, rhs)) {
+                HighsInt cutLen = inds.size();
+                mip.mipdata_->debugSolution.checkCut(
+                    inds.data(), cutVals.data(), cutLen, rhs);
+
+                // compute violation in untransformed space again
+                double viol = -rhs;
+                for (HighsInt j = 0; j < cutLen; ++j)
+                  viol += cutVals[j] *
+                          lpRelaxation.getSolution().col_value[inds[j]];
+
+                if (viol > 10 * mip.mipdata_->feastol) {
+                  mip.mipdata_->domain.tightenCoefficients(
+                      inds.data(), cutVals.data(), cutLen, rhs);
+                  cutpool.addCut(mip, inds.data(), cutVals.data(), inds.size(),
+                                 rhs);
+                }
+              }
+              // printf("cut is violated for k = %d\n", k);
+              break;
+            }
+          }
+          fLast = f;
+        }
       }
     }
 

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -395,6 +395,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
         HighsCDouble cutRhs = 0.0;
         std::vector<double> cutVals(numInds);
         std::vector<double> maxFrac(numInds);
+        std::vector<HighsCDouble> downSum(numInds);
+        std::vector<HighsCDouble> fSum(numInds);
 
         double fLast = 0;
         double scale = -1.0 / delta;
@@ -414,36 +416,19 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
               case 0:
                 cutVals[i] = std::max(cutVals[i], gj);
                 break;
-              case 1:
-                if (gj < fDiff) {
-                  isIntegral[i] = 2;
-
-                  double gjdown = std::floor(gj);
-                  double hj = gj - gjdown;
-                  maxFrac[i] = std::max(maxFrac[i], hj);
-
-                  cutVals[i] = double(maxFrac[i] + fDiff * gjdown);
-                } else {
-                  isIntegral[i] = 3;
-
-                  double gjup = std::ceil(gj - mip.mipdata_->epsilon);
-
-                  cutVals[i] = double(cutVals[i] + fDiff * gjup);
-                }
-                break;
-              case 2: {
+              case 1: {
                 double gjdown = std::floor(gj);
                 double hj = gj - gjdown;
                 maxFrac[i] = std::max(maxFrac[i], hj);
+                downSum[i] += fDiff * gjdown;
+                fSum[i] += fDiff;
 
-                cutVals[i] = double(maxFrac[i] + fDiff * gjdown);
-
+                if (fSum[i] < maxFrac[i]) {
+                  cutVals[i] = double(downSum[i] + fSum[i]);
+                } else {
+                  cutVals[i] = double(downSum[i] + maxFrac[i]);
+                }
                 break;
-              }
-              case 3: {
-                double gjup = std::ceil(gj - mip.mipdata_->epsilon);
-
-                cutVals[i] = double(cutVals[i] + fDiff * gjup);
               }
             }
           }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -243,7 +243,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       bool success = cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
 
       lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, true);
-      aggregatedPath.emplace_back(baseRowInds, baseRowVals);
+      if (!aggregatedPath.empty() || bestOutArcCol != -1 || bestInArcCol != -1)
+        aggregatedPath.emplace_back(baseRowInds, baseRowVals);
       rhs = 0;
 
       success =

--- a/src/mip/HighsSeparator.cpp
+++ b/src/mip/HighsSeparator.cpp
@@ -19,7 +19,8 @@
 #include "mip/HighsMipSolver.h"
 
 HighsSeparator::HighsSeparator(const HighsMipSolver& mipsolver,
-                               const char* name, const char* ch3_name) {
+                               const char* name, const char* ch3_name)
+    : numCutsFound(0), numCalls(0) {
   clockIndex = mipsolver.timer_.clock_def(name, ch3_name);
 }
 

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -261,7 +261,10 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
       continue;
     }
 
-    if (lb == -kHighsInf && ub == kHighsInf) return false;
+    if (lb == -kHighsInf && ub == kHighsInf) {
+      vectorsum.clear();
+      return false;
+    }
 
     if (lprelaxation.isColIntegral(col)) {
       if (lb == -kHighsInf || ub == kHighsInf) integersPositive = false;
@@ -355,7 +358,10 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
     };
 
     vectorsum.cleanup(IsZero);
-    if (maxError > mip.mipdata_->feastol) return false;
+    if (maxError > mip.mipdata_->feastol){
+      vectorsum.clear();
+      return false;
+    }
 
     inds = vectorsum.getNonzeros();
     numNz = inds.size();


### PR DESCRIPTION
It does not make a big difference but looks like a slight improvement on affected instances. It is a small extension of the already existing aggregation heuristics which produces a sequence of row aggregations where it tries to project out continuous variables with nonzero distance to their bounds in each step. This sequence of aggregations is then relaxed to form a so-called mixing set for which inequalities are separated. Using such a path to form a mixing set can be used to derive several special purpose cuts like flow path cuts and the path mixing separator is implemented to mimic the generation of flow path inequalities but is more general. I.e. it can also generate cuts when general integer variables are involved as it just relies on the MIR cuts derived from the individual aggregated rows of the path and mixes them into a single cut. When certain structure is present the cuts can be expected to be strong as they use information from several rows of the MIP and not just from a single row. The resulting inequalities can have a higher MIR-rank than 1, i.e. they would require several rounds of separation where cuts are generated from cuts to be found by the normal cMIR separation using single-row relaxations.