### PR TITLE
fix handling of quadratics in constraints of .lp file

### DIFF
--- a/extern/filereaderlp/def.hpp
+++ b/extern/filereaderlp/def.hpp
@@ -6,7 +6,7 @@
 
 void inline lpassert(bool condition) {
    if (!condition) {
-      throw std::invalid_argument("File not existant or illegal file format.");
+      throw std::invalid_argument("File not existent or illegal file format.");
    }
 }
 


### PR DESCRIPTION
Adds a missing break to avoid an endless loop in case of a wrong syntax in an .lp file. Parsing now fails instead.

Handle that there is no "/2" following quadratic term in constraints, at least for Gurobi: https://www.gurobi.com/documentation/9.5/refman/lp_format.html