### PR TITLE
Corrected getVariableKktFailures to handle semi-variables

### DIFF
--- a/src/lp_data/HighsSolution.h
+++ b/src/lp_data/HighsSolution.h
@@ -79,7 +79,8 @@ void getVariableKktFailures(const double primal_feasibility_tolerance,
                             const double dual_feasibility_tolerance,
                             const double lower, const double upper,
                             const double value, const double dual,
-                            HighsBasisStatus* status_pointer,
+                            const HighsBasisStatus* status_pointer,
+                            const HighsVarType integrality,
                             double& primal_infeasibility,
                             double& dual_infeasibility, double& value_residual);
 


### PR DESCRIPTION
Very simple change to getVariableKktFailures so that it doesn't identify a primal infeasibility when a semi-variable is zero but has bounds that don't include 0.