### PR TITLE
avoid sscanf to parse into double or identifier in lp reader

### DIFF
--- a/extern/filereaderlp/def.hpp
+++ b/extern/filereaderlp/def.hpp
@@ -10,9 +10,6 @@ void inline lpassert(bool condition) {
    }
 }
 
-const unsigned int LP_MAX_NAME_LENGTH = 255;
-const unsigned int LP_MAX_LINE_LENGTH = 560;
-
 const std::string LP_KEYWORD_MIN[] = {"minimize", "min", "minimum"};
 const std::string LP_KEYWORD_MAX[] = {"maximize", "max", "maximum"};
 const std::string LP_KEYWORD_ST[] = {"subject to", "such that", "st", "s.t."};


### PR DESCRIPTION
Following up on https://github.com/ERGO-Code/HiGHS/pull/787#issuecomment-1088331260.

Using an "arbitrary" long buffer for the line doesn't increase the time to read the line much, I believe, but the tokenizing afterwards indeed took a big hit.
I created an .lp with a very long line via
```sh
#!/bin/bash
echo "Min"
for i in `seq 1 100000`
do
  echo -n " + $i x$i"
done
echo
echo "End"
```
Before #787, HiGHS ran 1.2s on my machine on this file (most time spend in reading the lp file, it feels).
With #787, it took 32s.

Turned out that the `sscanf` calls are very slow with a large input buffer. They only look for a number or identifier in the begin of the string, but somehow get slower and slower the longer the string is.

This PR replaces the `sscanf` by a `strtod` and something else. The `strtod` doesn't seem to be affected by the length of the input (there was no change in performance if I only pass it the first 20 chars).
With this, HiGHS takes 0.7s (which is also better than 1.2s, btw).