### PR TITLE
fix performance bottleneck with moving around all implications in memory

### DIFF
--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -128,6 +128,7 @@ bool HighsImplications::computeImplications(HighsInt col, bool val) {
   HighsInt loc = 2 * col + val;
   implications[loc].computed = true;
   implications[loc].implics = std::move(implics);
+  this->numImplications += implications[loc].implics.size();
 
   return false;
 }
@@ -297,6 +298,7 @@ void HighsImplications::rebuild(HighsInt ncols,
   vlbs.clear();
   vlbs.shrink_to_fit();
   vlbs.resize(ncols);
+  numImplications = 0;
   HighsInt oldncols = oldvubs.size();
 
   nextCleanupCall = mipsolver.numNonzero();

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -123,12 +123,13 @@ bool HighsImplications::computeImplications(HighsInt col, bool val) {
     }
   }
 
-  implics.erase(binstart, implics.end());
-
   HighsInt loc = 2 * col + val;
   implications[loc].computed = true;
-  implications[loc].implics = std::move(implics);
-  this->numImplications += implications[loc].implics.size();
+  implics.erase(binstart, implics.end());
+  if (!implics.empty()) {
+    implications[loc].implics = std::move(implics);
+    this->numImplications += implications[loc].implics.size();
+  }
 
   return false;
 }

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -200,7 +200,7 @@ bool HighsImplications::runProbing(HighsInt col, HighsInt& numReductions) {
           substitution.offset = lbDown;
           substitution.scale = lbUp - lbDown;
           substitutions.push_back(substitution);
-          colsubstituted[implicsup[u].column] = true;
+          colsubstituted[implcol] = true;
           ++numReductions;
         } else {
           double lb = std::min(lbDown, lbUp);

--- a/src/mip/HighsImplications.h
+++ b/src/mip/HighsImplications.h
@@ -32,6 +32,7 @@ class HighsImplications {
     bool computed = false;
   };
   std::vector<Implics> implications;
+  int64_t numImplications;
 
   bool computeImplications(HighsInt col, bool val);
 
@@ -59,6 +60,7 @@ class HighsImplications {
     vubs.resize(numcol);
     vlbs.resize(numcol);
     nextCleanupCall = mipsolver.numNonzero();
+    numImplications = 0;
   }
 
   void reset() {
@@ -70,6 +72,7 @@ class HighsImplications {
     HighsInt numcol = mipsolver.numCol();
     implications.resize(2 * numcol);
     colsubstituted.resize(numcol);
+    numImplications = 0;
     vubs.clear();
     vubs.shrink_to_fit();
     vubs.resize(numcol);
@@ -80,7 +83,7 @@ class HighsImplications {
     nextCleanupCall = mipsolver.numNonzero();
   }
 
-  HighsInt getNumImplications() const { return implications.size(); }
+  HighsInt getNumImplications() const { return numImplications; }
 
   const std::vector<HighsDomainChange>& getImplications(HighsInt col, bool val,
                                                         bool& infeasible) {


### PR DESCRIPTION
Discovered this randomly when testing things. E.g. occurs on neos-5104907-jarama where I noticed that there is a 50% slowdown just due to the presence of multiple threads. As it turned out when looking in the profiler most time was spent in mapping and unmapping memory, as well as, moving it around, due to many implications of binary variables being found. The slowdown seemed to just be due to a switch in the memory allocator to support multithreading or something like that.

The change is functionally 100% equivalent but stores implications of binary variables in individual vectors instead of one big vector so that adding new implications does not require to touch memory of previous ones. Presolve time on neos-5104907-jarama went down from 33 seconds (threads=1) and 45 seconds(threads=8) to 3 seconds for both values. The thread number is expected to not have an effect as the threads just exist but do nothing but sleeping until they get work.