### PR TITLE
Extend MPS free-format reader

### DIFF
--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -406,9 +406,9 @@ FilereaderRetcode readMps(const HighsLogOptions& log_options,
     for (HighsInt iCol = previous_col + 1; iCol < numCol; iCol++)
       Qstart.push_back(hessian_nz);
     Qstart.push_back(hessian_nz);
-    assert(Qstart.size() == Qdim + 1);
-    assert(Qindex.size() == hessian_nz);
-    assert(Qvalue.size() == hessian_nz);
+    assert((HighsInt)Qstart.size() == Qdim + 1);
+    assert((HighsInt)Qindex.size() == hessian_nz);
+    assert((HighsInt)Qvalue.size() == hessian_nz);
   }
   // Determine the number of integer variables and set bounds of [0,1]
   // for integer variables without bounds
@@ -887,9 +887,8 @@ HighsStatus writeMps(
   if (q_dim) {
     // Write out Hessian info
     assert((HighsInt)q_start.size() >= q_dim + 1);
-    HighsInt hessian_num_nz = q_start[q_dim];
-    assert((HighsInt)q_index.size() >= hessian_num_nz);
-    assert((HighsInt)q_value.size() >= hessian_num_nz);
+    assert((HighsInt)q_index.size() >= q_start[q_dim]);
+    assert((HighsInt)q_value.size() >= q_start[q_dim]);
 
     // Assumes that Hessian entries are the lower triangle column-wise
     fprintf(file, "QUADOBJ\n");

--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -23,6 +23,22 @@ FreeFormatParserReturnCode HMpsFF::loadProblem(
   FreeFormatParserReturnCode result = parse(log_options, filename);
   if (result != FreeFormatParserReturnCode::kSuccess) return result;
 
+  if (!qrows_entries.empty()) {
+    highsLogUser(log_options, HighsLogType::kError,
+                 "Quadratic rows not supported by HiGHS\n");
+    return FreeFormatParserReturnCode::kParserError;
+  }
+  if (!sos_entries.empty()) {
+    highsLogUser(log_options, HighsLogType::kError,
+                 "SOS not supported by HiGHS\n");
+    return FreeFormatParserReturnCode::kParserError;
+  }
+  if (!cone_entries.empty()) {
+    highsLogUser(log_options, HighsLogType::kError,
+                 "Cones not supported by HiGHS\n");
+    return FreeFormatParserReturnCode::kParserError;
+  }
+
   colCost.assign(numCol, 0);
   for (auto i : coeffobj) colCost[i.first] = i.second;
   HighsInt status = fillMatrix();


### PR DESCRIPTION
I needed an MPS reader and decided to use the one from HiGHS. But I was missing some features and added them. Here they are.

- support `QCMATRIX` and proper support for `QSECTION`: quadratic entries for non-objective rows are stored in new `qrows_entries` vector
- add support for `CSECTION`: cones are stored in new `cone_*` members
- add support for SOS (`SOS` and `SETS` sections): SOS are stored in new `sos_*` members
- add flag to indicate whether variables that appear between `INTORG`/`INTEND` markers of `COLUMNS` section should be binary (most modern solvers and still the default) or integer (original IBM interpretation)
- fixed some compiler warnings in fixed-format reader