### PR TITLE
make the dualUB bailout more reliable

### DIFF
--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -463,11 +463,11 @@ bool HighsLpRelaxation::computeDualProof(const HighsDomain& globaldomain,
 
     if (std::abs(val) <= mipsolver.options_mip_->small_matrix_value) continue;
 
-    bool removeValue = std::abs(val) <= mipsolver.mipdata_->feastol ||
-                       globaldomain.col_lower_[i] == globaldomain.col_upper_[i];
+    bool removeValue = std::abs(val) <= mipsolver.mipdata_->feastol;
 
     if (!removeValue &&
-        mipsolver.variableType(i) == HighsVarType::kContinuous) {
+        (globaldomain.col_lower_[i] == globaldomain.col_upper_[i] ||
+         mipsolver.variableType(i) == HighsVarType::kContinuous)) {
       if (val > 0)
         removeValue =
             lpsolver.getSolution().col_value[i] - globaldomain.col_lower_[i] <=

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -796,7 +796,10 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
       if (info.max_dual_infeasibility <= mipsolver.mipdata_->feastol)
         return Status::kUnscaledDualFeasible;
 
-      return Status::kUnscaledInfeasible;
+      if (scaledmodelstatus == HighsModelStatus::kOptimal)
+        return Status::kUnscaledInfeasible;
+
+      return Status::kError;
     case HighsModelStatus::kIterationLimit: {
       if (!mipsolver.submip && resolve_on_error) {
         // printf(

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -597,10 +597,10 @@ void HighsLpRelaxation::storeDualInfProof() {
 
     if (removeValue) {
       if (val < 0) {
-        if (globaldomain.col_upper_[i] == kHighsInf) return false;
+        if (globaldomain.col_upper_[i] == kHighsInf) return;
         upper -= val * globaldomain.col_upper_[i];
       } else {
-        if (globaldomain.col_lower_[i] == -kHighsInf) return false;
+        if (globaldomain.col_lower_[i] == -kHighsInf) return;
         upper -= val * globaldomain.col_lower_[i];
       }
 

--- a/src/mip/HighsSearch.cpp
+++ b/src/mip/HighsSearch.cpp
@@ -1431,14 +1431,17 @@ bool HighsSearch::backtrack(bool recoverBasis) {
   while (true) {
     while (nodestack.back().opensubtrees == 0) {
       depthoffset += nodestack.back().skipDepthCount;
-      nodestack.pop_back();
-
-      if (nodestack.empty()) {
+      if (nodestack.size() == 1) {
+        if (recoverBasis && nodestack.back().nodeBasis)
+          lp->setStoredBasis(std::move(nodestack.back().nodeBasis));
+        nodestack.pop_back();
         localdom.backtrackToGlobal();
         lp->flushDomain(localdom);
+        if (recoverBasis) lp->recoverBasis();
         return false;
       }
 
+      nodestack.pop_back();
 #ifndef NDEBUG
       HighsDomainChange branchchg =
 #endif

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -263,8 +263,8 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
                     highs_info.sum_dual_infeasibilities);
       // Determine whether refinement will take place
       const bool objective_bound_refinement =
-	scaled_model_status == HighsModelStatus::kObjectiveBound &&
-	num_unscaled_dual_infeasibilities > 0;
+          scaled_model_status == HighsModelStatus::kObjectiveBound &&
+          num_unscaled_dual_infeasibilities > 0;
       refine_solution =
           options.simplex_unscaled_solution_strategy ==
               kSimplexUnscaledSolutionStrategyRefine &&
@@ -319,10 +319,12 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
         // matter due to solution status, so use primal simplex phase
         // 2
         options.simplex_strategy = kSimplexStrategyPrimal;
-	if (scaled_model_status == HighsModelStatus::kObjectiveBound) {
-	  printf("solveLpSimplex: Calling primal simplex after scaled_model_status == HighsModelStatus::kObjectiveBound\n");
-	  //	  assert(scaled_model_status != HighsModelStatus::kObjectiveBound);
-	}
+        if (scaled_model_status == HighsModelStatus::kObjectiveBound) {
+          printf(
+              "solveLpSimplex: Calling primal simplex after "
+              "scaled_model_status == HighsModelStatus::kObjectiveBound\n");
+          assert(scaled_model_status != HighsModelStatus::kObjectiveBound);
+        }
       } else {
         // Using dual simplex, so force Devex if starting from an advanced
         // basis with no steepest edge weights

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -318,8 +318,13 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
         // !status.has_dual_steepest_edge_weights) {
         ekk_info.dual_edge_weight_strategy =
             kSimplexDualEdgeWeightStrategyDevex;
-        // options.dual_simplex_cost_perturbation_multiplier = 0;
+        // when the status of the scaled LP was objective bound do not use cost
+        // perturbation to solve the unscaled LP so that the status can reliably
+        // be verified
+        if (scaled_model_status == HighsModelStatus::kObjectiveBound)
+          options.dual_simplex_cost_perturbation_multiplier = 0;
       }
+
       //
       // Solve the unscaled LP with scaled NLA
       //

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -262,6 +262,9 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
                     highs_info.max_dual_infeasibility,
                     highs_info.sum_dual_infeasibilities);
       // Determine whether refinement will take place
+      const bool objective_bound_refinement =
+	scaled_model_status == HighsModelStatus::kObjectiveBound &&
+	num_unscaled_dual_infeasibilities > 0;
       refine_solution =
           options.simplex_unscaled_solution_strategy ==
               kSimplexUnscaledSolutionStrategyRefine &&
@@ -269,7 +272,7 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
            scaled_model_status == HighsModelStatus::kInfeasible ||
            scaled_model_status == HighsModelStatus::kUnboundedOrInfeasible ||
            scaled_model_status == HighsModelStatus::kUnbounded ||
-           scaled_model_status == HighsModelStatus::kObjectiveBound ||
+           objective_bound_refinement ||
            scaled_model_status == HighsModelStatus::kObjectiveTarget ||
            scaled_model_status == HighsModelStatus::kUnknown);
       // Handle the case when refinement will not take place
@@ -316,6 +319,10 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
         // matter due to solution status, so use primal simplex phase
         // 2
         options.simplex_strategy = kSimplexStrategyPrimal;
+	if (scaled_model_status == HighsModelStatus::kObjectiveBound) {
+	  printf("solveLpSimplex: Calling primal simplex after scaled_model_status == HighsModelStatus::kObjectiveBound\n");
+	  //	  assert(scaled_model_status != HighsModelStatus::kObjectiveBound);
+	}
       } else {
         // Using dual simplex, so force Devex if starting from an advanced
         // basis with no steepest edge weights

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -322,8 +322,13 @@ HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
         if (scaled_model_status == HighsModelStatus::kObjectiveBound) {
           printf(
               "solveLpSimplex: Calling primal simplex after "
-              "scaled_model_status == HighsModelStatus::kObjectiveBound\n");
-          assert(scaled_model_status != HighsModelStatus::kObjectiveBound);
+              "scaled_model_status == HighsModelStatus::kObjectiveBound: solve "
+              "= %d; tick = %d; iter = %d\n",
+              (int)ekk_instance.debug_solve_call_num_,
+              (int)ekk_instance.debug_initial_build_synthetic_tick_,
+              (int)ekk_instance.iteration_count_);
+          //          assert(scaled_model_status !=
+          //          HighsModelStatus::kObjectiveBound);
         }
       } else {
         // Using dual simplex, so force Devex if starting from an advanced

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1014,11 +1014,9 @@ HighsStatus HEkk::unpermute() {
 HighsStatus HEkk::solve(const bool force_phase2) {
   debug_solve_call_num_++;
   debug_initial_build_synthetic_tick_ = build_synthetic_tick_;
-  const HighsInt debug_from_solve_call_num = -559;
-  const HighsInt debug_build_synthetic_tick = -2914940;
-  const HighsInt debug_to_solve_call_num = debug_from_solve_call_num;
-  debug_solve_report_ = debug_solve_call_num_ >= debug_from_solve_call_num &&
-                        debug_solve_call_num_ <= debug_to_solve_call_num &&
+  const HighsInt debug_from_solve_call_num = -7;
+  const HighsInt debug_build_synthetic_tick = -809680;
+  debug_solve_report_ = debug_solve_call_num_ == debug_from_solve_call_num &&
                         build_synthetic_tick_ == debug_build_synthetic_tick;
   const HighsInt time_from_solve_call_num = -1;
   const HighsInt time_to_solve_call_num = time_from_solve_call_num;

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1014,8 +1014,8 @@ HighsStatus HEkk::unpermute() {
 HighsStatus HEkk::solve(const bool force_phase2) {
   debug_solve_call_num_++;
   debug_initial_build_synthetic_tick_ = build_synthetic_tick_;
-  const HighsInt debug_from_solve_call_num = 3086;
-  const HighsInt debug_build_synthetic_tick = 3767900;
+  const HighsInt debug_from_solve_call_num = 559;
+  const HighsInt debug_build_synthetic_tick = 2914940;
   const HighsInt debug_to_solve_call_num = debug_from_solve_call_num;
   debug_solve_report_ = debug_solve_call_num_ >= debug_from_solve_call_num &&
                         debug_solve_call_num_ <= debug_to_solve_call_num &&

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1014,8 +1014,8 @@ HighsStatus HEkk::unpermute() {
 HighsStatus HEkk::solve(const bool force_phase2) {
   debug_solve_call_num_++;
   debug_initial_build_synthetic_tick_ = build_synthetic_tick_;
-  const HighsInt debug_from_solve_call_num = 559;
-  const HighsInt debug_build_synthetic_tick = 2914940;
+  const HighsInt debug_from_solve_call_num = -559;
+  const HighsInt debug_build_synthetic_tick = -2914940;
   const HighsInt debug_to_solve_call_num = debug_from_solve_call_num;
   debug_solve_report_ = debug_solve_call_num_ >= debug_from_solve_call_num &&
                         debug_solve_call_num_ <= debug_to_solve_call_num &&

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1014,8 +1014,8 @@ HighsStatus HEkk::unpermute() {
 HighsStatus HEkk::solve(const bool force_phase2) {
   debug_solve_call_num_++;
   debug_initial_build_synthetic_tick_ = build_synthetic_tick_;
-  const HighsInt debug_from_solve_call_num = -8;
-  const HighsInt debug_build_synthetic_tick = -12157180;
+  const HighsInt debug_from_solve_call_num = 3086;
+  const HighsInt debug_build_synthetic_tick = 3767900;
   const HighsInt debug_to_solve_call_num = debug_from_solve_call_num;
   debug_solve_report_ = debug_solve_call_num_ >= debug_from_solve_call_num &&
                         debug_solve_call_num_ <= debug_to_solve_call_num &&

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1011,7 +1011,7 @@ HighsStatus HEkk::unpermute() {
   return HighsStatus::kError;
 }
 
-HighsStatus HEkk::solve() {
+HighsStatus HEkk::solve(const bool force_phase2) {
   debug_solve_call_num_++;
   debug_initial_build_synthetic_tick_ = build_synthetic_tick_;
   const HighsInt debug_from_solve_call_num = -8;
@@ -1093,7 +1093,7 @@ HighsStatus HEkk::solve() {
     HEkkPrimal primal_solver(*this);
     workEdWt_ = NULL;
     workEdWtFull_ = NULL;
-    call_status = primal_solver.solve();
+    call_status = primal_solver.solve(force_phase2);
     assert(called_return_from_solve_);
     return_status = interpretCallStatus(options_->log_options, call_status,
                                         return_status, "HEkkPrimal::solve");
@@ -1119,7 +1119,7 @@ HighsStatus HEkk::solve() {
     HEkkDual dual_solver(*this);
     workEdWt_ = dual_solver.getWorkEdWt();
     workEdWtFull_ = dual_solver.getWorkEdWtFull();
-    call_status = dual_solver.solve();
+    call_status = dual_solver.solve(force_phase2);
     assert(called_return_from_solve_);
     return_status = interpretCallStatus(options_->log_options, call_status,
                                         return_status, "HEkkDual::solve");

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -66,7 +66,7 @@ class HEkk {
   HighsStatus undualise();
   HighsStatus permute();
   HighsStatus unpermute();
-  HighsStatus solve();
+  HighsStatus solve(const bool force_phase2 = false);
   HighsStatus cleanup();
   HighsStatus setBasis();
   HighsStatus setBasis(const HighsBasis& highs_basis);

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -344,7 +344,7 @@ class HEkk {
   friend class HEkkPrimal;
   friend class HEkkDual;
   friend class HEkkDualRow;
-  friend class HEkkDualRHS; // For  HEkkDualRHS::assessOptimality
+  friend class HEkkDualRHS;  // For  HEkkDualRHS::assessOptimality
 };
 
 #endif /* SIMPLEX_HEKK_H_ */

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -344,6 +344,7 @@ class HEkk {
   friend class HEkkPrimal;
   friend class HEkkDual;
   friend class HEkkDualRow;
+  friend class HEkkDualRHS; // For  HEkkDualRHS::assessOptimality
 };
 
 #endif /* SIMPLEX_HEKK_H_ */

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -2849,6 +2849,7 @@ double HEkkDual::computeExactDualObjectiveValue() {
   double norm_dual = 0;
   double norm_delta_dual = 0;
   for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
+    if (!basis.nonbasicFlag_[iCol]) continue;
     double exact_dual = lp.col_cost_[iCol] - dual_row.array[iCol];
 
     // printf(
@@ -2866,10 +2867,8 @@ double HEkkDual::computeExactDualObjectiveValue() {
       active_value = lp.col_lower_[iCol];
     else if (exact_dual < -ekk_instance_.options_->small_matrix_value)
       active_value = lp.col_upper_[iCol];
-    else if (basis.nonbasicFlag_[iCol])
-      active_value = info.workValue_[iCol];
     else
-      continue;
+      active_value = info.workValue_[iCol];
 
     // when the active value is infinite the dual objective lower bound is
     // -infinity
@@ -2888,6 +2887,7 @@ double HEkkDual::computeExactDualObjectiveValue() {
   }
 
   for (HighsInt iVar = lp.num_col_; iVar < numTot; iVar++) {
+    if (!basis.nonbasicFlag_[iVar]) continue;
     HighsInt iRow = iVar - lp.num_col_;
     double exact_dual = dual_col.array[iRow];
 
@@ -2907,10 +2907,8 @@ double HEkkDual::computeExactDualObjectiveValue() {
       active_value = lp.row_lower_[iRow];
     else if (exact_dual < -ekk_instance_.options_->small_matrix_value)
       active_value = lp.row_upper_[iRow];
-    else if (basis.nonbasicFlag_[iVar])
-      active_value = -info.workValue_[iVar];
     else
-      continue;
+      active_value = -info.workValue_[iVar];
 
     // when the active value is infinite the dual objective lower bound is
     // -infinity

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -1202,7 +1202,7 @@ void HEkkDual::iterate() {
   // Reporting:
   // Row-wise matrix after update in updateMatrix(variable_in, variable_out);
 
-  const HighsInt from_check_iter = -65;
+  const HighsInt from_check_iter = -11;
   const HighsInt to_check_iter = from_check_iter + 10;
   if (ekk_instance_.debug_solve_report_) {
     ekk_instance_.debug_iteration_report_ =

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -102,7 +102,7 @@ HighsStatus HEkkDual::solve(const bool pass_force_phase2) {
   // or if phase 2 is forced, in which case any dual infeasibilities
   // will be shifed
   const bool no_simplex_dual_infeasibilities =
-    dual_feasible_with_unperturbed_costs || force_phase2;
+      dual_feasible_with_unperturbed_costs || force_phase2;
   const bool near_optimal = no_simplex_dual_infeasibilities &&
                             info.num_primal_infeasibilities < 1000 &&
                             info.max_primal_infeasibility < 1e-3;
@@ -1202,7 +1202,7 @@ void HEkkDual::iterate() {
   // Reporting:
   // Row-wise matrix after update in updateMatrix(variable_in, variable_out);
 
-  const HighsInt from_check_iter = 65;
+  const HighsInt from_check_iter = -65;
   const HighsInt to_check_iter = from_check_iter + 10;
   if (ekk_instance_.debug_solve_report_) {
     ekk_instance_.debug_iteration_report_ =
@@ -2857,12 +2857,13 @@ double HEkkDual::computeExactDualObjectiveValue() {
   }
   // Compute dual infeasiblilities
   ekk_instance_.computeSimplexDualInfeasible();
-  if (info.num_dual_infeasibilities>0) {
-    printf("HEkkDual::computeExactDualObjectiveValue num / max / sum dual infeasibilities = %d / %g / %g\n",
-	   (int)info.num_dual_infeasibilities,
-	   info.max_dual_infeasibility,
-	   info.sum_dual_infeasibilities);
-    //    assert(info.num_dual_infeasibilities == 0);
+  if (info.num_dual_infeasibilities > 0) {
+    printf(
+        "HEkkDual::computeExactDualObjectiveValue num / max / sum dual "
+        "infeasibilities = %d / %g / %g\n",
+        (int)info.num_dual_infeasibilities, info.max_dual_infeasibility,
+        info.sum_dual_infeasibilities);
+    assert(info.num_dual_infeasibilities == 0);
   }
   HighsCDouble dual_objective = lp.offset_;
   double norm_dual = 0;
@@ -3003,4 +3004,3 @@ void HEkkDual::assessPossiblyDualUnbounded() {
     rebuild_reason = kRebuildReasonNo;
   }
 }
-

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -1202,7 +1202,7 @@ void HEkkDual::iterate() {
   // Reporting:
   // Row-wise matrix after update in updateMatrix(variable_in, variable_out);
 
-  const HighsInt from_check_iter = -999;
+  const HighsInt from_check_iter = 100;
   ;
   const HighsInt to_check_iter = from_check_iter + 10;
   if (ekk_instance_.debug_solve_report_) {

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -30,7 +30,7 @@
 
 using std::fabs;
 
-HighsStatus HEkkDual::solve() {
+HighsStatus HEkkDual::solve(const bool pass_force_phase2) {
   // Initialise control data for a particular solve
   initialiseSolve();
 
@@ -71,8 +71,9 @@ HighsStatus HEkkDual::solve() {
       info.num_dual_infeasibilities == 0;
   // Force phase 2 if dual infeasiblilities without cost perturbation
   // involved fixed variables or were (at most) small
-  force_phase2 = info.max_dual_infeasibility * info.max_dual_infeasibility <
-                 ekk_instance_.options_->dual_feasibility_tolerance;
+  force_phase2 = pass_force_phase2 ||
+                 info.max_dual_infeasibility * info.max_dual_infeasibility <
+                     ekk_instance_.options_->dual_feasibility_tolerance;
   if (ekk_instance_.debug_dual_feasible &&
       !dual_feasible_with_unperturbed_costs) {
     SimplexBasis& basis = ekk_instance_.basis_;
@@ -371,7 +372,7 @@ HighsStatus HEkkDual::solve() {
           info.primal_simplex_bound_perturbation_multiplier;
       info.primal_simplex_bound_perturbation_multiplier = 0;
       HEkkPrimal primal_solver(ekk_instance_);
-      HighsStatus call_status = primal_solver.solve();
+      HighsStatus call_status = primal_solver.solve(true);
       // Restore any bound perturbation
       info.primal_simplex_bound_perturbation_multiplier =
           save_primal_simplex_bound_perturbation_multiplier;
@@ -2756,8 +2757,7 @@ bool HEkkDual::bailoutOnDualObjective() {
     // reasons
     assert(ekk_instance_.model_status_ == HighsModelStatus::kTimeLimit ||
            ekk_instance_.model_status_ == HighsModelStatus::kIterationLimit ||
-           ekk_instance_.model_status_ == HighsModelStatus::kObjectiveBound ||
-           ekk_instance_.model_status_ == HighsModelStatus::kObjectiveTarget);
+           ekk_instance_.model_status_ == HighsModelStatus::kObjectiveBound);
   } else if (ekk_instance_.lp_.sense_ == ObjSense::kMinimize &&
              solve_phase == kSolvePhase2) {
     if (ekk_instance_.info_.updated_dual_objective_value >

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -1202,8 +1202,7 @@ void HEkkDual::iterate() {
   // Reporting:
   // Row-wise matrix after update in updateMatrix(variable_in, variable_out);
 
-  const HighsInt from_check_iter = 100;
-  ;
+  const HighsInt from_check_iter = 65;
   const HighsInt to_check_iter = from_check_iter + 10;
   if (ekk_instance_.debug_solve_report_) {
     ekk_instance_.debug_iteration_report_ =
@@ -1416,6 +1415,7 @@ void HEkkDual::chooseRow() {
   //
   // If reinversion is needed then skip this method
   if (rebuild_reason) return;
+  if (solve_phase == kSolvePhase2) dualRHS.assessOptimality();
   // Zero the infeasibility of any taboo rows
   ekk_instance_.applyTabooRowOut(dualRHS.work_infeasibility, 0);
   // Choose candidates repeatedly until candidate is OK or optimality is
@@ -3003,3 +3003,4 @@ void HEkkDual::assessPossiblyDualUnbounded() {
     rebuild_reason = kRebuildReasonNo;
   }
 }
+

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -1415,7 +1415,7 @@ void HEkkDual::chooseRow() {
   //
   // If reinversion is needed then skip this method
   if (rebuild_reason) return;
-  if (solve_phase == kSolvePhase2) dualRHS.assessOptimality();
+  //  if (solve_phase == kSolvePhase2) dualRHS.assessOptimality();
   // Zero the infeasibility of any taboo rows
   ekk_instance_.applyTabooRowOut(dualRHS.work_infeasibility, 0);
   // Choose candidates repeatedly until candidate is OK or optimality is

--- a/src/simplex/HEkkDual.h
+++ b/src/simplex/HEkkDual.h
@@ -50,7 +50,7 @@ class HEkkDual {
   /**
    * @brief Solve a model instance
    */
-  HighsStatus solve();
+  HighsStatus solve(const bool force_phase2 = false);
 
   const SimplexAlgorithm algorithm = SimplexAlgorithm::kDual;
 

--- a/src/simplex/HEkkDual.h
+++ b/src/simplex/HEkkDual.h
@@ -377,7 +377,7 @@ class HEkkDual {
 
   bool isBadBasisChange();
   void assessPossiblyDualUnbounded();
-  
+
   // Devex scalars
   HighsInt num_devex_iterations =
       0;  //!< Number of Devex iterations with the current framework

--- a/src/simplex/HEkkDual.h
+++ b/src/simplex/HEkkDual.h
@@ -377,7 +377,7 @@ class HEkkDual {
 
   bool isBadBasisChange();
   void assessPossiblyDualUnbounded();
-
+  
   // Devex scalars
   HighsInt num_devex_iterations =
       0;  //!< Number of Devex iterations with the current framework

--- a/src/simplex/HEkkDualRHS.cpp
+++ b/src/simplex/HEkkDualRHS.cpp
@@ -320,7 +320,8 @@ void HEkkDualRHS::updatePrimal(HVector* column, double theta) {
 
   const HighsInt to_entry = updatePrimal_inDense ? numRow : columnCount;
   for (HighsInt iEntry = 0; iEntry < to_entry; iEntry++) {
-    const HighsInt iRow = updatePrimal_inDense ? iEntry : variable_index[iEntry];
+    const HighsInt iRow =
+        updatePrimal_inDense ? iEntry : variable_index[iEntry];
     baseValue[iRow] -= theta * columnArray[iRow];
     // @primal_infeasibility calculation
     const double value = baseValue[iRow];
@@ -552,26 +553,32 @@ void HEkkDualRHS::assessOptimality() {
   for (HighsInt iRow = 0; iRow < num_row; iRow++) {
     if (work_infeasibility[iRow] > kHighsZero) {
       num_work_infeasibilities++;
-      max_work_infeasibility = std::max(work_infeasibility[iRow], max_work_infeasibility);
+      max_work_infeasibility =
+          std::max(work_infeasibility[iRow], max_work_infeasibility);
     }
   }
   ekk_instance_.computeSimplexPrimalInfeasible();
-  const HighsInt num_primal_infeasibilities = ekk_instance_.info_.num_primal_infeasibilities;
-  const double max_primal_infeasibility = ekk_instance_.info_.max_primal_infeasibility;
+  const HighsInt num_primal_infeasibilities =
+      ekk_instance_.info_.num_primal_infeasibilities;
+  const double max_primal_infeasibility =
+      ekk_instance_.info_.max_primal_infeasibility;
   const bool regular_report = false;
-  if (regular_report || (num_work_infeasibilities && !num_primal_infeasibilities)) {
-    printf("assessOptimality: %6d rows; workCount = %4d (%6.4f) "
-	   "num / max infeasibilities: work = %4d / %11.4g; simplex = %4d / %11.4g: %s\n",
-	   (int)num_row, (int)workCount,
-	   workCount>0 ? (1.0 * workCount)/num_row : 0,
-	   (int)num_work_infeasibilities, max_work_infeasibility,
-	   (int)num_primal_infeasibilities, max_primal_infeasibility,
-	   num_primal_infeasibilities == 0 ? "Optimal" : "");
+  if (regular_report ||
+      (num_work_infeasibilities && !num_primal_infeasibilities)) {
+    printf(
+        "assessOptimality: %6d rows; workCount = %4d (%6.4f) "
+        "num / max infeasibilities: work = %4d / %11.4g; simplex = %4d / "
+        "%11.4g: %s\n",
+        (int)num_row, (int)workCount,
+        workCount > 0 ? (1.0 * workCount) / num_row : 0,
+        (int)num_work_infeasibilities, max_work_infeasibility,
+        (int)num_primal_infeasibilities, max_primal_infeasibility,
+        num_primal_infeasibilities == 0 ? "Optimal" : "");
     if (num_work_infeasibilities && !num_primal_infeasibilities) {
       printf("assessOptimality: call %d; tick %d; iter %d\n",
-	     (int)ekk_instance_.debug_solve_call_num_,
-	     (int)ekk_instance_.debug_initial_build_synthetic_tick_,
-	     (int)ekk_instance_.iteration_count_);
+             (int)ekk_instance_.debug_solve_call_num_,
+             (int)ekk_instance_.debug_initial_build_synthetic_tick_,
+             (int)ekk_instance_.iteration_count_);
     }
   }
 }

--- a/src/simplex/HEkkDualRHS.cpp
+++ b/src/simplex/HEkkDualRHS.cpp
@@ -318,6 +318,22 @@ void HEkkDualRHS::updatePrimal(HVector* column, double theta) {
 
   bool updatePrimal_inDense = columnCount < 0 || columnCount > 0.4 * numRow;
 
+  vector<double> alt_work_infeasibility = work_infeasibility;
+  vector<double> alt_baseValue = ekk_instance_.info_.baseValue_;
+  const HighsInt to_entry = updatePrimal_inDense ? numRow : columnCount;
+  for (HighsInt iEntry = 0; iEntry < to_entry; iEntry++) {
+    const HighsInt iRow = updatePrimal_inDense ? iEntry : variable_index[iEntry];
+    alt_baseValue[iRow] -= theta * columnArray[iRow];
+    const double value = alt_baseValue[iRow];
+    const double less = baseLower[iRow] - value;
+    const double more = value - baseUpper[iRow];
+    const double infeas = less > Tp ? less : (more > Tp ? more : 0);
+    if (ekk_instance_.info_.store_squared_primal_infeasibility)
+      alt_work_infeasibility[iRow] = infeas * infeas;
+    else
+      alt_work_infeasibility[iRow] = fabs(infeas);
+  }
+
   if (updatePrimal_inDense) {
     for (HighsInt iRow = 0; iRow < numRow; iRow++) {
       baseValue[iRow] -= theta * columnArray[iRow];
@@ -325,7 +341,6 @@ void HEkkDualRHS::updatePrimal(HVector* column, double theta) {
       const double less = baseLower[iRow] - value;
       const double more = value - baseUpper[iRow];
       double infeas = less > Tp ? less : (more > Tp ? more : 0);
-      //    work_infeasibility[iRow] = infeas * infeas;
       if (ekk_instance_.info_.store_squared_primal_infeasibility)
         work_infeasibility[iRow] = infeas * infeas;
       else
@@ -345,7 +360,8 @@ void HEkkDualRHS::updatePrimal(HVector* column, double theta) {
         work_infeasibility[iRow] = fabs(infeas);
     }
   }
-
+  assert(alt_baseValue == ekk_instance_.info_.baseValue_);
+  assert(alt_work_infeasibility == work_infeasibility);
   analysis->simplexTimerStop(UpdatePrimalClock);
 }
 
@@ -478,6 +494,16 @@ void HEkkDualRHS::createArrayOfPrimalInfeasibilities() {
     const double less = baseLower[i] - value;
     const double more = value - baseUpper[i];
     double infeas = less > Tp ? less : (more > Tp ? more : 0);
+    // @primal_infeasibility calculation
+    double lower = baseLower[i];
+    double upper = baseUpper[i];
+    double primal_infeasibility = 0;
+    if (value < lower - Tp) {
+      primal_infeasibility = lower - value;
+    } else if (value > upper + Tp) {
+      primal_infeasibility = value - upper;
+    }
+    assert(std::fabs(primal_infeasibility-infeas) < 1e-12);
     if (ekk_instance_.info_.store_squared_primal_infeasibility)
       work_infeasibility[i] = infeas * infeas;
     else
@@ -564,7 +590,7 @@ void HEkkDualRHS::assessOptimality() {
   const bool regular_report = false;
   if (regular_report || (num_work_infeasibilities && !num_primal_infeasibilities)) {
     printf("assessOptimality: %6d rows; workCount = %4d (%6.4f) "
-	   "num / max infeasibilities: work = %4d / %11.7g; simplex = %4d / %11.7g: %s\n",
+	   "num / max infeasibilities: work = %4d / %11.4g; simplex = %4d / %11.4g: %s\n",
 	   (int)num_row, (int)workCount,
 	   workCount>0 ? (1.0 * workCount)/num_row : 0,
 	   (int)num_work_infeasibilities, max_work_infeasibility,

--- a/src/simplex/HEkkDualRHS.h
+++ b/src/simplex/HEkkDualRHS.h
@@ -105,8 +105,8 @@ class HEkkDualRHS {
    * @brief Update the primal value for the row where the basis change has
    * occurred
    */
-  void updatePivots(HighsInt iRow,  //!< row where the basis change has occurred
-                    double value    //!< New primal value in this row
+  void updatePivots(const HighsInt iRow,  //!< row where the basis change has occurred
+                    const double value    //!< New primal value in this row
   );
 
   /**

--- a/src/simplex/HEkkDualRHS.h
+++ b/src/simplex/HEkkDualRHS.h
@@ -127,6 +127,8 @@ class HEkkDualRHS {
    */
   void createArrayOfPrimalInfeasibilities();
 
+  void assessOptimality();
+  
   // References:
   HEkk& ekk_instance_;
 

--- a/src/simplex/HEkkDualRHS.h
+++ b/src/simplex/HEkkDualRHS.h
@@ -105,8 +105,9 @@ class HEkkDualRHS {
    * @brief Update the primal value for the row where the basis change has
    * occurred
    */
-  void updatePivots(const HighsInt iRow,  //!< row where the basis change has occurred
-                    const double value    //!< New primal value in this row
+  void updatePivots(
+      const HighsInt iRow,  //!< row where the basis change has occurred
+      const double value    //!< New primal value in this row
   );
 
   /**
@@ -128,7 +129,7 @@ class HEkkDualRHS {
   void createArrayOfPrimalInfeasibilities();
 
   void assessOptimality();
-  
+
   // References:
   HEkk& ekk_instance_;
 

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -64,7 +64,7 @@ HighsStatus HEkkPrimal::solve(const bool pass_force_phase2) {
   // or if phase 2 is forced, in which case any primal infeasibilities
   // will be shifed
   const bool no_simplex_primal_infeasibilities =
-    primal_feasible_with_unperturbed_bounds || force_phase2;
+      primal_feasible_with_unperturbed_bounds || force_phase2;
   const bool near_optimal = info.num_dual_infeasibilities < 1000 &&
                             info.max_dual_infeasibility < 1e-3 &&
                             no_simplex_primal_infeasibilities;
@@ -78,7 +78,7 @@ HighsStatus HEkkPrimal::solve(const bool pass_force_phase2) {
   if (near_optimal)
     highsLogDev(options.log_options, HighsLogType::kDetailed,
                 "Primal feasible and num / max / sum "
-		"dual infeasibilities of "
+                "dual infeasibilities of "
                 "%" HIGHSINT_FORMAT
                 " / %g "
                 "/ %g, so near-optimal\n",

--- a/src/simplex/HEkkPrimal.h
+++ b/src/simplex/HEkkPrimal.h
@@ -35,7 +35,7 @@ class HEkkPrimal {
   /**
    * @brief Solve a model instance
    */
-  HighsStatus solve();
+  HighsStatus solve(const bool force_phase2 = false);
 
  private:
   /**


### PR DESCRIPTION
This changes the mechanism by which the exact dual objective is computed. I think the current one would often fail to compute a valid dual objective under cost perturbation, because it does not consider the cases where the unperturbed duals may flip sign so that the opposite bound should be used for the exact dual objective. It also ignores that basic variables might get a nonzero dual value in the unperturbed space and also need to be considered with their corresponding bound for computing a valid exact dual objective.

Additionally, when the status now is determined to be kObjectiveBound for the scaled LP, then the unscaled LP is solved without cost perturbation to make the verification of whether the objective bound is reached more reliable.

This prevents many cases of wrong claims of reaching the dual objective bound and gets rid of most cases where the solver terminates with a dual infeasible solution. It may still happen that the solver terminates with dual infeasibilities but then they are guaranteed to be rather simple as the dual infeasible solution still provides a proof that the objective bound is reached. I.e. when there is a dual infeasibility for a nonbasic variable it must be removable with a bound flip and when there is one for a basic variable it must be bounded in the direction of its dual value. I think the latter would mean that the column can be chosen as leaving column in a primal simplex pivot?

With this change, however, there will be no bailout in cases where unbounded variables have a too large dual to reliably compute a finite bound and return -inf as the exact dual objective. In such a case instead of continuing the solve to optimality it could be better to clean up any cost perturbations with primal simplex starting in phase 2 by using bound shifts for reaching primal feasibility, but this should happen within HEkkDual, not within HApp as in the other branch.