### PR TITLE
Highspy Log Callback

### DIFF
--- a/highspy/__init__.py
+++ b/highspy/__init__.py
@@ -1,1 +1,13 @@
-from .highs_bindings import *
+from .highs import (
+    ObjSense,
+    HighsModelStatus,
+    HighsVarType,
+    HighsStatus,
+    HighsLogType,
+    HighsSolution,
+    Highs,
+    kHighsInf,
+    HIGHS_VERSION_MAJOR,
+    HIGHS_VERSION_MINOR,
+    HIGHS_VERSION_PATCH,
+)

--- a/highspy/highs.py
+++ b/highspy/highs.py
@@ -1,0 +1,25 @@
+from .highs_bindings import (
+    ObjSense,
+    HighsModelStatus,
+    HighsVarType,
+    HighsStatus,
+    HighsLogType,
+    CallbackTuple,
+    HighsSolution,
+    _Highs,
+    kHighsInf,
+    HIGHS_VERSION_MAJOR,
+    HIGHS_VERSION_MINOR,
+    HIGHS_VERSION_PATCH,
+)
+
+
+class Highs(_Highs):
+    def __init__(self):
+        super().__init__()
+        self._log_callback_tuple = CallbackTuple()
+
+    def setLogCallback(self, func, callback_data):
+        self._log_callback_tuple.callback = func
+        self._log_callback_tuple.callback_data = callback_data
+        super().setLogCallback(self._log_callback_tuple)

--- a/highspy/tests/test_highspy.py
+++ b/highspy/tests/test_highspy.py
@@ -1,6 +1,8 @@
 import unittest
 import highspy
 import numpy as np
+from pyomo.common.tee import capture_output
+from io import StringIO
 
 
 class TestHighsPy(unittest.TestCase):
@@ -179,3 +181,24 @@ class TestHighsPy(unittest.TestCase):
         h.checkSolutionFeasibility()
         h.run()
         h.checkSolutionFeasibility()
+
+    def test_log_callback(self):
+        h = self.get_basic_model()
+        h.setOptionValue('log_to_console', True)
+
+        class Foo(object):
+            def __str__(self):
+                return 'an instance of Foo'
+
+            def __repr__(self):
+                return self.__str__()
+
+        def log_callback(log_type, message, data):
+            print('got a log message: ', log_type, data, message)
+
+        h.setLogCallback(log_callback, Foo())
+        out = StringIO()
+        with capture_output(out) as t:
+            h.run()
+        out = out.getvalue()
+        self.assertIn('got a log message:  HighsLogType.kInfo an instance of Foo Presolving model', out)


### PR DESCRIPTION
This PR adds `setLogCallback` to the highspy interface. I had to create a small class, `CallbackTuple`, to hold the python function and python callback data. I also had to create a new `Highs` in Python that inherits from the `Highs` (now called `_Highs`) class created by pybind11. The reason for this is that I needed an instance of `CallbackTuple` that I knew would get deleted, avoiding a memory leak.

There may be a better way to do this, but it works.