### PR TITLE
Modify logging

### DIFF
--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -60,10 +60,8 @@ int main(int argc, char** argv) {
 void printHighsVersionCopyright(const HighsLogOptions& log_options) {
   highsLogUser(log_options, HighsLogType::kInfo,
                "Running HiGHS %d.%d.%d [date: %s, git hash: %s]\n",
-               (int)HIGHS_VERSION_MAJOR,
-	       (int)HIGHS_VERSION_MINOR,
-	       (int)HIGHS_VERSION_PATCH,
-               HIGHS_COMPILATION_DATE, HIGHS_GITHASH);
+               (int)HIGHS_VERSION_MAJOR, (int)HIGHS_VERSION_MINOR,
+               (int)HIGHS_VERSION_PATCH, HIGHS_COMPILATION_DATE, HIGHS_GITHASH);
   highsLogUser(log_options, HighsLogType::kInfo,
                "Copyright (c) 2021 ERGO-Code under MIT licence terms\n");
 }

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv) {
 
   // Create the Highs instance
   Highs highs;
-  
+
   // Pass the option settings to HiGHS
   highs.passOptions(options);
   //

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -22,14 +22,18 @@ void reportModelStatsOrError(const HighsLogOptions& log_options,
                              const HighsModel& model);
 
 int main(int argc, char** argv) {
+  // Create the Highs instance
+  Highs highs;
+  
   // Load user options.
   HighsOptions options;
-  std::string model_file;
+  //  highsOpenLogFile(options, "Highs.log");
+
   printHighsVersionCopyright(options.log_options);
 
+  std::string model_file;
   bool options_ok = loadOptions(argc, argv, options, model_file);
   if (!options_ok) return 0;
-  Highs highs;
   //
   // Pass the option seetings to HiGHS
   highs.passOptions(options);

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -22,18 +22,19 @@ void reportModelStatsOrError(const HighsLogOptions& log_options,
                              const HighsModel& model);
 
 int main(int argc, char** argv) {
-  HighsOptions options;
-  highsOpenLogFile(options, "Highs.log");
-
-  printHighsVersionCopyright(options.log_options);
-
-  // Load user options.
-  std::string model_file;
-  bool options_ok = loadOptions(argc, argv, options, model_file);
-  if (!options_ok) return 0;
 
   // Create the Highs instance
   Highs highs;
+  const HighsOptions& highs_options = highs.getOptions();
+
+  highs.openLogFile("Highs.log");
+  printHighsVersionCopyright(highs_options.log_options);
+
+  // Load user options.
+  std::string model_file;
+  HighsOptions options;
+  bool options_ok = loadOptions(argc, argv, options, model_file);
+  if (!options_ok) return 0;
 
   // Pass the option settings to HiGHS
   highs.passOptions(options);

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -22,20 +22,20 @@ void reportModelStatsOrError(const HighsLogOptions& log_options,
                              const HighsModel& model);
 
 int main(int argc, char** argv) {
-  // Create the Highs instance
-  Highs highs;
-  
-  // Load user options.
   HighsOptions options;
-  //  highsOpenLogFile(options, "Highs.log");
+  highsOpenLogFile(options, "FRED.log");
 
   printHighsVersionCopyright(options.log_options);
 
+  // Load user options.
   std::string model_file;
   bool options_ok = loadOptions(argc, argv, options, model_file);
   if (!options_ok) return 0;
-  //
-  // Pass the option seetings to HiGHS
+
+  // Create the Highs instance
+  Highs highs;
+  
+  // Pass the option settings to HiGHS
   highs.passOptions(options);
   //
   // Load the model from model_file

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -23,7 +23,7 @@ void reportModelStatsOrError(const HighsLogOptions& log_options,
 
 int main(int argc, char** argv) {
   HighsOptions options;
-  highsOpenLogFile(options, "FRED.log");
+  highsOpenLogFile(options, "Highs.log");
 
   printHighsVersionCopyright(options.log_options);
 
@@ -59,9 +59,10 @@ int main(int argc, char** argv) {
 
 void printHighsVersionCopyright(const HighsLogOptions& log_options) {
   highsLogUser(log_options, HighsLogType::kInfo,
-               "Running HiGHS %" HIGHSINT_FORMAT ".%" HIGHSINT_FORMAT
-               ".%" HIGHSINT_FORMAT " [date: %s, git hash: %s]\n",
-               HIGHS_VERSION_MAJOR, HIGHS_VERSION_MINOR, HIGHS_VERSION_PATCH,
+               "Running HiGHS %d.%d.%d [date: %s, git hash: %s]\n",
+               (int)HIGHS_VERSION_MAJOR,
+	       (int)HIGHS_VERSION_MINOR,
+	       (int)HIGHS_VERSION_PATCH,
                HIGHS_COMPILATION_DATE, HIGHS_GITHASH);
   highsLogUser(log_options, HighsLogType::kInfo,
                "Copyright (c) 2021 ERGO-Code under MIT licence terms\n");

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SOURCES
     TestHighsHessian.cpp
     TestHighsModel.cpp
     TestHSet.cpp
+    TestLogging.cpp
     TestLpValidation.cpp
     TestLpModification.cpp
     TestLpOrientation.cpp

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -79,6 +79,7 @@ TEST_CASE("filereader-edge-cases", "[highs_filereader]") {
     REQUIRE(read_status == HighsStatus::kError);
   }
 }
+
 TEST_CASE("filereader-free-format-parser", "[highs_filereader]") {
   std::string filename;
   filename = std::string(HIGHS_DIR) + "/check/instances/adlittle.mps";

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -8,19 +8,25 @@ const bool dev_run = true;
 TEST_CASE("logging", "[highs_logging]") {
   std::string model;
   std::string model_file;
+  std::string log_file;
   HighsStatus return_status;
 
-  Highs highs;
-  if (!dev_run) highs.setOptionValue("output_flag", false);
-
-  // Read mps
   model = "adlittle";
   model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
+  log_file = "temp.log";
+  
+  Highs highs;
+  if (!dev_run) highs.setOptionValue("output_flag", false);
+  // By default, initial output is just to to console
   return_status = highs.readModel(model_file);
   REQUIRE(return_status == HighsStatus::kOk);
 
-  highs.setOptionValue("log_file", "temp.log");
+  // Setting log_file to a non-empty string opens the file
+  highs.setOptionValue("log_file", log_file);
 
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kOk);
+
+  if (!dev_run) std::remove(log_file.c_str());
+
 }

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -1,6 +1,5 @@
 #include <cstdio>
 
-//#include "HMPSIO.h"
 #include "Highs.h"
 #include "catch.hpp"
 
@@ -13,7 +12,7 @@ TEST_CASE("logging", "[highs_logging]") {
 
   Highs highs;
   if (!dev_run) highs.setOptionValue("output_flag", false);
-  
+
   // Read mps
   model = "adlittle";
   model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
@@ -22,4 +21,6 @@ TEST_CASE("logging", "[highs_logging]") {
 
   highs.setOptionValue("log_file", "temp.log");
 
+  return_status = highs.run();
+  REQUIRE(return_status == HighsStatus::kOk);
 }

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -1,0 +1,25 @@
+#include <cstdio>
+
+//#include "HMPSIO.h"
+#include "Highs.h"
+#include "catch.hpp"
+
+const bool dev_run = true;
+
+TEST_CASE("logging", "[highs_logging]") {
+  std::string model;
+  std::string model_file;
+  HighsStatus return_status;
+
+  Highs highs;
+  if (!dev_run) highs.setOptionValue("output_flag", false);
+  
+  // Read mps
+  model = "adlittle";
+  model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
+  return_status = highs.readModel(model_file);
+  REQUIRE(return_status == HighsStatus::kOk);
+
+  highs.setOptionValue("log_file", "temp.log");
+
+}

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -14,7 +14,7 @@ TEST_CASE("logging", "[highs_logging]") {
   model = "adlittle";
   model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
   log_file = "temp.log";
-  
+
   Highs highs;
   if (!dev_run) highs.setOptionValue("output_flag", false);
   // By default, initial output is just to to console
@@ -28,5 +28,4 @@ TEST_CASE("logging", "[highs_logging]") {
   REQUIRE(return_status == HighsStatus::kOk);
 
   if (!dev_run) std::remove(log_file.c_str());
-
 }

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -11,7 +11,7 @@ TEST_CASE("logging", "[highs_logging]") {
   std::string log_file;
   HighsStatus return_status;
 
-  model = "adlittle";
+  model = "avgas";
   model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
   log_file = "temp.log";
 
@@ -26,6 +26,21 @@ TEST_CASE("logging", "[highs_logging]") {
 
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kOk);
+
+  // Setting log_file to an empty string closes the file and prevents
+  // further logging to file
+  highs.setOptionValue(kLogFileString, "");
+
+  // Setting log_to_console false suppresses logging to console
+  highs.setOptionValue("log_to_console", false);
+  // Writing out the the info should puroduce no output to console or file
+  highs.run();
+
+  // Setting log_to_console true restores logging to console
+  highs.setOptionValue("log_to_console", true);
+  if (dev_run) printf("After setting log_to_console = true\n");
+  // Writing out the the info should puroduce output to console
+  highs.run();
 
   if (!dev_run) std::remove(log_file.c_str());
 }

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -29,3 +29,21 @@ TEST_CASE("logging", "[highs_logging]") {
 
   if (!dev_run) std::remove(log_file.c_str());
 }
+
+TEST_CASE("no-logging", "[highs_logging]") {
+  std::string model;
+  std::string model_file;
+  std::string log_file;
+  HighsStatus return_status;
+
+  model = "adlittle";
+  model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
+
+  Highs highs;
+  if (!dev_run) highs.setOptionValue("output_flag", false);
+  return_status = highs.readModel(model_file);
+  REQUIRE(return_status == HighsStatus::kOk);
+
+  return_status = highs.run();
+  REQUIRE(return_status == HighsStatus::kOk);
+}

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -3,7 +3,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 
 TEST_CASE("logging", "[highs_logging]") {
   std::string model;
@@ -22,7 +22,7 @@ TEST_CASE("logging", "[highs_logging]") {
   REQUIRE(return_status == HighsStatus::kOk);
 
   // Setting log_file to a non-empty string opens the file
-  highs.setOptionValue("log_file", log_file);
+  highs.setOptionValue(kLogFileString, log_file);
 
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kOk);

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -222,6 +222,7 @@ void testSolvers(Highs& highs, IterationCount& model_iteration_count,
     testSolver(highs, "simplex", model_iteration_count, i);
   }
   // Only use IPX with 32-bit arithmetic
+  // ToDo This is no longer true
 #ifndef HIGHSINT64
   testSolver(highs, "ipm", model_iteration_count);
 #endif

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -2,7 +2,7 @@
 #include "SpecialLps.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double double_equal_tolerance = 1e-5;
 
 void solve(Highs& highs, std::string presolve,

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -120,39 +120,15 @@ TEST_CASE("MIP-nmck", "[highs_test_mip_solver]") {
   lp.integrality_ = {HighsVarType::kContinuous, HighsVarType::kContinuous,
                      HighsVarType::kInteger};
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
-  highs.setOptionValue("solver", "mip");
-  REQUIRE(highs.run() == HighsStatus::kOk);
+  highs.setOptionValue("highs_debug_level", kHighsDebugLevelCheap);
+  highs.setOptionValue("log_dev_level", 2);
+  HighsStatus return_status = highs.run();
+  REQUIRE(return_status == HighsStatus::kOk);
+  if (dev_run) highs.writeInfo("");
   const HighsInfo& info = highs.getInfo();
-  const HighsSolution& solution = highs.getSolution();
-  if (dev_run) {
-    printf("INFO: valid = %d\n", (int)info.valid);
-    printf("INFO: mip_node_count = %d\n", (int)info.mip_node_count);
-    printf("INFO: simplex_iteration_count = %d\n",
-           (int)info.simplex_iteration_count);
-    printf("INFO: ipm_iteration_count = %d\n", (int)info.ipm_iteration_count);
-    printf("INFO: qp_iteration_count = %d\n", (int)info.qp_iteration_count);
-    printf("INFO: crossover_iteration_count = %d\n",
-           (int)info.crossover_iteration_count);
-    printf("INFO: primal_solution_status = %d\n",
-           (int)info.primal_solution_status);
-    printf("INFO: dual_solution_status = %d\n", (int)info.dual_solution_status);
-    printf("INFO: basis_validity = %d\n", (int)info.basis_validity);
-    printf("INFO: objective_function_value = %g\n",
-           info.objective_function_value);
-    printf("INFO: mip_dual_bound = %g\n", info.mip_dual_bound);
-    printf("INFO: mip_gap = %g\n", info.mip_gap);
-    printf("INFO: num_primal_infeasibilities = %d\n",
-           (int)info.num_primal_infeasibilities);
-    printf("INFO: max_primal_infeasibility = %g\n",
-           info.max_primal_infeasibility);
-    printf("INFO: sum_primal_infeasibilities = %g\n",
-           info.sum_primal_infeasibilities);
-    printf("INFO: num_dual_infeasibilities = %d\n",
-           (int)info.num_dual_infeasibilities);
-    printf("INFO: max_dual_infeasibility = %g\n", info.max_dual_infeasibility);
-    printf("INFO: sum_dual_infeasibilities = %g\n",
-           info.sum_dual_infeasibilities);
-  }
+  REQUIRE(info.num_primal_infeasibilities == 0);
+  REQUIRE(info.max_primal_infeasibility == 0);
+  REQUIRE(info.sum_primal_infeasibilities == 0);
 }
 
 TEST_CASE("MIP-od", "[highs_test_mip_solver]") {

--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -9,14 +9,15 @@ const bool dev_run = false;
 
 TEST_CASE("internal-options", "[highs_options]") {
   HighsOptions options;
+  HighsLogOptions report_log_options = options.log_options;
   options.output_flag = false;
   OptionStatus return_status =
-      checkOptions(options.log_options, options.records);
+      checkOptions(report_log_options, options.records);
   REQUIRE(return_status == OptionStatus::kOk);
 
   std::string filename = std::string(HIGHS_DIR) + "/check/sample_options_file";
 
-  bool success = loadOptionsFromFile(options, filename);
+  bool success = loadOptionsFromFile(report_log_options, options, filename);
   REQUIRE(success == true);
   REQUIRE(options.presolve == kHighsOnString);
   REQUIRE(options.small_matrix_value == 0.001);
@@ -24,35 +25,38 @@ TEST_CASE("internal-options", "[highs_options]") {
 
   if (dev_run) reportOptions(stdout, options.records, true);
 
-  return_status = checkOptions(options.log_options, options.records);
+  return_status = checkOptions(report_log_options, options.records);
   REQUIRE(return_status == OptionStatus::kOk);
 
   // Check setting boolean options
   std::string setting_string = "fixed";
   return_status =
+      setLocalOptionValue(report_log_options, "mps_parser_type_free",
+                          options.log_options, options.records, setting_string);
+  REQUIRE(return_status == OptionStatus::kIllegalValue);
+
+  return_status =
       setLocalOptionValue(options.log_options, "mps_parser_type_free",
-                          options.records, setting_string);
+                          options.log_options, options.records, "fixed");
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
-  return_status = setLocalOptionValue(
-      options.log_options, "mps_parser_type_free", options.records, "fixed");
-  REQUIRE(return_status == OptionStatus::kIllegalValue);
-
-  return_status = setLocalOptionValue(
-      options.log_options, "mps_parser_type_free", options.records, "False");
+  return_status =
+      setLocalOptionValue(options.log_options, "mps_parser_type_free",
+                          options.log_options, options.records, "False");
   REQUIRE(return_status == OptionStatus::kOk);
 
-  return_status = setLocalOptionValue(
-      options.log_options, "mps_parser_type_free", options.records, "F");
+  return_status =
+      setLocalOptionValue(options.log_options, "mps_parser_type_free",
+                          options.log_options, options.records, "F");
   REQUIRE(return_status == OptionStatus::kOk);
 
   bool mps_parser_type_free = false;
   return_status =
-      setLocalOptionValue(options.log_options, "mps_parser_type_free",
+      setLocalOptionValue(report_log_options, "mps_parser_type_free",
                           options.records, mps_parser_type_free);
   REQUIRE(return_status == OptionStatus::kOk);
 
-  return_status = setLocalOptionValue(options.log_options, "mps_parser_type",
+  return_status = setLocalOptionValue(report_log_options, "mps_parser_type",
                                       options.records, true);
   REQUIRE(return_status == OptionStatus::kUnknownOption);
 
@@ -67,14 +71,14 @@ TEST_CASE("internal-options", "[highs_options]") {
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
   std::string allowed_matrix_scale_factor_string = "1e-7";
-  return_status =
-      setLocalOptionValue(options.log_options, "allowed_matrix_scale_factor",
-                          options.records, allowed_matrix_scale_factor_string);
+  return_status = setLocalOptionValue(
+      report_log_options, "allowed_matrix_scale_factor", options.log_options,
+      options.records, allowed_matrix_scale_factor_string);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
   return_status =
-      setLocalOptionValue(options.log_options, "allowed_matrix_scale_factor",
-                          options.records, "3.14159");
+      setLocalOptionValue(report_log_options, "allowed_matrix_scale_factor",
+                          options.log_options, options.records, "3.14159");
 
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
@@ -85,13 +89,13 @@ TEST_CASE("internal-options", "[highs_options]") {
 
   double allowed_matrix_scale_factor_double = 1e-7;
   return_status =
-      setLocalOptionValue(options.log_options, "allowed_matrix_scale_factor",
+      setLocalOptionValue(report_log_options, "allowed_matrix_scale_factor",
                           options.records, allowed_matrix_scale_factor_double);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
   HighsInt allowed_matrix_scale_factor = 12;
   return_status =
-      setLocalOptionValue(options.log_options, "allowed_matrix_scale_factor",
+      setLocalOptionValue(report_log_options, "allowed_matrix_scale_factor",
                           options.records, allowed_matrix_scale_factor);
   REQUIRE(return_status == OptionStatus::kOk);
 
@@ -102,74 +106,81 @@ TEST_CASE("internal-options", "[highs_options]") {
 
   // Check setting double options
 
-  return_status = setLocalOptionValue(options.log_options, "large_matrix_value",
+  return_status = setLocalOptionValue(report_log_options, "large_matrix_value",
                                       options.records, -1);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
-  return_status = setLocalOptionValue(options.log_options, "large_matrix_value",
-                                      options.records, "1");
+  return_status =
+      setLocalOptionValue(report_log_options, "large_matrix_value",
+                          options.log_options, options.records, "1");
   REQUIRE(return_status == OptionStatus::kOk);
 
-  return_status = setLocalOptionValue(options.log_options, "small_matrix_value",
+  return_status = setLocalOptionValue(report_log_options, "small_matrix_value",
                                       options.records, -1);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
-  return_status = setLocalOptionValue(options.log_options, "small_matrix_value",
-                                      options.records, "1e-6");
+  return_status =
+      setLocalOptionValue(report_log_options, "small_matrix_value",
+                          options.log_options, options.records, "1e-6");
   REQUIRE(return_status == OptionStatus::kOk);
 
   double small_matrix_value = 1e-7;
-  return_status = setLocalOptionValue(options.log_options, "small_matrix_value",
+  return_status = setLocalOptionValue(report_log_options, "small_matrix_value",
                                       options.records, small_matrix_value);
   REQUIRE(return_status == OptionStatus::kOk);
 
   // Check setting string options
 
-  return_status = setLocalOptionValue(options.log_options, kPresolveString,
-                                      options.records, "ml.mps");
+  return_status =
+      setLocalOptionValue(report_log_options, kPresolveString,
+                          options.log_options, options.records, "ml.mps");
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
   std::string model_file = "ml.mps";
-  return_status = setLocalOptionValue(options.log_options, kPresolveString,
-                                      options.records, model_file);
+  return_status =
+      setLocalOptionValue(report_log_options, kPresolveString,
+                          options.log_options, options.records, model_file);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
-  return_status = setLocalOptionValue(options.log_options, kPresolveString,
-                                      options.records, "off");
+  return_status =
+      setLocalOptionValue(report_log_options, kPresolveString,
+                          options.log_options, options.records, "off");
   REQUIRE(return_status == OptionStatus::kOk);
 
   std::string presolve = "choose";
-  return_status = setLocalOptionValue(options.log_options, kPresolveString,
-                                      options.records, presolve);
+  return_status =
+      setLocalOptionValue(report_log_options, kPresolveString,
+                          options.log_options, options.records, presolve);
   REQUIRE(return_status == OptionStatus::kOk);
 
-  return_status = setLocalOptionValue(options.log_options, kModelFileString,
-                                      options.records, model_file);
+  return_status =
+      setLocalOptionValue(report_log_options, kModelFileString,
+                          options.log_options, options.records, model_file);
   REQUIRE(return_status == OptionStatus::kUnknownOption);
 
   if (dev_run) reportOptions(stdout, options.records);
 
   bool get_mps_parser_type_free;
   return_status =
-      getLocalOptionValue(options.log_options, "mps_parser_type_free",
+      getLocalOptionValue(report_log_options, "mps_parser_type_free",
                           options.records, get_mps_parser_type_free);
   REQUIRE(return_status == OptionStatus::kOk);
   REQUIRE(get_mps_parser_type_free == false);
 
   HighsInt get_allowed_matrix_scale_factor;
   return_status =
-      getLocalOptionValue(options.log_options, "allowed_matrix_scale_factor",
+      getLocalOptionValue(report_log_options, "allowed_matrix_scale_factor",
                           options.records, get_allowed_matrix_scale_factor);
   REQUIRE(return_status == OptionStatus::kOk);
   REQUIRE(get_allowed_matrix_scale_factor == allowed_matrix_scale_factor);
 
   double get_small_matrix_value;
-  return_status = getLocalOptionValue(options.log_options, "small_matrix_value",
+  return_status = getLocalOptionValue(report_log_options, "small_matrix_value",
                                       options.records, get_small_matrix_value);
   REQUIRE(return_status == OptionStatus::kOk);
   REQUIRE(get_small_matrix_value == small_matrix_value);
 
-  return_status = checkOptions(options.log_options, options.records);
+  return_status = checkOptions(report_log_options, options.records);
   REQUIRE(return_status == OptionStatus::kOk);
   std::remove(model_file.c_str());
 }

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -937,7 +937,7 @@ class Highs {
    * @brief Opens a named log file
    */
   HighsStatus openLogFile(const std::string log_file = "");
-  
+
   std::string modelStatusToString(const HighsModelStatus model_status) const;
 
   std::string solutionStatusToString(const HighsInt solution_status) const;

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -927,6 +927,17 @@ class Highs {
    */
   double getRunTime() { return timer_.readRunHighsClock(); }
 
+  /**
+   * @brief Runs ipx crossover and if successful loads basis into Highs::basis_
+   */
+  HighsStatus crossover();
+  HighsStatus crossover(HighsSolution& solution);
+
+  /**
+   * @brief Opens a named log file
+   */
+  HighsStatus openLogFile(const std::string log_file = "");
+  
   std::string modelStatusToString(const HighsModelStatus model_status) const;
 
   std::string solutionStatusToString(const HighsInt solution_status) const;
@@ -1036,10 +1047,6 @@ class Highs {
     deprecationMessage("getSimplexIterationCount", "None");
     return info_.simplex_iteration_count;
   }
-
-  // Runs ipx crossover and if successful loads basis into Highs::basis_
-  HighsStatus crossover();
-  HighsStatus crossover(HighsSolution& solution);
 
   HighsStatus setHighsLogfile(FILE* logfile = NULL);
 

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -104,7 +104,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       type == HighsLogType::kWarning || type == HighsLogType::kError;
   va_list argptr;
   va_start(argptr, format);
-  const bool flush_streams = true;
+  const bool flush_streams = false;
   if (!logmsgcb) {
     // Write to log file stream unless it is NULL
     if (log_options_.log_file_stream) {
@@ -160,7 +160,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
     return;
   va_list argptr;
   va_start(argptr, format);
-  const bool flush_streams = true;
+  const bool flush_streams = false;
   if (!logmsgcb) {
     // Write to log file stream unless it is NULL
     if (log_options_.log_file_stream) {

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -104,7 +104,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       type == HighsLogType::kWarning || type == HighsLogType::kError;
   va_list argptr;
   va_start(argptr, format);
-  const bool flush_streams = false;
+  const bool flush_streams = true;
   if (!logmsgcb) {
     // Write to log file stream unless it is NULL
     if (log_options_.log_file_stream) {
@@ -160,7 +160,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
     return;
   va_list argptr;
   va_start(argptr, format);
-  const bool flush_streams = false;
+  const bool flush_streams = true;
   if (!logmsgcb) {
     // Write to log file stream unless it is NULL
     if (log_options_.log_file_stream) {

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -196,6 +196,29 @@ void highsSetLogCallback(HighsOptions& options) {
   msgcb_data = options.msgcb_data;
 }
 
+/*
+void highsOpenLogFile(HighsOptions& options, 
+		      const std::string log_file) {
+}
+
+void highsOpenLogFile(HighsLogOptions& log_options, 
+		      OptionRecordString& option,
+		      const std::string log_file) {
+  if (log_options.log_file_stream != NULL) {
+    // Current log file stream is not null, so flush and close it
+    fflush(log_options.log_file_stream);
+    fclose(log_options.log_file_stream);
+  }
+  if (log_file.compare("")) {
+    // New log file name is not empty, so open it
+    log_options.log_file_stream = fopen(log_file.c_str(), "w");
+  } else {
+    // New log file name is empty, so set the stream to null
+    log_options.log_file_stream = NULL;
+  }
+}
+*/
+
 void highsReportLogOptions(const HighsLogOptions& log_options_) {
   printf("\nHighs log options\n");
   if (log_options_.log_file_stream == NULL) {

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -196,8 +196,7 @@ void highsSetLogCallback(HighsOptions& options) {
   msgcb_data = options.msgcb_data;
 }
 
-void highsOpenLogFile(HighsOptions& options, 
-		      const std::string log_file) {
+void highsOpenLogFile(HighsOptions& options, const std::string log_file) {
   highsOpenLogFile(options.log_options, options.records, log_file);
 }
 

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -104,20 +104,23 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       type == HighsLogType::kWarning || type == HighsLogType::kError;
   va_list argptr;
   va_start(argptr, format);
-  if (logmsgcb == NULL) {
-    if (log_options_.log_file_stream != NULL) {
-      // Write to log file stream
+  const bool flush_streams = true;
+  if (!logmsgcb) {
+    // Write to log file stream unless it is NULL
+    if (log_options_.log_file_stream) {
       if (prefix)
         fprintf(log_options_.log_file_stream, "%-9s",
                 HighsLogTypeTag[(int)type]);
       vfprintf(log_options_.log_file_stream, format, argptr);
+      if (flush_streams) fflush(log_options_.log_file_stream);
       va_start(argptr, format);
     }
+    // Write to stdout unless log file stream is stdout
     if (*log_options_.log_to_console &&
         log_options_.log_file_stream != stdout) {
-      // Write to stdout unless log file stream is stdout
       if (prefix) fprintf(stdout, "%-9s", HighsLogTypeTag[(int)type]);
       vfprintf(stdout, format, argptr);
+      if (flush_streams) fflush(stdout);
     }
   } else {
     int len;
@@ -157,16 +160,20 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
     return;
   va_list argptr;
   va_start(argptr, format);
-  if (logmsgcb == NULL) {
-    if (log_options_.log_file_stream != NULL) {
+  const bool flush_streams = true;
+  if (!logmsgcb) {
+    // Write to log file stream unless it is NULL
+    if (log_options_.log_file_stream) {
       // Write to log file stream
       vfprintf(log_options_.log_file_stream, format, argptr);
+      if (flush_streams) fflush(log_options_.log_file_stream);
       va_start(argptr, format);
     }
+    // Write to stdout unless log file stream is stdout
     if (*log_options_.log_to_console &&
         log_options_.log_file_stream != stdout) {
-      // Write to stdout unless log file stream is stdout
       vfprintf(stdout, format, argptr);
+      if (flush_streams) fflush(stdout);
     }
   } else {
     int len;

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -196,28 +196,10 @@ void highsSetLogCallback(HighsOptions& options) {
   msgcb_data = options.msgcb_data;
 }
 
-/*
 void highsOpenLogFile(HighsOptions& options, 
 		      const std::string log_file) {
+  highsOpenLogFile(options.log_options, options.records, log_file);
 }
-
-void highsOpenLogFile(HighsLogOptions& log_options, 
-		      OptionRecordString& option,
-		      const std::string log_file) {
-  if (log_options.log_file_stream != NULL) {
-    // Current log file stream is not null, so flush and close it
-    fflush(log_options.log_file_stream);
-    fclose(log_options.log_file_stream);
-  }
-  if (log_file.compare("")) {
-    // New log file name is not empty, so open it
-    log_options.log_file_stream = fopen(log_file.c_str(), "w");
-  } else {
-    // New log file name is empty, so set the stream to null
-    log_options.log_file_stream = NULL;
-  }
-}
-*/
 
 void highsReportLogOptions(const HighsLogOptions& log_options_) {
   printf("\nHighs log options\n");

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -81,12 +81,7 @@ void highsSetLogCallback(void (*printmsgcb_)(HighsInt level, const char* msg,
 void highsSetLogCallback(HighsOptions& options  //!< the options
 );
 
-/*
 void highsOpenLogFile(HighsOptions& options, const std::string log_file);
-void highsOpenLogFile(HighsLogOptions& log_options, 
-		      OptionRecordString& option,
-		      const std::string log_file);
-*/
 
 void highsReportLogOptions(const HighsLogOptions& log_options_);
 

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -81,6 +81,13 @@ void highsSetLogCallback(void (*printmsgcb_)(HighsInt level, const char* msg,
 void highsSetLogCallback(HighsOptions& options  //!< the options
 );
 
+/*
+void highsOpenLogFile(HighsOptions& options, const std::string log_file);
+void highsOpenLogFile(HighsLogOptions& log_options, 
+		      OptionRecordString& option,
+		      const std::string log_file);
+*/
+
 void highsReportLogOptions(const HighsLogOptions& log_options_);
 
 std::string highsFormatToString(const char* format, ...);

--- a/src/io/LoadOptions.cpp
+++ b/src/io/LoadOptions.cpp
@@ -18,7 +18,8 @@
 
 // For extended options to be parsed from a file. Assuming options file is
 // specified.
-bool loadOptionsFromFile(HighsOptions& options, const std::string filename) {
+bool loadOptionsFromFile(const HighsLogOptions& report_log_options,
+                         HighsOptions& options, const std::string filename) {
   if (filename.size() == 0) return false;
 
   string line, option, value;
@@ -36,7 +37,7 @@ bool loadOptionsFromFile(HighsOptions& options, const std::string filename) {
 
       HighsInt equals = line.find_first_of("=");
       if (equals < 0 || equals >= (HighsInt)line.size() - 1) {
-        highsLogUser(options.log_options, HighsLogType::kError,
+        highsLogUser(report_log_options, HighsLogType::kError,
                      "Error on line %" HIGHSINT_FORMAT " of options file.\n",
                      line_count);
         return false;
@@ -45,12 +46,12 @@ bool loadOptionsFromFile(HighsOptions& options, const std::string filename) {
       value = line.substr(equals + 1, line.size() - equals);
       trim(option, non_chars);
       trim(value, non_chars);
-      if (setLocalOptionValue(options.log_options, option, options.records,
-                              value) != OptionStatus::kOk)
+      if (setLocalOptionValue(report_log_options, option, options.log_options,
+                              options.records, value) != OptionStatus::kOk)
         return false;
     }
   } else {
-    highsLogUser(options.log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "Options file not found.\n");
     return false;
   }

--- a/src/io/LoadOptions.h
+++ b/src/io/LoadOptions.h
@@ -20,6 +20,7 @@
 #include "lp_data/HighsOptions.h"
 
 // For extended options to be parsed from filename
-bool loadOptionsFromFile(HighsOptions& options, const std::string filename);
+bool loadOptionsFromFile(const HighsLogOptions& report_log_options,
+                         HighsOptions& options, const std::string filename);
 
 #endif

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2847,3 +2847,8 @@ HighsStatus Highs::crossover(HighsSolution& solution) {
 
   return HighsStatus::kOk;
 }
+
+HighsStatus Highs::openLogFile(const std::string log_file) {
+  highsOpenLogFile(options_.log_options, options_.records, log_file);
+  return HighsStatus::kOk;
+}

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2440,15 +2440,27 @@ HighsStatus Highs::callSolveMip() {
   if (use_mip_feasibility_tolerance) {
     // Overwrite max infeasibility to include integrality if there is a solution
     if (solver.solution_objective_ != kHighsInf) {
-      info_.num_primal_infeasibilities = kHighsIllegalInfeasibilityCount;
-      info_.max_primal_infeasibility =
-          std::max({solver.row_violation_, solver.bound_violation_,
-                    solver.integrality_violation_});
-      if (info_.max_primal_infeasibility > options_.mip_feasibility_tolerance) {
+      const double mip_max_bound_violation =
+          std::max(solver.row_violation_, solver.bound_violation_);
+      const double mip_max_infeasibility =
+          std::max(mip_max_bound_violation, solver.integrality_violation_);
+      const double delta_max_bound_violation =
+          std::abs(mip_max_bound_violation - info_.max_primal_infeasibility);
+      // Possibly report a mis-match between the max bound violation
+      // returned by the MIP solver, and the value obtained from the
+      // solution
+      if (delta_max_bound_violation > 1e-12)
+        highsLogDev(options_.log_options, HighsLogType::kWarning,
+                    "Inconsistent max bound violation: MIP solver (%10.4g); LP "
+                    "(%10.4g); Difference of %10.4g\n",
+                    mip_max_bound_violation, info_.max_primal_infeasibility,
+                    delta_max_bound_violation);
+      info_.max_integrality_violation = solver.integrality_violation_;
+      if (info_.max_integrality_violation >
+          options_.mip_feasibility_tolerance) {
         info_.primal_solution_status = kSolutionStatusInfeasible;
-        // model_status_ = HighsModelStatus::kNotset;
+        assert(model_status_ == HighsModelStatus::kInfeasible);
       }
-      info_.sum_primal_infeasibilities = kHighsIllegalInfeasibilityMeasure;
     }
     // Recover the primal feasibility tolerance
     options_.primal_feasibility_tolerance = primal_feasibility_tolerance;

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -80,16 +80,18 @@ HighsStatus Highs::setOptionValue(const std::string& option,
 
 HighsStatus Highs::setOptionValue(const std::string& option,
                                   const std::string value) {
-  if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk)
+  HighsLogOptions report_log_options = options_.log_options;
+  if (setLocalOptionValue(report_log_options, option, options_.log_options,
+                          options_.records, value) == OptionStatus::kOk)
     return HighsStatus::kOk;
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::setOptionValue(const std::string& option,
                                   const char* value) {
-  if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk)
+  HighsLogOptions report_log_options = options_.log_options;
+  if (setLocalOptionValue(report_log_options, option, options_.log_options,
+                          options_.records, value) == OptionStatus::kOk)
     return HighsStatus::kOk;
   return HighsStatus::kError;
 }
@@ -100,7 +102,9 @@ HighsStatus Highs::readOptions(const std::string filename) {
                  "Empty file name so not reading options\n");
     return HighsStatus::kWarning;
   }
-  if (!loadOptionsFromFile(options_, filename)) return HighsStatus::kError;
+  HighsLogOptions report_log_options = options_.log_options;
+  if (!loadOptionsFromFile(report_log_options, options_, filename))
+    return HighsStatus::kError;
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -30,6 +30,7 @@ void HighsInfo::clear() {
   objective_function_value = 0;
   mip_dual_bound = 0;
   mip_gap = kHighsInf;
+  max_integrality_violation = kHighsIllegalInfeasibilityMeasure;
   num_primal_infeasibilities = kHighsIllegalInfeasibilityCount;
   max_primal_infeasibility = kHighsIllegalInfeasibilityMeasure;
   sum_primal_infeasibilities = kHighsIllegalInfeasibilityMeasure;

--- a/src/lp_data/HighsInfo.h
+++ b/src/lp_data/HighsInfo.h
@@ -140,6 +140,7 @@ struct HighsInfoStruct {
   double objective_function_value;
   double mip_dual_bound;
   double mip_gap;
+  double max_integrality_violation;
   HighsInt num_primal_infeasibilities;
   double max_primal_infeasibility;
   double sum_primal_infeasibilities;
@@ -259,6 +260,11 @@ class HighsInfo : public HighsInfoStruct {
 
     record_double = new InfoRecordDouble("mip_gap", "MIP solver gap (%)",
                                          advanced, &mip_gap, 0);
+    records.push_back(record_double);
+
+    record_double = new InfoRecordDouble("max_integrality_violation",
+                                         "Max integrality violation", advanced,
+                                         &max_integrality_violation, 0);
     records.push_back(record_double);
 
     record_int = new InfoRecordInt("num_primal_infeasibilities",

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -14,8 +14,33 @@
  * @brief
  */
 #include "lp_data/HighsOptions.h"
+#include <cassert>
 
 void setLogOptions();
+
+void highsOpenLogFile(HighsLogOptions& log_options, 
+		      std::vector<OptionRecord*>& option_records,
+		      const std::string log_file) {
+  HighsInt index;
+  OptionStatus status =
+    getOptionIndex(log_options, "log_file", option_records, index);
+  assert(status == OptionStatus::kOk);
+  if (log_options.log_file_stream != NULL) {
+    // Current log file stream is not null, so flush and close it
+    fflush(log_options.log_file_stream);
+    fclose(log_options.log_file_stream);
+  }
+  if (log_file.compare("")) {
+    // New log file name is not empty, so open it
+    log_options.log_file_stream = fopen(log_file.c_str(), "w");
+  } else {
+    // New log file name is empty, so set the stream to null
+    log_options.log_file_stream = NULL;
+  }
+  OptionRecordString& option = *(OptionRecordString*)option_records[index];
+  option.assignvalue(log_file);
+}
+
 std::string optionEntryTypeToString(const HighsOptionType type) {
   if (type == HighsOptionType::kBool) {
     return "bool";
@@ -443,6 +468,7 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
                                atof(value.c_str()));
   } else {
     // Setting a string option value
+    /*
     if (!name.compare(kLogFileString)) {
       // Changing the name of the log file
       if (log_options.log_file_stream != NULL) {
@@ -458,6 +484,7 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
         log_options.log_file_stream = NULL;
       }
     }
+    */
     if (!name.compare(kModelFileString)) {
       // Don't allow model filename to be changed - it's only an
       // option so that reading of run-time options works

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -54,24 +54,24 @@ std::string optionEntryTypeToString(const HighsOptionType type) {
   }
 }
 
-bool commandLineOffChooseOnOk(const HighsLogOptions& log_options,
+bool commandLineOffChooseOnOk(const HighsLogOptions& report_log_options,
                               const string& value) {
   if (value == kHighsOffString || value == kHighsChooseString ||
       value == kHighsOnString)
     return true;
-  highsLogUser(log_options, HighsLogType::kWarning,
+  highsLogUser(report_log_options, HighsLogType::kWarning,
                "Value \"%s\" is not one of \"%s\", \"%s\" or \"%s\"\n",
                value.c_str(), kHighsOffString.c_str(),
                kHighsChooseString.c_str(), kHighsOnString.c_str());
   return false;
 }
 
-bool commandLineSolverOk(const HighsLogOptions& log_options,
+bool commandLineSolverOk(const HighsLogOptions& report_log_options,
                          const string& value) {
   if (value == kSimplexString || value == kHighsChooseString ||
       value == kIpmString)
     return true;
-  highsLogUser(log_options, HighsLogType::kWarning,
+  highsLogUser(report_log_options, HighsLogType::kWarning,
                "Value \"%s\" is not one of \"%s\", \"%s\" or \"%s\"\n",
                value.c_str(), kSimplexString.c_str(),
                kHighsChooseString.c_str(), kIpmString.c_str());
@@ -91,19 +91,19 @@ bool boolFromString(const std::string value, bool& bool_value) {
   return true;
 }
 
-OptionStatus getOptionIndex(const HighsLogOptions& log_options,
+OptionStatus getOptionIndex(const HighsLogOptions& report_log_options,
                             const std::string& name,
                             const std::vector<OptionRecord*>& option_records,
                             HighsInt& index) {
   HighsInt num_options = option_records.size();
   for (index = 0; index < num_options; index++)
     if (option_records[index]->name == name) return OptionStatus::kOk;
-  highsLogUser(log_options, HighsLogType::kError,
+  highsLogUser(report_log_options, HighsLogType::kError,
                "getOptionIndex: Option \"%s\" is unknown\n", name.c_str());
   return OptionStatus::kUnknownOption;
 }
 
-OptionStatus checkOptions(const HighsLogOptions& log_options,
+OptionStatus checkOptions(const HighsLogOptions& report_log_options,
                           const std::vector<OptionRecord*>& option_records) {
   bool error_found = false;
   HighsInt num_options = option_records.size();
@@ -115,7 +115,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
       if (check_index == index) continue;
       std::string check_name = option_records[check_index]->name;
       if (check_name == name) {
-        highsLogUser(log_options, HighsLogType::kError,
+        highsLogUser(report_log_options, HighsLogType::kError,
                      "checkOptions: Option %" HIGHSINT_FORMAT
                      " (\"%s\") has the same name as "
                      "option %" HIGHSINT_FORMAT " \"%s\"\n",
@@ -134,7 +134,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
             ((OptionRecordBool*)option_records[check_index])[0];
         if (check_option.type == HighsOptionType::kBool) {
           if (check_option.value == value_pointer) {
-            highsLogUser(log_options, HighsLogType::kError,
+            highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
                          " (\"%s\") has the same "
                          "value pointer as option %" HIGHSINT_FORMAT
@@ -148,7 +148,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
     } else if (type == HighsOptionType::kInt) {
       // Check HighsInt option
       OptionRecordInt& option = ((OptionRecordInt*)option_records[index])[0];
-      if (checkOption(log_options, option) != OptionStatus::kOk)
+      if (checkOption(report_log_options, option) != OptionStatus::kOk)
         error_found = true;
       // Check that there are no other options with the same value pointers
       HighsInt* value_pointer = option.value;
@@ -158,7 +158,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
             ((OptionRecordInt*)option_records[check_index])[0];
         if (check_option.type == HighsOptionType::kInt) {
           if (check_option.value == value_pointer) {
-            highsLogUser(log_options, HighsLogType::kError,
+            highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
                          " (\"%s\") has the same "
                          "value pointer as option %" HIGHSINT_FORMAT
@@ -173,7 +173,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
       // Check double option
       OptionRecordDouble& option =
           ((OptionRecordDouble*)option_records[index])[0];
-      if (checkOption(log_options, option) != OptionStatus::kOk)
+      if (checkOption(report_log_options, option) != OptionStatus::kOk)
         error_found = true;
       // Check that there are no other options with the same value pointers
       double* value_pointer = option.value;
@@ -183,7 +183,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
             ((OptionRecordDouble*)option_records[check_index])[0];
         if (check_option.type == HighsOptionType::kDouble) {
           if (check_option.value == value_pointer) {
-            highsLogUser(log_options, HighsLogType::kError,
+            highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
                          " (\"%s\") has the same "
                          "value pointer as option %" HIGHSINT_FORMAT
@@ -206,7 +206,7 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
             ((OptionRecordString*)option_records[check_index])[0];
         if (check_option.type == HighsOptionType::kString) {
           if (check_option.value == value_pointer) {
-            highsLogUser(log_options, HighsLogType::kError,
+            highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
                          " (\"%s\") has the same "
                          "value pointer as option %" HIGHSINT_FORMAT
@@ -220,16 +220,16 @@ OptionStatus checkOptions(const HighsLogOptions& log_options,
     }
   }
   if (error_found) return OptionStatus::kIllegalValue;
-  highsLogUser(log_options, HighsLogType::kInfo,
+  highsLogUser(report_log_options, HighsLogType::kInfo,
                "checkOptions: Options are OK\n");
   return OptionStatus::kOk;
 }
 
-OptionStatus checkOption(const HighsLogOptions& log_options,
+OptionStatus checkOption(const HighsLogOptions& report_log_options,
                          const OptionRecordInt& option) {
   if (option.lower_bound > option.upper_bound) {
     highsLogUser(
-        log_options, HighsLogType::kError,
+        report_log_options, HighsLogType::kError,
         "checkOption: Option \"%s\" has inconsistent bounds [%" HIGHSINT_FORMAT
         ", %" HIGHSINT_FORMAT "]\n",
         option.name.c_str(), option.lower_bound, option.upper_bound);
@@ -238,7 +238,7 @@ OptionStatus checkOption(const HighsLogOptions& log_options,
   if (option.default_value < option.lower_bound ||
       option.default_value > option.upper_bound) {
     highsLogUser(
-        log_options, HighsLogType::kError,
+        report_log_options, HighsLogType::kError,
         "checkOption: Option \"%s\" has default value %" HIGHSINT_FORMAT
         " "
         "inconsistent with bounds [%" HIGHSINT_FORMAT ", %" HIGHSINT_FORMAT
@@ -249,7 +249,7 @@ OptionStatus checkOption(const HighsLogOptions& log_options,
   }
   HighsInt value = *option.value;
   if (value < option.lower_bound || value > option.upper_bound) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "checkOption: Option \"%s\" has value %" HIGHSINT_FORMAT
                  " inconsistent with "
                  "bounds [%" HIGHSINT_FORMAT ", %" HIGHSINT_FORMAT "]\n",
@@ -260,18 +260,18 @@ OptionStatus checkOption(const HighsLogOptions& log_options,
   return OptionStatus::kOk;
 }
 
-OptionStatus checkOption(const HighsLogOptions& log_options,
+OptionStatus checkOption(const HighsLogOptions& report_log_options,
                          const OptionRecordDouble& option) {
   if (option.lower_bound > option.upper_bound) {
     highsLogUser(
-        log_options, HighsLogType::kError,
+        report_log_options, HighsLogType::kError,
         "checkOption: Option \"%s\" has inconsistent bounds [%g, %g]\n",
         option.name.c_str(), option.lower_bound, option.upper_bound);
     return OptionStatus::kIllegalValue;
   }
   if (option.default_value < option.lower_bound ||
       option.default_value > option.upper_bound) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "checkOption: Option \"%s\" has default value %g "
                  "inconsistent with bounds [%g, %g]\n",
                  option.name.c_str(), option.default_value, option.lower_bound,
@@ -280,7 +280,7 @@ OptionStatus checkOption(const HighsLogOptions& log_options,
   }
   double value = *option.value;
   if (value < option.lower_bound || value > option.upper_bound) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "checkOption: Option \"%s\" has value %g inconsistent with "
                  "bounds [%g, %g]\n",
                  option.name.c_str(), value, option.lower_bound,
@@ -290,17 +290,17 @@ OptionStatus checkOption(const HighsLogOptions& log_options,
   return OptionStatus::kOk;
 }
 
-OptionStatus checkOptionValue(const HighsLogOptions& log_options,
+OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
                               OptionRecordInt& option, const HighsInt value) {
   if (value < option.lower_bound) {
-    highsLogUser(log_options, HighsLogType::kWarning,
+    highsLogUser(report_log_options, HighsLogType::kWarning,
                  "checkOptionValue: Value %" HIGHSINT_FORMAT
                  " for option \"%s\" is below "
                  "lower bound of %" HIGHSINT_FORMAT "\n",
                  value, option.name.c_str(), option.lower_bound);
     return OptionStatus::kIllegalValue;
   } else if (value > option.upper_bound) {
-    highsLogUser(log_options, HighsLogType::kWarning,
+    highsLogUser(report_log_options, HighsLogType::kWarning,
                  "checkOptionValue: Value %" HIGHSINT_FORMAT
                  " for option \"%s\" is above "
                  "upper bound of %" HIGHSINT_FORMAT "\n",
@@ -310,16 +310,16 @@ OptionStatus checkOptionValue(const HighsLogOptions& log_options,
   return OptionStatus::kOk;
 }
 
-OptionStatus checkOptionValue(const HighsLogOptions& log_options,
+OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
                               OptionRecordDouble& option, const double value) {
   if (value < option.lower_bound) {
-    highsLogUser(log_options, HighsLogType::kWarning,
+    highsLogUser(report_log_options, HighsLogType::kWarning,
                  "checkOptionValue: Value %g for option \"%s\" is below "
                  "lower bound of %g\n",
                  value, option.name.c_str(), option.lower_bound);
     return OptionStatus::kIllegalValue;
   } else if (value > option.upper_bound) {
-    highsLogUser(log_options, HighsLogType::kWarning,
+    highsLogUser(report_log_options, HighsLogType::kWarning,
                  "checkOptionValue: Value %g for option \"%s\" is above "
                  "upper bound of %g\n",
                  value, option.name.c_str(), option.upper_bound);
@@ -328,25 +328,25 @@ OptionStatus checkOptionValue(const HighsLogOptions& log_options,
   return OptionStatus::kOk;
 }
 
-OptionStatus checkOptionValue(const HighsLogOptions& log_options,
+OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
                               OptionRecordString& option,
                               const std::string value) {
   // Setting a string option. For some options only particular values
   // are permitted, so check them
   if (option.name == kPresolveString) {
-    if (!commandLineOffChooseOnOk(log_options, value) && value != "mip")
+    if (!commandLineOffChooseOnOk(report_log_options, value) && value != "mip")
       return OptionStatus::kIllegalValue;
   } else if (option.name == kSolverString) {
-    if (!commandLineSolverOk(log_options, value))
+    if (!commandLineSolverOk(report_log_options, value))
       return OptionStatus::kIllegalValue;
   } else if (option.name == kParallelString) {
-    if (!commandLineOffChooseOnOk(log_options, value))
+    if (!commandLineOffChooseOnOk(report_log_options, value))
       return OptionStatus::kIllegalValue;
   }
   return OptionStatus::kOk;
 }
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
                                  std::vector<OptionRecord*>& option_records,
                                  const bool value) {
@@ -354,12 +354,12 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
   //  printf("setLocalOptionValue: \"%s\" with bool %" HIGHSINT_FORMAT "\n",
   //  name.c_str(), value);
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kBool) {
     highsLogUser(
-        log_options, HighsLogType::kError,
+        report_log_options, HighsLogType::kError,
         "setLocalOptionValue: Option \"%s\" cannot be assigned a bool\n",
         name.c_str());
     return OptionStatus::kIllegalValue;
@@ -368,7 +368,7 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
                              value);
 }
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
                                  std::vector<OptionRecord*>& option_records,
                                  const HighsInt value) {
@@ -376,21 +376,21 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
   //  printf("setLocalOptionValue: \"%s\" with HighsInt %" HIGHSINT_FORMAT "\n",
   //  name.c_str(), value);
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kInt) {
     highsLogUser(
-        log_options, HighsLogType::kError,
+        report_log_options, HighsLogType::kError,
         "setLocalOptionValue: Option \"%s\" cannot be assigned an int\n",
         name.c_str());
     return OptionStatus::kIllegalValue;
   }
   return setLocalOptionValue(
-      log_options, ((OptionRecordInt*)option_records[index])[0], value);
+      report_log_options, ((OptionRecordInt*)option_records[index])[0], value);
 }
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
                                  std::vector<OptionRecord*>& option_records,
                                  const double value) {
@@ -398,27 +398,29 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
   //  printf("setLocalOptionValue: \"%s\" with double %g\n", name.c_str(),
   //  value);
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kDouble) {
     highsLogUser(
-        log_options, HighsLogType::kError,
+        report_log_options, HighsLogType::kError,
         "setLocalOptionValue: Option \"%s\" cannot be assigned a double\n",
         name.c_str());
     return OptionStatus::kIllegalValue;
   }
-  return setLocalOptionValue(
-      log_options, ((OptionRecordDouble*)option_records[index])[0], value);
+  return setLocalOptionValue(report_log_options,
+                             ((OptionRecordDouble*)option_records[index])[0],
+                             value);
 }
 
-OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
+                                 HighsLogOptions& log_options,
                                  std::vector<OptionRecord*>& option_records,
                                  const std::string value) {
   HighsInt index;
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type == HighsOptionType::kBool) {
@@ -426,7 +428,7 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
     bool return_status = boolFromString(value, value_bool);
     if (!return_status) {
       highsLogUser(
-          log_options, HighsLogType::kError,
+          report_log_options, HighsLogType::kError,
           "setLocalOptionValue: Value \"%s\" cannot be interpreted as a bool\n",
           value.c_str());
       return OptionStatus::kIllegalValue;
@@ -441,7 +443,7 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
     const int value_num_char = strlen(value_char);
     const bool converted_ok = scanned_num_char == value_num_char;
     if (!converted_ok) {
-      highsLogDev(log_options, HighsLogType::kError,
+      highsLogDev(report_log_options, HighsLogType::kError,
                   "setLocalOptionValue: Value = \"%s\" converts via sscanf as "
                   "%" HIGHSINT_FORMAT
                   " "
@@ -450,21 +452,22 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
                   value.c_str(), value_int, scanned_num_char, value_num_char);
       return OptionStatus::kIllegalValue;
     }
-    return setLocalOptionValue(
-        log_options, ((OptionRecordInt*)option_records[index])[0], value_int);
+    return setLocalOptionValue(report_log_options,
+                               ((OptionRecordInt*)option_records[index])[0],
+                               value_int);
   } else if (type == HighsOptionType::kDouble) {
     HighsInt value_int = atoi(value.c_str());
     double value_double = atof(value.c_str());
     double value_int_double = value_int;
     if (value_double == value_int_double) {
-      highsLogDev(log_options, HighsLogType::kInfo,
+      highsLogDev(report_log_options, HighsLogType::kInfo,
                   "setLocalOptionValue: Value = \"%s\" converts via atoi as "
                   "%" HIGHSINT_FORMAT
                   " "
                   "so is %g as double, and %g via atof\n",
                   value.c_str(), value_int, value_int_double, value_double);
     }
-    return setLocalOptionValue(log_options,
+    return setLocalOptionValue(report_log_options,
                                ((OptionRecordDouble*)option_records[index])[0],
                                atof(value.c_str()));
   } else {
@@ -480,24 +483,26 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
     if (!name.compare(kModelFileString)) {
       // Don't allow model filename to be changed - it's only an
       // option so that reading of run-time options works
-      highsLogUser(log_options, HighsLogType::kError,
+      highsLogUser(report_log_options, HighsLogType::kError,
                    "setLocalOptionValue: model filename cannot be set\n");
       return OptionStatus::kUnknownOption;
     } else {
       return setLocalOptionValue(
-          log_options, ((OptionRecordString*)option_records[index])[0], value);
+          report_log_options, ((OptionRecordString*)option_records[index])[0],
+          value);
     }
   }
 }
 
-OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
+                                 HighsLogOptions& log_options,
                                  std::vector<OptionRecord*>& option_records,
                                  const char* value) {
   // Handles values passed as explicit values in quotes
   std::string value_as_string(value);
-  return setLocalOptionValue(log_options, name, option_records,
-                             value_as_string);
+  return setLocalOptionValue(report_log_options, name, log_options,
+                             option_records, value_as_string);
 }
 
 OptionStatus setLocalOptionValue(OptionRecordBool& option, const bool value) {
@@ -505,42 +510,46 @@ OptionStatus setLocalOptionValue(OptionRecordBool& option, const bool value) {
   return OptionStatus::kOk;
 }
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  OptionRecordInt& option,
                                  const HighsInt value) {
-  OptionStatus return_status = checkOptionValue(log_options, option, value);
+  OptionStatus return_status =
+      checkOptionValue(report_log_options, option, value);
   if (return_status != OptionStatus::kOk) return return_status;
   option.assignvalue(value);
   return OptionStatus::kOk;
 }
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  OptionRecordDouble& option,
                                  const double value) {
-  OptionStatus return_status = checkOptionValue(log_options, option, value);
+  OptionStatus return_status =
+      checkOptionValue(report_log_options, option, value);
   if (return_status != OptionStatus::kOk) return return_status;
   option.assignvalue(value);
   return OptionStatus::kOk;
 }
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  OptionRecordString& option,
                                  const std::string value) {
-  OptionStatus return_status = checkOptionValue(log_options, option, value);
+  OptionStatus return_status =
+      checkOptionValue(report_log_options, option, value);
   if (return_status != OptionStatus::kOk) return return_status;
   option.assignvalue(value);
   return OptionStatus::kOk;
 }
 
-OptionStatus passLocalOptions(const HighsLogOptions& log_options,
+OptionStatus passLocalOptions(const HighsLogOptions& report_log_options,
                               const HighsOptions& from_options,
                               HighsOptions& to_options) {
   // (Attempt to) set option value from the HighsOptions passed in
   OptionStatus return_status;
-  std::string empty_file = "";
-  std::string from_log_file = from_options.log_file;
-  std::string original_to_log_file = to_options.log_file;
-  FILE* original_to_log_file_stream = to_options.log_options.log_file_stream;
+  //  std::string empty_file = "";
+  //  std::string from_log_file = from_options.log_file;
+  //  std::string original_to_log_file = to_options.log_file;
+  //  FILE* original_to_log_file_stream =
+  //  to_options.log_options.log_file_stream;
   HighsInt num_options = to_options.records.size();
   // Check all the option values before setting any of them - in case
   // to_options are the main Highs options. Checks are only needed for
@@ -551,21 +560,22 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
       HighsInt value =
           *(((OptionRecordInt*)from_options.records[index])[0].value);
       return_status = checkOptionValue(
-          log_options, ((OptionRecordInt*)to_options.records[index])[0], value);
+          report_log_options, ((OptionRecordInt*)to_options.records[index])[0],
+          value);
       if (return_status != OptionStatus::kOk) return return_status;
     } else if (type == HighsOptionType::kDouble) {
       double value =
           *(((OptionRecordDouble*)from_options.records[index])[0].value);
       return_status = checkOptionValue(
-          log_options, ((OptionRecordDouble*)to_options.records[index])[0],
-          value);
+          report_log_options,
+          ((OptionRecordDouble*)to_options.records[index])[0], value);
       if (return_status != OptionStatus::kOk) return return_status;
     } else if (type == HighsOptionType::kString) {
       std::string value =
           *(((OptionRecordString*)from_options.records[index])[0].value);
       return_status = checkOptionValue(
-          log_options, ((OptionRecordString*)to_options.records[index])[0],
-          value);
+          report_log_options,
+          ((OptionRecordString*)to_options.records[index])[0], value);
       if (return_status != OptionStatus::kOk) return return_status;
     }
   }
@@ -581,28 +591,30 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
       HighsInt value =
           *(((OptionRecordInt*)from_options.records[index])[0].value);
       return_status = setLocalOptionValue(
-          log_options, ((OptionRecordInt*)to_options.records[index])[0], value);
+          report_log_options, ((OptionRecordInt*)to_options.records[index])[0],
+          value);
       if (return_status != OptionStatus::kOk) return return_status;
     } else if (type == HighsOptionType::kDouble) {
       double value =
           *(((OptionRecordDouble*)from_options.records[index])[0].value);
       return_status = setLocalOptionValue(
-          log_options, ((OptionRecordDouble*)to_options.records[index])[0],
-          value);
+          report_log_options,
+          ((OptionRecordDouble*)to_options.records[index])[0], value);
       if (return_status != OptionStatus::kOk) return return_status;
     } else {
       std::string value =
           *(((OptionRecordString*)from_options.records[index])[0].value);
       return_status = setLocalOptionValue(
-          log_options, ((OptionRecordString*)to_options.records[index])[0],
-          value);
+          report_log_options,
+          ((OptionRecordString*)to_options.records[index])[0], value);
       if (return_status != OptionStatus::kOk) return return_status;
     }
   }
+  /*
   if (from_log_file.compare(original_to_log_file)) {
     // The log file name has changed
     if (from_options.log_options.log_file_stream &&
-	!original_to_log_file.compare(empty_file)) {
+        !original_to_log_file.compare(empty_file)) {
       // The stream corresponding to from_log_file is non-null and the
       // original log file name was empty, so to_options inherits the
       // stream, but associated with the (necessarily) non-empty name
@@ -618,19 +630,20 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
       highsOpenLogFile(to_options, to_options.log_file);
     }
   }
+  */
   return OptionStatus::kOk;
 }
 
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, bool& value) {
   HighsInt index;
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kBool) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "getLocalOptionValue: Option \"%s\" requires value of type "
                  "%s, not bool\n",
                  name.c_str(), optionEntryTypeToString(type).c_str());
@@ -642,15 +655,15 @@ OptionStatus getLocalOptionValue(
 }
 
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, HighsInt& value) {
   HighsInt index;
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kInt) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "getLocalOptionValue: Option \"%s\" requires value of type "
                  "%s, not HighsInt\n",
                  name.c_str(), optionEntryTypeToString(type).c_str());
@@ -662,15 +675,15 @@ OptionStatus getLocalOptionValue(
 }
 
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, double& value) {
   HighsInt index;
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kDouble) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "getLocalOptionValue: Option \"%s\" requires value of type "
                  "%s, not double\n",
                  name.c_str(), optionEntryTypeToString(type).c_str());
@@ -682,15 +695,15 @@ OptionStatus getLocalOptionValue(
 }
 
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, std::string& value) {
   HighsInt index;
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kString) {
-    highsLogUser(log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "getLocalOptionValue: Option \"%s\" requires value of type "
                  "%s, not string\n",
                  name.c_str(), optionEntryTypeToString(type).c_str());
@@ -702,11 +715,11 @@ OptionStatus getLocalOptionValue(
 }
 
 OptionStatus getLocalOptionType(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, HighsOptionType& type) {
   HighsInt index;
   OptionStatus status =
-      getOptionIndex(log_options, name, option_records, index);
+      getOptionIndex(report_log_options, name, option_records, index);
   if (status != OptionStatus::kOk) return status;
   type = option_records[index]->type;
   return OptionStatus::kOk;

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -545,6 +545,8 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
                               HighsOptions& to_options) {
   // (Attempt to) set option value from the HighsOptions passed in
   OptionStatus return_status;
+  std::string from_log_file = from_options.log_file;
+  std::string original_to_log_file = to_options.log_file;
   HighsInt num_options = to_options.records.size();
   // Check all the option values before setting any of them - in case
   // to_options are the main Highs options. Checks are only needed for
@@ -603,6 +605,18 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
       if (return_status != OptionStatus::kOk) return return_status;
     }
   }
+  if (from_log_file.compare(original_to_log_file)) {
+    // The log file name has changed
+    if (from_options.log_file_stream) {
+      assert(from_log_file.compare(""));
+      // The stream corresponding to from_log_file was non-null, so
+      // to_options inherits it. This ensures that the stream to
+      // Highs.log opened in RunHighs.cpp is retained.
+      to_options.log_file_stream = from_options.log_file_stream;
+    } else {
+      highsOpenLogFile(to_options, to_options.log_file);
+    }
+  }    
   return OptionStatus::kOk;
 }
 

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -14,16 +14,17 @@
  * @brief
  */
 #include "lp_data/HighsOptions.h"
+
 #include <cassert>
 
 void setLogOptions();
 
-void highsOpenLogFile(HighsLogOptions& log_options, 
-		      std::vector<OptionRecord*>& option_records,
-		      const std::string log_file) {
+void highsOpenLogFile(HighsLogOptions& log_options,
+                      std::vector<OptionRecord*>& option_records,
+                      const std::string log_file) {
   HighsInt index;
   OptionStatus status =
-    getOptionIndex(log_options, "log_file", option_records, index);
+      getOptionIndex(log_options, "log_file", option_records, index);
   assert(status == OptionStatus::kOk);
   if (log_options.log_file_stream != NULL) {
     // Current log file stream is not null, so flush and close it
@@ -470,10 +471,10 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
     // Setting a string option value
     if (!name.compare(kLogFileString)) {
       OptionRecordString& option = *(OptionRecordString*)option_records[index];
-      std::string original_log_file = "FRED.log";//option.value;
+      std::string original_log_file = "FRED.log";  // option.value;
       if (value.compare(original_log_file)) {
-	// Changing the name of the log file
-	 highsOpenLogFile(log_options, options_records, value);
+        // Changing the name of the log file
+        highsOpenLogFile(log_options, option_records, value);
       }
     }
     if (!name.compare(kModelFileString)) {
@@ -607,7 +608,7 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
     } else {
       highsOpenLogFile(to_options, to_options.log_file);
     }
-  }    
+  }
   return OptionStatus::kOk;
 }
 

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -468,23 +468,14 @@ OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
                                atof(value.c_str()));
   } else {
     // Setting a string option value
-    /*
     if (!name.compare(kLogFileString)) {
-      // Changing the name of the log file
-      if (log_options.log_file_stream != NULL) {
-        // Current log file stream is not null, so flush and close it
-        fflush(log_options.log_file_stream);
-        fclose(log_options.log_file_stream);
-      }
-      if (value.compare("")) {
-        // New log file name is not empty, so open it
-        log_options.log_file_stream = fopen(value.c_str(), "w");
-      } else {
-        // New log file name is empty, so set the stream to null
-        log_options.log_file_stream = NULL;
+      OptionRecordString& option = *(OptionRecordString*)option_records[index];
+      std::string original_log_file = "FRED.log";//option.value;
+      if (value.compare(original_log_file)) {
+	// Changing the name of the log file
+	 highsOpenLogFile(log_options, options_records, value);
       }
     }
-    */
     if (!name.compare(kModelFileString)) {
       // Don't allow model filename to be changed - it's only an
       // option so that reading of run-time options works

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -601,10 +601,6 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
   }
   if (from_log_file.compare(original_to_log_file)) {
     // The log file name has changed
-    printf("%s = original_to_log_file.compare(%s) = %s\n",
-	   original_to_log_file.c_str(),
-	   empty_file.c_str(),
-	   highsBoolToString(original_to_log_file.compare(empty_file)).c_str());
     if (from_options.log_options.log_file_stream &&
 	!original_to_log_file.compare(empty_file)) {
       // The stream corresponding to from_log_file is non-null and the

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -17,7 +17,7 @@
 
 #include <cassert>
 
-void setLogOptions();
+// void setLogOptions();
 
 void highsOpenLogFile(HighsLogOptions& log_options,
                       std::vector<OptionRecord*>& option_records,
@@ -599,12 +599,13 @@ OptionStatus passLocalOptions(const HighsLogOptions& log_options,
   }
   if (from_log_file.compare(original_to_log_file)) {
     // The log file name has changed
-    if (from_options.log_file_stream) {
+    if (from_options.log_options.log_file_stream) {
       assert(from_log_file.compare(""));
       // The stream corresponding to from_log_file was non-null, so
       // to_options inherits it. This ensures that the stream to
       // Highs.log opened in RunHighs.cpp is retained.
-      to_options.log_file_stream = from_options.log_file_stream;
+      to_options.log_options.log_file_stream =
+          from_options.log_options.log_file_stream;
     } else {
       highsOpenLogFile(to_options, to_options.log_file);
     }
@@ -877,7 +878,7 @@ void reportOption(FILE* file, const OptionRecordString& option,
 }
 
 void HighsOptions::setLogOptions() {
-  this->log_options.log_file_stream = this->log_file_stream;
+  //  this->log_options.log_file_stream = this->log_file_stream;
   this->log_options.output_flag = &this->output_flag;
   this->log_options.log_to_console = &this->log_to_console;
   this->log_options.log_dev_level = &this->log_dev_level;

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -878,7 +878,6 @@ void reportOption(FILE* file, const OptionRecordString& option,
 }
 
 void HighsOptions::setLogOptions() {
-  //  this->log_options.log_file_stream = this->log_file_stream;
   this->log_options.output_flag = &this->output_flag;
   this->log_options.log_to_console = &this->log_to_console;
   this->log_options.log_dev_level = &this->log_dev_level;

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -358,6 +358,7 @@ struct HighsOptionsStruct {
   void (*logmsgcb)(HighsLogType type, const char* msg, void* msgcb_data) = NULL;
   void* msgcb_data = NULL;
   HighsLogOptions log_options;
+  HighsInt log_file_index;
   virtual ~HighsOptionsStruct() {}
 };
 
@@ -607,6 +608,8 @@ class HighsOptions : public HighsOptionsStruct {
     record_string = new OptionRecordString(kLogFileString, "Log file", advanced,
                                            &log_file, "Highs.log"); // ""); // 
     records.push_back(record_string);
+    // Record the index of the log_file option
+    log_file_index = records.size();
 
     record_bool =
         new OptionRecordBool("write_solution_to_file",

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -132,94 +132,96 @@ void highsOpenLogFile(HighsLogOptions& log_options,
                       std::vector<OptionRecord*>& option_records,
                       const std::string log_file);
 
-bool commandLineOffChooseOnOk(const HighsLogOptions& log_options,
+bool commandLineOffChooseOnOk(const HighsLogOptions& report_log_options,
                               const string& value);
-bool commandLineSolverOk(const HighsLogOptions& log_options,
+bool commandLineSolverOk(const HighsLogOptions& report_log_options,
                          const string& value);
 
 bool boolFromString(const std::string value, bool& bool_value);
 
-OptionStatus getOptionIndex(const HighsLogOptions& log_options,
+OptionStatus getOptionIndex(const HighsLogOptions& report_log_options,
                             const std::string& name,
                             const std::vector<OptionRecord*>& option_records,
                             HighsInt& index);
 
-OptionStatus checkOptions(const HighsLogOptions& log_options,
+OptionStatus checkOptions(const HighsLogOptions& report_log_options,
                           const std::vector<OptionRecord*>& option_records);
-OptionStatus checkOption(const HighsLogOptions& log_options,
+OptionStatus checkOption(const HighsLogOptions& report_log_options,
                          const OptionRecordInt& option);
-OptionStatus checkOption(const HighsLogOptions& log_options,
+OptionStatus checkOption(const HighsLogOptions& report_log_options,
                          const OptionRecordDouble& option);
 
-OptionStatus checkOptionValue(const HighsLogOptions& log_options,
+OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
                               std::vector<OptionRecord*>& option_records,
                               const HighsInt value);
-OptionStatus checkOptionValue(const HighsLogOptions& log_options,
+OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
                               std::vector<OptionRecord*>& option_records,
                               const double value);
-OptionStatus checkOptionValue(const HighsLogOptions& log_options,
+OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
                               std::vector<OptionRecord*>& option_records,
                               const std::string value);
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
                                  std::vector<OptionRecord*>& option_records,
                                  const bool value);
 
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
                                  std::vector<OptionRecord*>& option_records,
                                  const HighsInt value);
 #ifdef HIGHSINT64
 inline OptionStatus setLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     std::vector<OptionRecord*>& option_records, const int value) {
-  return setLocalOptionValue(log_options, name, option_records,
+  return setLocalOptionValue(report_log_options, name, option_records,
                              HighsInt{value});
 }
 #endif
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
                                  std::vector<OptionRecord*>& option_records,
                                  const double value);
-OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
+                                 HighsLogOptions& log_options,
                                  std::vector<OptionRecord*>& option_records,
                                  const std::string value);
-OptionStatus setLocalOptionValue(HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  const std::string& name,
+                                 HighsLogOptions& log_options,
                                  std::vector<OptionRecord*>& option_records,
                                  const char* value);
 
 OptionStatus setLocalOptionValue(OptionRecordBool& option, const bool value);
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  OptionRecordInt& option, const HighsInt value);
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  OptionRecordDouble& option,
                                  const double value);
-OptionStatus setLocalOptionValue(const HighsLogOptions& log_options,
+OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                  OptionRecordString& option,
                                  std::string const value);
 
-OptionStatus passLocalOptions(const HighsLogOptions& log_options,
+OptionStatus passLocalOptions(const HighsLogOptions& report_log_options,
                               const HighsOptions& from_options,
                               HighsOptions& to_options);
 
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, bool& value);
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, HighsInt& value);
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, double& value);
 OptionStatus getLocalOptionValue(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, std::string& value);
 
 OptionStatus getLocalOptionType(
-    const HighsLogOptions& log_options, const std::string& name,
+    const HighsLogOptions& report_log_options, const std::string& name,
     const std::vector<OptionRecord*>& option_records, HighsOptionType& type);
 
 void resetLocalOptions(std::vector<OptionRecord*>& option_records);
@@ -606,7 +608,7 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_string);
 
     record_string = new OptionRecordString(kLogFileString, "Log file", advanced,
-                                           &log_file, "");  // "Highs.log"); //
+                                           &log_file, "");
     records.push_back(record_string);
 
     record_bool =

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -601,7 +601,7 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_string);
 
     record_string = new OptionRecordString(kLogFileString, "Log file", advanced,
-                                           &log_file, "Highs.log");
+                                           &log_file, "Highs.log"); // ""); // 
     records.push_back(record_string);
 
     record_bool =
@@ -892,7 +892,7 @@ class HighsOptions : public HighsOptionsStruct {
                              &less_infeasible_DSE_choose_row, true);
     records.push_back(record_bool);
 
-    log_file_stream = fopen(log_file.c_str(), "w");
+    log_file_stream = log_file.empty() ? NULL : fopen(log_file.c_str(), "w");
     log_options.log_file_stream = log_file_stream;
     log_options.output_flag = &output_flag;
     log_options.log_to_console = &log_to_console;

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -128,9 +128,9 @@ class OptionRecordString : public OptionRecord {
   virtual ~OptionRecordString() {}
 };
 
-void highsOpenLogFile(HighsLogOptions& log_options, 
-		      std::vector<OptionRecord*>& option_records,
-		      const std::string log_file);
+void highsOpenLogFile(HighsLogOptions& log_options,
+                      std::vector<OptionRecord*>& option_records,
+                      const std::string log_file);
 
 bool commandLineOffChooseOnOk(const HighsLogOptions& log_options,
                               const string& value);
@@ -606,7 +606,7 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_string);
 
     record_string = new OptionRecordString(kLogFileString, "Log file", advanced,
-                                           &log_file, ""); // "Highs.log"); // 
+                                           &log_file, "");  // "Highs.log"); //
     records.push_back(record_string);
     // Record the index of the log_file option
     log_file_index = records.size();

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -128,6 +128,10 @@ class OptionRecordString : public OptionRecord {
   virtual ~OptionRecordString() {}
 };
 
+void highsOpenLogFile(HighsLogOptions& log_options, 
+		      std::vector<OptionRecord*>& option_records,
+		      const std::string log_file);
+
 bool commandLineOffChooseOnOk(const HighsLogOptions& log_options,
                               const string& value);
 bool commandLineSolverOk(const HighsLogOptions& log_options,

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -606,7 +606,7 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_string);
 
     record_string = new OptionRecordString(kLogFileString, "Log file", advanced,
-                                           &log_file, "Highs.log"); // ""); // 
+                                           &log_file, ""); // "Highs.log"); // 
     records.push_back(record_string);
     // Record the index of the log_file option
     log_file_index = records.size();

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -19,8 +19,8 @@
 #include "io/LoadOptions.h"
 #include "util/stringutil.h"
 
-bool loadOptions(int argc, char** argv, HighsOptions& options,
-                 std::string& model_file) {
+bool loadOptions(const HighsLogOptions& report_log_options, int argc,
+                 char** argv, HighsOptions& options, std::string& model_file) {
   try {
     cxxopts::Options cxx_options(argv[0], "HiGHS options");
     cxx_options.positional_help("[file]").show_positional_help();
@@ -88,28 +88,31 @@ bool loadOptions(int argc, char** argv, HighsOptions& options,
 
     if (result.count(kPresolveString)) {
       std::string value = result[kPresolveString].as<std::string>();
-      if (setLocalOptionValue(options.log_options, kPresolveString,
-                              options.records, value) != OptionStatus::kOk)
+      if (setLocalOptionValue(report_log_options, kPresolveString,
+                              options.log_options, options.records,
+                              value) != OptionStatus::kOk)
         return false;
     }
 
     if (result.count(kSolverString)) {
       std::string value = result[kSolverString].as<std::string>();
-      if (setLocalOptionValue(options.log_options, kSolverString,
-                              options.records, value) != OptionStatus::kOk)
+      if (setLocalOptionValue(report_log_options, kSolverString,
+                              options.log_options, options.records,
+                              value) != OptionStatus::kOk)
         return false;
     }
 
     if (result.count(kParallelString)) {
       std::string value = result[kParallelString].as<std::string>();
-      if (setLocalOptionValue(options.log_options, kParallelString,
-                              options.records, value) != OptionStatus::kOk)
+      if (setLocalOptionValue(report_log_options, kParallelString,
+                              options.log_options, options.records,
+                              value) != OptionStatus::kOk)
         return false;
     }
 
     if (result.count(kTimeLimitString)) {
       double value = result[kTimeLimitString].as<double>();
-      if (setLocalOptionValue(options.log_options, kTimeLimitString,
+      if (setLocalOptionValue(report_log_options, kTimeLimitString,
                               options.records, value) != OptionStatus::kOk)
         return false;
     }
@@ -120,7 +123,7 @@ bool loadOptions(int argc, char** argv, HighsOptions& options,
         std::cout << "Multiple options files not implemented.\n";
         return false;
       }
-      if (!loadOptionsFromFile(options, v[0])) return false;
+      if (!loadOptionsFromFile(report_log_options, options, v[0])) return false;
     }
 
     if (result.count(kSolutionFileString)) {
@@ -129,29 +132,31 @@ bool loadOptions(int argc, char** argv, HighsOptions& options,
         std::cout << "Multiple solution files not implemented.\n";
         return false;
       }
-      if (setLocalOptionValue(options.log_options, kSolutionFileString,
-                              options.records, v[0]) != OptionStatus::kOk ||
-          setLocalOptionValue(options.log_options, "write_solution_to_file",
+      if (setLocalOptionValue(report_log_options, kSolutionFileString,
+                              options.log_options, options.records,
+                              v[0]) != OptionStatus::kOk ||
+          setLocalOptionValue(report_log_options, "write_solution_to_file",
                               options.records, true) != OptionStatus::kOk)
         return false;
     }
 
     if (result.count(kRandomSeedString)) {
       HighsInt value = result[kRandomSeedString].as<HighsInt>();
-      if (setLocalOptionValue(options.log_options, kRandomSeedString,
+      if (setLocalOptionValue(report_log_options, kRandomSeedString,
                               options.records, value) != OptionStatus::kOk)
         return false;
     }
 
     if (result.count(kRangingString)) {
       std::string value = result[kRangingString].as<std::string>();
-      if (setLocalOptionValue(options.log_options, kRangingString,
-                              options.records, value) != OptionStatus::kOk)
+      if (setLocalOptionValue(report_log_options, kRangingString,
+                              options.log_options, options.records,
+                              value) != OptionStatus::kOk)
         return false;
     }
 
   } catch (const cxxopts::OptionException& e) {
-    highsLogUser(options.log_options, HighsLogType::kError,
+    highsLogUser(report_log_options, HighsLogType::kError,
                  "Error parsing options: %s\n", e.what());
     return false;
   }

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -320,17 +320,17 @@ void HEkkPrimal::initialiseInstance() {
     highsLogDev(ekk_instance_.options_->log_options, HighsLogType::kInfo,
                 "HEkkPrimal:: LP has %" HIGHSINT_FORMAT " free columns\n",
                 num_free_col);
-    nonbasic_free_col_set.setup(num_free_col, num_tot,
-                                ekk_instance_.options_->output_flag,
-                                ekk_instance_.options_->log_file_stream, debug);
+    nonbasic_free_col_set.setup(
+        num_free_col, num_tot, ekk_instance_.options_->output_flag,
+        ekk_instance_.options_->log_options.log_file_stream, debug);
   }
   // Set up the hyper-sparse CHUZC data
   hyper_chuzc_candidate.resize(1 + max_num_hyper_chuzc_candidates);
   hyper_chuzc_measure.resize(1 + max_num_hyper_chuzc_candidates);
-  hyper_chuzc_candidate_set.setup(max_num_hyper_chuzc_candidates, num_tot,
-                                  ekk_instance_.options_->output_flag,
-                                  ekk_instance_.options_->log_file_stream,
-                                  debug);
+  hyper_chuzc_candidate_set.setup(
+      max_num_hyper_chuzc_candidates, num_tot,
+      ekk_instance_.options_->output_flag,
+      ekk_instance_.options_->log_options.log_file_stream, debug);
 }
 
 void HEkkPrimal::initialiseSolve() {


### PR DESCRIPTION
Prevents Highs.log from being created when the Highs class is instantiated, and also rather more robust with respect to logging options