### PR TITLE
Fix infeasible solution

### DIFF
--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -183,7 +183,7 @@ enum class HighsBasisStatus : uint8_t {
 };
 
 // Default and max allowed power-of-two matrix scale factor
-const HighsInt kDefaultAllowedMatrixPow2Scale = 10;
+const HighsInt kDefaultAllowedMatrixPow2Scale = 20;
 const HighsInt kMaxAllowedMatrixPow2Scale = 30;
 
 // Illegal values of num/max/sum infeasibility - used to indicate that true

--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -183,7 +183,7 @@ enum class HighsBasisStatus : uint8_t {
 };
 
 // Default and max allowed power-of-two matrix scale factor
-const HighsInt kDefaultAllowedMatrixPow2Scale = 20;
+const HighsInt kDefaultAllowedMatrixPow2Scale = 10;
 const HighsInt kMaxAllowedMatrixPow2Scale = 30;
 
 // Illegal values of num/max/sum infeasibility - used to indicate that true

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -597,6 +597,15 @@ HighsStatus Highs::run() {
   highs::parallel::initialize_scheduler(options_.threads);
 
   max_threads = highs::parallel::num_threads();
+  if (options_.threads != 0 && max_threads != options_.threads) {
+    highsLogUser(
+        options_.log_options, HighsLogType::kError,
+        "Option 'threads' is set to %d but global scheduler has already been "
+        "initialized to use %d threads. The previous scheduler instance can be "
+        "destroyed by calling HighsTaskExecutor::shutdown().\n",
+        (int)options_.threads, max_threads);
+    return HighsStatus::kError;
+  }
   assert(max_threads > 0);
   if (max_threads <= 0)
     highsLogDev(options_.log_options, HighsLogType::kWarning,

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -207,6 +207,7 @@ void checkLpSolutionFeasibility(const HighsOptions& options, const HighsLp& lp,
                                 const HighsSolution& solution);
 
 HighsStatus calculateRowValues(const HighsLp& lp, HighsSolution& solution);
+HighsStatus calculateRowValuesQuad(const HighsLp& lp, HighsSolution& solution);
 HighsStatus calculateColDuals(const HighsLp& lp, HighsSolution& solution);
 
 bool isBoundInfeasible(const HighsLogOptions& log_options, const HighsLp& lp);

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -625,11 +625,11 @@ double HighsMipSolverData::transformNewIncumbent(
     const std::vector<double>& sol) {
   HighsSolution solution;
   solution.col_value = sol;
-  calculateRowValues(*mipsolver.model_, solution);
+  calculateRowValuesQuad(*mipsolver.orig_model_, solution);
   solution.value_valid = true;
 
   postSolveStack.undoPrimal(*mipsolver.options_mip_, solution);
-  calculateRowValues(*mipsolver.orig_model_, solution);
+  calculateRowValuesQuad(*mipsolver.orig_model_, solution);
   bool allow_try_again = true;
 try_again:
 
@@ -672,7 +672,7 @@ try_again:
       integrality_violation_ <=
           mipsolver.options_mip_->mip_feasibility_tolerance &&
       row_violation_ <=
-          mipsolver.options_mip_->mip_feasibility_tolerance + kHighsTiny;
+          mipsolver.options_mip_->mip_feasibility_tolerance;
 
   if (!feasible && allow_try_again) {
     // printf(

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -671,8 +671,7 @@ try_again:
       bound_violation_ <= mipsolver.options_mip_->mip_feasibility_tolerance &&
       integrality_violation_ <=
           mipsolver.options_mip_->mip_feasibility_tolerance &&
-      row_violation_ <=
-          mipsolver.options_mip_->mip_feasibility_tolerance;
+      row_violation_ <= mipsolver.options_mip_->mip_feasibility_tolerance;
 
   if (!feasible && allow_try_again) {
     // printf(

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -358,13 +358,12 @@ void HighsMipSolverData::runSetup() {
   if (mipsolver.solution_objective_ != kHighsInf) {
     incumbent = postSolveStack.getReducedPrimalSolution(mipsolver.solution_);
     double solobj = mipsolver.solution_objective_ - mipsolver.model_->offset_;
-    bool feasible =
-        mipsolver.bound_violation_ <=
-            mipsolver.options_mip_->mip_feasibility_tolerance &&
-        mipsolver.integrality_violation_ <=
-            mipsolver.options_mip_->mip_feasibility_tolerance &&
-        mipsolver.row_violation_ <=
-            mipsolver.options_mip_->mip_feasibility_tolerance + kHighsTiny;
+    bool feasible = mipsolver.bound_violation_ <=
+                        mipsolver.options_mip_->mip_feasibility_tolerance &&
+                    mipsolver.integrality_violation_ <=
+                        mipsolver.options_mip_->mip_feasibility_tolerance &&
+                    mipsolver.row_violation_ <=
+                        mipsolver.options_mip_->mip_feasibility_tolerance;
     if (numRestarts == 0) {
       highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
                    "\nMIP start solution is %s, objective value is %.12g\n",
@@ -642,29 +641,43 @@ try_again:
   assert((HighsInt)solution.col_value.size() ==
          mipsolver.orig_model_->num_col_);
   for (HighsInt i = 0; i != mipsolver.orig_model_->num_col_; ++i) {
-    obj += mipsolver.orig_model_->col_cost_[i] * solution.col_value[i];
-
-    bound_violation_ =
-        std::max(bound_violation_,
-                 mipsolver.orig_model_->col_lower_[i] - solution.col_value[i]);
-    bound_violation_ =
-        std::max(bound_violation_,
-                 solution.col_value[i] - mipsolver.orig_model_->col_upper_[i]);
+    const double value = solution.col_value[i];
+    obj += mipsolver.orig_model_->col_cost_[i] * value;
 
     if (mipsolver.orig_model_->integrality_[i] == HighsVarType::kInteger) {
-      double intval = std::floor(solution.col_value[i] + 0.5);
-      integrality_violation_ = std::max(
-          std::abs(intval - solution.col_value[i]), integrality_violation_);
+      double intval = std::floor(value + 0.5);
+      integrality_violation_ =
+          std::max(std::fabs(intval - value), integrality_violation_);
     }
+
+    const double lower = mipsolver.orig_model_->col_lower_[i];
+    const double upper = mipsolver.orig_model_->col_upper_[i];
+    double primal_infeasibility = 0;
+    if (value < lower - mipsolver.options_mip_->mip_feasibility_tolerance) {
+      primal_infeasibility = lower - value;
+    } else if (value >
+               upper + mipsolver.options_mip_->mip_feasibility_tolerance) {
+      primal_infeasibility = value - upper;
+    } else
+      continue;
+
+    bound_violation_ = std::max(bound_violation_, primal_infeasibility);
   }
 
   for (HighsInt i = 0; i != mipsolver.orig_model_->num_row_; ++i) {
-    row_violation_ =
-        std::max(row_violation_,
-                 mipsolver.orig_model_->row_lower_[i] - solution.row_value[i]);
-    row_violation_ =
-        std::max(row_violation_,
-                 solution.row_value[i] - mipsolver.orig_model_->row_upper_[i]);
+    const double value = solution.row_value[i];
+    const double lower = mipsolver.orig_model_->row_lower_[i];
+    const double upper = mipsolver.orig_model_->row_upper_[i];
+    double primal_infeasibility;
+    if (value < lower - mipsolver.options_mip_->mip_feasibility_tolerance) {
+      primal_infeasibility = lower - value;
+    } else if (value >
+               upper + mipsolver.options_mip_->mip_feasibility_tolerance) {
+      primal_infeasibility = value - upper;
+    } else
+      continue;
+
+    row_violation_ = std::max(row_violation_, primal_infeasibility);
   }
 
   bool feasible =
@@ -721,7 +734,7 @@ try_again:
         mipsolver.integrality_violation_ <=
             mipsolver.options_mip_->mip_feasibility_tolerance &&
         mipsolver.row_violation_ <=
-            mipsolver.options_mip_->mip_feasibility_tolerance + kHighsTiny;
+            mipsolver.options_mip_->mip_feasibility_tolerance;
     highsLogUser(
         mipsolver.options_mip_->log_options, HighsLogType::kWarning,
         "Untransformed solution with objective %g is violated by %.12g for the "

--- a/src/parallel/HighsTaskExecutor.cpp
+++ b/src/parallel/HighsTaskExecutor.cpp
@@ -2,7 +2,7 @@
 
 using namespace highs;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 static thread_local HighsSplitDeque* threadLocalWorkerDequePtr{nullptr};
 HighsSplitDeque*& HighsTaskExecutor::threadLocalWorkerDeque() {
   return threadLocalWorkerDequePtr;

--- a/src/parallel/HighsTaskExecutor.cpp
+++ b/src/parallel/HighsTaskExecutor.cpp
@@ -14,3 +14,5 @@ thread_local HighsSplitDeque* HighsTaskExecutor::threadLocalWorkerDequePtr{
 
 cache_aligned::shared_ptr<HighsTaskExecutor> HighsTaskExecutor::globalExecutor{
     nullptr};
+
+HighsSpinMutex HighsTaskExecutor::initMutex;

--- a/src/parallel/HighsTaskExecutor.h
+++ b/src/parallel/HighsTaskExecutor.h
@@ -34,7 +34,7 @@ class HighsTaskExecutor {
  private:
   using cache_aligned = highs::cache_aligned;
 
-#ifdef _MSC_VER
+#ifdef _WIN32
   static HighsSplitDeque*& threadLocalWorkerDeque();
 #else
   static thread_local HighsSplitDeque* threadLocalWorkerDequePtr;

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -504,7 +504,7 @@ void HFactor::buildSimple() {
    */
   luClear();
 
-  const bool progress_report = num_basic != num_row;
+  const bool progress_report = false;
   const HighsInt progress_frequency = 100000;
 
   // Set all values of permute to -1 so that unpermuted (rank
@@ -808,7 +808,7 @@ HighsInt HFactor::buildKernel() {
   double fake_fill = 0;
   double fake_eliminate = 0;
 
-  const bool progress_report = num_basic != num_row;
+  const bool progress_report = false;
   const HighsInt progress_frequency = 10000;
   HighsInt search_k = 0;
 

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -808,7 +808,7 @@ HighsInt HFactor::buildKernel() {
   double fake_fill = 0;
   double fake_eliminate = 0;
 
-  const bool progress_report = false;
+  const bool progress_report = false;  // num_basic != num_row;
   const HighsInt progress_frequency = 10000;
   HighsInt search_k = 0;
 
@@ -847,10 +847,10 @@ HighsInt HFactor::buildKernel() {
             break;
           }
         }
-        //        printf(
-        //            "HFactor::buildKernel stage = %6d: min_col_count = %3d; "
-        //            "min_row_count = %3d\n",
-        //            (int)search_k, (int)min_col_count, (int)min_row_count);
+        printf(
+            "HFactor::buildKernel stage = %6d: min_col_count = %3d; "
+            "min_row_count = %3d\n",
+            (int)search_k, (int)min_col_count, (int)min_row_count);
       }
     }
     search_k++;


### PR DESCRIPTION
@jajhall there is one warning where HiGHS terminates with an infeasible solution in the most recent MIP runs. I remember that the check for this instances showed an infeasibility in the original space that I suspected to be due to rounding errors as the computed infeasibility was for row bounds and was just one smallest possible deviation that a double precision value could be above the feasibility tolerance. As the computed row values are subject to rounding errors I at that time did not want to discard the solution since it was feasible in the presolved space and was checked with quad precision there.
I now removed the hacky allowance of a tiny extra tolerance and compute the row values with quad precision instead. For this I simply added one additional function at the place where the function for computing the row values was used before. This should avoid to ever terminate with an infeasible solution, even very slightly infeasible, and still accept solutions when the exceeding of the feasibility tolerance is due to rounding errors as quad precision is used now.

Also the change to the default max scaling factor last minute might not have been a great idea as it seems to have some side effects leading some MIP instances to timeout that could otherwise be solved rather reliably. For the release I'd suggest to rollback to the previous value for now and do some more extensive testing whether to increase it for the next release where I have time to investigate. The effect for timing out must be some unexpected side effect since the LP performance is not altered.