### PR TITLE
link explicitly against thread library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if(OpenMP_CXX_FOUND)
     set(OPENMP ON)
 endif()
 
+find_package(Threads REQUIRED)
+
 if(LINUX AND NOT MSVC)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT ipo_supported OUTPUT error)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,6 +305,7 @@ else ()
 endif()
 
 add_library(libhighs ${sources})
+target_link_libraries(libhighs ${CMAKE_THREAD_LIBS_INIT})
 
 if (IPX_ON)
     target_link_libraries(libhighs libipx)


### PR DESCRIPTION
In current master the qpsolver uses std::thread. This requires linking against pthreads on *nix systems if building with gcc or clang - otherwise you get linker errors like those reported by @jajhall  in https://github.com/ERGO-Code/HiGHS/pull/592

Apparently -fopenmp causes gcc to link against pthreads -> Highs compiles by coincidence on most linux systems without explicitly linking against pthreads.

Problems araise if openmp is not used, either due to the changes in PR 592 or because you're using a gcc/clang version with disabled openmp support. 

In CMakeLists.txt line 355 (only relevant for FAST_BUILD):
```
if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
    target_link_libraries (libhighs "pthread")
endif()
```
I am not sure why this was added, probably some workaround for a problem I don't know -> left it in, but I tested the changes in a virtual machine with FreeBSD 13 (thanks to vagrant). 
It turned out that current master does not compile on FreeBSD due to linker errors with pthreads.
Looks like FreeBSD intentionally disabled openmp in the clang version they ship as default compiler [1]. With this PR it compiles. I'm not a BSD user and did not test netBSD or openBSD.

On Windows with Visual C++ ${CMAKE_THREAD_LIBS_INIT} is empty and Highs compiles. I can't test on MacOS.

[1] https://www.phoronix.com/scan.php?page=news_item&px=FreeBSD-OpenMP-Base