### PR TITLE
Improve pkg-config experience

### DIFF
--- a/highs.pc.in
+++ b/highs.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-includedir=@CMAKE_INSTALL_PREFIX@/@include@
+libdir=${prefix}/lib
+includedir=${prefix}/include
 
 Name: HiGHS
 Description: Linear Optimization Software

--- a/osi-highs.pc.in
+++ b/osi-highs.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_PREFIX@/lib
-includedir=@CMAKE_INSTALL_PREFIX@/include
+libdir=${prefix}/lib
+includedir=${prefix}/include
 
 Name: OsiHiGHS
 Description: COIN-OR Open Solver Interface for HiGHS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -395,7 +395,7 @@ if (OSI_FOUND)
     configure_file(${HIGHS_SOURCE_DIR}/osi-highs.pc.in
         "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/osi-highs.pc" @ONLY)
     install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/osi-highs.pc"
-        DESTINATION lib/pkg-config)
+        DESTINATION lib/pkgconfig)
 endif()
 
 
@@ -475,7 +475,7 @@ install(EXPORT highs-targets FILE highs-targets.cmake DESTINATION
 install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake" 
     DESTINATION lib/cmake/highs)
 install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc" 
-    DESTINATION lib/pkg-config)
+    DESTINATION lib/pkgconfig)
 
 else() 
 


### PR DESCRIPTION
These are some small fixes which should aid with using highs as a library via pkg-config. This should fix #504, which is why I did not open a seperate issue beforehand.