### PR TITLE
Add default semi variable upper bound

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -245,24 +245,10 @@ void minimal_api_mip() {
 					 integrality,
 					 colvalue, rowvalue,
 					 &modelstatus);
-
   // Should return error
   assert( return_status == -1 );
 
-  // Non-empty integrality for a continuous problem yields a warning
-  integrality[numcol-1] = 0;
-
-  return_status = Highs_mipCall(numcol, numrow, numnz, a_format,
-					 sense, offset, colcost, collower, colupper, rowlower, rowupper,
-					 astart, aindex, avalue,
-					 integrality,
-					 colvalue, rowvalue,
-					 &modelstatus);
-
-  // Should return warning
-  assert( return_status == 1 );
-
-  // Genuine integrality is fine
+  // Correct integrality
   integrality[numcol-1] = 1;
 
   return_status = Highs_mipCall(numcol, numrow, numnz, a_format,
@@ -271,7 +257,6 @@ void minimal_api_mip() {
 					 integrality,
 					 colvalue, rowvalue,
 					 &modelstatus);
-
   // Should return OK
   assert( return_status == 0 );
 

--- a/check/TestSemiVariables.cpp
+++ b/check/TestSemiVariables.cpp
@@ -24,9 +24,10 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   const HighsInt semi_col = 2;
   const double save_semi_col_lower = lp.col_lower_[semi_col];
   const double save_semi_col_upper = lp.col_upper_[semi_col];
+  // Legal to have infinte upper bounds on semi-variables
   lp.col_upper_[semi_col] = inf;
   return_status = highs.passModel(model);
-  REQUIRE(return_status == HighsStatus::kError);
+  REQUIRE(return_status == HighsStatus::kOk);
   lp.col_upper_[semi_col] = save_semi_col_upper;
 
   return_status = highs.passModel(model);

--- a/check/TestSemiVariables.cpp
+++ b/check/TestSemiVariables.cpp
@@ -6,8 +6,6 @@ const double inf = kHighsInf;
 const bool dev_run = false;
 const double double_equal_tolerance = 1e-5;
 
-HighsLp baseLp();
-
 TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   Highs highs;
   const HighsInfo& info = highs.getInfo();
@@ -16,7 +14,19 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   if (!dev_run) highs.setOptionValue("output_flag", false);
   HighsModel model;
   HighsLp& lp = model.lp_;
-  lp = baseLp();
+  lp.num_col_ = 4;
+  lp.num_row_ = 4;
+  lp.col_cost_ = {1, 2, -4, -3};
+  lp.col_lower_ = {0, 0, 1.1, 0};
+  lp.col_upper_ = {inf, inf, inf, inf};
+  lp.row_lower_ = {-inf, 0, 0, 0.5};
+  lp.row_upper_ = {5, inf, inf, inf};
+  lp.a_matrix_.start_ = {0, 3, 6, 7, 8};
+  lp.a_matrix_.index_ = {0, 1, 2, 0, 1, 2, 3, 3};
+  lp.a_matrix_.value_ = {1, 2, -1, 1, -1, 3, 1, 1};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.sense_ = ObjSense::kMaximize;
+
   const HighsVarType continuous = HighsVarType::kContinuous;
   const HighsVarType semi_continuous = HighsVarType::kSemiContinuous;
   const HighsVarType semi_integer = HighsVarType::kSemiInteger;
@@ -24,19 +34,17 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   const HighsInt semi_col = 2;
   const double save_semi_col_lower = lp.col_lower_[semi_col];
   const double save_semi_col_upper = lp.col_upper_[semi_col];
+  optimal_objective_function_value = 6.83333;
   // Legal to have infinte upper bounds on semi-variables
   lp.col_upper_[semi_col] = inf;
   return_status = highs.passModel(model);
   REQUIRE(return_status == HighsStatus::kOk);
-  lp.col_upper_[semi_col] = save_semi_col_upper;
-
-  return_status = highs.passModel(model);
-  REQUIRE(return_status == HighsStatus::kOk);
   REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kOptimal);
   if (dev_run) highs.writeSolution("", kSolutionStylePretty);
-  optimal_objective_function_value = 6.83333;
   REQUIRE(fabs(info.objective_function_value -
                optimal_objective_function_value) < double_equal_tolerance);
+
   // Remove the semi-condition and resolve
   highs.changeColIntegrality(semi_col, continuous);
   REQUIRE(highs.run() == HighsStatus::kOk);
@@ -72,6 +80,52 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
                optimal_objective_function_value) < double_equal_tolerance);
 }
 
+TEST_CASE("semi-variable-upper-bound", "[highs_test_semi_variables]") {
+  Highs highs;
+  if (!dev_run) highs.setOptionValue("output_flag", false);
+  HighsLp lp;
+  lp.num_col_ = 2;
+  lp.num_row_ = 0;
+  lp.col_cost_ = {1, 2};
+  lp.col_lower_ = {1, 0};
+  lp.col_upper_ = {inf, 1};
+  lp.sense_ = ObjSense::kMaximize;
+  lp.integrality_ = {HighsVarType::kSemiContinuous, HighsVarType::kContinuous};
+
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+
+  // Problem is unbounded due to infinite upper bound on x0, so
+  // modified upper bound is active in solution, and run returns error
+  REQUIRE(highs.run() == HighsStatus::kError);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kSolveError);
+
+  REQUIRE(highs.changeColBounds(0, 2e5, inf) == HighsStatus::kOk);
+  // Problem is still unbounded due to infinite upper bound on x0, but
+  // lower bound is too large to set modified upper bound, so run
+  // returns error
+  REQUIRE(highs.run() == HighsStatus::kError);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kSolveError);
+
+  REQUIRE(highs.changeColBounds(0, 1, inf) == HighsStatus::kOk);
+  std::vector<HighsInt> index = {0, 1};
+  std::vector<double> value = {-1, 1e4};
+  REQUIRE(highs.addRow(0, 0, 2, &index[0], &value[0]) == HighsStatus::kOk);
+  // Problem is no longer unbounded due to equation linking the
+  // semi-variable to the continuous variable. However, optimal value
+  // of semi-variable is 1e4, so it is active at the modified upper
+  // bound.
+  REQUIRE(highs.run() == HighsStatus::kError);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kSolveError);
+
+  highs.setOptionValue("default_semi_variable_upper_bound", 2e4);
+  // Problem is no longer unbounded due to equation linking the
+  // semi-variable to the continuous variable. However, modified upper
+  // bound now exceeds the optimal value of semi-variable is 1e4, so
+  // problem is solved OK
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kOptimal);
+}
+
 TEST_CASE("semi-variable-file", "[highs_test_semi_variables]") {
   Highs highs;
   const HighsInfo& info = highs.getInfo();
@@ -105,21 +159,4 @@ TEST_CASE("semi-variable-file", "[highs_test_semi_variables]") {
   REQUIRE(highs.run() == HighsStatus::kOk);
   REQUIRE(fabs(info.objective_function_value -
                optimal_objective_function_value) < double_equal_tolerance);
-}
-
-HighsLp baseLp() {
-  HighsLp lp;
-  lp.num_col_ = 4;
-  lp.num_row_ = 4;
-  lp.col_cost_ = {1, 2, -4, -3};
-  lp.col_lower_ = {0, 0, 1.1, 0};
-  lp.col_upper_ = {inf, inf, 10, inf};
-  lp.row_lower_ = {-inf, 0, 0, 0.5};
-  lp.row_upper_ = {5, inf, inf, inf};
-  lp.a_matrix_.start_ = {0, 3, 6, 7, 8};
-  lp.a_matrix_.index_ = {0, 1, 2, 0, 1, 2, 3, 3};
-  lp.a_matrix_.value_ = {1, 2, -1, 1, -1, 3, 1, 1};
-  lp.a_matrix_.format_ = MatrixFormat::kColwise;
-  lp.sense_ = ObjSense::kMaximize;
-  return lp;
 }

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1111,7 +1111,6 @@ class Highs {
   HighsBasis basis_;
   HighsModel model_;
   HighsModel presolved_model_;
-  //  HighsModel presolve_;
   HighsTimer timer_;
 
   HighsOptions options_;
@@ -1126,7 +1125,6 @@ class Highs {
   HEkk ekk_instance_;
 
   HighsInt max_threads = 0;
-
   // This is strictly for debugging. It's used to check whether
   // returnFromRun() was called after the previous call to
   // Highs::run() and, assuming that this is always done, it checks

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -75,4 +75,11 @@ struct HighsScale {
   std::vector<double> row;
 };
 
+struct HighsLpMods {
+  std::vector<HighsInt> save_semi_variable_upper_bound_index;
+  std::vector<double> save_semi_variable_upper_bound_value;
+  void clear();
+  bool isClear();
+};
+
 #endif /* LP_DATA_HSTRUCT_H_ */

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -260,12 +260,6 @@ HighsStatus Highs::passModel(HighsModel model) {
   return_status = interpretCallStatus(
       options_.log_options, assessLp(lp, options_), return_status, "assessLp");
   if (return_status == HighsStatus::kError) return return_status;
-  // Check validity of any integrality
-  return_status =
-      interpretCallStatus(options_.log_options, assessIntegrality(lp, options_),
-                          return_status, "assessIntegrality");
-  if (return_status == HighsStatus::kError) return return_status;
-
   // Check validity of any Hessian, normalising its entries
   return_status = interpretCallStatus(options_.log_options,
                                       assessHessian(hessian, options_),
@@ -679,8 +673,21 @@ HighsStatus Highs::run() {
     highsLogDev(options_.log_options, HighsLogType::kVerbose,
                 "Solving model: %s\n", model_.lp_.model_name_.c_str());
 
+  // Check validity of any integrality, keeping a record of any upper
+  // bound modifications for semi-variables
+  call_status = assessIntegrality(model_.lp_, options_);
+  if (call_status == HighsStatus::kError)
+    return returnFromRun(HighsStatus::kError);
+
   if (!options_.solver.compare(kHighsChooseString) && model_.isQp()) {
-    // Solve the model as a QP
+    // Choosing method according to model class, and model is a QP
+    //
+    // Ensure that it's not MIQP!
+    if (model_.isMip()) {
+      highsLogUser(options_.log_options, HighsLogType::kError,
+                   "Canot solve MIQP problems with HiGHS\n");
+      return returnFromRun(HighsStatus::kError);
+    }
     call_status = callSolveQp();
     return_status = interpretCallStatus(options_.log_options, call_status,
                                         return_status, "callSolveQp");
@@ -688,7 +695,7 @@ HighsStatus Highs::run() {
   }
 
   if (!options_.solver.compare(kHighsChooseString) && model_.isMip()) {
-    // Solve the model as a MIP
+    // Choosing method according to model class, and model is a MIP
     call_status = callSolveMip();
     return_status = interpretCallStatus(options_.log_options, call_status,
                                         return_status, "callSolveMip");
@@ -2885,6 +2892,9 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status) {
 
   // Record that returnFromRun() has been called
   called_return_from_run = true;
+  // Unapply any modifications that have not yet been unapplied
+  this->model_.lp_.unapplyMods();
+
   // Unless solved as a MIP, report on the solution
   const bool solved_as_mip =
       !options_.solver.compare(kHighsChooseString) && model_.isMip();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2554,6 +2554,14 @@ HighsStatus Highs::callSolveMip() {
     // There is no primal solution: should be so by default
     assert(!solution_.value_valid);
   }
+  // Check that no modified upper bounds for semi-variables are active
+  if (solution_.value_valid &&
+      activeModifiedUpperBounds(options_, model_.lp_, solution_.col_value)) {
+    solution_.value_valid = false;
+    model_status_ = HighsModelStatus::kSolveError;
+    scaled_model_status_ = model_status_;
+    return_status = HighsStatus::kError;
+  }
   // There is no dual solution: should be so by default
   assert(!solution_.dual_valid);
   // There is no basis: should be so by default

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -676,8 +676,10 @@ HighsStatus Highs::run() {
   // Check validity of any integrality, keeping a record of any upper
   // bound modifications for semi-variables
   call_status = assessIntegrality(model_.lp_, options_);
-  if (call_status == HighsStatus::kError)
+  if (call_status == HighsStatus::kError) {
+    setHighsModelStatusAndClearSolutionAndBasis(HighsModelStatus::kSolveError);
     return returnFromRun(HighsStatus::kError);
+  }
 
   if (!options_.solver.compare(kHighsChooseString) && model_.isQp()) {
     // Choosing method according to model class, and model is a QP

--- a/src/lp_data/HighsLp.cpp
+++ b/src/lp_data/HighsLp.cpp
@@ -136,6 +136,8 @@ void HighsLp::clear() {
   this->clearScale();
   this->is_scaled_ = false;
   this->is_moved_ = false;
+
+  this->mods_.clear();
 }
 
 void HighsLp::clearScale() {
@@ -209,4 +211,32 @@ void HighsLp::moveBackLpAndUnapplyScaling(HighsLp lp) {
   *this = std::move(lp);
   this->unapplyScale();
   assert(this->is_moved_ == false);
+}
+
+void HighsLp::unapplyMods() {
+  std::vector<HighsInt>& upper_bound_index =
+      this->mods_.save_semi_variable_upper_bound_index;
+  std::vector<double>& upper_bound_value =
+      this->mods_.save_semi_variable_upper_bound_value;
+  const HighsInt num_upper_bound = upper_bound_index.size();
+  if (!num_upper_bound) {
+    assert(!upper_bound_value.size());
+    return;
+  }
+  for (HighsInt k = 0; k < num_upper_bound; k++) {
+    HighsInt iCol = upper_bound_index[k];
+    this->col_upper_[iCol] = upper_bound_value[k];
+  }
+  this->mods_.clear();
+}
+
+void HighsLpMods::clear() {
+  this->save_semi_variable_upper_bound_index.clear();
+  this->save_semi_variable_upper_bound_value.clear();
+}
+
+bool HighsLpMods::isClear() {
+  if (this->save_semi_variable_upper_bound_index.size()) return false;
+  if (this->save_semi_variable_upper_bound_value.size()) return false;
+  return true;
 }

--- a/src/lp_data/HighsLp.h
+++ b/src/lp_data/HighsLp.h
@@ -50,6 +50,7 @@ class HighsLp {
   HighsScale scale_;
   bool is_scaled_;
   bool is_moved_;
+  HighsLpMods mods_;
 
   bool operator==(const HighsLp& lp);
   bool equalButForNames(const HighsLp& lp) const;
@@ -67,6 +68,7 @@ class HighsLp {
   void unapplyScale();
   void moveBackLpAndUnapplyScaling(HighsLp lp);
   void exactResize();
+  void unapplyMods();
   void clear();
 };
 

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -581,6 +581,29 @@ HighsStatus assessIntegrality(HighsLp& lp, const HighsOptions& options) {
   return return_status;
 }
 
+bool activeModifiedUpperBounds(const HighsOptions& options,
+			       const HighsLp& lp,
+			       const std::vector<double>col_value) {
+  const std::vector<HighsInt>& upper_bound_index =
+      lp.mods_.save_semi_variable_upper_bound_index;
+  const HighsInt num_modified_upper = upper_bound_index.size();
+  HighsInt num_active_modified_upper = 0;
+  for (HighsInt k = 0; k < num_modified_upper; k++)
+    if (col_value[upper_bound_index[k]] >
+	lp.col_upper_[upper_bound_index[k]] - options.primal_feasibility_tolerance)
+      num_active_modified_upper++;
+  if (num_active_modified_upper) {
+    highsLogUser(options.log_options, HighsLogType::kError,
+                   "%" HIGHSINT_FORMAT
+                   " semi-variables are active at modified upper bounds\n",
+		 num_active_modified_upper);
+  } else {
+    highsLogUser(options.log_options, HighsLogType::kInfo,
+		 "No semi-variables are active at modified upper bounds\n");
+  }
+  return num_active_modified_upper;
+}
+
 HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp) {
   double max_residual = 0;
   HighsInt num_change = 0;

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -571,11 +571,12 @@ HighsStatus assessIntegrality(HighsLp& lp, const HighsOptions& options) {
     return_status = HighsStatus::kError;
   }
   if (num_illegal_upper) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "%" HIGHSINT_FORMAT
-                 " semi-continuous/integer variable(s) have upper bounds "
-                 "exceeding %g\n",
-                 num_illegal_upper, kMaxSemiVariableUpper);
+    highsLogUser(
+        options.log_options, HighsLogType::kError,
+        "%" HIGHSINT_FORMAT
+        " semi-continuous/integer variables have upper bounds "
+        "exceeding %g that cannot be modified due to large lower bounds\n",
+        num_illegal_upper, kMaxSemiVariableUpper);
     return_status = HighsStatus::kError;
   }
   return return_status;
@@ -595,7 +596,8 @@ bool activeModifiedUpperBounds(const HighsOptions& options, const HighsLp& lp,
   if (num_active_modified_upper) {
     highsLogUser(options.log_options, HighsLogType::kError,
                  "%" HIGHSINT_FORMAT
-                 " semi-variables are active at modified upper bounds\n",
+                 " semi-variables are active at modified upper bounds, "
+                 "consider increasing default_semi_variable_upper_bound\n",
                  num_active_modified_upper);
   } else {
     highsLogUser(options.log_options, HighsLogType::kInfo,

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -581,25 +581,25 @@ HighsStatus assessIntegrality(HighsLp& lp, const HighsOptions& options) {
   return return_status;
 }
 
-bool activeModifiedUpperBounds(const HighsOptions& options,
-			       const HighsLp& lp,
-			       const std::vector<double>col_value) {
+bool activeModifiedUpperBounds(const HighsOptions& options, const HighsLp& lp,
+                               const std::vector<double> col_value) {
   const std::vector<HighsInt>& upper_bound_index =
       lp.mods_.save_semi_variable_upper_bound_index;
   const HighsInt num_modified_upper = upper_bound_index.size();
   HighsInt num_active_modified_upper = 0;
   for (HighsInt k = 0; k < num_modified_upper; k++)
     if (col_value[upper_bound_index[k]] >
-	lp.col_upper_[upper_bound_index[k]] - options.primal_feasibility_tolerance)
+        lp.col_upper_[upper_bound_index[k]] -
+            options.primal_feasibility_tolerance)
       num_active_modified_upper++;
   if (num_active_modified_upper) {
     highsLogUser(options.log_options, HighsLogType::kError,
-                   "%" HIGHSINT_FORMAT
-                   " semi-variables are active at modified upper bounds\n",
-		 num_active_modified_upper);
+                 "%" HIGHSINT_FORMAT
+                 " semi-variables are active at modified upper bounds\n",
+                 num_active_modified_upper);
   } else {
     highsLogUser(options.log_options, HighsLogType::kInfo,
-		 "No semi-variables are active at modified upper bounds\n");
+                 "No semi-variables are active at modified upper bounds\n");
   }
   return num_active_modified_upper;
 }
@@ -2617,6 +2617,8 @@ HighsLp withoutSemiVariables(const HighsLp& lp_) {
   lp.num_col_ += num_semi_variables;
   lp.num_row_ += 2 * num_semi_variables;
   assert(index.size() == new_num_nz);
+  // Clear any modifications inherited from lp_
+  lp.mods_.clear();
   return lp;
 }
 

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -58,9 +58,8 @@ HighsStatus assessBounds(const HighsOptions& options, const char* type,
 HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp);
 
 HighsStatus assessIntegrality(HighsLp& lp, const HighsOptions& options);
-bool activeModifiedUpperBounds(const HighsOptions& options,
-			       const HighsLp& lp,
-			       const std::vector<double>col_value);
+bool activeModifiedUpperBounds(const HighsOptions& options, const HighsLp& lp,
+                               const std::vector<double> col_value);
 
 bool considerScaling(const HighsOptions& options, HighsLp& lp);
 void scaleLp(const HighsOptions& options, HighsLp& lp);

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -58,6 +58,10 @@ HighsStatus assessBounds(const HighsOptions& options, const char* type,
 HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp);
 
 HighsStatus assessIntegrality(HighsLp& lp, const HighsOptions& options);
+bool activeModifiedUpperBounds(const HighsOptions& options,
+			       const HighsLp& lp,
+			       const std::vector<double>col_value);
+
 bool considerScaling(const HighsOptions& options, HighsLp& lp);
 void scaleLp(const HighsOptions& options, HighsLp& lp);
 bool equilibrationScaleMatrix(const HighsOptions& options, HighsLp& lp,

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -326,6 +326,7 @@ struct HighsOptionsStruct {
   HighsInt presolve_substitution_maxfillin;
   bool simplex_initial_condition_check;
   bool no_unnecessary_rebuild_refactor;
+  double default_semi_variable_upper_bound;
   double simplex_initial_condition_tolerance;
   double rebuild_refactor_solution_error_tolerance;
   double dual_steepest_edge_weight_error_tolerance;
@@ -856,6 +857,12 @@ class HighsOptions : public HighsOptionsStruct {
         "No unnecessary refactorization on simplex rebuild", advanced,
         &no_unnecessary_rebuild_refactor, true);
     records.push_back(record_bool);
+
+    record_double = new OptionRecordDouble(
+        "default_semi_variable_upper_bound",
+        "Default upper bound for semi-variables with excessive upper bound", advanced,
+        &default_semi_variable_upper_bound, 0.0, 1e3, 1e6);
+    records.push_back(record_double);
 
     record_double = new OptionRecordDouble(
         "simplex_initial_condition_tolerance",

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -860,8 +860,8 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_double = new OptionRecordDouble(
         "default_semi_variable_upper_bound",
-        "Default upper bound for semi-variables with excessive upper bound", advanced,
-        &default_semi_variable_upper_bound, 0.0, 1e3, 1e6);
+        "Default upper bound for semi-variables with excessive upper bound",
+        advanced, &default_semi_variable_upper_bound, 0.0, 1e3, 1e6);
     records.push_back(record_double);
 
     record_double = new OptionRecordDouble(


### PR DESCRIPTION
Large upper bounds on semi-variables are now replaced when possible, and only within run(), by values that give acceptable matrix coefficients when a binary is introduced to transform semi-variable problems into pure MIPs. If the new bounds are active in the optimal solution, run() returns kError. 