### PR TITLE
revert to previous solution but use union type punning to avoid warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -427,37 +427,51 @@ install(FILES ${HIGHS_BINARY_DIR}/libhighs_export.h DESTINATION include)
 
 if (IPX_ON)
     if (UNIX)
-    #target_compile_options(libhighs PRIVATE "-Wno-defaulted-function-deleted")
-    #target_compile_options(libhighs PRIVATE "-Wno-return-type-c-linkage")
-    target_compile_options(libhighs PRIVATE "-Wno-return-type" "-Wno-switch")
+        #target_compile_options(libhighs PRIVATE "-Wno-defaulted-function-deleted")
+        #target_compile_options(libhighs PRIVATE "-Wno-return-type-c-linkage")
+        target_compile_options(libhighs PRIVATE "-Wno-return-type" "-Wno-switch")
 
-    target_compile_options(libhighs PRIVATE "-Wno-unused-variable")
-    target_compile_options(libhighs PRIVATE "-Wno-unused-const-variable")
-    target_compile_options(libhighs PRIVATE "-Wno-sign-compare")
-    #target_compile_options(libhighs PRIVATE "-Wno-logical-op-parentheses")
+        target_compile_options(libhighs PRIVATE "-Wno-unused-variable")
+        target_compile_options(libhighs PRIVATE "-Wno-unused-const-variable")
+        target_compile_options(libhighs PRIVATE "-Wno-sign-compare")
+        #target_compile_options(libhighs PRIVATE "-Wno-logical-op-parentheses")
 
-    #target_compile_options(libipx PRIVATE "-Wno-defaulted-function-deleted")
-    #target_compile_options(libipx PRIVATE "-Wno-return-type-c-linkage")
-    target_compile_options(libipx PRIVATE "-Wno-return-type" "-Wno-switch")
+        #target_compile_options(libipx PRIVATE "-Wno-defaulted-function-deleted")
+        #target_compile_options(libipx PRIVATE "-Wno-return-type-c-linkage")
+        target_compile_options(libipx PRIVATE "-Wno-return-type" "-Wno-switch")
 
-    target_compile_options(libipx PRIVATE "-Wno-unused-variable")
-    target_compile_options(libipx PRIVATE "-Wno-sign-compare")
-    #target_compile_options(libipx PRIVATE "-Wno-logical-op-parentheses")
+        target_compile_options(libipx PRIVATE "-Wno-unused-variable")
+        target_compile_options(libipx PRIVATE "-Wno-sign-compare")
+        #target_compile_options(libipx PRIVATE "-Wno-logical-op-parentheses")
     endif()
 
-    install(TARGETS libhighs libipx libbasiclu EXPORT highs-targets
+    if (WIN32)
+        install(TARGETS libhighs libipx libbasiclu EXPORT highs-targets
+            LIBRARY DESTINATION bin
+            ARCHIVE DESTINATION lib
+            INCLUDES DESTINATION include)
+    else()
+        install(TARGETS libhighs libipx libbasiclu EXPORT highs-targets
             LIBRARY DESTINATION lib
             ARCHIVE DESTINATION lib
             INCLUDES DESTINATION include)
+    endif()
 
     # Add library targets to the build-tree export set
     export(TARGETS libhighs libipx libbasiclu
     FILE "${HIGHS_BINARY_DIR}/highs-targets.cmake")
 else()
-    install(TARGETS libhighs EXPORT highs-targets
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib
-            INCLUDES DESTINATION include)
+    if (WIN32)
+        install(TARGETS libhighs EXPORT highs-targets
+                LIBRARY DESTINATION bin
+                ARCHIVE DESTINATION lib
+                INCLUDES DESTINATION include)
+    else()
+        install(TARGETS libhighs EXPORT highs-targets
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib
+                INCLUDES DESTINATION include)
+    endif()
 
     # Add library targets to the build-tree export set
     export(TARGETS libhighs 

--- a/src/parallel/HighsTask.h
+++ b/src/parallel/HighsTask.h
@@ -22,12 +22,6 @@
 
 class HighsSplitDeque;
 
-#if __GNUG__ && __GNUC__ < 5
-#define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
-#else
-#define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
-#endif
-
 class HighsTask {
   friend class HighsSplitDeque;
 

--- a/src/parallel/HighsTask.h
+++ b/src/parallel/HighsTask.h
@@ -30,7 +30,6 @@ class HighsSplitDeque;
 
 class HighsTask {
   friend class HighsSplitDeque;
-  using TaskPtr = void (*)(const char*);
 
  public:
   enum Constants {
@@ -40,39 +39,44 @@ class HighsTask {
  private:
   struct Metadata {
     std::atomic<HighsSplitDeque*> stealer;
-    TaskPtr taskPtr;
   };
 
-  Metadata metadata;
-  char taskData[kMaxTaskSize - sizeof(Metadata)];
+  class CallableBase {
+   public:
+    virtual void operator()() = 0;
+  };
 
   template <typename F>
-  class CallableAdaptor {
-    // this union is used to declare space for a functor of type F
-    // on the stack but avoid calling it constructor since it is usually not
-    // default constructible. Since it is stacically asserted to be trivially
-    // copyable and trivially destructible the functor member f can still be
-    // assigned by memcopying the functors bytes into it and does not need to be
-    // destructed.
-    union FunctorSpace {
-      char dummyMember;
-      F f;
-    };
+  class Callable : public CallableBase {
+    F functor;
 
    public:
-    static void do_call(const char* functorBytes) {
-      // declaring F f would fail as type F is not default constructible
-      FunctorSpace s{};
-      std::memcpy(reinterpret_cast<char*>(&s.f), functorBytes, sizeof(F));
-      s.f();
+    Callable(F&& functor) : functor(std::forward<F>(functor)) {}
+
+    virtual void operator()() override {
+      F callFunctor = std::move(functor);
+      callFunctor();
     }
   };
+
+  char taskData[kMaxTaskSize - sizeof(Metadata)];
+  Metadata metadata;
+
+  CallableBase& getCallable() {
+    union {
+      CallableBase* callablePtr;
+      char* storagePtr;
+    } u;
+
+    u.storagePtr = this->taskData;
+    return *u.callablePtr;
+  }
 
   /// run task as stealer and return the owner's split deque if the owner is
   /// waiting and needs to be signaled
   HighsSplitDeque* run(HighsSplitDeque* stealer) {
     metadata.stealer.store(stealer, std::memory_order_relaxed);
-    metadata.taskPtr(taskData);
+    getCallable()();
     HighsSplitDeque* waitingOwner = metadata.stealer.exchange(
         reinterpret_cast<HighsSplitDeque*>(uintptr_t{1}),
         std::memory_order_release);
@@ -91,16 +95,16 @@ class HighsTask {
                   "given task type exceeds maximum size allowed for deque\n");
     static_assert(std::is_trivially_destructible<F>::value,
                   "given task type must be trivially destructible\n");
-    static_assert(IS_TRIVIALLY_COPYABLE(F),
-                  "given task type must be trivially copyable\n");
     metadata.stealer.store(nullptr, std::memory_order_relaxed);
 
-    std::memcpy(taskData, &f, sizeof(F));
-    metadata.taskPtr = &CallableAdaptor<F>::do_call;
+    new (taskData) Callable<F>(std::forward<F>(f));
+
+    assert(static_cast<CallableBase*>(reinterpret_cast<Callable<F>*>(
+               taskData)) == reinterpret_cast<CallableBase*>(taskData));
   }
 
   /// run task as owner
-  void run() { metadata.taskPtr(taskData); }
+  void run() { getCallable()(); }
 
   /// request notification of the owner when the is finished.
   /// Should be called while the owner holds its wait mutex


### PR DESCRIPTION
I reverted to a previous solution for calling a task. This solution has the advantage that it does not require the compiler generated type of the lambda expression to be trivially copyable, for which the static assert failed for some compilers. The disadvantage is that the pointer to the CallableBase class generated by a cast is not standard compliant. The base class could in principle have an offset and hence a pointer obtained by a simple cast reinterpret_cast from a derived class might not retrieve the correct pointer to the base class.
I avoided any warnings about strict aliasing violations by doing "type punning" of the pointer via a union. Also I added an assert that will fail at runtime if there should ever be an offset generated for the classes. In reality compilers do not do ever this for such cases with trivial single inheritance of one level so this should be safe in practice.

I would propose to merge into master for v1.2.1 to address issue #720. Runtime behavior is not affected.

Also contains (I think) a fix for #721, by installing libraries into bin on windows. This split between `FAST_BUILD=on/off` becomes more and more messy and I propose that we remove this soon. There should not be an option for FAST_BUILD but all builds should use the same path in how the targets are set up. To speed things up when building highs there are different things we could do. E.g. we can exclude some interfaces from the default compilation by using `EXCLUDE_FROM_ALL` or it is also easily possible to simply type `make highs` instead of `make` to only build the highs target when developing code without changing anything. We could also, e.g., exclude the unit_test build from the all target and only build the unit_tests as part of running ctest, which I think happens already.
But having these two build options causes these undesirable problems as in #721 where only one of the options works but behaves still differently regarding whether shared libraries are built or not. Installation differs between `FAST_BUILD=on/off` and regarding this particular issue what `FAST_BUILD=on` does is correct and the default for whether shared libraries are built also differs.