### PR TITLE
Ditch CMake generate_export_header in favor of a short self-written one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,9 +525,6 @@ endif()
 
 endif()
 
-include(GenerateExportHeader)
-generate_export_header(libhighs)
-
 # # Comment out for scaffold/ tests
 # add_subdirectory(scaffold)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -303,6 +303,7 @@ set(headers
     util/stringutil.h
     Highs.h
     interfaces/highs_c_api.h
+    libhighs_export.h
 )
 
 if (IPX_ON)
@@ -423,7 +424,6 @@ foreach ( file ${headers} )
     install( FILES ${file} DESTINATION include/${dir} )
 endforeach()
 install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION include)
-install(FILES ${HIGHS_BINARY_DIR}/libhighs_export.h DESTINATION include)
 
 if (IPX_ON)
     if (UNIX)
@@ -762,6 +762,7 @@ set(headers_fast_build_
     util/HVectorBase.h
     util/stringutil.h
     Highs.h
+    libhighs_export.h
     interfaces/highs_c_api.h
 )
 
@@ -784,7 +785,6 @@ foreach ( file ${headers_fast_build_} )
     install( FILES ${file} DESTINATION include/${dir} )
 endforeach()
 install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION include)
-install(FILES ${HIGHS_BINARY_DIR}/libhighs_export.h DESTINATION include)
 
 
 # target_compile_options(libhighs PRIVATE "-Wall")
@@ -792,6 +792,9 @@ install(FILES ${HIGHS_BINARY_DIR}/libhighs_export.h DESTINATION include)
 
 target_include_directories(libhighs PUBLIC ipm/ipx/src
     ipm/ipx/include ipm/basiclu/src ipm/basiclu/include)
+
+# to tell the api export macro we are building the library
+target_compile_definitions(libhighs PRIVATE BUILDING_LIBHIGHS)
 
 if (IPX_ON)
     target_sources(libhighs PRIVATE ${basiclu_sources} ${ipx_sources} ipm/IpxWrapper.cpp)

--- a/src/libhighs_export.h
+++ b/src/libhighs_export.h
@@ -1,0 +1,16 @@
+#ifndef LIBHIGHS_EXPORT_H
+#define LIBHIGHS_EXPORT_H
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_LIBHIGHS
+    #define LIBHIGHS_EXPORT __declspec(dllexport)
+  #else
+    #define LIBHIGHS_EXPORT __declspec(dllimport)
+  #endif
+  #define LIBHIGHS_NO_EXPORT
+#else
+  #define LIBHIGHS_EXPORT __attribute__ ((visibility ("default")))
+  #define LIBHIGHS_NO_EXPORT  __attribute__ ((visibility ("hidden")))
+#endif
+
+#endif /* LIBHIGHS_EXPORT_H */


### PR DESCRIPTION
This is what removing the dependency on `generate_export_header` would look like (see #742 ). I do not have MSVC so it might be necessary to test on different systems.

On that note, it seems the export macros from this header are actually used in only a single file throughout the whole code base:

```
src/parallel/HighsTaskExecutor.h:46:  static LIBHIGHS_EXPORT cache_aligned::shared_ptr<HighsTaskExecutor>
src/parallel/HighsTaskExecutor.h:48:  static LIBHIGHS_EXPORT HighsSpinMutex initMutex;
```

So I guess the shared libraries export all symbols at the moment anyway and an alternative solution would be to remove the export macro entirely until more fine-grained control of exported symbols is needed.