### PR TITLE
Fix rank deficiency

### DIFF
--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -277,6 +277,28 @@ TEST_CASE("AlienBasis-delay-singularity1", "[highs_test_alien_basis]") {
   REQUIRE(rank_deficiency == required_rank_deficiency);
 }
 
+TEST_CASE("AlienBasis-qap10", "[highs_test_alien_basis]") {
+  // Alien basis example derived from sub-MIP when solving qap10
+  //
+  // Has logical in col_set that duplicates structural column
+  HighsSparseMatrix matrix;
+  matrix.num_col_ = 15;
+  matrix.num_row_ = 3;
+  matrix.start_ = {0, 3, 5, 6, 8, 9, 10, 12, 14, 17, 20, 23, 26, 29, 31, 32};
+  matrix.index_ = {2, 0, 1, 2, 0, 0, 2, 0, 0, 0, 0, 2, 0, 2, 2, 0, 1, 1, 0, 2, 0, 1,  2, 2, 1, 0, 2, 1, 0,  2, 0, 1};
+  matrix.value_ = {1, 0.5, 0.5, 0.75, 1, 1, 0.5, 1, 1, 1, 2, 0.5, 1, -1, 1, 1, 1, 1, 1, -1, 0.5, 0.5, 1.125, 1.5, 1, 1, -0.5, 2, 2, -0.5, 1, 1};
+  
+  std::vector<HighsInt> col_set = {0, 1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 15};
+  const HighsInt required_rank_deficiency = 0;
+  
+  if (dev_run) reportColSet("\nOriginal", col_set);
+  HFactor factor;
+  factor.setup(matrix, col_set);
+  HighsInt rank_deficiency = factor.build();
+  REQUIRE(rank_deficiency == required_rank_deficiency);
+   
+}
+
 TEST_CASE("AlienBasis-LP", "[highs_test_alien_basis]") {
   const HighsInt num_seed = 10;
   bool avgas = true;
@@ -511,3 +533,4 @@ void testAlienBasis(const bool avgas, const HighsInt seed) {
     highs.run();
   }
 }
+

--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -285,18 +285,20 @@ TEST_CASE("AlienBasis-qap10", "[highs_test_alien_basis]") {
   matrix.num_col_ = 15;
   matrix.num_row_ = 3;
   matrix.start_ = {0, 3, 5, 6, 8, 9, 10, 12, 14, 17, 20, 23, 26, 29, 31, 32};
-  matrix.index_ = {2, 0, 1, 2, 0, 0, 2, 0, 0, 0, 0, 2, 0, 2, 2, 0, 1, 1, 0, 2, 0, 1,  2, 2, 1, 0, 2, 1, 0,  2, 0, 1};
-  matrix.value_ = {1, 0.5, 0.5, 0.75, 1, 1, 0.5, 1, 1, 1, 2, 0.5, 1, -1, 1, 1, 1, 1, 1, -1, 0.5, 0.5, 1.125, 1.5, 1, 1, -0.5, 2, 2, -0.5, 1, 1};
-  
+  matrix.index_ = {2, 0, 1, 2, 0, 0, 2, 0, 0, 0, 0, 2, 0, 2, 2, 0,
+                   1, 1, 0, 2, 0, 1, 2, 2, 1, 0, 2, 1, 0, 2, 0, 1};
+  matrix.value_ = {1,     0.5, 0.5, 0.75, 1,    1, 0.5, 1,    1,  1,   2,
+                   0.5,   1,   -1,  1,    1,    1, 1,   1,    -1, 0.5, 0.5,
+                   1.125, 1.5, 1,   1,    -0.5, 2, 2,   -0.5, 1,  1};
+
   std::vector<HighsInt> col_set = {0, 1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 13, 15};
-  const HighsInt required_rank_deficiency = 0;
-  
+  const HighsInt required_rank_deficiency = 10;
+
   if (dev_run) reportColSet("\nOriginal", col_set);
   HFactor factor;
   factor.setup(matrix, col_set);
   HighsInt rank_deficiency = factor.build();
   REQUIRE(rank_deficiency == required_rank_deficiency);
-   
 }
 
 TEST_CASE("AlienBasis-LP", "[highs_test_alien_basis]") {
@@ -533,4 +535,3 @@ void testAlienBasis(const bool avgas, const HighsInt seed) {
     highs.run();
   }
 }
-

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1083,9 +1083,6 @@ void accommodateAlienBasis(HighsLpSolverObject& solver_object) {
       basic_index.push_back(num_col + iRow);
   }
   HighsInt num_basic_variables = basic_index.size();
-  if (lp.num_col_ == 15 && lp.num_row_ == 3 && num_basic_variables == 13) {
-    printf("lp.num_col_ == 15 && lp.num_row_ == 3 && num_basic_variables == 13\n");
-  }
   HFactor factor;
   factor.setupGeneral(&lp.a_matrix_, num_basic_variables, &basic_index[0],
                       kDefaultPivotThreshold, kDefaultPivotTolerance,

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1083,6 +1083,9 @@ void accommodateAlienBasis(HighsLpSolverObject& solver_object) {
       basic_index.push_back(num_col + iRow);
   }
   HighsInt num_basic_variables = basic_index.size();
+  if (lp.num_col_ == 15 && lp.num_row_ == 3 && num_basic_variables == 13) {
+    printf("lp.num_col_ == 15 && lp.num_row_ == 3 && num_basic_variables == 13\n");
+  }
   HFactor factor;
   factor.setupGeneral(&lp.a_matrix_, num_basic_variables, &basic_index[0],
                       kDefaultPivotThreshold, kDefaultPivotTolerance,

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -518,9 +518,14 @@ void HFactor::buildSimple() {
    * 1. Prepare basis matrix and deal with unit columns
    */
 
-  const bool report_unit = false;
-  const bool report_singletons = false;
-  const bool report_markowitz = false;
+  const bool report_switch = 
+    num_col == 15 && num_row == 3 && num_basic == 13;
+  const bool report_unit = report_switch;
+  const bool report_singletons = report_switch;
+  const bool report_markowitz = report_switch;
+  //  const bool report_unit = false;
+  //  const bool report_singletons = false;
+  //const bool report_markowitz = false;
   const bool report_anything =
       report_unit || report_singletons || report_markowitz;
   HighsInt BcountX = 0;

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -517,15 +517,9 @@ void HFactor::buildSimple() {
   /**
    * 1. Prepare basis matrix and deal with unit columns
    */
-
-  const bool report_switch = 
-    num_col == 15 && num_row == 3 && num_basic == 13;
-  const bool report_unit = report_switch;
-  const bool report_singletons = report_switch;
-  const bool report_markowitz = report_switch;
-  //  const bool report_unit = false;
-  //  const bool report_singletons = false;
-  //const bool report_markowitz = false;
+  const bool report_unit = false;
+  const bool report_singletons = false;
+  const bool report_markowitz = false;
   const bool report_anything =
       report_unit || report_singletons || report_markowitz;
   HighsInt BcountX = 0;
@@ -548,21 +542,25 @@ void HFactor::buildSimple() {
     HighsInt iMat = basic_index[iCol];
     HighsInt iRow = -1;
     int8_t pivot_type = kPivotIllegal;
+    // Look for unit columns as pivots. If there is already a pivot
+    // corresponding to the nonzero in a unit column - evidenced by
+    // mr_count_before[iRow] being negative - then, obviously, it
+    // can't be used. However, it doesn't imply an error, or even rank
+    // deficiency now that build() is being used to determine
+    // rank. Treat it as a column to be handled in the kernel, so that
+    // any rank deficiency or singularity is detected as late as
+    // possible.
     if (iMat >= num_col) {
-      if (report_unit) printf("Stage %d: Logical\n", (int)(l_start.size() - 1));
       // 1.1 Logical column
-      pivot_type = kPivotLogical;
+      //
       // Check for double pivot
       HighsInt lc_iRow = iMat - num_col;
       if (mr_count_before[lc_iRow] >= 0) {
+        if (report_unit)
+          printf("Stage %d: Logical\n", (int)(l_start.size() - 1));
+        pivot_type = kPivotLogical;
         iRow = lc_iRow;
       } else {
-        highsLogDev(log_options, HighsLogType::kError,
-                    "INVERT Error: Found a logical column with pivot "
-                    "already in row %" HIGHSINT_FORMAT "\n",
-                    lc_iRow);
-        // Treat this as a column to be handled in the kernel, so that
-        // the rank deficiency is detected as late as possible.
         mr_count_before[lc_iRow]++;
         b_index[BcountX] = lc_iRow;
         b_value[BcountX++] = 1.0;
@@ -583,11 +581,6 @@ void HFactor::buildSimple() {
         pivot_type = kPivotColSingleton;  //;kPivotUnit;//
         iRow = lc_iRow;
       } else {
-        if (unit_col)
-          highsLogDev(log_options, HighsLogType::kError,
-                      "INVERT Error: Found a second unit column with pivot in "
-                      "row %" HIGHSINT_FORMAT "\n",
-                      lc_iRow);
         for (HighsInt k = start; k < start + count; k++) {
           mr_count_before[a_index[k]]++;
           assert(BcountX < b_index.size());
@@ -605,7 +598,10 @@ void HFactor::buildSimple() {
       u_pivot_index.push_back(iRow);
       u_pivot_value.push_back(1);
       u_start.push_back(u_index.size());
-      mr_count_before[iRow] = -num_row;
+      // Was -num_row, but this is incorrect since the negation needs
+      // to be great enough so that, starting from it, the accumulated
+      // count can never reach zero
+      mr_count_before[iRow] = -num_basic;
       assert(pivot_type != kPivotIllegal);
       this->refactor_info_.pivot_row.push_back(iRow);
       this->refactor_info_.pivot_var.push_back(iMat);


### PR DESCRIPTION
One-line fix for the bug causing the assert when solving qap10, plus some changed comments, shifted reporting and deletion of error  reporting when the matrix being factorized has a duplicate unit column - it's not an error when the rank of an alien basis is being identified.