### PR TITLE
fix gap calculation for info_.mip_gap in callSolveMip

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2600,8 +2600,8 @@ HighsStatus Highs::callSolveMip() {
   info_.mip_node_count = solver.node_count_;
   info_.mip_dual_bound = solver.dual_bound_;
   info_.mip_gap =
-      100 * std::abs(info_.objective_function_value - info_.mip_dual_bound) /
-      std::max(1.0, std::abs(info_.objective_function_value));
+      100 * std::abs(solver.primal_bound_ - info_.mip_dual_bound) /
+      std::max(1.0, std::abs(solver.primal_bound_));
   info_.valid = true;
   if (model_status_ == HighsModelStatus::kOptimal)
     checkOptimality("MIP", return_status);


### PR DESCRIPTION
It seems info_.objective_function_value accounts for objective sense and info_.mip_dual_bound is for minimization which leads to incorrect gap calculation for maximization problems see https://github.com/ERGO-Code/HiGHS/blob/8585b91291062b2fd95f13bcf9b488ce9b203834/src/lp_data/Highs.cpp#L2602-L2604.