### PR TITLE
Add a guard to avoid defining `__STDC_FORMAT_MACROS` twice

### DIFF
--- a/src/util/HighsInt.h
+++ b/src/util/HighsInt.h
@@ -20,7 +20,9 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #endif
 #include <inttypes.h>
 


### PR DESCRIPTION
This resulted in a (harmless but scary-looking) build warning in SciPy, because we build a Python extension with both HiGHS
and NumPy in it, and NumPy headers define this macro with a value of `1`. Both defines are common and it doesn't really matter, but the compiler sees this as a redefinition.