### PR TITLE
solution_.dual_valid set true after no crossover and postsolve so that dual values are reported in solution file

### DIFF
--- a/src/ipm/IpxWrapper.cpp
+++ b/src/ipm/IpxWrapper.cpp
@@ -217,9 +217,15 @@ HighsStatus reportIpxIpmCrossoverStatus(const HighsOptions& options,
   else
     method_name = "Crossover";
   if (status == IPX_STATUS_not_run) {
-    highsLogUser(options.log_options, HighsLogType::kWarning,
-                 "Ipx: %s not run\n", method_name.c_str());
-    return HighsStatus::kWarning;
+    if (ipm_status || options.run_crossover) {
+      // Warn if method not run is IPM or run_crossover option is true
+      highsLogUser(options.log_options, HighsLogType::kWarning,
+		   "Ipx: %s not run\n", method_name.c_str());
+      return HighsStatus::kWarning;
+    }
+    // OK if method not run is crossover and run_crossover option is
+    // false!
+    return HighsStatus::kOk;
   } else if (status == IPX_STATUS_optimal) {
     highsLogUser(options.log_options, HighsLogType::kInfo, "Ipx: %s optimal\n",
                  method_name.c_str());

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -968,8 +968,9 @@ HighsStatus Highs::run() {
           solution_ = presolve_.data_.recovered_solution_;
           solution_.value_valid = true;
           if (ipx_no_crossover) {
-            // IPX was used without crossover, so only have a primal solution
-            solution_.dual_valid = false;
+            // IPX was used without crossover, so only have primal and dual
+            // solution
+            solution_.dual_valid = true;
             basis_.clear();
             basis_.valid = false;
           } else {

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -678,14 +678,16 @@ HighsStatus ipxSolutionToHighsSolution(
       primal_truncation_norm =
           std::max(primal_truncation, primal_truncation_norm);
       dual_truncation_norm = std::max(dual_truncation, dual_truncation_norm);
+      /*
       if (dual_truncation > 1e-2 || primal_truncation > 1e-2)
         printf(
-            "%s %4d: [%11.4g, %11.4g, %11.4g] residual = %11.4g; new = %11.4g; "
+            "%s %5d: [%11.4g, %11.4g, %11.4g] residual = %11.4g; new = %11.4g; "
             "truncation = %11.4g | "
             "dual = %11.4g; new = %11.4g; truncation = %11.4g\n",
             is_col ? "Col" : "Row", (int)(is_col ? col : row), lower, value,
             upper, residual, new_value, primal_truncation, dual, new_dual,
             dual_truncation);
+      */
       if (is_col) {
         highs_solution.col_value[col] = new_value;
         highs_solution.col_dual[col] = new_dual;
@@ -697,19 +699,19 @@ HighsStatus ipxSolutionToHighsSolution(
     // Assess the truncations
     //  if (dual_truncation_norm >= dual_margin)
     highsLogDev(options.log_options, HighsLogType::kInfo,
-                "ipxSolutionToHighsSolution: Norm of %4d col  primal "
+                "ipxSolutionToHighsSolution: Norm of %6d col  primal "
                 "truncations is %10.4g\n",
                 num_col_primal_truncations, col_primal_truncation_norm);
     highsLogDev(options.log_options, HighsLogType::kInfo,
-                "ipxSolutionToHighsSolution: Norm of %4d row  primal "
+                "ipxSolutionToHighsSolution: Norm of %6d row  primal "
                 "truncations is %10.4g\n",
                 num_primal_truncations, primal_truncation_norm);
     highsLogDev(options.log_options, HighsLogType::kInfo,
-                "ipxSolutionToHighsSolution: Norm of %4d col    dual "
+                "ipxSolutionToHighsSolution: Norm of %6d col    dual "
                 "truncations is %10.4g\n",
                 num_col_dual_truncations, col_dual_truncation_norm);
     highsLogDev(options.log_options, HighsLogType::kInfo,
-                "ipxSolutionToHighsSolution: Norm of %4d row    dual "
+                "ipxSolutionToHighsSolution: Norm of %6d row    dual "
                 "truncations is %10.4g\n",
                 num_dual_truncations, dual_truncation_norm);
     // Determine the new residuals


### PR DESCRIPTION
Very minor change. Had forgotten to set solution_.dual_valid set true after no crossover so dual values weren't being reported in the solution file. Also removed printf statements when truncating primal and dual values to ensure  feasiblility before postsolve.