### PR TITLE
Bug fixes

### DIFF
--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -900,10 +900,10 @@ class HighsOptions : public HighsOptionsStruct {
         kMaxPivotThreshold);
     records.push_back(record_double);
 
-    record_int = new OptionRecordInt("presolve_substitution_maxfillin",
-                                     "Strategy for CHUZC sort in dual simplex",
-                                     advanced, &presolve_substitution_maxfillin,
-                                     0, 10, kHighsIInf);
+    record_int = new OptionRecordInt(
+        "presolve_substitution_maxfillin",
+        "Maximal fillin allowed for substitutions in presolve", advanced,
+        &presolve_substitution_maxfillin, 0, 10, kHighsIInf);
     records.push_back(record_int);
 
     record_double = new OptionRecordDouble(

--- a/src/mip/HighsCliqueTable.h
+++ b/src/mip/HighsCliqueTable.h
@@ -27,6 +27,10 @@ class HighsDomain;
 class HighsMipSolver;
 class HighsLp;
 
+namespace presolve {
+class HighsPostsolveStack;
+}
+
 class HighsCliqueTable {
  public:
   struct CliqueVar {
@@ -299,7 +303,9 @@ class HighsCliqueTable {
   void runCliqueMerging(HighsDomain& globaldomain,
                         std::vector<CliqueVar>& clique, bool equation = false);
 
-  void rebuild(HighsInt ncols, const HighsDomain& globaldomain,
+  void rebuild(HighsInt ncols,
+               const presolve::HighsPostsolveStack& postSolveStack,
+               const HighsDomain& globaldomain,
                const std::vector<HighsInt>& cIndex,
                const std::vector<HighsInt>& rIndex);
 

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -307,24 +307,32 @@ void HighsImplications::rebuild(HighsInt ncols,
   for (HighsInt i = 0; i != oldncols; ++i) {
     HighsInt newi = orig2reducedcol[i];
 
-    if (newi == -1) continue;
+    if (newi == -1 ||
+        !mipsolver.mipdata_->postSolveStack.isColLinearlyTransformable(newi))
+      continue;
 
     for (const auto& oldvub : oldvubs[i]) {
-      if (orig2reducedcol[oldvub.first] == -1) continue;
+      HighsInt newVubCol = orig2reducedcol[oldvub.first];
+      if (newVubCol == -1) continue;
 
-      if (!mipsolver.mipdata_->domain.isBinary(orig2reducedcol[oldvub.first]))
+      if (!mipsolver.mipdata_->domain.isBinary(newVubCol) ||
+          !mipsolver.mipdata_->postSolveStack.isColLinearlyTransformable(
+              newVubCol))
         continue;
-      addVUB(newi, orig2reducedcol[oldvub.first], oldvub.second.coef,
-             oldvub.second.constant);
+
+      addVUB(newi, newVubCol, oldvub.second.coef, oldvub.second.constant);
     }
 
     for (const auto& oldvlb : oldvlbs[i]) {
-      if (orig2reducedcol[oldvlb.first] == -1) continue;
+      HighsInt newVlbCol = orig2reducedcol[oldvlb.first];
+      if (newVlbCol == -1) continue;
 
-      if (!mipsolver.mipdata_->domain.isBinary(orig2reducedcol[oldvlb.first]))
+      if (!mipsolver.mipdata_->domain.isBinary(newVlbCol) ||
+          !mipsolver.mipdata_->postSolveStack.isColLinearlyTransformable(
+              newVlbCol))
         continue;
-      addVLB(newi, orig2reducedcol[oldvlb.first], oldvlb.second.coef,
-             oldvlb.second.constant);
+
+      addVLB(newi, newVlbCol, oldvlb.second.coef, oldvlb.second.constant);
     }
 
     // todo also add old implications once implications can be added

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -834,8 +834,9 @@ void HPresolve::shrinkProblem(HighsPostsolveStack& postSolveStack) {
   if (mipsolver != nullptr) {
     mipsolver->mipdata_->rowMatrixSet = false;
     mipsolver->mipdata_->domain = HighsDomain(*mipsolver);
-    mipsolver->mipdata_->cliquetable.rebuild(
-        model->num_col_, mipsolver->mipdata_->domain, newColIndex, newRowIndex);
+    mipsolver->mipdata_->cliquetable.rebuild(model->num_col_, postSolveStack,
+                                             mipsolver->mipdata_->domain,
+                                             newColIndex, newRowIndex);
     mipsolver->mipdata_->implications.rebuild(model->num_col_, newColIndex,
                                               newRowIndex);
     mipsolver->mipdata_->cutpool =

--- a/src/presolve/HighsPostsolveStack.cpp
+++ b/src/presolve/HighsPostsolveStack.cpp
@@ -30,6 +30,8 @@ void HighsPostsolveStack::initializeIndexMaps(HighsInt numRow,
 
   origColIndex.resize(numCol);
   std::iota(origColIndex.begin(), origColIndex.end(), 0);
+
+  linearlyTransformable.resize(numCol, true);
 }
 
 void HighsPostsolveStack::compressIndexMaps(


### PR DESCRIPTION
I discovered some further bugs when I wanted to start to look into some prerequisites for user cut callbacks. I believe the callback likely is supposed to operate in the original model's space. I.e. it must be possible to transform the LP relaxation solution in to the original space, which already is the case, but then it must be possible to transform a cutting plane back to the presolved space. Regarding the duplicate column reduction this is not generally possible, except when both columns that are duplicate with the same scale. For now I added a flag that is set for columns that are involved in such a reduction to mark them as not linearly transformable in the postsolve information, i.e. a linear expression involving these columns cannot be transformed to the reduced problem. In that case clique and implication information involving such columns is discarded now. Clique information was not much of an issue before because the only relevant case where bad things could happen was when two binary variables where merged into an integer which then got its bounds tightened to have ub-lb == 1 so that it got converted back into a binary variable. For continuous columns, however, some wrong variable bound information might have been there in rare circumstances.