### PR TITLE
Fix const method signatures in highs_c_api.cpp

### DIFF
--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -309,11 +309,11 @@ HighsInt Highs_resetOptions(void* highs) {
   return (HighsInt)((Highs*)highs)->resetOptions();
 }
 
-HighsInt Highs_writeOptions(void* highs, const char* filename) {
+HighsInt Highs_writeOptions(const void* highs, const char* filename) {
   return (HighsInt)((Highs*)highs)->writeOptions(filename);
 }
 
-HighsInt Highs_writeOptionsDeviations(void* highs, const char* filename) {
+HighsInt Highs_writeOptionsDeviations(const void* highs, const char* filename) {
   return (HighsInt)((Highs*)highs)->writeOptions(filename, true);
 }
 


### PR DESCRIPTION
Closes #734 

Looks like a mismatch between the header and the actual method.

Current release:
```
(base) oscar@Oscars-MBP build % cmake --build . --config Release --parallel
Consolidate compiler generated dependencies of target libhighs
[  0%] Building CXX object src/CMakeFiles/libhighs.dir/interfaces/highs_c_api.cpp.o
[  1%] Linking CXX shared library ../lib/libhighs.dylib
[ 99%] Built target libhighs
[100%] Linking CXX executable ../bin/highs
[100%] Built target highs
(base) oscar@Oscars-MBP build % nm lib/libhighs.dylib | grep Highs_writeOptions
0000000000286960 T __Z18Highs_writeOptionsPvPKc
0000000000286a50 T __Z28Highs_writeOptionsDeviationsPvPKc
```
This PR:
```
(base) oscar@Oscars-MBP build % cmake --build . --config Release --parallel    
Consolidate compiler generated dependencies of target libhighs
[  0%] Building CXX object src/CMakeFiles/libhighs.dir/interfaces/highs_c_api.cpp.o
[  1%] Linking CXX shared library ../lib/libhighs.dylib
[ 99%] Built target libhighs
[100%] Linking CXX executable ../bin/highs
[100%] Built target highs
(base) oscar@Oscars-MBP build % nm lib/libhighs.dylib | grep Highs_writeOptions
0000000000286960 T _Highs_writeOptions
0000000000286a50 T _Highs_writeOptionsDeviations
```