### PR TITLE
Mps short names

### DIFF
--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -197,7 +197,7 @@ FilereaderRetcode readMps(const HighsLogOptions& log_options,
     highsLogUser(log_options, HighsLogType::kWarning,
                  "COLUMNS section entries contain %8" HIGHSINT_FORMAT
                  " with row not in ROWS  "
-                 "  section: ignored",
+                 "  section: ignored\n",
                  num_alien_entries);
 #ifdef HiGHSDEV
   printf("readMPS: Read COLUMNS OK\n");
@@ -227,7 +227,7 @@ FilereaderRetcode readMps(const HighsLogOptions& log_options,
         num_alien_entries++;
         highsLogUser(log_options, HighsLogType::kInfo,
                      "RHS     section contains row %-8s not in ROWS    "
-                     "section, line: %s",
+                     "section, line: %s\n",
                      name.c_str(), line);
       }
     } else {
@@ -248,7 +248,7 @@ FilereaderRetcode readMps(const HighsLogOptions& log_options,
     highsLogUser(log_options, HighsLogType::kWarning,
                  "RHS     section entries contain %8" HIGHSINT_FORMAT
                  " with row not in ROWS  "
-                 "  section: ignored",
+                 "  section: ignored\n",
                  num_alien_entries);
 #ifdef HiGHSDEV
   printf("readMPS: Read RHS     OK\n");
@@ -322,7 +322,7 @@ FilereaderRetcode readMps(const HighsLogOptions& log_options,
     highsLogUser(log_options, HighsLogType::kWarning,
                  "RANGES  section entries contain %8" HIGHSINT_FORMAT
                  " with row not in ROWS  "
-                 "  section: ignored",
+                 "  section: ignored\n",
                  num_alien_entries);
 #ifdef HiGHSDEV
   printf("readMPS: Read RANGES  OK\n");
@@ -388,7 +388,7 @@ FilereaderRetcode readMps(const HighsLogOptions& log_options,
     highsLogUser(log_options, HighsLogType::kWarning,
                  "BOUNDS  section entries contain %8" HIGHSINT_FORMAT
                  " with col not in "
-                 "COLUMNS section: ignored",
+                 "COLUMNS section: ignored\n",
                  num_alien_entries);
 #ifdef HiGHSDEV
   printf("readMPS: Read BOUNDS  OK\n");
@@ -513,7 +513,7 @@ HighsStatus writeModelAsMps(const HighsOptions& options,
       highsLogUser(options.log_options, HighsLogType::kWarning,
                    "Maximum name length is %" HIGHSINT_FORMAT
                    " so using free format rather "
-                   "than fixed format",
+                   "than fixed format\n",
                    max_name_length);
       use_free_format = true;
       warning_found = true;
@@ -555,7 +555,7 @@ HighsStatus writeMps(
 #endif
   FILE* file = fopen(filename.c_str(), "w");
   if (file == 0) {
-    highsLogUser(log_options, HighsLogType::kError, "Cannot open file %s",
+    highsLogUser(log_options, HighsLogType::kError, "Cannot open file %s\n",
                  filename.c_str());
     return HighsStatus::kError;
   }
@@ -570,7 +570,7 @@ HighsStatus writeMps(
     highsLogUser(
         log_options, HighsLogType::kError,
         "Cannot write fixed MPS with names of length (up to) %" HIGHSINT_FORMAT
-        "",
+        "\n",
         max_name_length);
     return HighsStatus::kError;
   }

--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -670,6 +670,21 @@ HighsStatus writeMps(
   // BOUNDS
   //  LO BOUND     CFOOD01           850.
   //
+  // NB d6cube has (eg)
+  // COLUMNS
+  //        1      1                   1.   4                  -1.
+  //        1      5                  -1.   1151                1.
+  // Indexed from 0
+  //           1         2         3         4         5         6
+  // 0123456789012345678901234567890123456789012345678901234567890
+  // x11x22222222xx33333333xx444444444444xxx55555555xx666666666666
+  //
+  // In fixed format the first column name is "      1 ", and its first entry is
+  // in row "1       ".
+  //
+  // The free format reader thought that it had a name of "1      1" containing
+  // spaces.
+
   fprintf(file, "NAME        %s\n", model_name.c_str());
   fprintf(file, "ROWS\n");
   fprintf(file, " N  COST\n");

--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -569,18 +569,40 @@ typename HMpsFF::Parsekey HMpsFF::parseCols(const HighsLogOptions& log_options,
 
       continue;
     }
-
-    // Detect if file is in fixed format.
+    // Detect whether the file is in fixed format with spaces in
+    // names, even if there are no known examples!
+    //
     // end_marker should be the end index of the row name:
-    // more than 13 minus the 4 whitespaces we have trimmed from the start so
-    // more than 9
+    //
+    // If the names are at least 8 characters, end_marker should be
+    // more than 13 minus the 4 whitespaces we have trimmed from the
+    // start so more than 9
+    //
+    // However, free format MPS can have names with only one character
+    // (pyomo.mps). Have to distinguish this from 8-character names
+    // with spaaces. Best bet is to see whether "marker" is in the set
+    // of row names. If it is, then assume that the names are short
     if (end_marker < 9) {
-      std::string name = strline.substr(0, 10);
-      name = trim(name);
-      if (name.size() > 8)
-        return HMpsFF::Parsekey::kFail;
-      else
-        return HMpsFF::Parsekey::kFixedFormat;
+      auto mit = rowname2idx.find(marker);
+      if (mit == rowname2idx.end()) {
+        // marker is not a row name, so continue to look at name
+        std::string name = strline.substr(0, 10);
+        // Delete trailing spaces
+        name = trim(name);
+        if (name.size() > 8) {
+          highsLogUser(log_options, HighsLogType::kError,
+                       "Row name |%s| with spaces exceeds fixed format name "
+                       "length of 8\n",
+                       name.c_str());
+          return HMpsFF::Parsekey::kFail;
+        } else {
+          highsLogUser(log_options, HighsLogType::kWarning,
+                       "Row name |%s| with spaces has length %1d, so assume "
+                       "fixed format\n",
+                       name.c_str(), (int)name.size());
+          return HMpsFF::Parsekey::kFixedFormat;
+        }
+      }
     }
 
     // new column?


### PR DESCRIPTION
#571 is another issue where short row and column names are fooling the free format MPS reader into thinking that it's a file in fixed format with spaces in the (row) names. The Netlib example that I always thought had strict spaces in its names is d6cube, but they are just very odd row names like "     1  " that can be read as "1" in free format. So, I've added code that, when a name with spaces might previously have been identified - because the MPS line is (eg) "x1 x3 40" - if the second word "x3" is found in the row names, it's accepted as being such. Otherwise the file is given to the fixed format reader and fails.