### PR TITLE
Parallel compiler warnings

### DIFF
--- a/src/parallel/HighsTask.h
+++ b/src/parallel/HighsTask.h
@@ -63,7 +63,7 @@ class HighsTask {
     static void do_call(const char* functorBytes) {
       // declaring F f would fail as type F is not default constructible
       FunctorSpace s{};
-      std::memcpy(&s.f, functorBytes, sizeof(F));
+      std::memcpy(reinterpret_cast<char*>(&s.f), functorBytes, sizeof(F));
       s.f();
     }
   };


### PR DESCRIPTION
Context: for SciPy, there is a push to turn on the `-Werror` flag when switching to our new build system (meson).  HiGHS currently has just a few warnings that might have upstream solutions.

Here is an attempt at solving the current build warnings for `-Wclass-memaccess` we see using GCC.  The issue is that lambdas are not necessarily trivially copyable, so I understand that the current code using unions and memcpy to avoid heap allocations may be undefined behavior and vary compiler to compiler (or at the very least, it seems like it's abusing union/struct packing).

This PR's patch is obviously not the solution as we don't want to bump minimum compiler support to only those implementing C++17 standards, but it's the best I could come up with in an hour or so and demonstrates the kind of solution that is hopefully possible.  This seems to be an application that `std::launder` was made for, so I wonder if there will ever be a clean solution without C++17 compiler support.  The other thing to do would just add the `-Wno-class-memaccess` flag for these sources.

cc @rgommers 

EDIT: well the CI results maybe suggest my solution wasn't as good as I thought it was :)