### PR TITLE
open ifstream in zstr as binary always

### DIFF
--- a/extern/zstr/zstr.hpp
+++ b/extern/zstr/zstr.hpp
@@ -414,7 +414,11 @@ class ifstream
 {
 public:
     explicit ifstream(const std::string filename, std::ios_base::openmode mode = std::ios_base::in, size_t buff_size = default_buff_size)
-        : detail::strict_fstream_holder< strict_fstream::ifstream >(filename, mode),
+        : detail::strict_fstream_holder< strict_fstream::ifstream >(filename, mode
+#ifdef _WIN32  // to avoid problems with conversion of \r\n, only windows as otherwise there are problems on mac
+           | std::ios_base::binary
+#endif
+           ),
           std::istream(new istreambuf(_fs.rdbuf(), buff_size))
     {
         exceptions(std::ios_base::badbit);
@@ -424,7 +428,11 @@ public:
         _fs.close();
     }
     void open(const std::string filename, std::ios_base::openmode mode = std::ios_base::in) {
-        _fs.open(filename, mode);
+        _fs.open(filename, mode
+#ifdef _WIN32  // to avoid problems with conversion of \r\n, only windows as otherwise there are problems on mac
+           | std::ios_base::binary
+#endif
+           );
         std::istream::operator=(std::istream(new istreambuf(_fs.rdbuf())));
     }
     bool is_open() const {


### PR DESCRIPTION
Sorry that things come in small pieces.
I had problems reading compressed input on Windows with zstr. (There was an exception from `std::string` thrown.)

Turned out that this is due to mateidavid/zstr#15, i.e., not opening the input stream as binary. On Windows, there are some conversions of carriage-return (`\r`) happening in that case that cause trouble.

This PR changes the zstr library to always open the input stream in binary form.
As far as I understand zstr/issues#15, this means that `\r` in the input are not converted away.
Fortunately, your LP and MPS readers seem to handle this case:
- In the fixed-form MPS reader, deleting trailing whitespace includes removing `\r`, because `isspace('\r')` is true:  https://github.com/ERGO-Code/HiGHS/blob/master/src/io/HMPSIO.cpp#L474-L484
- In the free-form MPS reader, you use your own `trim()` function to remove white-space, which includes `\r`: https://github.com/ERGO-Code/HiGHS/blob/master/src/util/stringutil.h#L27
- In the LP reader, there is an explicit check for `\r`: https://github.com/ERGO-Code/HiGHS/blob/master/extern/filereaderlp/reader.cpp#L898-L900