### PR TITLE
fix bug with aggregating badly scaled rows

### DIFF
--- a/src/mip/HighsDebugSol.cpp
+++ b/src/mip/HighsDebugSol.cpp
@@ -15,6 +15,7 @@
 #ifdef HIGHS_DEBUGSOL
 
 #include "io/FilereaderMps.h"
+#include "lp_data/HighsLpUtils.h"
 #include "mip/HighsDomain.h"
 #include "mip/HighsMipSolver.h"
 #include "mip/HighsMipSolverData.h"
@@ -163,6 +164,29 @@ void HighsDebugSol::checkCut(const HighsInt* Rindex, const double* Rvalue,
     violation += debugSolution[Rindex[i]] * Rvalue[i];
 
   assert(violation <= mipsolver->mipdata_->feastol);
+}
+
+void HighsDebugSol::checkRowAggregation(const HighsLp& lp,
+                                        const HighsInt* Rindex,
+                                        const double* Rvalue, HighsInt Rlen) {
+  if (!debugSolActive) return;
+  HighsCDouble violation = 0.0;
+
+  HighsSolution dbgSol;
+  dbgSol.dual_valid = false;
+  dbgSol.value_valid = true;
+  dbgSol.col_value = debugSolution;
+  calculateRowValues(lp, dbgSol);
+  for (HighsInt i = 0; i < Rlen; ++i) {
+    if (Rindex[i] < lp.num_col_)
+      violation += dbgSol.col_value[Rindex[i]] * Rvalue[i];
+    else
+      violation += dbgSol.row_value[Rindex[i] - lp.num_col_] * Rvalue[i];
+  }
+
+  double viol = fabs(double(violation));
+
+  assert(viol <= mipsolver->mipdata_->feastol);
 }
 
 void HighsDebugSol::checkRow(const HighsInt* Rindex, const double* Rvalue,

--- a/src/mip/HighsDebugSol.h
+++ b/src/mip/HighsDebugSol.h
@@ -19,6 +19,7 @@
 
 class HighsDomain;
 class HighsMipSolver;
+class HighsLp;
 
 #include <set>
 #include <vector>
@@ -64,6 +65,9 @@ struct HighsDebugSol {
 
   void checkRow(const HighsInt* Rindex, const double* Rvalue, HighsInt Rlen,
                 double Rlower, double Rupper);
+
+  void checkRowAggregation(const HighsLp& lp, const HighsInt* Rindex,
+                           const double* Rvalue, HighsInt Rlen);
 
   void checkClique(const HighsCliqueTable::CliqueVar* clq, HighsInt clqlen);
 
@@ -112,6 +116,9 @@ struct HighsDebugSol {
 
   void checkRow(const HighsInt* Rindex, const double* Rvalue, HighsInt Rlen,
                 double Rlower, double Rupper) const {}
+
+  void checkRowAggregation(const HighsLp& lp, const HighsInt* Rindex,
+                           const double* Rvalue, HighsInt Rlen) const {}
 
   void checkClique(const HighsCliqueTable::CliqueVar* clq,
                    HighsInt clqlen) const {}

--- a/src/mip/HighsTableauSeparator.cpp
+++ b/src/mip/HighsTableauSeparator.cpp
@@ -228,6 +228,10 @@ void HighsTableauSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
       if (maxAbsVal / minAbsVal > 1e6) continue;
     }
 
+    mip.mipdata_->debugSolution.checkRowAggregation(
+        lpSolver.getLp(), baseRowInds.data(), baseRowVals.data(),
+        baseRowInds.size());
+
     double rhs = 0;
     cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
     if (mip.mipdata_->domain.infeasible()) break;

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -352,8 +352,8 @@ struct HighsHashHelpers {
     // make sure input value is never zero and at most 31bits are used
     value = (pair_hash<0>(value, value >> 32) >> 33) | 1;
 
-    // make sure that the constant has at most 61 bits, as otherwise the modulo
-    // algorithm for multiplication mod M61 might not work properly due to
+    // make sure that the constant has at most 31 bits, as otherwise the modulo
+    // algorithm for multiplication mod M31 might not work properly due to
     // overflow
     u32 a = c[index & 63] & M31();
     HighsInt degree = (index >> 6) + 1;
@@ -378,7 +378,7 @@ struct HighsHashHelpers {
 
     u32 a = c[index & 63] & M31();
     HighsInt degree = (index >> 6) + 1;
-    // add the additive inverse (M61() - hashvalue) instead of the hash value
+    // add the additive inverse (M31() - hashvalue) instead of the hash value
     // itself
     hash += M31() - multiply_modM31(value, modexp_M31(a, degree));
     hash = (hash >> 31) + (hash & M31());


### PR DESCRIPTION
There was a bug with dropping slack variables when they have a small coefficient in the aggregation of rows for cut separation. The problem was revealed on the model map10, which contains this nicely scaled row:
```
c_budget: +5810588 y_0 +9116395 y_2 +4923337 y_4 +6850358 y_5 +6013002 y_6 +3719301 y_9 +6399260 y_10
  +8984064 y_11 +8350050 y_12 +7842548 y_13 +7833365 y_14 +9296870 y_15 +5778723 y_16 +10555125 y_17 +8122574 y_18
  +6189976 y_19 +7132556 y_20 +4864997 y_21 +5503031 y_22 +2886441 y_23 +4715238 y_24 +5576715 y_25 +8089838 y_26
  +9525671 y_27 +9904038 y_28 +6482219 y_29 +4794968 y_30 +8095721 y_31 +5504687 y_32 +4348961 y_33 +6643785 y_34
  +5136083 y_35 +3216062 y_36 +9465637 y_37 +7837762 y_38 +5392847 y_39 +9235057 y_40 +7960955 y_41 +8600248 y_42
  +6960438 y_43 +4847333 y_44 +5321123 y_45 +6800869 y_46 +3914003 y_47 +9465441 y_48 +6422718 y_49 +3571666 y_50
  +6477380 y_51 +8236689 y_52 +3723630 y_53 +10974946 y_54 +5604000 y_55 +10362447 y_56 +7692087 y_57
  +6402447 y_59 +6137960 y_60 +4773868 y_64 +6222170 y_65 +6127007 y_66 +6780557 y_67 +7562981 y_68 +9060576 y_69
  +9627682 y_70 +7032139 y_71 +3692975 y_72 +3002140 y_73 +7315215 y_74 +3119570 y_75 +7935163 y_76 +4450873 y_78
  +7204909 y_81 +3004756 y_82 +6160027 y_83 +9708096 y_84 +5418153 y_85 +2224967 y_86 +6670754 y_87 +10627561 y_88
  +9242930 y_89 +2964250 y_90 +4678036 y_91 +10170224 y_92 +8624719 y_93 +10576908 y_94 +8523242 y_95
  +3423753 y_96 +4185305 y_97 +4724145 y_98 +3569328 y_99 +7414620 y_100 +8693921 y_101 +7847816 y_102
  +6479684 y_103 +6097080 y_104 +9211424 y_107 +10235369 y_108 +9101786 y_110 +4913033 y_112 +8532797 y_113
  +4293805 y_114 +9335165 y_115 +3673860 y_116 +8237427 y_117 +6726783 y_118 +9325847 y_119 +5459981 y_120
  +8470201 y_121 +9897825 y_122 +2111850 y_123 +3843868 y_125 +6183888 y_126 +3671359 y_127 +1998323 y_128
  +8897612 y_129 +6821032 y_130 +5548528 y_131 +1217117 y_132 +10986613 y_133 +10358126 y_134 +10223603 y_135
  +1107082 y_136 +8146717 y_138 +4417056 y_139 +2761030 y_140 +5416262 y_141 +8796977 y_142 +5493363 y_143
  +9241993 y_144 +7074167 y_145 <= +85628419
```
The row is not scaled down by the MIP solver since it is all integral and the gcd of the values is 1. Now what happened is that this row was given a weight slightly below 1e-9 which was the threshold for dropping entries in the row aggregation. The weight was not zeroed because the weight times the maximal absolute row coefficient is above 1e-6, the fasibility tolerance. Hence the coefficient value for this row slightly above 1e-9 for the logical column introduced during separation was simply dropped leading to errors in the right hand side value. I fixed this by never dropping logical columns as their weights are not subject to numerical error when aggregating rows since they are the only row contributing to this entry.

Also, considering possible inputs like above, I wonder if we should consider increasing the maximal scale factor to the maximum value now that the scaled NLA in unscaled space is used. Maybe you can run some LP tests for this and see whether it has any negative consequences.