### PR TITLE
Fix uninitialized warnings

### DIFF
--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -154,10 +154,10 @@ bool HighsImplications::runProbing(HighsInt col, HighsInt& numReductions) {
       return true;
 
     // analyze implications
-    const HighsDomainChange* implicsup;
-    const HighsDomainChange* implicsdown;
-    HighsInt nimplicsup;
-    HighsInt nimplicsdown;
+    const HighsDomainChange* implicsup = nullptr;
+    const HighsDomainChange* implicsdown = nullptr;
+    HighsInt nimplicsup = 0;
+    HighsInt nimplicsdown = 0;
     nimplicsdown = getImplications(col, 0, implicsdown, infeasible);
     nimplicsup = getImplications(col, 1, implicsup, infeasible);
     HighsInt u = 0;


### PR DESCRIPTION
Warnings:
```
[1474/1557] Compiling C++ object scipy/optimize/_highs/libhighs.a.p/.._..__lib_highs_src_mip_HighsImplications.cpp.obj
../scipy/_lib/highs/src/mip/HighsImplications.cpp: In member function 'bool HighsImplications::runProbing(HighsInt, HighsInt&)':
../scipy/_lib/highs/src/mip/HighsImplications.cpp:167:46: warning: 'implicsdown' may be used uninitialized in this function [-Wmaybe-uninitialized]
  167 |       if (implicsup[u].column < implicsdown[d].column)
      |  
```
Related issue: https://github.com/rgommers/scipy/issues/120