### PR TITLE
fix possible memory leak in HighsHashTable::clear()

### DIFF
--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -995,7 +995,12 @@ class HighsHashTable {
 
  public:
   void clear() {
-    if (numElements) makeEmptyTable(128);
+    if (numElements) {
+      u64 capacity = tableSizeMask + 1;
+      for (u64 i = 0; i < capacity; ++i)
+        if (occupied(metadata[i])) entries.get()[i].~Entry();
+      makeEmptyTable(128);
+    }
   }
 
   const ValueType* find(const KeyType& key) const {


### PR DESCRIPTION
Should go into 1.2.1. It fixes a memory leak when clear() is called in the hashtable which is the case in the Modk separator.