### PR TITLE
Added unit test for singular and incomplete advanced basis start

### DIFF
--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -206,8 +206,9 @@ TEST_CASE("AlienBasis-rectangular-completion", "[highs_test_alien_basis]") {
   double solution_error = 0;
   for (HighsInt iRow = 0; iRow < num_row; iRow++)
     solution_error += std::abs(rhs.array[iRow] - solution[iRow]);
-  if (dev_run) printf("AlienBasis-rectangular-completion: solution_error = %g\n",
-		      solution_error);
+  if (dev_run)
+    printf("AlienBasis-rectangular-completion: solution_error = %g\n",
+           solution_error);
   fflush(stdout);
 
   REQUIRE(solution_error < 1e-8);
@@ -546,18 +547,21 @@ TEST_CASE("AlienBasis-reuse-basis", "[highs_test_alien_basis]") {
   highs.addRow(-inf, 108, 3, &new_index[0], &new_value[0]);
   const bool singlar_also = true;
   if (singlar_also) {
+    const HighsInt from_col = 0;
+    const HighsInt to_col = 0;
     HighsInt get_num_col;
     double get_cost;
     double get_lower;
     double get_upper;
     HighsInt get_num_nz;
-    highs.getCols(0, 0, get_num_col, &get_cost, &get_lower, &get_upper,
-                  get_num_nz, NULL, NULL, NULL);
+    highs.getCols(from_col, to_col, get_num_col, &get_cost, &get_lower,
+                  &get_upper, get_num_nz, NULL, NULL, NULL);
     vector<HighsInt> get_start(get_num_col + 1);
     vector<HighsInt> get_index(get_num_nz);
     vector<double> get_value(get_num_nz);
-    highs.getCols(0, 0, get_num_col, &get_cost, &get_lower, &get_upper,
-                  get_num_nz, &get_start[0], &get_index[0], &get_value[0]);
+    highs.getCols(from_col, to_col, get_num_col, &get_cost, &get_lower,
+                  &get_upper, get_num_nz, &get_start[0], &get_index[0],
+                  &get_value[0]);
 
     // Make the first two columns parallel, so that the saved basis is
     // singular, as well as having too few basic variables

--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -206,8 +206,8 @@ TEST_CASE("AlienBasis-rectangular-completion", "[highs_test_alien_basis]") {
   double solution_error = 0;
   for (HighsInt iRow = 0; iRow < num_row; iRow++)
     solution_error += std::abs(rhs.array[iRow] - solution[iRow]);
-  printf("AlienBasis-rectangular-completion: solution_error = %g\n",
-         solution_error);
+  if (dev_run) printf("AlienBasis-rectangular-completion: solution_error = %g\n",
+		      solution_error);
   fflush(stdout);
 
   REQUIRE(solution_error < 1e-8);
@@ -514,4 +514,66 @@ void testAlienBasis(const bool avgas, const HighsInt seed) {
     REQUIRE(highs.setBasis(basis) == HighsStatus::kOk);
     highs.run();
   }
+}
+
+TEST_CASE("AlienBasis-reuse-basis", "[highs_test_alien_basis]") {
+  HighsLp lp;
+  lp.num_col_ = 2;
+  lp.num_row_ = 3;
+  lp.col_cost_ = {400, 650};
+  lp.col_lower_ = {0, 0};
+  lp.col_upper_ = {inf, inf};
+  lp.row_lower_ = {-inf, -inf, -inf};
+  lp.row_upper_ = {140, 14, 85};
+  lp.a_matrix_.start_ = {0, 3, 6};
+  lp.a_matrix_.index_ = {0, 1, 2, 0, 1, 2};
+  lp.a_matrix_.value_ = {15, 2, 10, 25, 3, 20};
+  lp.sense_ = ObjSense::kMaximize;
+  Highs highs;
+  if (!dev_run) highs.setOptionValue("output_flag", false);
+  highs.passModel(lp);
+  highs.run();
+  highs.writeSolution("", 1);
+  HighsBasis basis = highs.getBasis();
+  // Add another variable
+  vector<HighsInt> new_index = {0, 1, 2};
+  vector<double> new_value = {50, 4, 30};
+  highs.addCol(850, 0, inf, 3, &new_index[0], &new_value[0]);
+  // Add a new constraint
+  new_value[0] = 15;
+  new_value[1] = 24;
+  new_value[2] = 30;
+  highs.addRow(-inf, 108, 3, &new_index[0], &new_value[0]);
+  const bool singlar_also = true;
+  if (singlar_also) {
+    HighsInt get_num_col;
+    double get_cost;
+    double get_lower;
+    double get_upper;
+    HighsInt get_num_nz;
+    highs.getCols(0, 0, get_num_col, &get_cost, &get_lower, &get_upper,
+                  get_num_nz, NULL, NULL, NULL);
+    vector<HighsInt> get_start(get_num_col + 1);
+    vector<HighsInt> get_index(get_num_nz);
+    vector<double> get_value(get_num_nz);
+    highs.getCols(0, 0, get_num_col, &get_cost, &get_lower, &get_upper,
+                  get_num_nz, &get_start[0], &get_index[0], &get_value[0]);
+
+    // Make the first two columns parallel, so that the saved basis is
+    // singular, as well as having too few basic variables
+    REQUIRE(highs.changeCoeff(0, 1, 30) == HighsStatus::kOk);
+    REQUIRE(highs.changeCoeff(1, 1, 4) == HighsStatus::kOk);
+    REQUIRE(highs.changeCoeff(2, 1, 20) == HighsStatus::kOk);
+    REQUIRE(highs.changeCoeff(3, 1, 30) == HighsStatus::kOk);
+  }
+
+  if (dev_run) highs.setOptionValue("log_dev_level", 3);
+  highs.setOptionValue("simplex_scale_strategy", 0);
+  // Make the basis status for new row and column nonbasic
+  basis.col_status.push_back(HighsBasisStatus::kNonbasic);
+  basis.row_status.push_back(HighsBasisStatus::kNonbasic);
+  basis.alien = true;
+  REQUIRE(highs.setBasis(basis) == HighsStatus::kOk);
+  highs.run();
+  highs.writeSolution("", 1);
 }

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -3,7 +3,7 @@
 #include "HighsLpUtils.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 
 // No commas in test case name.
 TEST_CASE("LP-dimension-validation", "[highs_data]") {

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -581,6 +581,12 @@ bool considerScaling(const HighsOptions& options, HighsLp& lp) {
   const bool allow_scaling =
       lp.num_col_ > 0 &&
       options.simplex_scale_strategy != kSimplexScaleStrategyOff;
+  if (lp.scale_.has_scaling && !allow_scaling) {
+    // LP had scaling before, but now it is not permitted, clear any
+    // scaling. Return true as scaling position has changed
+    lp.clearScale();
+    return true;
+  }
   const bool scaling_not_tried = lp.scale_.strategy == kSimplexScaleStrategyOff;
   const bool new_scaling_strategy =
       options.simplex_scale_strategy != lp.scale_.strategy &&


### PR DESCRIPTION
This follows from the comment by @chrhansk  in #669 about the way he was using HiGHS (He's solving NLPs by SLP, it would seem). I wanted to confirm that accommodateAlienBasis can handle a basis that's an old optimal basis extended with both a row and column, and with matrix coefficients changed so that it's got numerical rank deficiency.