### PR TITLE
Add CI for mingw (MSYS2).

### DIFF
--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -3,7 +3,7 @@ name: build-mingw
 on: ["push", "pull_request"]
 
 jobs:
-  mingw-idx32:
+  mingw:
     runs-on: windows-latest
 
     defaults:
@@ -18,7 +18,8 @@ jobs:
       matrix:
         msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
         build-type: [Release, Debug]
-        fast-build: [ON, OFF]
+        fast-build: [On, Off]
+        int64: [On, Off]
         include:
           - msystem: MINGW64
             target-prefix: mingw-w64-x86_64
@@ -28,6 +29,11 @@ jobs:
             target-prefix: mingw-w64-ucrt-x86_64
           - msystem: CLANG64
             target-prefix: mingw-w64-clang-x86_64
+        exclude:
+          - msystem: MINGW32
+            int64: On
+          - fast-build: On
+            int64: On
 
     steps:
     - uses: msys2/setup-msys2@v2
@@ -42,77 +48,15 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Configure CMake
-      env:
-        BUILD_TYPE: ${{ matrix.build-type }}
-        FAST_BUILD: ${{ matrix.fast-build }}
       run: |
         mkdir build && cd build
-        cmake .. -DFAST_BUILD=${FAST_BUILD} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+        cmake .. -DFAST_BUILD=${{ matrix.fast-build }} -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DHIGHSINT64=${{ matrix.int64 }}
 
     - name: Build
-      env:
-        BUILD_TYPE: ${{ matrix.build-type }}
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cd build && cmake --build . --config ${BUILD_TYPE} --parallel 4
+      run: cd build && cmake --build . --config ${{ matrix.build-type }} --parallel 4
 
     - name: Test
-      env:
-        BUILD_TYPE: ${{ matrix.build-type }}
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: cd build && ctest --timeout 300 --output-on-failure -C ${BUILD_TYPE}
-
-  mingw-idx64:
-    runs-on: windows-latest
-
-    defaults:
-      run:
-        # Use MSYS2 as default shell
-        shell: msys2 {0}
-
-    strategy:
-      # Allow other runners in the matrix to continue if some fail
-      fail-fast: false
-
-      matrix:
-        msystem: [MINGW64, UCRT64, CLANG64]
-        build-type: [Release, Debug]
-        include:
-          - msystem: MINGW64
-            target-prefix: mingw-w64-x86_64
-          - msystem: UCRT64
-            target-prefix: mingw-w64-ucrt-x86_64
-          - msystem: CLANG64
-            target-prefix: mingw-w64-clang-x86_64
-
-    steps:
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.msystem }}
-        install: >-
-          base-devel
-          ${{ matrix.target-prefix }}-cmake
-          ${{ matrix.target-prefix }}-cc
-          ${{ matrix.target-prefix }}-ninja
-
-    - uses: actions/checkout@v3
-
-    - name: Configure CMake
-      env:
-        BUILD_TYPE: ${{ matrix.build-type }}
-      run: |
-        mkdir build && cd build
-        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DFAST_BUILD=OFF -DHIGHSINT64=on
-
-    - name: Build
-      env:
-        BUILD_TYPE: ${{ matrix.build-type }}
-      # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cd build && cmake --build . --config ${BUILD_TYPE} --parallel 4
-
-    - name: Test
-      env:
-        BUILD_TYPE: ${{ matrix.build-type }}
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: cd build && ctest --timeout 300 --output-on-failure -C ${BUILD_TYPE}
+      run: cd build && ctest --timeout 300 --output-on-failure -C ${{ matrix.build-type }}

--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -75,13 +75,11 @@ jobs:
       fail-fast: false
 
       matrix:
-        msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
+        msystem: [MINGW64, UCRT64, CLANG64]
         build-type: [Release, Debug]
         include:
           - msystem: MINGW64
             target-prefix: mingw-w64-x86_64
-          - msystem: MINGW32
-            target-prefix: mingw-w64-i686
           - msystem: UCRT64
             target-prefix: mingw-w64-ucrt-x86_64
           - msystem: CLANG64

--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -16,22 +16,18 @@ jobs:
       fail-fast: false
 
       matrix:
-        msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
+        msystem: [MINGW64, UCRT64, CLANG64]
         build-type: [Release, Debug]
         fast-build: [On, Off]
         int64: [On, Off]
         include:
           - msystem: MINGW64
             target-prefix: mingw-w64-x86_64
-          - msystem: MINGW32
-            target-prefix: mingw-w64-i686
           - msystem: UCRT64
             target-prefix: mingw-w64-ucrt-x86_64
           - msystem: CLANG64
             target-prefix: mingw-w64-clang-x86_64
         exclude:
-          - msystem: MINGW32
-            int64: On
           - fast-build: On
             int64: On
 

--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -1,0 +1,120 @@
+name: build-mingw
+
+on: ["push", "pull_request"]
+
+jobs:
+  mingw-idx32:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        # Use MSYS2 as default shell
+        shell: msys2 {0}
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
+        build-type: [Release, Debug]
+        fast-build: [ON, OFF]
+        include:
+          - msystem: MINGW64
+            target-prefix: mingw-w64-x86_64
+          - msystem: MINGW32
+            target-prefix: mingw-w64-i686
+          - msystem: UCRT64
+            target-prefix: mingw-w64-ucrt-x86_64
+          - msystem: CLANG64
+            target-prefix: mingw-w64-clang-x86_64
+
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        install: >-
+          base-devel
+          ${{ matrix.target-prefix }}-cmake
+          ${{ matrix.target-prefix }}-cc
+          ${{ matrix.target-prefix }}-ninja
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      env:
+        BUILD_TYPE: ${{ matrix.build-type }}
+        FAST_BUILD: ${{ matrix.fast-build }}
+      run: |
+        mkdir build && cd build
+        cmake .. -DFAST_BUILD=${FAST_BUILD} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
+
+    - name: Build
+      env:
+        BUILD_TYPE: ${{ matrix.build-type }}
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cd build && cmake --build . --config ${BUILD_TYPE} --parallel 4
+
+    - name: Test
+      env:
+        BUILD_TYPE: ${{ matrix.build-type }}
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: cd build && ctest --timeout 300 --output-on-failure -C ${BUILD_TYPE}
+
+  mingw-idx64:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        # Use MSYS2 as default shell
+        shell: msys2 {0}
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        msystem: [MINGW64, MINGW32, UCRT64, CLANG64]
+        build-type: [Release, Debug]
+        include:
+          - msystem: MINGW64
+            target-prefix: mingw-w64-x86_64
+          - msystem: MINGW32
+            target-prefix: mingw-w64-i686
+          - msystem: UCRT64
+            target-prefix: mingw-w64-ucrt-x86_64
+          - msystem: CLANG64
+            target-prefix: mingw-w64-clang-x86_64
+
+    steps:
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        install: >-
+          base-devel
+          ${{ matrix.target-prefix }}-cmake
+          ${{ matrix.target-prefix }}-cc
+          ${{ matrix.target-prefix }}-ninja
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      env:
+        BUILD_TYPE: ${{ matrix.build-type }}
+      run: |
+        mkdir build && cd build
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DFAST_BUILD=OFF -DHIGHSINT64=on
+
+    - name: Build
+      env:
+        BUILD_TYPE: ${{ matrix.build-type }}
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cd build && cmake --build . --config ${BUILD_TYPE} --parallel 4
+
+    - name: Test
+      env:
+        BUILD_TYPE: ${{ matrix.build-type }}
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: cd build && ctest --timeout 300 --output-on-failure -C ${BUILD_TYPE}


### PR DESCRIPTION
These checks run essentially the same tests that are currently run in `build-windows.yml` but with mingw toolchains instead of MSVC.
It uses the main mingw environments that are provided by MSYS2. See also:
https://www.msys2.org/docs/environments/

The tests for mingw-w64-i686 are currently failing. Closes #625.
