### PR TITLE
skip implicit integer columns in primal heuristic

### DIFF
--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -193,16 +193,16 @@ class HeuristicNeighborhood {
         numFixed(0),
         startCheckedChanges(localdom.getDomainChangeStack().size()),
         nCheckedChanges(startCheckedChanges) {
-    for (HighsInt i : mipsolver.mipdata_->integral_cols)
+    for (HighsInt i : mipsolver.mipdata_->integer_cols)
       if (localdom.col_lower_[i] == localdom.col_upper_[i]) ++numFixed;
 
-    numTotal = mipsolver.mipdata_->integral_cols.size() - numFixed;
+    numTotal = mipsolver.mipdata_->integer_cols.size() - numFixed;
   }
 
   double getFixingRate() {
     while (nCheckedChanges < localdom.getDomainChangeStack().size()) {
       HighsInt col = localdom.getDomainChangeStack()[nCheckedChanges++].column;
-      if (localdom.variableType(col) == HighsVarType::kContinuous) continue;
+      if (localdom.variableType(col) != HighsVarType::kInteger) continue;
       if (localdom.isFixed(col)) fixedCols.insert(col);
     }
 


### PR DESCRIPTION
This was the intention to begin with but was done inconsistently. I will keep this as a pull request for now and wait for the current benchmark runs to finish. Once they have finished I will compare this change only on those models again which have any implicit integer variable as this is a much smaller subset.