### PR TITLE
Fix 717

### DIFF
--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -46,8 +46,8 @@ struct HighsLogOptions {
   bool* output_flag;
   bool* log_to_console;
   HighsInt* log_dev_level;
-  void (*log_callback)(HighsLogType, const char*, void*);
-  void* log_callback_data;
+  void (*log_callback)(HighsLogType, const char*, void*) = nullptr;
+  void* log_callback_data = nullptr;
 };
 
 /**

--- a/src/util/HighsSparseMatrix.cpp
+++ b/src/util/HighsSparseMatrix.cpp
@@ -255,12 +255,12 @@ void HighsSparseMatrix::addCols(const HighsSparseMatrix new_cols,
   // Adding columns to a row-wise partitioned matrix needs the
   // partition information
   const bool partitioned = this->format_ == MatrixFormat::kRowwisePartitioned;
+  // Cannot handle the row-wise partitioned case
+  assert(!partitioned);
   if (partitioned) {
     //    if (in_partition == NULL) { printf("in_partition == NULL\n"); }
     assert(in_partition != NULL);
   }
-  // Cannot handle the row-wise case
-  assert(!this->isRowwise());
   assert(num_new_col >= 0);
   assert(num_new_nz >= 0);
   if (num_new_col == 0) {
@@ -283,7 +283,8 @@ void HighsSparseMatrix::addCols(const HighsSparseMatrix new_cols,
   // Check that nonzeros aren't being appended to a matrix with no rows
   assert(num_new_nz <= 0 || num_row > 0);
 
-  if (this->format_ == MatrixFormat::kRowwise) {
+  const bool allow_flip_090222 = false;
+  if (allow_flip_090222 && this->format_ == MatrixFormat::kRowwise) {
     // Matrix is currently a standard row-wise matrix, so flip
     // column-wise if there are more new nonzeros than current
     // nonzeros
@@ -321,12 +322,44 @@ void HighsSparseMatrix::addCols(const HighsSparseMatrix new_cols,
     this->value_.resize(new_num_nz);
     // Copy in the new indices and values
     for (HighsInt iEl = 0; iEl < num_new_nz; iEl++) {
+      assert(99==33);
       this->index_[num_nz + iEl] = new_matrix_index[iEl];
       this->value_[num_nz + iEl] = new_matrix_value[iEl];
     }
   } else {
     // Matrix is row-wise
-    assert(1 == 0);
+    //
+    // Determine the row lengths of the new columns being added
+    std::vector<HighsInt> new_row_length;
+    new_row_length.assign(num_row, 0);
+    for (HighsInt iEl = 0; iEl < num_new_nz; iEl++) 
+      new_row_length[new_matrix_index[iEl]]++;
+    // Now shift the indices and values to make space    
+    HighsInt entry_offset = num_new_nz;
+    HighsInt to_original_el = this->start_[num_row];
+    for (HighsInt iRow = num_row-1; iRow>0; iRow--) {
+      entry_offset -= new_row_length[iRow];
+      HighsInt from_original_el = this->start_[iRow];
+      // Can now use this new_row_length to store the start for the
+      // new entries
+      new_row_length[iRow] = from_original_el + entry_offset;
+      for (HighsInt iEl = to_original_el-1; iEl >= from_original_el; iEl--) {
+	this->index_[iEl + entry_offset] = this->index_[iEl];
+	this->value_[iEl + entry_offset] = this->value_[iEl];
+      }
+      to_original_el = from_original_el;
+      this->start_[iRow] = entry_offset + from_original_el;
+    }
+    // Now insert the indices and values for the new columns
+    for (HighsInt iCol = 0; iCol < num_new_col; iCol++) {
+      for (HighsInt iEl = new_matrix_start[iCol]; iEl < new_matrix_start[iCol+1]; iEl++) {
+	HighsInt iRow = new_matrix_index[iEl];
+	this->index_[new_row_length[iRow]] = num_col + iCol;
+	this->value_[new_row_length[iRow]] = new_matrix_value[iEl];
+	new_row_length[iRow]++;
+      }
+    }
+    this->num_col_ += num_new_col;
   }
 }
 

--- a/src/util/HighsSparseMatrix.cpp
+++ b/src/util/HighsSparseMatrix.cpp
@@ -283,16 +283,11 @@ void HighsSparseMatrix::addCols(const HighsSparseMatrix new_cols,
   // Check that nonzeros aren't being appended to a matrix with no rows
   assert(num_new_nz <= 0 || num_row > 0);
 
-  const bool allow_flip_090222 = false;
-  if (allow_flip_090222 && this->format_ == MatrixFormat::kRowwise) {
-    // Matrix is currently a standard row-wise matrix, so flip
-    // column-wise if there are more new nonzeros than current
-    // nonzeros
-    if (num_new_nz > num_nz) {
-      assert(1 == 0);
-      this->ensureColwise();
-    }
-  }
+  // If matrix is currently a standard row-wise matrix and there are
+  // more new nonzeros than current nonzeros so flip column-wise
+  if (this->format_ == MatrixFormat::kRowwise && num_new_nz > num_nz)
+    this->ensureColwise();
+
   // Determine the new number of columns and nonzeros in the matrix
   HighsInt new_num_col = num_col + num_new_col;
   HighsInt new_num_nz = num_nz + num_new_nz;
@@ -322,43 +317,51 @@ void HighsSparseMatrix::addCols(const HighsSparseMatrix new_cols,
     this->value_.resize(new_num_nz);
     // Copy in the new indices and values
     for (HighsInt iEl = 0; iEl < num_new_nz; iEl++) {
-      assert(99==33);
       this->index_[num_nz + iEl] = new_matrix_index[iEl];
       this->value_[num_nz + iEl] = new_matrix_value[iEl];
     }
   } else {
     // Matrix is row-wise
-    //
-    // Determine the row lengths of the new columns being added
-    std::vector<HighsInt> new_row_length;
-    new_row_length.assign(num_row, 0);
-    for (HighsInt iEl = 0; iEl < num_new_nz; iEl++) 
-      new_row_length[new_matrix_index[iEl]]++;
-    // Now shift the indices and values to make space    
-    HighsInt entry_offset = num_new_nz;
-    HighsInt to_original_el = this->start_[num_row];
-    for (HighsInt iRow = num_row-1; iRow>0; iRow--) {
-      entry_offset -= new_row_length[iRow];
-      HighsInt from_original_el = this->start_[iRow];
-      // Can now use this new_row_length to store the start for the
-      // new entries
-      new_row_length[iRow] = from_original_el + entry_offset;
-      for (HighsInt iEl = to_original_el-1; iEl >= from_original_el; iEl--) {
-	this->index_[iEl + entry_offset] = this->index_[iEl];
-	this->value_[iEl + entry_offset] = this->value_[iEl];
+    if (num_new_nz) {
+      // Adding a positive number of nonzeros
+      this->index_.resize(new_num_nz);
+      this->value_.resize(new_num_nz);
+      // Determine the row lengths of the new columns being added
+      std::vector<HighsInt> new_row_length;
+      new_row_length.assign(num_row, 0);
+      for (HighsInt iEl = 0; iEl < num_new_nz; iEl++)
+        new_row_length[new_matrix_index[iEl]]++;
+      // Now shift the indices and values to make space
+      HighsInt entry_offset = num_new_nz;
+      HighsInt to_original_el = this->start_[num_row];
+      this->start_[num_row] = new_num_nz;
+      for (HighsInt iRow = num_row - 1; iRow >= 0; iRow--) {
+        entry_offset -= new_row_length[iRow];
+        HighsInt from_original_el = this->start_[iRow];
+        // Can now use this new_row_length to store the start for the
+        // new entries
+        new_row_length[iRow] = to_original_el + entry_offset;
+        for (HighsInt iEl = to_original_el - 1; iEl >= from_original_el;
+             iEl--) {
+          this->index_[iEl + entry_offset] = this->index_[iEl];
+          this->value_[iEl + entry_offset] = this->value_[iEl];
+        }
+        to_original_el = from_original_el;
+        this->start_[iRow] = entry_offset + from_original_el;
       }
-      to_original_el = from_original_el;
-      this->start_[iRow] = entry_offset + from_original_el;
-    }
-    // Now insert the indices and values for the new columns
-    for (HighsInt iCol = 0; iCol < num_new_col; iCol++) {
-      for (HighsInt iEl = new_matrix_start[iCol]; iEl < new_matrix_start[iCol+1]; iEl++) {
-	HighsInt iRow = new_matrix_index[iEl];
-	this->index_[new_row_length[iRow]] = num_col + iCol;
-	this->value_[new_row_length[iRow]] = new_matrix_value[iEl];
-	new_row_length[iRow]++;
+      // Now insert the indices and values for the new columns
+      for (HighsInt iCol = 0; iCol < num_new_col; iCol++) {
+        for (HighsInt iEl = new_matrix_start[iCol];
+             iEl < new_matrix_start[iCol + 1]; iEl++) {
+          HighsInt iRow = new_matrix_index[iEl];
+          this->index_[new_row_length[iRow]] = num_col + iCol;
+          this->value_[new_row_length[iRow]] = new_matrix_value[iEl];
+          new_row_length[iRow]++;
+        }
       }
     }
+    // Have to increase the number of columns, even if no nonzeros are being
+    // added
     this->num_col_ += num_new_col;
   }
 }


### PR DESCRIPTION
This fixes #717 adding unit test for it, and nontrivial LP-building. Also exposed bug in unit tests due to log_callback not being initialised when an HighsLogOptions instance is used in isolation. Both log_callback and log_callback_data now initialised to nullptr in struct.