### PR TITLE
Check 752

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -153,10 +153,11 @@ TEST_CASE("MIP-maximize", "[highs_test_mip_solver]") {
   double optimal_objective;
   special_lps.distillationMip(lp, require_model_status, optimal_objective);
   // Add an offset to make sure this is handled correctly
-  const double offset = -20;
+  double offset = -20;
   lp.offset_ = offset;
   optimal_objective += offset;
   Highs highs;
+  if (!dev_run) highs.setOptionValue("output_flag", false);
   const HighsInfo& info = highs.getInfo();
   const HighsOptions& options = highs.getOptions();
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
@@ -174,6 +175,42 @@ TEST_CASE("MIP-maximize", "[highs_test_mip_solver]") {
   lp.sense_ = ObjSense::kMaximize;
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(std::abs(info.objective_function_value - optimal_objective) <
+          double_equal_tolerance);
+  REQUIRE(std::abs(info.objective_function_value - info.mip_dual_bound) <=
+          options.mip_abs_gap);
+  REQUIRE(std::abs(info.mip_gap) <= options.mip_rel_gap);
+
+  // Now test with a larger problem
+  const bool use_avgas = false;
+  const std::string model = use_avgas ? "avgas" : "dcmulti";
+  const std::string filename =
+      std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
+  highs.readModel(filename);
+  optimal_objective = use_avgas ? -6.0 : 188182;
+  offset = 0;  // 5;
+  optimal_objective += offset;
+  lp = highs.getLp();
+  lp.offset_ = offset;
+  // Turn the model into a maximization MIP
+  for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
+    lp.col_cost_[iCol] *= -1;
+    if (use_avgas) lp.integrality_.push_back(HighsVarType::kInteger);
+  }
+  lp.offset_ *= -1;
+  optimal_objective *= -1;
+  lp.sense_ = ObjSense::kMaximize;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  highs.setOptionValue("presolve", kHighsOffString);
+
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  if (dev_run) {
+    printf("optimal_objective =             %11.4g\n", optimal_objective);
+    printf("info.objective_function_value = %11.4g\n",
+           info.objective_function_value);
+    printf("info.mip_dual_bound =           %11.4g\n", info.mip_dual_bound);
+    printf("info.mip_gap =                  %11.4g\n", info.mip_gap);
+  }
   REQUIRE(std::abs(info.objective_function_value - optimal_objective) <
           double_equal_tolerance);
   REQUIRE(std::abs(info.objective_function_value - info.mip_dual_bound) <=

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -202,6 +202,7 @@ TEST_CASE("MIP-maximize", "[highs_test_mip_solver]") {
   lp.sense_ = ObjSense::kMaximize;
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   highs.setOptionValue("presolve", kHighsOffString);
+  highs.setOptionValue("mip_rel_gap", 0.0);
 
   REQUIRE(highs.run() == HighsStatus::kOk);
   if (dev_run) {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2599,9 +2599,7 @@ HighsStatus Highs::callSolveMip() {
   // Set the MIP-specific values of info_
   info_.mip_node_count = solver.node_count_;
   info_.mip_dual_bound = solver.dual_bound_;
-  info_.mip_gap =
-      100 * std::abs(info_.objective_function_value - info_.mip_dual_bound) /
-      std::max(1.0, std::abs(info_.objective_function_value));
+  info_.mip_gap = solver.gap_;
   info_.valid = true;
   if (model_status_ == HighsModelStatus::kOptimal)
     checkOptimality("MIP", return_status);

--- a/src/mip/HighsMipSolver.h
+++ b/src/mip/HighsMipSolver.h
@@ -35,6 +35,7 @@ class HighsMipSolver {
   double row_violation_;
   double dual_bound_;
   double primal_bound_;
+  double gap_;
   int64_t node_count_;
 
   bool submip;

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1023,7 +1023,7 @@ void HighsMipSolverData::printDisplayLine(char first) {
   if (upper_bound != kHighsInf) {
     ub = upper_bound + offset;
 
-    if (std::abs(ub) <= epsilon) ub = 0;
+    if (std::fabs(ub) <= epsilon) ub = 0;
     lb = std::min(ub, lb);
     if (ub == 0.0)
       gap = lb == 0.0 ? 0.0 : kHighsInf;
@@ -1039,11 +1039,13 @@ void HighsMipSolverData::printDisplayLine(char first) {
     std::array<char, 16> ub_string;
     if (mipsolver.options_mip_->objective_bound < ub) {
       ub = mipsolver.options_mip_->objective_bound;
-      ub_string = convertToPrintString(ub, "*");
+      ub_string =
+          convertToPrintString((int)mipsolver.orig_model_->sense_ * ub, "*");
     } else
-      ub_string = convertToPrintString(ub);
+      ub_string = convertToPrintString((int)mipsolver.orig_model_->sense_ * ub);
 
-    std::array<char, 16> lb_string = convertToPrintString(lb);
+    std::array<char, 16> lb_string =
+        convertToPrintString((int)mipsolver.orig_model_->sense_ * lb);
 
     highsLogUser(
         mipsolver.options_mip_->log_options, HighsLogType::kInfo,
@@ -1058,11 +1060,13 @@ void HighsMipSolverData::printDisplayLine(char first) {
     std::array<char, 16> ub_string;
     if (mipsolver.options_mip_->objective_bound < ub) {
       ub = mipsolver.options_mip_->objective_bound;
-      ub_string = convertToPrintString(ub, "*");
+      ub_string =
+          convertToPrintString((int)mipsolver.orig_model_->sense_ * ub, "*");
     } else
-      ub_string = convertToPrintString(ub);
+      ub_string = convertToPrintString((int)mipsolver.orig_model_->sense_ * ub);
 
-    std::array<char, 16> lb_string = convertToPrintString(lb);
+    std::array<char, 16> lb_string =
+        convertToPrintString((int)mipsolver.orig_model_->sense_ * lb);
 
     highsLogUser(
         mipsolver.options_mip_->log_options, HighsLogType::kInfo,


### PR DESCRIPTION
I've extended MIP-maximize to expose errors in `info.mip_gap` and `info.mip_dual_bound` when solving maximization MIPs

@lgottwald, could you modify `cleanupSolve()` 
- to retain the value of `gap` so that it can be copied into `info.mip_gap` in `Highs::callSolveMip`
- to adjust the bounds for the objective sense so that `solver.dual_bound_` is correct when copied into `info.mip_dual_bound`  in `Highs::callSolveMip`
Thanks!

This will close the issue raised via #752 