### PR TITLE
FilereaderLp.cpp now returns FilereaderRetcode::kFileNotFound when this happens, and not FilereaderRetcode::kParserError!

### DIFF
--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -141,6 +141,15 @@ FilereaderRetcode FilereaderLp::readModelFromFile(const HighsOptions& options,
     lp.sense_ = m.sense == ObjectiveSense::MIN ? ObjSense::kMinimize
                                                : ObjSense::kMaximize;
   } catch (std::invalid_argument& ex) {
+    // lpassert in extern/filereaderlp/def.hpp throws
+    // std::invalid_argument whatever the error. Hence, unless
+    // something is done specially - here or elsewhere -
+    // FilereaderRetcode::kParserError will be returned.
+    //
+    // This is misleading when the file isn't found, as it's not a
+    // parser error
+    FILE* file = fopen(filename.c_str(), "r");
+    if (file == nullptr) return FilereaderRetcode::kFileNotFound;
     return FilereaderRetcode::kParserError;
   }
   lp.ensureColwise();

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -150,6 +150,7 @@ FilereaderRetcode FilereaderLp::readModelFromFile(const HighsOptions& options,
     // parser error
     FILE* file = fopen(filename.c_str(), "r");
     if (file == nullptr) return FilereaderRetcode::kFileNotFound;
+    fclose(file);
     return FilereaderRetcode::kParserError;
   }
   lp.ensureColwise();


### PR DESCRIPTION
This caused confusion for a user and I. He'd had a .lp model that he's wanting to solve from the command line.

He had caused parser errors in the past - because he uses semi-continuous variables - and recently was generating models could be read, but not solved - because the semi-continuous variables had infinite upper bounds. I fixed the solver issue, and he came up with finite upper bounds. But he was still getting "parser errors". 

We were baffled until I spotted that "parser errors" were reported if the .lp file wasn't found. 

He'd got his file name wrong in the command line!

My fix may not be the most elegant, @feldmeier, but it works!