### PR TITLE
fixes for cmake after switching default to FAST_BUILD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,9 +105,10 @@ else()
         HIGHS_HAVE_BUILTIN_CLZ)
 endif()
 
+include(CheckCXXCompilerFlag)
+
 if (NOT FAST_BUILD)
 # Function to set compiler flags on and off easily.
-include(CheckCXXCompilerFlag)
 function(enable_cxx_compiler_flag_if_supported flag)
     string(FIND "${CMAKE_CXX_FLAGS}" "${flag}" flag_already_set)
     if(flag_already_set EQUAL -1)
@@ -169,8 +170,6 @@ else()
 endif(CMAKE_CSharp_COMPILER)
 endif()
 
-if (NOT FAST_BUILD)
-
 check_cxx_compiler_flag("-fno-omit-frame-pointer" NO_OMIT_FRAME_POINTER_FLAG_SUPPORTED)
 if(NO_OMIT_FRAME_POINTER_FLAG_SUPPORTED)
     set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_FLAGS_RELEASE} -fno-omit-frame-pointer")
@@ -187,6 +186,11 @@ endif()
 # set (CMAKE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_LINKER_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
 # set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
 # set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+
+# if zlib is found, then we can enable reading zlib-compressed input
+find_package(ZLIB 1.2.3)
+
+if (NOT FAST_BUILD)
 
 include(CPack)
 set(CPACK_RESOURCE_FILE_LICENSE "${HIGHS_SOURCE_DIR}/COPYING")
@@ -302,20 +306,12 @@ if(NOT MSVC)
     endif()
 endif()
 
-# if zlib is found, then we can enable reading zlib-compressed input
-find_package(ZLIB 1.2.3)
-
 set(IPX_ON ON)
 
 # whether to use shared or static libraries
 option(SHARED "Build shared libraries" ON)
 set(BUILD_SHARED_LIBS ${SHARED})
 message(STATUS "Build shared libraries: " ${SHARED})
-
-# make 'Release' the default build type
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
-endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL Release)
     set(HiGHSRELEASE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 # targets build and install / export.
 
 # Note: ON by default yet
-option(FAST_BUILD "Fast build: only build static lib and exe and quick test." ON)
+option(FAST_BUILD "Fast build: only build static lib and exe and quick test." OFF)
 option(FORTRAN "Build Fortran interface" OFF)
 option(CSHARP "Build CSharp interface" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -608,6 +608,11 @@ target_include_directories(libhighs PUBLIC . ipm/ io/ lp_data/ mip/ model/ simpl
                            presolve/ util/ test/ interfaces/ ../extern/)
 target_include_directories(libhighs PUBLIC ${HIGHS_BINARY_DIR})
 
+if (ZLIB_FOUND)
+    target_include_directories(libhighs PUBLIC ${ZLIB_INCLUDE_DIRS} ../extern/zstr)
+    target_link_libraries(libhighs ${ZLIB_LIBRARIES})
+endif()
+
 # on UNIX system the 'lib' prefix is automatically added
 set_target_properties(libhighs PROPERTIES
     OUTPUT_NAME "highs"

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -848,10 +848,10 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
         //     "error: lpsolver reached iteration limit, resolving with basis "
         //     "from ipm\n");
         Highs ipm;
-        ipm.passModel(lpsolver.getLp());
-        ipm.setOptionValue("solver", "ipm");
         ipm.setOptionValue("output_flag", false);
+        ipm.setOptionValue("solver", "ipm");
         ipm.setOptionValue("ipm_iteration_limit", 200);
+        ipm.passModel(lpsolver.getLp());
         // todo @ Julian : If you remove this you can see the looping on
         // istanbul-no-cutoff
         ipm.setOptionValue("simplex_iteration_limit",


### PR DESCRIPTION
Fixes to use proper flags and to use zlib if available after changes in #801