### PR TITLE
Integrality validation

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -230,20 +230,49 @@ void minimal_api_mip() {
   HighsInt aindex[6] = {0, 1, 0, 1, 0, 1};
   double avalue[6] = {1.0, 4.0, 1.0, 2.0, 1.0, 1.0};
 
+  // Give an illegal value to an entry in integrality
   HighsInt integrality[3] = {0, 0, -1};
 
   double* colvalue = (double*)malloc(sizeof(double) * numcol);
   double* rowvalue = (double*)malloc(sizeof(double) * numrow);
 
   HighsInt modelstatus;
+  HighsInt return_status;
 
-  HighsInt return_status = Highs_mipCall(numcol, numrow, numnz, a_format,
+  return_status = Highs_mipCall(numcol, numrow, numnz, a_format,
 					 sense, offset, colcost, collower, colupper, rowlower, rowupper,
 					 astart, aindex, avalue,
 					 integrality,
 					 colvalue, rowvalue,
 					 &modelstatus);
 
+  // Should return error
+  assert( return_status == -1 );
+
+  // Non-empty integrality for a continuous problem yields a warning
+  integrality[numcol-1] = 0;
+
+  return_status = Highs_mipCall(numcol, numrow, numnz, a_format,
+					 sense, offset, colcost, collower, colupper, rowlower, rowupper,
+					 astart, aindex, avalue,
+					 integrality,
+					 colvalue, rowvalue,
+					 &modelstatus);
+
+  // Should return warning
+  assert( return_status == 1 );
+
+  // Genuine integrality is fine
+  integrality[numcol-1] = 1;
+
+  return_status = Highs_mipCall(numcol, numrow, numnz, a_format,
+					 sense, offset, colcost, collower, colupper, rowlower, rowupper,
+					 astart, aindex, avalue,
+					 integrality,
+					 colvalue, rowvalue,
+					 &modelstatus);
+
+  // Should return OK
   assert( return_status == 0 );
 
   if (dev_run) {
@@ -781,15 +810,15 @@ void test_getColsByRange() {
 }
 
 int main() {
-    minimal_api();
-    full_api();
-    minimal_api_lp();
-    minimal_api_mip();
-    minimal_api_qp();
-    full_api_lp();
-    //  full_api_mip();
-    full_api_qp();
-    options();
-    test_getColsByRange();
+  minimal_api();
+  full_api();
+  minimal_api_lp();
+  minimal_api_mip();
+  minimal_api_qp();
+  full_api_lp();
+  //  full_api_mip();
+  full_api_qp();
+  options();
+  test_getColsByRange();
   return 0;
 }

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -230,7 +230,7 @@ void minimal_api_mip() {
   HighsInt aindex[6] = {0, 1, 0, 1, 0, 1};
   double avalue[6] = {1.0, 4.0, 1.0, 2.0, 1.0, 1.0};
 
-  HighsInt integrality[6] = {0, 0, 1};
+  HighsInt integrality[3] = {0, 0, -1};
 
   double* colvalue = (double*)malloc(sizeof(double) * numcol);
   double* rowvalue = (double*)malloc(sizeof(double) * numrow);

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -349,12 +349,18 @@ HighsStatus Highs::passModel(
     lp.integrality_.resize(num_col);
     for (HighsInt iCol = 0; iCol < num_col; iCol++) {
       HighsInt integrality_status = integrality[iCol];
-      /*
-      assert(integrality_status == (HighsInt)HighsVarType::kContinuous ||
-             integrality_status == (HighsInt)HighsVarType::kInteger ||
-	     integrality_status == (HighsInt)HighsVarType::kSemiContinuous ||
-             integrality_status == (HighsInt)HighsVarType::kSemiInteger);
-      */
+      const bool legal_integrality_status =
+          integrality_status == (HighsInt)HighsVarType::kContinuous ||
+          integrality_status == (HighsInt)HighsVarType::kInteger ||
+          integrality_status == (HighsInt)HighsVarType::kSemiContinuous ||
+          integrality_status == (HighsInt)HighsVarType::kSemiInteger;
+      if (!legal_integrality_status) {
+        highsLogDev(
+            options_.log_options, HighsLogType::kError,
+            "Model has illegal integer value of %d for integrality[%d]\n",
+            (int)integrality_status, iCol);
+        return HighsStatus::kError;
+      }
       lp.integrality_[iCol] = (HighsVarType)integrality_status;
     }
   }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -349,8 +349,12 @@ HighsStatus Highs::passModel(
     lp.integrality_.resize(num_col);
     for (HighsInt iCol = 0; iCol < num_col; iCol++) {
       HighsInt integrality_status = integrality[iCol];
+      /*
       assert(integrality_status == (HighsInt)HighsVarType::kContinuous ||
-             integrality_status == (HighsInt)HighsVarType::kInteger);
+             integrality_status == (HighsInt)HighsVarType::kInteger ||
+	     integrality_status == (HighsInt)HighsVarType::kSemiContinuous ||
+             integrality_status == (HighsInt)HighsVarType::kSemiInteger);
+      */
       lp.integrality_[iCol] = (HighsVarType)integrality_status;
     }
   }


### PR DESCRIPTION
This adds validation when `integrality` is passed as a HighsInt pointer. If values are not in {0, 1, 2, 3} then an error is reported and returned. 
Elsewhere, if `integrality` is not empty in assessIntegrality (lp_data/HighsLpUtils.h) a warning is returned (ultimately) from Highs::passModel. I thought of this as a helpful trigger to users that non-zero entries had not been set. However, it's open for discussion!