### PR TITLE
Introduced info_.max_integrality_violation

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -2,7 +2,7 @@
 #include "SpecialLps.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double double_equal_tolerance = 1e-5;
 
 void solve(Highs& highs, std::string presolve,
@@ -120,39 +120,15 @@ TEST_CASE("MIP-nmck", "[highs_test_mip_solver]") {
   lp.integrality_ = {HighsVarType::kContinuous, HighsVarType::kContinuous,
                      HighsVarType::kInteger};
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
-  highs.setOptionValue("solver", "mip");
-  REQUIRE(highs.run() == HighsStatus::kOk);
+  highs.setOptionValue("highs_debug_level", kHighsDebugLevelCheap);
+  highs.setOptionValue("log_dev_level", 2);
+  HighsStatus return_status = highs.run();
+  REQUIRE(return_status == HighsStatus::kOk);
+  if (dev_run) highs.writeInfo("");
   const HighsInfo& info = highs.getInfo();
-  const HighsSolution& solution = highs.getSolution();
-  if (dev_run) {
-    printf("INFO: valid = %d\n", (int)info.valid);
-    printf("INFO: mip_node_count = %d\n", (int)info.mip_node_count);
-    printf("INFO: simplex_iteration_count = %d\n",
-           (int)info.simplex_iteration_count);
-    printf("INFO: ipm_iteration_count = %d\n", (int)info.ipm_iteration_count);
-    printf("INFO: qp_iteration_count = %d\n", (int)info.qp_iteration_count);
-    printf("INFO: crossover_iteration_count = %d\n",
-           (int)info.crossover_iteration_count);
-    printf("INFO: primal_solution_status = %d\n",
-           (int)info.primal_solution_status);
-    printf("INFO: dual_solution_status = %d\n", (int)info.dual_solution_status);
-    printf("INFO: basis_validity = %d\n", (int)info.basis_validity);
-    printf("INFO: objective_function_value = %g\n",
-           info.objective_function_value);
-    printf("INFO: mip_dual_bound = %g\n", info.mip_dual_bound);
-    printf("INFO: mip_gap = %g\n", info.mip_gap);
-    printf("INFO: num_primal_infeasibilities = %d\n",
-           (int)info.num_primal_infeasibilities);
-    printf("INFO: max_primal_infeasibility = %g\n",
-           info.max_primal_infeasibility);
-    printf("INFO: sum_primal_infeasibilities = %g\n",
-           info.sum_primal_infeasibilities);
-    printf("INFO: num_dual_infeasibilities = %d\n",
-           (int)info.num_dual_infeasibilities);
-    printf("INFO: max_dual_infeasibility = %g\n", info.max_dual_infeasibility);
-    printf("INFO: sum_dual_infeasibilities = %g\n",
-           info.sum_dual_infeasibilities);
-  }
+  REQUIRE(info.num_primal_infeasibilities == 0);
+  REQUIRE(info.max_primal_infeasibility == 0);
+  REQUIRE(info.sum_primal_infeasibilities == 0);
 }
 
 TEST_CASE("MIP-od", "[highs_test_mip_solver]") {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2436,15 +2436,27 @@ HighsStatus Highs::callSolveMip() {
   if (use_mip_feasibility_tolerance) {
     // Overwrite max infeasibility to include integrality if there is a solution
     if (solver.solution_objective_ != kHighsInf) {
-      info_.num_primal_infeasibilities = kHighsIllegalInfeasibilityCount;
-      info_.max_primal_infeasibility =
-          std::max({solver.row_violation_, solver.bound_violation_,
-                    solver.integrality_violation_});
-      if (info_.max_primal_infeasibility > options_.mip_feasibility_tolerance) {
+      const double mip_max_bound_violation =
+          std::max(solver.row_violation_, solver.bound_violation_);
+      const double mip_max_infeasibility =
+          std::max(mip_max_bound_violation, solver.integrality_violation_);
+      const double delta_max_bound_violation =
+          std::abs(mip_max_bound_violation - info_.max_primal_infeasibility);
+      // Possibly report a mis-match between the max bound violation
+      // returned by the MIP solver, and the value obtained from the
+      // solution
+      if (delta_max_bound_violation > 1e-12)
+        highsLogDev(options_.log_options, HighsLogType::kWarning,
+                    "Inconsistent max bound violation: MIP solver (%10.4g); LP "
+                    "(%10.4g); Difference of %10.4g\n",
+                    mip_max_bound_violation, info_.max_primal_infeasibility,
+                    delta_max_bound_violation);
+      info_.max_integrality_violation = solver.integrality_violation_;
+      if (info_.max_integrality_violation >
+          options_.mip_feasibility_tolerance) {
         info_.primal_solution_status = kSolutionStatusInfeasible;
-        // model_status_ = HighsModelStatus::kNotset;
+        assert(model_status_ == HighsModelStatus::kInfeasible);
       }
-      info_.sum_primal_infeasibilities = kHighsIllegalInfeasibilityMeasure;
     }
     // Recover the primal feasibility tolerance
     options_.primal_feasibility_tolerance = primal_feasibility_tolerance;

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -30,6 +30,7 @@ void HighsInfo::clear() {
   objective_function_value = 0;
   mip_dual_bound = 0;
   mip_gap = kHighsInf;
+  max_integrality_violation = kHighsIllegalInfeasibilityMeasure;
   num_primal_infeasibilities = kHighsIllegalInfeasibilityCount;
   max_primal_infeasibility = kHighsIllegalInfeasibilityMeasure;
   sum_primal_infeasibilities = kHighsIllegalInfeasibilityMeasure;

--- a/src/lp_data/HighsInfo.h
+++ b/src/lp_data/HighsInfo.h
@@ -140,6 +140,7 @@ struct HighsInfoStruct {
   double objective_function_value;
   double mip_dual_bound;
   double mip_gap;
+  double max_integrality_violation;
   HighsInt num_primal_infeasibilities;
   double max_primal_infeasibility;
   double sum_primal_infeasibilities;
@@ -259,6 +260,11 @@ class HighsInfo : public HighsInfoStruct {
 
     record_double = new InfoRecordDouble("mip_gap", "MIP solver gap (%)",
                                          advanced, &mip_gap, 0);
+    records.push_back(record_double);
+
+    record_double = new InfoRecordDouble("max_integrality_violation",
+                                         "Max integrality violation", advanced,
+                                         &max_integrality_violation, 0);
     records.push_back(record_double);
 
     record_int = new InfoRecordInt("num_primal_infeasibilities",


### PR DESCRIPTION
I've introduced max_integrality_violation to HighsInfo

- So num/sum/max_primal_infeasibilit(ies)/(y) only correspond to variable and constraint bounds
- Since integrality violations are governed by options_.mip_feasibility_tolerance 

As well as clearing up a mess in debug code to check that num/sum/max_primal_infeasibilit(ies)/(y) have been set correctly when HiGHS returns from run(), it also means that if someone has a model_status of kInfeasible for their MIP, they can see whether it's due to violating bounds or integrality, and possibly judge whether to accept the solution or adjust tolerances and re-solve.