### PR TITLE
Modify df max scale factor

### DIFF
--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -66,8 +66,9 @@ TEST_CASE("internal-options", "[highs_options]") {
       options.log_options, "allowed_matrix_scale_factor", options.records, -1);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
-  return_status = setLocalOptionValue(
-      options.log_options, "allowed_matrix_scale_factor", options.records, 25);
+  return_status =
+      setLocalOptionValue(options.log_options, "allowed_matrix_scale_factor",
+                          options.records, kMaxAllowedMatrixPow2Scale + 5);
   REQUIRE(return_status == OptionStatus::kIllegalValue);
 
   std::string allowed_matrix_scale_factor_string = "1e-7";
@@ -218,7 +219,8 @@ TEST_CASE("highs-options", "[highs_options]") {
   return_status = highs.setOptionValue("allowed_matrix_scale_factor", -1);
   REQUIRE(return_status == HighsStatus::kError);
 
-  return_status = highs.setOptionValue("allowed_matrix_scale_factor", 25);
+  return_status = highs.setOptionValue("allowed_matrix_scale_factor",
+                                       kMaxAllowedMatrixPow2Scale + 5);
   REQUIRE(return_status == HighsStatus::kError);
 
   std::string allowed_matrix_scale_factor_string = "1e-7";

--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -182,6 +182,10 @@ enum class HighsBasisStatus : uint8_t {
              // and postsolve
 };
 
+// Default and max allowed power-of-two matrix scale factor
+const HighsInt kDefaultAllowedMatrixPow2Scale = 20;
+const HighsInt kMaxAllowedMatrixPow2Scale = 30;
+
 // Illegal values of num/max/sum infeasibility - used to indicate that true
 // values aren't known
 const HighsInt kHighsIllegalInfeasibilityCount = -1;

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -787,7 +787,7 @@ class HighsOptions : public HighsOptionsStruct {
         new OptionRecordInt("allowed_matrix_scale_factor",
                             "Largest power-of-two factor permitted when "
                             "scaling the constraint matrix",
-                            advanced, &allowed_matrix_scale_factor, 0, 10, 20);
+                            advanced, &allowed_matrix_scale_factor, 0, 20, 30);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -783,11 +783,12 @@ class HighsOptions : public HighsOptionsStruct {
                             advanced, &cost_scale_factor, -20, 0, 20);
     records.push_back(record_int);
 
-    record_int =
-        new OptionRecordInt("allowed_matrix_scale_factor",
-                            "Largest power-of-two factor permitted when "
-                            "scaling the constraint matrix",
-                            advanced, &allowed_matrix_scale_factor, 0, 20, 30);
+    record_int = new OptionRecordInt(
+        "allowed_matrix_scale_factor",
+        "Largest power-of-two factor permitted when "
+        "scaling the constraint matrix",
+        advanced, &allowed_matrix_scale_factor, 0,
+        kDefaultAllowedMatrixPow2Scale, kMaxAllowedMatrixPow2Scale);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(


### PR DESCRIPTION
Default allowable power-of-two scale factor increased from 10 to 20, and max increased from 20 to 30.

Only changes iteration count for 33/144 LPs, with a couple of smaller LPs slower by 30-40%, but s250r10 60% faster.

So, LP-wise this change is fine.

