### PR TITLE
Mip aggregation heuristic

### DIFF
--- a/src/mip/HighsCliqueTable.h
+++ b/src/mip/HighsCliqueTable.h
@@ -103,7 +103,7 @@ class HighsCliqueTable {
 
   HighsRandom randgen;
   HighsInt nfixings;
-
+  HighsInt numEntries;
   HighsInt splay(HighsInt cliqueid, HighsInt root);
 
   void unlink(HighsInt node);
@@ -161,6 +161,7 @@ class HighsCliqueTable {
     colsubstituted.resize(ncols);
     nfixings = 0;
     numSplayCalls = 0;
+    numEntries = 0;
   }
 
   bool processNewEdge(HighsDomain& globaldom, CliqueVar v1, CliqueVar v2);

--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -1315,8 +1315,10 @@ bool HighsCutGeneration::generateConflict(HighsDomain& localdomain,
 
     upper[i] = globaldomain.col_upper_[col] - globaldomain.col_lower_[col];
 
-    solval[i] =
-        vals[i] < 0 ? localdomain.col_upper_[col] : localdomain.col_lower_[col];
+    solval[i] = vals[i] < 0 ? std::min(globaldomain.col_upper_[col],
+                                       localdomain.col_upper_[col])
+                            : std::max(globaldomain.col_lower_[col],
+                                       localdomain.col_lower_[col]);
     if (vals[i] < 0 && globaldomain.col_upper_[col] != kHighsInf) {
       rhs -= globaldomain.col_upper_[col] * vals[i];
       vals[i] = -vals[i];

--- a/src/mip/HighsCutGeneration.h
+++ b/src/mip/HighsCutGeneration.h
@@ -88,6 +88,11 @@ class HighsCutGeneration {
   /// given local domain
   bool generateConflict(HighsDomain& localdom, std::vector<HighsInt>& proofinds,
                         std::vector<double>& proofvals, double& proofrhs);
+
+  /// applies postprocessing to an externally generated cut and adds it to the
+  /// cutpool if it is violated enough
+  bool finalizeAndAddCut(std::vector<HighsInt>& inds, std::vector<double>& vals,
+                         double& rhs);
 };
 
 #endif

--- a/src/mip/HighsDomain.h
+++ b/src/mip/HighsDomain.h
@@ -485,6 +485,8 @@ class HighsDomain {
   HighsDomainChange flip(const HighsDomainChange& domchg) const;
 
   double feastol() const;
+
+  HighsInt numModelNonzeros() const { return mipsolver->numNonzero(); }
 };
 
 #endif

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -112,16 +112,14 @@ restart:
     // perform the dive and put the open nodes to the queue
     size_t plungestart = mipdata_->num_nodes;
     bool limit_reached = false;
-    bool heuristicsCalled = false;
+    bool considerHeuristics = true;
     while (true) {
-      if (!heuristicsCalled && mipdata_->moreHeuristicsAllowed()) {
+      if (considerHeuristics && mipdata_->moreHeuristicsAllowed()) {
         search.evaluateNode();
         if (search.currentNodePruned()) {
           ++mipdata_->num_leaves;
           search.flushStatistics();
         } else {
-          heuristicsCalled = true;
-
           if (mipdata_->incumbent.empty())
             mipdata_->heuristics.randomizedRounding(
                 mipdata_->lp.getLpSolver().getSolution().col_value);
@@ -136,6 +134,8 @@ restart:
           mipdata_->heuristics.flushStatistics();
         }
       }
+
+      considerHeuristics = false;
 
       if (mipdata_->domain.infeasible()) break;
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1175,7 +1175,10 @@ restart:
     if (!mipsolver.submip &&
         mipsolver.options_mip_->presolve != kHighsOffString) {
       double fixingRate = percentageInactiveIntegers();
-      if (fixingRate >= 10.0) break;
+      if (fixingRate >= 10.0) {
+        stall = -1;
+        break;
+      }
     }
 
     ++nseparounds;
@@ -1351,7 +1354,7 @@ restart:
         highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
                      "\n%.1f%% inactive integer columns, restarting\n",
                      fixingRate);
-        maxSepaRounds = std::min(maxSepaRounds, nseparounds);
+        if (stall != -1) maxSepaRounds = std::min(maxSepaRounds, nseparounds);
         performRestart();
         ++numRestartsRoot;
         if (mipsolver.modelstatus_ == HighsModelStatus::kNotset) goto restart;

--- a/src/mip/HighsModkSeparator.cpp
+++ b/src/mip/HighsModkSeparator.cpp
@@ -80,6 +80,8 @@ void HighsModkSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
   double rhs;
 
   const HighsSolution& lpSolution = lpRelaxation.getSolution();
+  HighsInt numNonzeroRhs = 0;
+  HighsInt maxIntRowLen = 1000 + 0.1 * lp.num_col_;
 
   for (HighsInt row = 0; row != lp.num_row_; ++row) {
     if (skipRow[row]) continue;
@@ -142,7 +144,7 @@ void HighsModkSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       for (HighsInt i = 0; i != rowlen; ++i) {
         if (mipsolver.variableType(inds[i]) == HighsVarType::kContinuous)
           continue;
-        if (transLp.boundDistance(inds[i]) > 0) {
+        if (solval[i] > mipsolver.mipdata_->feastol) {
           intSystemIndex.push_back(inds[i]);
           intSystemValue.push_back((int64_t)std::round(intscale * vals[i]));
         }
@@ -152,23 +154,31 @@ void HighsModkSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       intrhs = (int64_t)std::round(rhs);
 
       for (HighsInt i = 0; i != rowlen; ++i) {
-        if (transLp.boundDistance(inds[i]) > 0) {
+        if (solval[i] > mipsolver.mipdata_->feastol) {
           intSystemIndex.push_back(inds[i]);
           intSystemValue.push_back((int64_t)std::round(vals[i]));
         }
       }
     }
 
-    intSystemIndex.push_back(lp.num_col_);
-    intSystemValue.push_back(intrhs);
-    intSystemStart.push_back(intSystemValue.size());
-    if (leqRow)
-      integralScales.emplace_back(row, intscale);
-    else
-      integralScales.emplace_back(row, -intscale);
+    HighsInt intRowLen = intSystemValue.size() - intSystemStart.back();
+    if (intRowLen <= maxIntRowLen) {
+      numNonzeroRhs += (intrhs != 0);
+
+      intSystemIndex.push_back(lp.num_col_);
+      intSystemValue.push_back(intrhs);
+      intSystemStart.push_back(intSystemValue.size());
+      if (leqRow)
+        integralScales.emplace_back(row, intscale);
+      else
+        integralScales.emplace_back(row, -intscale);
+    } else {
+      intSystemIndex.resize(intSystemStart.back());
+      intSystemValue.resize(intSystemStart.back());
+    }
   }
 
-  if (integralScales.empty()) return;
+  if (integralScales.empty() || numNonzeroRhs == 0) return;
 
   std::vector<HighsInt> tmpinds;
   std::vector<double> tmpvals;

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -199,6 +199,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       lpAggregator.addRow(i, scales[s]);
 
       HighsInt currPathLen = 1;
+      bool haveContinuousCol = false;
       const double maxWeight = 1. / mip.mipdata_->feastol;
       const double minWeight = mip.mipdata_->feastol;
 
@@ -237,6 +238,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
           if (addedSubstitutionRows) continue;
 
+          haveContinuousCol = true;
           if (baseRowVals[j] < 0) {
             if (colInArcs[col].first == colInArcs[col].second) continue;
             if (bestOutArcCol == -1 ||
@@ -273,7 +275,6 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
         if (success || (bestOutArcCol == -1 && bestInArcCol == -1)) break;
 
-        ++currPathLen;
         // we prefer to use an out edge if the bound distances are equal in
         // feasibility tolerance otherwise we choose an inArc. This tie breaking
         // is arbitrary, but we should direct the substitution to prefer one
@@ -343,6 +344,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
           lpAggregator.addRow(row, weight);
         }
+
+        ++currPathLen;
       }
 
       // if the path has length at least 2 try to separate a path mixing cut
@@ -510,6 +513,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       }
 
       lpAggregator.clear();
+
+      if (!success && !haveContinuousCol) break;
     }
   }
 }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -167,326 +167,349 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
   const HighsInt maxPathLen = 6;
   std::vector<std::pair<std::vector<HighsInt>, std::vector<double>>>
       aggregatedPath;
+  double scales[2];
   for (HighsInt i = 0; i != lp.num_row_; ++i) {
     switch (rowtype[i]) {
       case RowType::kUnusuable:
         continue;
+      case RowType::kEq:
+        if (lpSolution.row_dual[i] < -mip.mipdata_->epsilon) {
+          scales[0] = -1.0;
+          scales[1] = 1.0;
+        } else {
+          scales[0] = 1.0;
+          scales[1] = -1.0;
+        }
+        break;
       case RowType::kLeq:
-        lpAggregator.addRow(i, -1.0);
+        scales[0] = -1.0;
+        scales[1] = 1.0;
+        break;
+      case RowType::kGeq:
+        scales[0] = 1.0;
+        scales[1] = -1.0;
         break;
       default:
-        lpAggregator.addRow(i, 1.0);
+        assert(false);
     }
 
-    HighsInt currPathLen = 1;
-    const double maxWeight = 1. / mip.mipdata_->feastol;
-    const double minWeight = mip.mipdata_->feastol;
+    bool success = false;
 
-    auto checkWeight = [&](double w) {
-      w = std::abs(w);
-      return w <= maxWeight && w >= minWeight;
-    };
+    for (HighsInt s = 0; s != 2 && !success; ++s) {
+      lpAggregator.addRow(i, scales[s]);
 
-    aggregatedPath.clear();
+      HighsInt currPathLen = 1;
+      const double maxWeight = 1. / mip.mipdata_->feastol;
+      const double minWeight = mip.mipdata_->feastol;
 
-    while (currPathLen != maxPathLen) {
-      lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, false);
-      HighsInt baseRowLen = baseRowInds.size();
-      bool addedSubstitutionRows = false;
+      auto checkWeight = [&](double w) {
+        w = std::abs(w);
+        return w <= maxWeight && w >= minWeight;
+      };
 
-      HighsInt bestOutArcCol = -1;
-      double outArcColVal = 0.0;
-      double outArcColBoundDist = 0.0;
+      aggregatedPath.clear();
 
-      HighsInt bestInArcCol = -1;
-      double inArcColVal = 0.0;
-      double inArcColBoundDist = 0.0;
+      while (currPathLen != maxPathLen) {
+        lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, false);
+        HighsInt baseRowLen = baseRowInds.size();
+        bool addedSubstitutionRows = false;
 
-      for (HighsInt j = 0; j != baseRowLen; ++j) {
-        HighsInt col = baseRowInds[j];
-        if (col >= lp.num_col_ || transLp.boundDistance(col) == 0.0 ||
-            lpRelaxation.isColIntegral(col))
-          continue;
+        HighsInt bestOutArcCol = -1;
+        double outArcColVal = 0.0;
+        double outArcColBoundDist = 0.0;
 
-        if (colSubstitutions[col].first != -1) {
-          addedSubstitutionRows = true;
-          lpAggregator.addRow(colSubstitutions[col].first,
-                              -baseRowVals[j] / colSubstitutions[col].second);
-          continue;
+        HighsInt bestInArcCol = -1;
+        double inArcColVal = 0.0;
+        double inArcColBoundDist = 0.0;
+
+        for (HighsInt j = 0; j != baseRowLen; ++j) {
+          HighsInt col = baseRowInds[j];
+          if (col >= lp.num_col_ || transLp.boundDistance(col) == 0.0 ||
+              lpRelaxation.isColIntegral(col))
+            continue;
+
+          if (colSubstitutions[col].first != -1) {
+            addedSubstitutionRows = true;
+            lpAggregator.addRow(colSubstitutions[col].first,
+                                -baseRowVals[j] / colSubstitutions[col].second);
+            continue;
+          }
+
+          if (addedSubstitutionRows) continue;
+
+          if (baseRowVals[j] < 0) {
+            if (colInArcs[col].first == colInArcs[col].second) continue;
+            if (bestOutArcCol == -1 ||
+                transLp.boundDistance(col) > outArcColBoundDist) {
+              bestOutArcCol = col;
+              outArcColVal = baseRowVals[j];
+              outArcColBoundDist = transLp.boundDistance(col);
+            }
+          } else {
+            if (colOutArcs[col].first == colOutArcs[col].second) continue;
+            if (bestInArcCol == -1 ||
+                transLp.boundDistance(col) > inArcColBoundDist) {
+              bestInArcCol = col;
+              inArcColVal = baseRowVals[j];
+              inArcColBoundDist = transLp.boundDistance(col);
+            }
+          }
         }
 
         if (addedSubstitutionRows) continue;
 
-        if (baseRowVals[j] < 0) {
-          if (colInArcs[col].first == colInArcs[col].second) continue;
-          if (bestOutArcCol == -1 ||
-              transLp.boundDistance(col) > outArcColBoundDist) {
-            bestOutArcCol = col;
-            outArcColVal = baseRowVals[j];
-            outArcColBoundDist = transLp.boundDistance(col);
+        double rhs = 0;
+
+        success = cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
+
+        lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, true);
+        if (!aggregatedPath.empty() || bestOutArcCol != -1 ||
+            bestInArcCol != -1)
+          aggregatedPath.emplace_back(baseRowInds, baseRowVals);
+        rhs = 0;
+
+        success = success ||
+                  cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
+
+        if (success || (bestOutArcCol == -1 && bestInArcCol == -1)) break;
+
+        ++currPathLen;
+        // we prefer to use an out edge if the bound distances are equal in
+        // feasibility tolerance otherwise we choose an inArc. This tie breaking
+        // is arbitrary, but we should direct the substitution to prefer one
+        // direction to increase diversity.
+        if (bestInArcCol == -1 ||
+            (bestOutArcCol != -1 &&
+             outArcColBoundDist >= inArcColBoundDist - mip.mipdata_->feastol)) {
+          HighsInt inArcRow = randgen.integer(colInArcs[bestOutArcCol].first,
+                                              colInArcs[bestOutArcCol].second);
+
+          HighsInt row = inArcRows[inArcRow].first;
+          double weight = -outArcColVal / inArcRows[inArcRow].second;
+
+          if (!checkWeight(weight)) {
+            bool foundRow = false;
+            for (HighsInt nextRow = inArcRow + 1;
+                 nextRow < colInArcs[bestOutArcCol].second && !foundRow;
+                 ++nextRow) {
+              row = inArcRows[nextRow].first;
+              weight = -outArcColVal / inArcRows[nextRow].second;
+              foundRow = checkWeight(weight);
+            }
+
+            for (HighsInt nextRow = colInArcs[bestOutArcCol].first;
+                 nextRow < inArcRow && !foundRow; ++nextRow) {
+              row = inArcRows[nextRow].first;
+              weight = -outArcColVal / inArcRows[nextRow].second;
+              foundRow = checkWeight(weight);
+            }
+
+            if (!foundRow) {
+              if (bestInArcCol == -1)
+                break;
+              else
+                goto check_out_arc_col;
+            }
           }
+
+          lpAggregator.addRow(row, weight);
         } else {
-          if (colOutArcs[col].first == colOutArcs[col].second) continue;
-          if (bestInArcCol == -1 ||
-              transLp.boundDistance(col) > inArcColBoundDist) {
-            bestInArcCol = col;
-            inArcColVal = baseRowVals[j];
-            inArcColBoundDist = transLp.boundDistance(col);
+        check_out_arc_col:
+          HighsInt outArcRow = randgen.integer(colOutArcs[bestInArcCol].first,
+                                               colOutArcs[bestInArcCol].second);
+
+          HighsInt row = outArcRows[outArcRow].first;
+          double weight = -inArcColVal / outArcRows[outArcRow].second;
+
+          if (!checkWeight(weight)) {
+            bool foundRow = false;
+            for (HighsInt nextRow = outArcRow + 1;
+                 nextRow < colOutArcs[bestInArcCol].second && !foundRow;
+                 ++nextRow) {
+              row = outArcRows[nextRow].first;
+              weight = -inArcColVal / outArcRows[nextRow].second;
+              foundRow = checkWeight(weight);
+            }
+
+            for (HighsInt nextRow = colOutArcs[bestInArcCol].first;
+                 nextRow < outArcRow && !foundRow; ++nextRow) {
+              row = outArcRows[nextRow].first;
+              weight = -inArcColVal / outArcRows[nextRow].second;
+              foundRow = checkWeight(weight);
+            }
+
+            if (!foundRow) break;
           }
+
+          lpAggregator.addRow(row, weight);
         }
       }
 
-      if (addedSubstitutionRows) continue;
-
-      double rhs = 0;
-
-      bool success = cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
-
-      lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, true);
-      if (!aggregatedPath.empty() || bestOutArcCol != -1 || bestInArcCol != -1)
-        aggregatedPath.emplace_back(baseRowInds, baseRowVals);
-      rhs = 0;
-
-      success =
-          success || cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
-
-      if (success || (bestOutArcCol == -1 && bestInArcCol == -1)) break;
-
-      ++currPathLen;
-      // we prefer to use an out edge if the bound distances are equal in
-      // feasibility tolerance otherwise we choose an inArc. This tie breaking
-      // is arbitrary, but we should direct the substitution to prefer one
-      // direction to increase diversity.
-      if (bestInArcCol == -1 ||
-          (bestOutArcCol != -1 &&
-           outArcColBoundDist >= inArcColBoundDist - mip.mipdata_->feastol)) {
-        HighsInt inArcRow = randgen.integer(colInArcs[bestOutArcCol].first,
-                                            colInArcs[bestOutArcCol].second);
-
-        HighsInt row = inArcRows[inArcRow].first;
-        double weight = -outArcColVal / inArcRows[inArcRow].second;
-
-        if (!checkWeight(weight)) {
-          bool success = false;
-          for (HighsInt nextRow = inArcRow + 1;
-               nextRow < colInArcs[bestOutArcCol].second && !success;
-               ++nextRow) {
-            row = inArcRows[nextRow].first;
-            weight = -outArcColVal / inArcRows[nextRow].second;
-            success = checkWeight(weight);
-          }
-
-          for (HighsInt nextRow = colInArcs[bestOutArcCol].first;
-               nextRow < inArcRow && !success; ++nextRow) {
-            row = inArcRows[nextRow].first;
-            weight = -outArcColVal / inArcRows[nextRow].second;
-            success = checkWeight(weight);
-          }
-
-          if (!success) {
-            if (bestInArcCol == -1)
-              break;
-            else
-              goto check_out_arc_col;
-          }
-        }
-
-        lpAggregator.addRow(row, weight);
-      } else {
-      check_out_arc_col:
-        HighsInt outArcRow = randgen.integer(colOutArcs[bestInArcCol].first,
-                                             colOutArcs[bestInArcCol].second);
-
-        HighsInt row = outArcRows[outArcRow].first;
-        double weight = -inArcColVal / outArcRows[outArcRow].second;
-
-        if (!checkWeight(weight)) {
-          bool success = false;
-          for (HighsInt nextRow = outArcRow + 1;
-               nextRow < colOutArcs[bestInArcCol].second && !success;
-               ++nextRow) {
-            row = outArcRows[nextRow].first;
-            weight = -inArcColVal / outArcRows[nextRow].second;
-            success = checkWeight(weight);
-          }
-
-          for (HighsInt nextRow = colOutArcs[bestInArcCol].first;
-               nextRow < outArcRow && !success; ++nextRow) {
-            row = outArcRows[nextRow].first;
-            weight = -inArcColVal / outArcRows[nextRow].second;
-            success = checkWeight(weight);
-          }
-
-          if (!success) break;
-        }
-
-        lpAggregator.addRow(row, weight);
-      }
-    }
-
-    // if the path has length at least 2 try to separate a path mixing cut
-    HighsInt pathLen = aggregatedPath.size();
-    if (pathLen > 1) {
-      // generate path mixing cut
-      HighsHashTable<HighsInt, HighsInt> indexPos;
-
-      std::vector<HighsInt> inds;
-      std::vector<double> solval;
-      std::vector<double> upper;
-      std::vector<uint8_t> isIntegral;
-      inds.reserve(lp.num_col_ + lp.num_row_);
-      solval.reserve(lp.num_col_ + lp.num_row_);
-      upper.reserve(lp.num_col_ + lp.num_row_);
-      isIntegral.reserve(lp.num_col_ + lp.num_row_);
-
-      std::vector<double> rhs(pathLen);
-      std::vector<double> tmpUpper;
-      std::vector<double> tmpSolval;
-
-      double delta = 1.0;
-
-      for (HighsInt k = 0; k < pathLen; ++k) {
-        bool integralPositive = false;
-
-        if (!transLp.transform(aggregatedPath[k].second, tmpUpper, tmpSolval,
-                               aggregatedPath[k].first, rhs[k],
-                               integralPositive)) {
-          pathLen = k;
-          break;
-        }
-
-        if (rhs[k] > kHighsTiny ||
-            (k > 0 && rhs[k - 1] <= rhs[k] + mip.mipdata_->feastol)) {
-          pathLen = k;
-          break;
-        }
-        rhs[k] = std::min(0., rhs[k]);
-        delta = std::max(std::abs(rhs[k]), delta);
-
-        HighsInt len = aggregatedPath[k].first.size();
-        for (HighsInt j = 0; j < len; ++j) {
-          HighsInt index = aggregatedPath[k].first[j];
-          HighsInt* pos = &indexPos[index];
-          if (*pos == 0) {
-            inds.push_back(index);
-            solval.push_back(tmpSolval[j]);
-            upper.push_back(tmpUpper[j]);
-            isIntegral.push_back(lpRelaxation.isColIntegral(index));
-            if (isIntegral.back())
-              delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
-            *pos = inds.size();
-          } else {
-            assert(inds[*pos - 1] == index);
-            assert(solval[*pos - 1] == tmpSolval[j]);
-            assert(upper[*pos - 1] == tmpUpper[j]);
-            if (isIntegral[*pos - 1])
-              delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
-          }
-        }
-      }
-
+      // if the path has length at least 2 try to separate a path mixing cut
+      HighsInt pathLen = aggregatedPath.size();
       if (pathLen > 1) {
-        delta = std::exp2(std::ceil(std::log2(delta + 1.0)));
+        // generate path mixing cut
+        HighsHashTable<HighsInt, HighsInt> indexPos;
 
-        HighsInt numInds = inds.size();
+        std::vector<HighsInt> inds;
+        std::vector<double> solval;
+        std::vector<double> upper;
+        std::vector<uint8_t> isIntegral;
+        inds.reserve(lp.num_col_ + lp.num_row_);
+        solval.reserve(lp.num_col_ + lp.num_row_);
+        upper.reserve(lp.num_col_ + lp.num_row_);
+        isIntegral.reserve(lp.num_col_ + lp.num_row_);
 
-        std::vector<double> valueMatrix;
-        valueMatrix.resize(pathLen * numInds, 0.0);
+        std::vector<double> rhs(pathLen);
+        std::vector<double> tmpUpper;
+        std::vector<double> tmpSolval;
 
-        HighsCDouble cutRhs = 0.0;
-        std::vector<double> cutVals(numInds);
-        std::vector<double> maxFrac(numInds);
-        std::vector<HighsCDouble> downSum(numInds);
-        std::vector<HighsCDouble> fSum(numInds);
-
-        double fLast = 0;
-        double scale = -1.0 / delta;
+        double delta = 1.0;
 
         for (HighsInt k = 0; k < pathLen; ++k) {
-          double f = rhs[k] * scale;
-          HighsCDouble fDiff = HighsCDouble(f) - fLast;
+          bool integralPositive = false;
+
+          if (!transLp.transform(aggregatedPath[k].second, tmpUpper, tmpSolval,
+                                 aggregatedPath[k].first, rhs[k],
+                                 integralPositive)) {
+            pathLen = k;
+            break;
+          }
+
+          if (rhs[k] > kHighsTiny ||
+              (k > 0 && rhs[k - 1] <= rhs[k] + mip.mipdata_->feastol)) {
+            pathLen = k;
+            break;
+          }
+          rhs[k] = std::min(0., rhs[k]);
+          delta = std::max(std::abs(rhs[k]), delta);
+
           HighsInt len = aggregatedPath[k].first.size();
-          cutRhs += fDiff;
           for (HighsInt j = 0; j < len; ++j) {
-            HighsInt i = indexPos[aggregatedPath[k].first[j]] - 1;
-            assert(i >= 0);
-
-            double gj = aggregatedPath[k].second[j] * scale;
-
-            switch (isIntegral[i]) {
-              case 0:
-                cutVals[i] = std::max(cutVals[i], gj);
-                break;
-              case 1: {
-                double gjdown = std::floor(gj);
-                double hj = gj - gjdown;
-                maxFrac[i] = std::max(maxFrac[i], hj);
-                downSum[i] += fDiff * gjdown;
-                fSum[i] += fDiff;
-
-                if (fSum[i] < maxFrac[i]) {
-                  cutVals[i] = double(downSum[i] + fSum[i]);
-                } else {
-                  cutVals[i] = double(downSum[i] + maxFrac[i]);
-                }
-                break;
-              }
+            HighsInt index = aggregatedPath[k].first[j];
+            HighsInt* pos = &indexPos[index];
+            if (*pos == 0) {
+              inds.push_back(index);
+              solval.push_back(tmpSolval[j]);
+              upper.push_back(tmpUpper[j]);
+              isIntegral.push_back(lpRelaxation.isColIntegral(index));
+              if (isIntegral.back())
+                delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
+              *pos = inds.size();
+            } else {
+              assert(inds[*pos - 1] == index);
+              assert(solval[*pos - 1] == tmpSolval[j]);
+              assert(upper[*pos - 1] == tmpUpper[j]);
+              if (isIntegral[*pos - 1])
+                delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
             }
           }
+        }
 
-          if (k > 0) {
-            double viol = double(cutRhs);
-            for (HighsInt j = 0; j < numInds; ++j) {
-              viol -= solval[j] * cutVals[j];
+        if (pathLen > 1) {
+          delta = std::exp2(std::ceil(std::log2(delta + 1.0)));
+
+          HighsInt numInds = inds.size();
+
+          std::vector<double> valueMatrix;
+          valueMatrix.resize(pathLen * numInds, 0.0);
+
+          HighsCDouble cutRhs = 0.0;
+          std::vector<double> cutVals(numInds);
+          std::vector<double> maxFrac(numInds);
+          std::vector<HighsCDouble> downSum(numInds);
+          std::vector<HighsCDouble> fSum(numInds);
+
+          double fLast = 0;
+          double scale = -1.0 / delta;
+
+          for (HighsInt k = 0; k < pathLen; ++k) {
+            double f = rhs[k] * scale;
+            HighsCDouble fDiff = HighsCDouble(f) - fLast;
+            HighsInt len = aggregatedPath[k].first.size();
+            cutRhs += fDiff;
+            for (HighsInt j = 0; j < len; ++j) {
+              HighsInt i = indexPos[aggregatedPath[k].first[j]] - 1;
+              assert(i >= 0);
+
+              double gj = aggregatedPath[k].second[j] * scale;
+
+              switch (isIntegral[i]) {
+                case 0:
+                  cutVals[i] = std::max(cutVals[i], gj);
+                  break;
+                case 1: {
+                  double gjdown = std::floor(gj);
+                  double hj = gj - gjdown;
+                  maxFrac[i] = std::max(maxFrac[i], hj);
+                  downSum[i] += fDiff * gjdown;
+                  fSum[i] += fDiff;
+
+                  if (fSum[i] < maxFrac[i]) {
+                    cutVals[i] = double(downSum[i] + fSum[i]);
+                  } else {
+                    cutVals[i] = double(downSum[i] + maxFrac[i]);
+                  }
+                  break;
+                }
+              }
             }
 
-            viol *= delta;
-
-            if (viol > 10 * mip.mipdata_->feastol) {
-              scale = -delta;
-              double rhs = double(cutRhs) * scale;
+            if (k > 0) {
+              double viol = double(cutRhs);
               for (HighsInt j = 0; j < numInds; ++j) {
-                cutVals[j] *= scale;
+                viol -= solval[j] * cutVals[j];
               }
 
-              for (HighsInt j = numInds - 1; j >= 0; --j) {
-                if (std::abs(cutVals[j]) <= mip.mipdata_->epsilon) {
-                  --numInds;
-                  std::swap(cutVals[j], cutVals[numInds]);
-                  std::swap(inds[j], inds[numInds]);
+              viol *= delta;
+
+              if (viol > 10 * mip.mipdata_->feastol) {
+                scale = -delta;
+                double rhs = double(cutRhs) * scale;
+                for (HighsInt j = 0; j < numInds; ++j) {
+                  cutVals[j] *= scale;
                 }
-              }
 
-              cutVals.resize(numInds);
-              inds.resize(numInds);
+                for (HighsInt j = numInds - 1; j >= 0; --j) {
+                  if (std::abs(cutVals[j]) <= mip.mipdata_->epsilon) {
+                    --numInds;
+                    std::swap(cutVals[j], cutVals[numInds]);
+                    std::swap(inds[j], inds[numInds]);
+                  }
+                }
 
-              if (transLp.untransform(cutVals, inds, rhs)) {
-                HighsInt cutLen = inds.size();
-                mip.mipdata_->debugSolution.checkCut(
-                    inds.data(), cutVals.data(), cutLen, rhs);
+                cutVals.resize(numInds);
+                inds.resize(numInds);
 
-                // compute violation in untransformed space again
-                double viol = -rhs;
-                for (HighsInt j = 0; j < cutLen; ++j)
-                  viol += cutVals[j] *
-                          lpRelaxation.getSolution().col_value[inds[j]];
-
-                if (viol > 10 * mip.mipdata_->feastol) {
-                  mip.mipdata_->domain.tightenCoefficients(
+                if (transLp.untransform(cutVals, inds, rhs)) {
+                  HighsInt cutLen = inds.size();
+                  mip.mipdata_->debugSolution.checkCut(
                       inds.data(), cutVals.data(), cutLen, rhs);
-                  cutpool.addCut(mip, inds.data(), cutVals.data(), inds.size(),
-                                 rhs);
+
+                  // compute violation in untransformed space again
+                  double viol = -rhs;
+                  for (HighsInt j = 0; j < cutLen; ++j)
+                    viol += cutVals[j] *
+                            lpRelaxation.getSolution().col_value[inds[j]];
+
+                  if (viol > 10 * mip.mipdata_->feastol) {
+                    mip.mipdata_->domain.tightenCoefficients(
+                        inds.data(), cutVals.data(), cutLen, rhs);
+                    success = success ||
+                              cutpool.addCut(mip, inds.data(), cutVals.data(),
+                                             inds.size(), rhs) != -1;
+                  }
                 }
+                // printf("cut is violated for k = %d\n", k);
+                break;
               }
-              // printf("cut is violated for k = %d\n", k);
-              break;
             }
+            fLast = f;
           }
-          fLast = f;
         }
       }
-    }
 
-    lpAggregator.clear();
+      lpAggregator.clear();
+    }
   }
 }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -164,7 +164,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
   HighsCutGeneration cutGen(lpRelaxation, cutpool);
   std::vector<HighsInt> baseRowInds;
   std::vector<double> baseRowVals;
-  const HighsInt maxPathLen = 6;
+  constexpr HighsInt maxPathLen = 6;
+  HighsInt currentPath[maxPathLen];
   std::vector<std::pair<std::vector<HighsInt>, std::vector<double>>>
       aggregatedPath;
   double scales[2];
@@ -198,8 +199,16 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
     for (HighsInt s = 0; s != 2; ++s) {
       lpAggregator.addRow(i, scales[s]);
 
+      currentPath[0] = i;
       HighsInt currPathLen = 1;
-      bool haveContinuousCol = false;
+
+      auto isRowInCurrentPath = [&](HighsInt row) {
+        for (HighsInt j = 0; j < currPathLen; ++j)
+          if (currentPath[j] == row) return true;
+        return false;
+      };
+
+      bool tryNegatedScale = false;
       const double maxWeight = 1. / mip.mipdata_->feastol;
       const double minWeight = mip.mipdata_->feastol;
 
@@ -239,9 +248,33 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
           if (addedSubstitutionRows) continue;
 
           if (baseRowVals[j] < 0) {
-            haveContinuousCol = haveContinuousCol ||
-                                colOutArcs[col].first != colOutArcs[col].second;
+            if (currPathLen == 1 && !tryNegatedScale) {
+              if (colOutArcs[col].second - colOutArcs[col].first <=
+                  currPathLen) {
+                for (HighsInt k = colOutArcs[col].first;
+                     k < colOutArcs[col].second; ++k) {
+                  if (outArcRows[k].first != i) {
+                    tryNegatedScale = true;
+                    break;
+                  }
+                }
+              } else
+                tryNegatedScale = true;
+            }
+
             if (colInArcs[col].first == colInArcs[col].second) continue;
+            if (colInArcs[col].second - colInArcs[col].first <= currPathLen) {
+              bool haveRow = false;
+              for (HighsInt k = colInArcs[col].first; k < colInArcs[col].second;
+                   ++k) {
+                if (!isRowInCurrentPath(inArcRows[k].first)) {
+                  haveRow = true;
+                  break;
+                }
+              }
+
+              if (!haveRow) continue;
+            }
             if (bestOutArcCol == -1 ||
                 transLp.boundDistance(col) > outArcColBoundDist) {
               bestOutArcCol = col;
@@ -249,9 +282,32 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
               outArcColBoundDist = transLp.boundDistance(col);
             }
           } else {
-            haveContinuousCol = haveContinuousCol ||
-                                colInArcs[col].first != colInArcs[col].second;
+            if (currPathLen == 1 && !tryNegatedScale) {
+              if (colInArcs[col].second - colInArcs[col].first <= currPathLen) {
+                for (HighsInt k = colInArcs[col].first;
+                     k < colInArcs[col].second; ++k) {
+                  if (inArcRows[k].first != i) {
+                    tryNegatedScale = true;
+                    break;
+                  }
+                }
+              } else
+                tryNegatedScale = true;
+            }
+
             if (colOutArcs[col].first == colOutArcs[col].second) continue;
+            if (colOutArcs[col].second - colOutArcs[col].first <= currPathLen) {
+              bool haveRow = false;
+              for (HighsInt k = colOutArcs[col].first;
+                   k < colOutArcs[col].second; ++k) {
+                if (!isRowInCurrentPath(outArcRows[k].first)) {
+                  haveRow = true;
+                  break;
+                }
+              }
+
+              if (!haveRow) continue;
+            }
             if (bestInArcCol == -1 ||
                 transLp.boundDistance(col) > inArcColBoundDist) {
               bestInArcCol = col;
@@ -291,21 +347,21 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
           HighsInt row = inArcRows[inArcRow].first;
           double weight = -outArcColVal / inArcRows[inArcRow].second;
 
-          if (!checkWeight(weight)) {
+          if (isRowInCurrentPath(row) || !checkWeight(weight)) {
             bool foundRow = false;
             for (HighsInt nextRow = inArcRow + 1;
                  nextRow < colInArcs[bestOutArcCol].second && !foundRow;
                  ++nextRow) {
               row = inArcRows[nextRow].first;
               weight = -outArcColVal / inArcRows[nextRow].second;
-              foundRow = checkWeight(weight);
+              foundRow = !isRowInCurrentPath(row) && checkWeight(weight);
             }
 
             for (HighsInt nextRow = colInArcs[bestOutArcCol].first;
                  nextRow < inArcRow && !foundRow; ++nextRow) {
               row = inArcRows[nextRow].first;
               weight = -outArcColVal / inArcRows[nextRow].second;
-              foundRow = checkWeight(weight);
+              foundRow = !isRowInCurrentPath(row) && checkWeight(weight);
             }
 
             if (!foundRow) {
@@ -316,6 +372,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
             }
           }
 
+          currentPath[currPathLen] = row;
           lpAggregator.addRow(row, weight);
         } else {
         check_out_arc_col:
@@ -325,26 +382,27 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
           HighsInt row = outArcRows[outArcRow].first;
           double weight = -inArcColVal / outArcRows[outArcRow].second;
 
-          if (!checkWeight(weight)) {
+          if (isRowInCurrentPath(row) || !checkWeight(weight)) {
             bool foundRow = false;
             for (HighsInt nextRow = outArcRow + 1;
                  nextRow < colOutArcs[bestInArcCol].second && !foundRow;
                  ++nextRow) {
               row = outArcRows[nextRow].first;
               weight = -inArcColVal / outArcRows[nextRow].second;
-              foundRow = checkWeight(weight);
+              foundRow = !isRowInCurrentPath(row) && checkWeight(weight);
             }
 
             for (HighsInt nextRow = colOutArcs[bestInArcCol].first;
                  nextRow < outArcRow && !foundRow; ++nextRow) {
               row = outArcRows[nextRow].first;
               weight = -inArcColVal / outArcRows[nextRow].second;
-              foundRow = checkWeight(weight);
+              foundRow = !isRowInCurrentPath(row) && checkWeight(weight);
             }
 
             if (!foundRow) break;
           }
 
+          currentPath[currPathLen] = row;
           lpAggregator.addRow(row, weight);
         }
 
@@ -517,7 +575,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
       lpAggregator.clear();
 
-      if (!haveContinuousCol) break;
+      if (!tryNegatedScale) break;
     }
   }
 }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -182,12 +182,12 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
         }
         break;
       case RowType::kLeq:
-        scales[0] = 1.0;
-        scales[1] = -1.0;
-        break;
-      case RowType::kGeq:
         scales[0] = -1.0;
         scales[1] = 1.0;
+        break;
+      case RowType::kGeq:
+        scales[0] = 1.0;
+        scales[1] = -1.0;
         break;
       default:
         assert(false);
@@ -514,7 +514,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
       lpAggregator.clear();
 
-      if (success || !haveContinuousCol) break;
+      if (!haveContinuousCol) break;
     }
   }
 }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -173,21 +173,21 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       case RowType::kUnusuable:
         continue;
       case RowType::kEq:
-        if (lpSolution.row_dual[i] < -mip.mipdata_->epsilon) {
-          scales[0] = -1.0;
-          scales[1] = 1.0;
-        } else {
+        if (lpSolution.row_dual[i] <= mip.mipdata_->epsilon) {
           scales[0] = 1.0;
           scales[1] = -1.0;
+        } else {
+          scales[0] = -1.0;
+          scales[1] = 1.0;
         }
         break;
       case RowType::kLeq:
-        scales[0] = -1.0;
-        scales[1] = 1.0;
-        break;
-      case RowType::kGeq:
         scales[0] = 1.0;
         scales[1] = -1.0;
+        break;
+      case RowType::kGeq:
+        scales[0] = -1.0;
+        scales[1] = 1.0;
         break;
       default:
         assert(false);
@@ -195,7 +195,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
     bool success = false;
 
-    for (HighsInt s = 0; s != 2 && !success; ++s) {
+    for (HighsInt s = 0; s != 2; ++s) {
       lpAggregator.addRow(i, scales[s]);
 
       HighsInt currPathLen = 1;
@@ -514,7 +514,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
       lpAggregator.clear();
 
-      if (!success && !haveContinuousCol) break;
+      if (success || !haveContinuousCol) break;
     }
   }
 }

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -125,11 +125,11 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
   std::vector<std::pair<HighsInt, double>> inArcRows;
   inArcRows.reserve(maxAggrRowSize);
-  std::vector<std::pair<HighsInt, int>> colInArcs(lp.num_col_);
+  std::vector<std::pair<HighsInt, HighsInt>> colInArcs(lp.num_col_);
 
   std::vector<std::pair<HighsInt, double>> outArcRows;
   outArcRows.reserve(maxAggrRowSize);
-  std::vector<std::pair<HighsInt, int>> colOutArcs(lp.num_col_);
+  std::vector<std::pair<HighsInt, HighsInt>> colOutArcs(lp.num_col_);
 
   for (HighsInt col : mip.mipdata_->continuous_cols) {
     if (transLp.boundDistance(col) == 0.0) continue;
@@ -238,8 +238,9 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
           if (addedSubstitutionRows) continue;
 
-          haveContinuousCol = true;
           if (baseRowVals[j] < 0) {
+            haveContinuousCol = haveContinuousCol ||
+                                colOutArcs[col].first != colOutArcs[col].second;
             if (colInArcs[col].first == colInArcs[col].second) continue;
             if (bestOutArcCol == -1 ||
                 transLp.boundDistance(col) > outArcColBoundDist) {
@@ -248,6 +249,8 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
               outArcColBoundDist = transLp.boundDistance(col);
             }
           } else {
+            haveContinuousCol = haveContinuousCol ||
+                                colInArcs[col].first != colInArcs[col].second;
             if (colOutArcs[col].first == colOutArcs[col].second) continue;
             if (bestInArcCol == -1 ||
                 transLp.boundDistance(col) > inArcColBoundDist) {

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -148,12 +148,14 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
             outArcRows.emplace_back(lp.a_index_[i], lp.a_value_[i]);
           break;
         case RowType::kGeq:
-        case RowType::kEq:
           if (lp.a_value_[i] > 0)
             inArcRows.emplace_back(lp.a_index_[i], lp.a_value_[i]);
           else
             outArcRows.emplace_back(lp.a_index_[i], lp.a_value_[i]);
           break;
+        case RowType::kEq:
+          inArcRows.emplace_back(lp.a_index_[i], lp.a_value_[i]);
+          outArcRows.emplace_back(lp.a_index_[i], lp.a_value_[i]);
       }
     }
 

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -266,6 +266,17 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
       return false;
     }
 
+    // store the old bound type so that we can restore it if the continuous
+    // column is relaxed out anyways. This allows to correctly transform and
+    // then untransform multiple base rows which is useful to compute cuts based
+    // on several transformed base rows. It could otherwise lead to bugs if a
+    // column is first transformed with a simple bound and not relaxed but for
+    // another base row is transformed and relaxed with a variable bound. Should
+    // the non-relaxed column now be untransformed we would wrongly use the
+    // variable bound even though this is not the correct way to untransform the
+    // column.
+    BoundType oldBoundType = boundTypes[col];
+
     if (lprelaxation.isColIntegral(col)) {
       if (lb == -kHighsInf || ub == kHighsInf) integersPositive = false;
       bool useVbd = false;
@@ -322,6 +333,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
           tmpRhs -= lb * vals[i];
           vals[i] = 0.0;
           removeZeros = true;
+          boundTypes[col] = oldBoundType;
         }
         break;
       case BoundType::kSimpleUb:
@@ -329,18 +341,25 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
           tmpRhs -= ub * vals[i];
           vals[i] = 0.0;
           removeZeros = true;
+          boundTypes[col] = oldBoundType;
         }
         break;
       case BoundType::kVariableLb:
         tmpRhs -= bestVlb[col]->second.constant * vals[i];
         vectorsum.add(bestVlb[col]->first, vals[i] * bestVlb[col]->second.coef);
-        if (vals[i] > 0) vals[i] = 0;
+        if (vals[i] > 0) {
+          boundTypes[col] = oldBoundType;
+          vals[i] = 0;
+        }
         break;
       case BoundType::kVariableUb:
         tmpRhs -= bestVub[col]->second.constant * vals[i];
         vectorsum.add(bestVub[col]->first, vals[i] * bestVub[col]->second.coef);
         vals[i] = -vals[i];
-        if (vals[i] > 0) vals[i] = 0;
+        if (vals[i] > 0) {
+          boundTypes[col] = oldBoundType;
+          vals[i] = 0;
+        }
     }
   }
 


### PR DESCRIPTION
This makes some changes to the row aggregation heuristic for cut separation, and additionally contains 1 bugfix and a small change regarding the timing when heuristics are called. The aggregation heuristic's behavior was not as intended at several places leaving some room for improvements. E.g. the where some cases where I used code like 'success = success || generateCut()' where the `generateCut()` function was not called if success was true due to short circuit evaluation. Also the heuristic was not checking whether a row is part of the current aggregation which could lead to adding a row twice. The changed code gives much better dual bounds on quite some problems and allows to solve some that where not solved before, e.g. the instance lotsize from the benchmark set which none of the other listed solvers solves within two hours. The benchmark test set is still running right now to check the performance impact of this changes.

Also I added some working limits to avoid blowing up the clique table with too many entries. This avoids some cases where the MIP solver got stuck in the clique merging routine, but I need to look into another instance where it still happens.