### PR TITLE
fix unintended behavior of RINS heuristic

### DIFF
--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -281,6 +281,7 @@ restart:
 
       double activeIntegerRatio =
           1.0 - mipdata_->percentageInactiveIntegers() / 100.0;
+      activeIntegerRatio *= activeIntegerRatio;
 
       if (!doRestart) {
         double gapReduction = 1.0;

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -710,12 +710,13 @@ retry:
 
     double change = 0.0;
     // select a set of fractional variables to fix
-    for (auto fracint : heurlp.getFractionalIntegers()) {
-      double fixval = getFixVal(fracint.first, fracint.second);
+    for (auto fracint = heurlp.getFractionalIntegers().begin();
+         fracint != fixcandend; ++fracint) {
+      double fixval = getFixVal(fracint->first, fracint->second);
 
-      if (localdom.col_lower_[fracint.first] < fixval) {
+      if (localdom.col_lower_[fracint->first] < fixval) {
         ++numBranched;
-        heur.branchUpwards(fracint.first, fixval, fracint.second);
+        heur.branchUpwards(fracint->first, fixval, fracint->second);
         if (localdom.infeasible()) {
           localdom.conflictAnalysis(mipsolver.mipdata_->conflictPool);
           break;
@@ -724,9 +725,9 @@ retry:
         fixingrate = neighborhood.getFixingRate();
       }
 
-      if (localdom.col_upper_[fracint.first] > fixval) {
+      if (localdom.col_upper_[fracint->first] > fixval) {
         ++numBranched;
-        heur.branchDownwards(fracint.first, fixval, fracint.second);
+        heur.branchDownwards(fracint->first, fixval, fracint->second);
         if (localdom.infeasible()) {
           localdom.conflictAnalysis(mipsolver.mipdata_->conflictPool);
           break;
@@ -737,7 +738,7 @@ retry:
 
       if (fixingrate >= maxfixingrate) break;
 
-      change += std::abs(fixval - fracint.second);
+      change += std::abs(fixval - fracint->second);
       if (change >= 0.5) break;
     }
 

--- a/src/presolve/HighsSymmetry.cpp
+++ b/src/presolve/HighsSymmetry.cpp
@@ -1370,19 +1370,30 @@ void HighsSymmetryDetection::switchToNextNode(HighsInt backtrackDepth) {
 }
 
 bool HighsSymmetryDetection::compareCurrentGraph(
-    const HighsHashTable<std::tuple<HighsInt, HighsInt, HighsUInt>>&
-        otherGraph) {
+    const HighsHashTable<std::tuple<HighsInt, HighsInt, HighsUInt>>& otherGraph,
+    HighsInt& wrongCell) {
   for (HighsInt i = 0; i < numCol; ++i) {
     HighsInt colCell = vertexToCell[i];
 
     for (HighsInt j = Gstart[i]; j != Gend[i]; ++j)
       if (!otherGraph.find(std::make_tuple(vertexToCell[Gedge[j].first],
-                                           colCell, Gedge[j].second)))
+                                           colCell, Gedge[j].second))) {
+        // return which cell does not match in its neighborhood as this should
+        // have been detected with the hashing it can very rarely happen due to
+        // a hash collision. In such a case we want to backtrack to the last
+        // time where we targeted this particular cell. Otherwise we could spent
+        // a long time searching for a matching leave value until every
+        // combination is exhausted and for each leave in this subtree the graph
+        // comparison will fail on this edge.
+        wrongCell = colCell;
         return false;
+      }
     for (HighsInt j = Gend[i]; j != Gstart[i + 1]; ++j)
       if (!otherGraph.find(
-              std::make_tuple(Gedge[j].first, colCell, Gedge[j].second)))
+              std::make_tuple(Gedge[j].first, colCell, Gedge[j].second))) {
+        wrongCell = colCell;
         return false;
+      }
   }
 
   return true;
@@ -1701,12 +1712,13 @@ void HighsSymmetryDetection::run(HighsSymmetries& symmetries) {
           --backtrackDepth;
         switchToNextNode(backtrackDepth);
       } else {
+        HighsInt wrongCell = -1;
         HighsInt backtrackDepth = nodeStack.size() - 1;
         assert(currNodeCertificate.size() == firstLeaveCertificate.size());
         if (firstLeavePrefixLen == currNodeCertificate.size() ||
             bestLeavePrefixLen == currNodeCertificate.size()) {
           if (firstLeavePrefixLen == currNodeCertificate.size() &&
-              compareCurrentGraph(firstLeaveGraph)) {
+              compareCurrentGraph(firstLeaveGraph, wrongCell)) {
             HighsInt k = (numAutomorphisms++) & 63;
             HighsInt* permutation = automorphisms.data() + k * numVertices;
             for (HighsInt i = 0; i < numVertices; ++i) {
@@ -1733,7 +1745,7 @@ void HighsSymmetryDetection::run(HighsSymmetries& symmetries) {
             backtrackDepth = std::min(backtrackDepth, firstPathDepth);
           } else if (!bestLeavePartition.empty() &&
                      bestLeavePrefixLen == currNodeCertificate.size() &&
-                     compareCurrentGraph(bestLeaveGraph)) {
+                     compareCurrentGraph(bestLeaveGraph, wrongCell)) {
             HighsInt k = (numAutomorphisms++) & 63;
             HighsInt* permutation = automorphisms.data() + k * numVertices;
             for (HighsInt i = 0; i < numVertices; ++i) {
@@ -1770,6 +1782,21 @@ void HighsSymmetryDetection::run(HighsSymmetries& symmetries) {
               ++possibleBacktrackDepth;
 
             backtrackDepth = std::min(possibleBacktrackDepth, backtrackDepth);
+          } else {
+            // This case can be caused by a hash collision which was now
+            // detected in the graph comparison call. The graph comparison call
+            // will return the cell where the vertex neighborhood caused a
+            // mismatch on the edges. This would have been detected by
+            // an exact partition refinement when we targeted that cell the last
+            // time, so that is where we can backtrack to.
+            HighsInt possibleBacktrackDepth;
+            for (possibleBacktrackDepth = backtrackDepth;
+                 possibleBacktrackDepth >= 0; --possibleBacktrackDepth) {
+              if (nodeStack[possibleBacktrackDepth].targetCell == wrongCell) {
+                backtrackDepth = possibleBacktrackDepth;
+                break;
+              }
+            }
           }
         } else {
           // leave must have a lexicographically smaller certificate value

--- a/src/presolve/HighsSymmetry.h
+++ b/src/presolve/HighsSymmetry.h
@@ -210,7 +210,8 @@ class HighsSymmetryDetection {
 
   bool compareCurrentGraph(
       const HighsHashTable<std::tuple<HighsInt, HighsInt, HighsUInt>>&
-          otherGraph);
+          otherGraph,
+      HighsInt& wrongCell);
 
   void removeFixPoints();
   void initializeGroundSet();


### PR DESCRIPTION
Just discovered this. The RINS heuristic implementation extends the original scheme by fixing additional variables, but the implemented behavior fixed additional variables before the RINS fixings where all applied.