### PR TITLE
Parser and presolve fixes

### DIFF
--- a/src/io/LoadOptions.cpp
+++ b/src/io/LoadOptions.cpp
@@ -23,6 +23,10 @@ bool loadOptionsFromFile(HighsOptions& options, const std::string filename) {
 
   string line, option, value;
   HighsInt line_count = 0;
+  // loadOptionsFromFile needs its own non-chars string since the
+  // default setting in io/stringutil.h excludes \" and \' that can
+  // appear in an MPS name - the only other place where trim() is used
+  const std::string non_chars = "\t\n\v\f\r\"\' ";
   std::ifstream file(filename);
   if (file.is_open()) {
     while (file.good()) {
@@ -39,8 +43,8 @@ bool loadOptionsFromFile(HighsOptions& options, const std::string filename) {
       }
       option = line.substr(0, equals);
       value = line.substr(equals + 1, line.size() - equals);
-      trim(option);
-      trim(value);
+      trim(option, non_chars);
+      trim(value, non_chars);
       if (setLocalOptionValue(options.log_options, option, options.records,
                               value) != OptionStatus::kOk)
         return false;

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2452,12 +2452,13 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postSolveStack,
       double abs1Val = std::abs(Avalue[nzPos1]);
       double abs2Val = std::abs(Avalue[nzPos2]);
       bool colAtPos1Better;
-      if (abs1Val > 0.5 * abs2Val)
-        colAtPos1Better = true;
-      else if (abs2Val > 0.5 * abs1Val)
-        colAtPos1Better = false;
-      else
+      double ratio = std::max(abs1Val, abs2Val) / std::min(abs1Val, abs2Val);
+      if (ratio <= 2.0)
         colAtPos1Better = colsize[Acol[nzPos1]] < colsize[Acol[nzPos2]];
+      else if (abs1Val > abs2Val)
+        colAtPos1Better = true;
+      else
+        colAtPos1Better = false;
 
       if (colAtPos1Better) {
         substcol = Acol[nzPos1];

--- a/src/util/HighsDataStack.h
+++ b/src/util/HighsDataStack.h
@@ -53,23 +53,23 @@ class HighsDataStack {
 
   template <typename T>
   void push(const std::vector<T>& r) {
-    HighsInt offset = data.size();
-    HighsInt numData = r.size();
+    std::size_t offset = data.size();
+    std::size_t numData = r.size();
     // store the data
-    data.resize(offset + numData * sizeof(T) + sizeof(HighsInt));
+    data.resize(offset + numData * sizeof(T) + sizeof(std::size_t));
     if (!r.empty())
       std::memcpy(data.data() + offset, r.data(), numData * sizeof(T));
     // store the vector size
     offset += numData * sizeof(T);
-    std::memcpy(data.data() + offset, &numData, sizeof(HighsInt));
+    std::memcpy(data.data() + offset, &numData, sizeof(std::size_t));
   }
 
   template <typename T>
   void pop(std::vector<T>& r) {
     // pop the vector size
-    position -= sizeof(HighsInt);
-    HighsInt numData;
-    std::memcpy(&numData, &data[position], sizeof(HighsInt));
+    position -= sizeof(std::size_t);
+    std::size_t numData;
+    std::memcpy(&numData, &data[position], sizeof(std::size_t));
     // pop the data
     position -= numData * sizeof(T);
     r.resize(numData);

--- a/src/util/stringutil.h
+++ b/src/util/stringutil.h
@@ -24,7 +24,7 @@ int strIsWhitespace(const char* str);
 void strToLower(char* str);
 void strTrim(char* str);
 
-const std::string non_chars = "\t\n\v\f\r\" ";
+const std::string non_chars = "\t\n\v\f\r ";
 std::string& ltrim(std::string& str, const std::string& chars = non_chars);
 std::string& rtrim(std::string& str, const std::string& chars = non_chars);
 std::string& trim(std::string& str, const std::string& chars = non_chars);


### PR DESCRIPTION
Fixes an issue where presolve uses dense columns in doubleton equations to do substitutions leading to excessive presolve time on sgpf5y6. Also fixes an issue in the MPS parser leading to warnings on istanbul-no-cutoff and to the miplib solution checker rejecting the solution due to column names that don't match. The column names differ because the " character is trimmed sometimes from the names.