### PR TITLE
Small change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,15 @@
 
 cmake_minimum_required(VERSION 3.15)
 
+# set preference for clang compiler and intel compiler over gcc and other compilers
+include(Platform/${CMAKE_SYSTEM_NAME}-Determine-C OPTIONAL)
+include(Platform/${CMAKE_SYSTEM_NAME}-C OPTIONAL)
+set(CMAKE_C_COMPILER_NAMES clang icc cc ${CMAKE_C_COMPILER_NAMES})
+
+include(Platform/${CMAKE_SYSTEM_NAME}-Determine-CXX OPTIONAL)
+include(Platform/${CMAKE_SYSTEM_NAME}-CXX OPTIONAL)
+set(CMAKE_CXX_COMPILER_NAMES clang++ icpc c++ ${CMAKE_CXX_COMPILER_NAMES})
+
 project(HIGHS VERSION 1.1 LANGUAGES CXX C)
 set(HIGHS_VERSION_PATCH 1)
 

--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -439,7 +439,7 @@ bool HighsCutGeneration::separateLiftedMixedIntegerCover() {
         HighsCDouble uih = u[i] + h;
         HighsCDouble mihplusdeltai = mih + a[i] - cplusthreshold;
         if (z <= mihplusdeltai) {
-          assert(mih <= z);
+          assert(mih <= z + epsilon);
           return double(uih * ulminusetaplusone * (al - r));
         }
 


### PR DESCRIPTION
I did some testing and clang yields 3-4% better performance on my machine (AMD) and on oronsay (Intel). I added a small bit to the CMakeLists.txt that will use clang over gcc when it is available.