### PR TITLE
only print log header for functions that produce info output

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -39,19 +39,16 @@
 Highs::Highs() {}
 
 HighsStatus Highs::clear() {
-  this->logHeader();
   resetOptions();
   return clearModel();
 }
 
 HighsStatus Highs::clearModel() {
-  this->logHeader();
   model_.clear();
   return clearSolver();
 }
 
 HighsStatus Highs::clearSolver() {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   clearPresolve();
   clearUserSolverData();
@@ -159,7 +156,6 @@ HighsStatus Highs::getOptionType(const std::string& option,
 }
 
 HighsStatus Highs::resetOptions() {
-  this->logHeader();
   resetLocalOptions(options_.records);
   return HighsStatus::kOk;
 }
@@ -242,7 +238,6 @@ HighsStatus Highs::writeInfo(const std::string filename) const {
 // associated with it. Hence returnFromHighs is called at the end of
 // each
 HighsStatus Highs::passModel(HighsModel model) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   // Clear the incumbent model and any associated data
   clearModel();
@@ -307,7 +302,6 @@ HighsStatus Highs::passModel(HighsModel model) {
 }
 
 HighsStatus Highs::passModel(HighsLp lp) {
-  this->logHeader();
   HighsModel model;
   model.lp_ = std::move(lp);
   return passModel(std::move(model));
@@ -321,7 +315,6 @@ HighsStatus Highs::passModel(
     const double* row_upper, const HighsInt* a_start, const HighsInt* a_index,
     const double* a_value, const HighsInt* q_start, const HighsInt* q_index,
     const double* q_value, const HighsInt* integrality) {
-  this->logHeader();
   HighsModel model;
   HighsLp& lp = model.lp_;
   // Check that the formats of the constraint matrix and Hessian are valid
@@ -421,14 +414,12 @@ HighsStatus Highs::passModel(const HighsInt num_col, const HighsInt num_row,
                              const double* row_upper, const HighsInt* a_start,
                              const HighsInt* a_index, const double* a_value,
                              const HighsInt* integrality) {
-  this->logHeader();
   return passModel(num_col, num_row, num_nz, 0, a_format, 0, sense, offset,
                    costs, col_lower, col_upper, row_lower, row_upper, a_start,
                    a_index, a_value, NULL, NULL, NULL, integrality);
 }
 
 HighsStatus Highs::passHessian(HighsHessian hessian_) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   HighsHessian& hessian = model_.hessian_;
   hessian = std::move(hessian_);
@@ -455,7 +446,6 @@ HighsStatus Highs::passHessian(HighsHessian hessian_) {
 HighsStatus Highs::passHessian(const HighsInt dim, const HighsInt num_nz,
                                const HighsInt format, const HighsInt* start,
                                const HighsInt* index, const double* value) {
-  this->logHeader();
   HighsHessian hessian;
   if (!qFormatOk(num_nz, format)) return HighsStatus::kError;
   HighsInt num_col = model_.lp_.num_col_;
@@ -518,7 +508,6 @@ HighsStatus Highs::readModel(const std::string filename) {
 }
 
 HighsStatus Highs::readBasis(const std::string filename) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   // Try to read basis file into read_basis
   HighsBasis read_basis = basis_;
@@ -543,7 +532,6 @@ HighsStatus Highs::readBasis(const std::string filename) {
 }
 
 HighsStatus Highs::writeModel(const std::string filename) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
 
   // Ensure that the LP is column-wise
@@ -570,7 +558,6 @@ HighsStatus Highs::writeModel(const std::string filename) {
 }
 
 HighsStatus Highs::writeBasis(const std::string filename) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   FILE* file;
@@ -1281,7 +1268,6 @@ HighsStatus Highs::run() {
 }
 
 HighsStatus Highs::getDualRay(bool& has_dual_ray, double* dual_ray_value) {
-  this->logHeader();
   if (!ekk_instance_.status_.has_invert)
     return invertRequirementError("getDualRay");
   return getDualRayInterface(has_dual_ray, dual_ray_value);
@@ -1289,14 +1275,12 @@ HighsStatus Highs::getDualRay(bool& has_dual_ray, double* dual_ray_value) {
 
 HighsStatus Highs::getPrimalRay(bool& has_primal_ray,
                                 double* primal_ray_value) {
-  this->logHeader();
   if (!ekk_instance_.status_.has_invert)
     return invertRequirementError("getPrimalRay");
   return getPrimalRayInterface(has_primal_ray, primal_ray_value);
 }
 
 HighsStatus Highs::getRanging() {
-  this->logHeader();
   // Create a HighsLpSolverObject of references to data in the Highs
   // class, and the scaled/unscaled model status
   HighsLpSolverObject solver_object(model_.lp_, basis_, solution_, info_,
@@ -1307,14 +1291,12 @@ HighsStatus Highs::getRanging() {
 }
 
 HighsStatus Highs::getRanging(HighsRanging& ranging) {
-  this->logHeader();
   HighsStatus return_status = getRanging();
   ranging = this->ranging_;
   return return_status;
 }
 
 HighsStatus Highs::getBasicVariables(HighsInt* basic_variables) {
-  this->logHeader();
   if (basic_variables == NULL) {
     highsLogUser(options_.log_options, HighsLogType::kError,
                  "getBasicVariables: basic_variables is NULL\n");
@@ -1326,7 +1308,6 @@ HighsStatus Highs::getBasicVariables(HighsInt* basic_variables) {
 HighsStatus Highs::getBasisInverseRow(const HighsInt row, double* row_vector,
                                       HighsInt* row_num_nz,
                                       HighsInt* row_indices) {
-  this->logHeader();
   if (row_vector == NULL) {
     highsLogUser(options_.log_options, HighsLogType::kError,
                  "getBasisInverseRow: row_vector is NULL\n");
@@ -1356,7 +1337,6 @@ HighsStatus Highs::getBasisInverseRow(const HighsInt row, double* row_vector,
 HighsStatus Highs::getBasisInverseCol(const HighsInt col, double* col_vector,
                                       HighsInt* col_num_nz,
                                       HighsInt* col_indices) {
-  this->logHeader();
   if (col_vector == NULL) {
     highsLogUser(options_.log_options, HighsLogType::kError,
                  "getBasisInverseCol: col_vector is NULL\n");
@@ -1386,7 +1366,6 @@ HighsStatus Highs::getBasisInverseCol(const HighsInt col, double* col_vector,
 HighsStatus Highs::getBasisSolve(const double* Xrhs, double* solution_vector,
                                  HighsInt* solution_num_nz,
                                  HighsInt* solution_indices) {
-  this->logHeader();
   if (Xrhs == NULL) {
     highsLogUser(options_.log_options, HighsLogType::kError,
                  "getBasisSolve: Xrhs is NULL\n");
@@ -1414,7 +1393,6 @@ HighsStatus Highs::getBasisTransposeSolve(const double* Xrhs,
                                           double* solution_vector,
                                           HighsInt* solution_num_nz,
                                           HighsInt* solution_indices) {
-  this->logHeader();
   if (Xrhs == NULL) {
     highsLogUser(options_.log_options, HighsLogType::kError,
                  "getBasisTransposeSolve: Xrhs is NULL\n");
@@ -1441,7 +1419,6 @@ HighsStatus Highs::getBasisTransposeSolve(const double* Xrhs,
 HighsStatus Highs::getReducedRow(const HighsInt row, double* row_vector,
                                  HighsInt* row_num_nz, HighsInt* row_indices,
                                  const double* pass_basis_inverse_row_vector) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   HighsLp& lp = model_.lp_;
   // Ensure that the LP is column-wise
@@ -1497,7 +1474,6 @@ HighsStatus Highs::getReducedRow(const HighsInt row, double* row_vector,
 HighsStatus Highs::getReducedColumn(const HighsInt col, double* col_vector,
                                     HighsInt* col_num_nz,
                                     HighsInt* col_indices) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   HighsLp& lp = model_.lp_;
   // Ensure that the LP is column-wise
@@ -1530,7 +1506,6 @@ HighsStatus Highs::getReducedColumn(const HighsInt col, double* col_vector,
 }
 
 HighsStatus Highs::setSolution(const HighsSolution& solution) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   // Check if primal solution is valid.
   if (model_.lp_.num_col_ > 0 &&
@@ -1574,14 +1549,12 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
 HighsStatus Highs::setLogCallback(void (*log_callback)(HighsLogType,
                                                        const char*, void*),
                                   void* log_callback_data) {
-  this->logHeader();
   options_.log_options.log_callback = log_callback;
   options_.log_options.log_callback_data = log_callback_data;
   return HighsStatus::kOk;
 }
 
 HighsStatus Highs::setBasis(const HighsBasis& basis, const std::string origin) {
-  this->logHeader();
   if (basis.alien) {
     // An alien basis needs to be checked properly, since it may be
     // singular, or even incomplete.
@@ -1623,7 +1596,6 @@ HighsStatus Highs::setBasis(const HighsBasis& basis, const std::string origin) {
 }
 
 HighsStatus Highs::setBasis() {
-  this->logHeader();
   // Invalidate the basis for HiGHS
   //
   // Don't set to logical basis since that causes presolve to be
@@ -1706,7 +1678,6 @@ HighsStatus Highs::getIterate() {
 HighsStatus Highs::addRow(const double lower_bound, const double upper_bound,
                           const HighsInt num_new_nz, const HighsInt* indices,
                           const double* values) {
-  this->logHeader();
   HighsInt starts = 0;
   return addRows(1, &lower_bound, &upper_bound, num_new_nz, &starts, indices,
                  values);
@@ -1717,7 +1688,6 @@ HighsStatus Highs::addRows(const HighsInt num_new_row,
                            const double* upper_bounds,
                            const HighsInt num_new_nz, const HighsInt* starts,
                            const HighsInt* indices, const double* values) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   clearPresolve();
   return_status = interpretCallStatus(
@@ -1732,7 +1702,6 @@ HighsStatus Highs::addRows(const HighsInt num_new_row,
 HighsStatus Highs::addCol(const double cost, const double lower_bound,
                           const double upper_bound, const HighsInt num_new_nz,
                           const HighsInt* indices, const double* values) {
-  this->logHeader();
   HighsInt starts = 0;
   return addCols(1, &cost, &lower_bound, &upper_bound, num_new_nz, &starts,
                  indices, values);
@@ -1743,7 +1712,6 @@ HighsStatus Highs::addCols(const HighsInt num_new_col, const double* costs,
                            const double* upper_bounds,
                            const HighsInt num_new_nz, const HighsInt* starts,
                            const HighsInt* indices, const double* values) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   clearPresolve();
   return_status = interpretCallStatus(
@@ -1756,7 +1724,6 @@ HighsStatus Highs::addCols(const HighsInt num_new_col, const double* costs,
 }
 
 HighsStatus Highs::changeObjectiveSense(const ObjSense sense) {
-  this->logHeader();
   if ((sense == ObjSense::kMinimize) !=
       (model_.lp_.sense_ == ObjSense::kMinimize)) {
     model_.lp_.sense_ = sense;
@@ -1768,7 +1735,6 @@ HighsStatus Highs::changeObjectiveSense(const ObjSense sense) {
 }
 
 HighsStatus Highs::changeObjectiveOffset(const double offset) {
-  this->logHeader();
   // Update the objective value
   info_.objective_function_value += (offset - model_.lp_.offset_);
   model_.lp_.offset_ = offset;
@@ -1778,14 +1744,12 @@ HighsStatus Highs::changeObjectiveOffset(const double offset) {
 
 HighsStatus Highs::changeColIntegrality(const HighsInt col,
                                         const HighsVarType integrality) {
-  this->logHeader();
   return changeColsIntegrality(1, &col, &integrality);
 }
 
 HighsStatus Highs::changeColsIntegrality(const HighsInt from_col,
                                          const HighsInt to_col,
                                          const HighsVarType* integrality) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_col, to_col, model_.lp_.num_col_)) {
@@ -1806,7 +1770,6 @@ HighsStatus Highs::changeColsIntegrality(const HighsInt from_col,
 HighsStatus Highs::changeColsIntegrality(const HighsInt num_set_entries,
                                          const HighsInt* set,
                                          const HighsVarType* integrality) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   clearPresolve();
   // Ensure that the set and data are in ascending order
@@ -1829,7 +1792,6 @@ HighsStatus Highs::changeColsIntegrality(const HighsInt num_set_entries,
 
 HighsStatus Highs::changeColsIntegrality(const HighsInt* mask,
                                          const HighsVarType* integrality) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   create(index_collection, mask, model_.lp_.num_col_);
@@ -1843,13 +1805,11 @@ HighsStatus Highs::changeColsIntegrality(const HighsInt* mask,
 }
 
 HighsStatus Highs::changeColCost(const HighsInt col, const double cost) {
-  this->logHeader();
   return changeColsCost(1, &col, &cost);
 }
 
 HighsStatus Highs::changeColsCost(const HighsInt from_col,
                                   const HighsInt to_col, const double* cost) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_col, to_col, model_.lp_.num_col_)) {
@@ -1868,7 +1828,6 @@ HighsStatus Highs::changeColsCost(const HighsInt from_col,
 
 HighsStatus Highs::changeColsCost(const HighsInt num_set_entries,
                                   const HighsInt* set, const double* cost) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   // Check for NULL data in "set" version of changeColsCost since
   // values are sorted with set
@@ -1894,7 +1853,6 @@ HighsStatus Highs::changeColsCost(const HighsInt num_set_entries,
 }
 
 HighsStatus Highs::changeColsCost(const HighsInt* mask, const double* cost) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   create(index_collection, mask, model_.lp_.num_col_);
@@ -1908,14 +1866,12 @@ HighsStatus Highs::changeColsCost(const HighsInt* mask, const double* cost) {
 
 HighsStatus Highs::changeColBounds(const HighsInt col, const double lower,
                                    const double upper) {
-  this->logHeader();
   return changeColsBounds(1, &col, &lower, &upper);
 }
 
 HighsStatus Highs::changeColsBounds(const HighsInt from_col,
                                     const HighsInt to_col, const double* lower,
                                     const double* upper) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_col, to_col, model_.lp_.num_col_)) {
@@ -1936,7 +1892,6 @@ HighsStatus Highs::changeColsBounds(const HighsInt from_col,
 HighsStatus Highs::changeColsBounds(const HighsInt num_set_entries,
                                     const HighsInt* set, const double* lower,
                                     const double* upper) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   // Check for NULL data in "set" version of changeColsBounds since
   // values are sorted with set
@@ -1970,7 +1925,6 @@ HighsStatus Highs::changeColsBounds(const HighsInt num_set_entries,
 
 HighsStatus Highs::changeColsBounds(const HighsInt* mask, const double* lower,
                                     const double* upper) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   create(index_collection, mask, model_.lp_.num_col_);
@@ -1985,14 +1939,12 @@ HighsStatus Highs::changeColsBounds(const HighsInt* mask, const double* lower,
 
 HighsStatus Highs::changeRowBounds(const HighsInt row, const double lower,
                                    const double upper) {
-  this->logHeader();
   return changeRowsBounds(1, &row, &lower, &upper);
 }
 
 HighsStatus Highs::changeRowsBounds(const HighsInt from_row,
                                     const HighsInt to_row, const double* lower,
                                     const double* upper) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_row, to_row, model_.lp_.num_row_)) {
@@ -2013,7 +1965,6 @@ HighsStatus Highs::changeRowsBounds(const HighsInt from_row,
 HighsStatus Highs::changeRowsBounds(const HighsInt num_set_entries,
                                     const HighsInt* set, const double* lower,
                                     const double* upper) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   // Check for NULL data in "set" version of changeRowsBounds since
   // values are sorted with set
@@ -2047,7 +1998,6 @@ HighsStatus Highs::changeRowsBounds(const HighsInt num_set_entries,
 
 HighsStatus Highs::changeRowsBounds(const HighsInt* mask, const double* lower,
                                     const double* upper) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   create(index_collection, mask, model_.lp_.num_row_);
@@ -2062,7 +2012,6 @@ HighsStatus Highs::changeRowsBounds(const HighsInt* mask, const double* lower,
 
 HighsStatus Highs::changeCoeff(const HighsInt row, const HighsInt col,
                                const double value) {
-  this->logHeader();
   if (row < 0 || row >= model_.lp_.num_row_) {
     highsLogUser(options_.log_options, HighsLogType::kError,
                  "Row %" HIGHSINT_FORMAT
@@ -2104,7 +2053,6 @@ HighsStatus Highs::getCols(const HighsInt from_col, const HighsInt to_col,
                            HighsInt& num_col, double* costs, double* lower,
                            double* upper, HighsInt& num_nz, HighsInt* start,
                            HighsInt* index, double* value) {
-  this->logHeader();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_col, to_col, model_.lp_.num_col_)) {
     highsLogUser(options_.log_options, HighsLogType::kError,
@@ -2120,7 +2068,6 @@ HighsStatus Highs::getCols(const HighsInt num_set_entries, const HighsInt* set,
                            HighsInt& num_col, double* costs, double* lower,
                            double* upper, HighsInt& num_nz, HighsInt* start,
                            HighsInt* index, double* value) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   HighsIndexCollection index_collection;
   if (!create(index_collection, num_set_entries, set, model_.lp_.num_col_)) {
@@ -2137,7 +2084,6 @@ HighsStatus Highs::getCols(const HighsInt* mask, HighsInt& num_col,
                            double* costs, double* lower, double* upper,
                            HighsInt& num_nz, HighsInt* start, HighsInt* index,
                            double* value) {
-  this->logHeader();
   HighsIndexCollection index_collection;
   create(index_collection, mask, model_.lp_.num_col_);
   getColsInterface(index_collection, num_col, costs, lower, upper, num_nz,
@@ -2149,7 +2095,6 @@ HighsStatus Highs::getRows(const HighsInt from_row, const HighsInt to_row,
                            HighsInt& num_row, double* lower, double* upper,
                            HighsInt& num_nz, HighsInt* start, HighsInt* index,
                            double* value) {
-  this->logHeader();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_row, to_row, model_.lp_.num_row_)) {
     highsLogUser(options_.log_options, HighsLogType::kError,
@@ -2165,7 +2110,6 @@ HighsStatus Highs::getRows(const HighsInt num_set_entries, const HighsInt* set,
                            HighsInt& num_row, double* lower, double* upper,
                            HighsInt& num_nz, HighsInt* start, HighsInt* index,
                            double* value) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   HighsIndexCollection index_collection;
   if (!create(index_collection, num_set_entries, set, model_.lp_.num_row_)) {
@@ -2181,7 +2125,6 @@ HighsStatus Highs::getRows(const HighsInt num_set_entries, const HighsInt* set,
 HighsStatus Highs::getRows(const HighsInt* mask, HighsInt& num_row,
                            double* lower, double* upper, HighsInt& num_nz,
                            HighsInt* start, HighsInt* index, double* value) {
-  this->logHeader();
   HighsIndexCollection index_collection;
   create(index_collection, mask, model_.lp_.num_row_);
   getRowsInterface(index_collection, num_row, lower, upper, num_nz, start,
@@ -2191,7 +2134,6 @@ HighsStatus Highs::getRows(const HighsInt* mask, HighsInt& num_row,
 
 HighsStatus Highs::getCoeff(const HighsInt row, const HighsInt col,
                             double& value) {
-  this->logHeader();
   if (row < 0 || row >= model_.lp_.num_row_) {
     highsLogUser(
         options_.log_options, HighsLogType::kError,
@@ -2215,7 +2157,6 @@ HighsStatus Highs::getCoeff(const HighsInt row, const HighsInt col,
 }
 
 HighsStatus Highs::deleteCols(const HighsInt from_col, const HighsInt to_col) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_col, to_col, model_.lp_.num_col_)) {
@@ -2229,7 +2170,6 @@ HighsStatus Highs::deleteCols(const HighsInt from_col, const HighsInt to_col) {
 
 HighsStatus Highs::deleteCols(const HighsInt num_set_entries,
                               const HighsInt* set) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   clearPresolve();
   HighsIndexCollection index_collection;
@@ -2243,7 +2183,6 @@ HighsStatus Highs::deleteCols(const HighsInt num_set_entries,
 }
 
 HighsStatus Highs::deleteCols(HighsInt* mask) {
-  this->logHeader();
   clearPresolve();
   const HighsInt original_num_col = model_.lp_.num_col_;
   HighsIndexCollection index_collection;
@@ -2255,7 +2194,6 @@ HighsStatus Highs::deleteCols(HighsInt* mask) {
 }
 
 HighsStatus Highs::deleteRows(const HighsInt from_row, const HighsInt to_row) {
-  this->logHeader();
   clearPresolve();
   HighsIndexCollection index_collection;
   if (!create(index_collection, from_row, to_row, model_.lp_.num_row_)) {
@@ -2269,7 +2207,6 @@ HighsStatus Highs::deleteRows(const HighsInt from_row, const HighsInt to_row) {
 
 HighsStatus Highs::deleteRows(const HighsInt num_set_entries,
                               const HighsInt* set) {
-  this->logHeader();
   if (num_set_entries <= 0) return HighsStatus::kOk;
   clearPresolve();
   HighsIndexCollection index_collection;
@@ -2283,7 +2220,6 @@ HighsStatus Highs::deleteRows(const HighsInt num_set_entries,
 }
 
 HighsStatus Highs::deleteRows(HighsInt* mask) {
-  this->logHeader();
   clearPresolve();
   const HighsInt original_num_row = model_.lp_.num_row_;
   HighsIndexCollection index_collection;
@@ -2295,7 +2231,6 @@ HighsStatus Highs::deleteRows(HighsInt* mask) {
 }
 
 HighsStatus Highs::scaleCol(const HighsInt col, const double scale_value) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   clearPresolve();
   HighsStatus call_status = scaleColInterface(col, scale_value);
@@ -2306,7 +2241,6 @@ HighsStatus Highs::scaleCol(const HighsInt col, const double scale_value) {
 }
 
 HighsStatus Highs::scaleRow(const HighsInt row, const double scale_value) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   clearPresolve();
   HighsStatus call_status = scaleRowInterface(row, scale_value);
@@ -2318,7 +2252,6 @@ HighsStatus Highs::scaleRow(const HighsInt row, const double scale_value) {
 
 HighsStatus Highs::postsolve(const HighsSolution& solution,
                              const HighsBasis& basis) {
-  this->logHeader();
   const bool can_run_postsolve =
       model_presolve_status_ == HighsPresolveStatus::kNotPresolved ||
       model_presolve_status_ == HighsPresolveStatus::kReduced ||
@@ -2337,7 +2270,6 @@ HighsStatus Highs::postsolve(const HighsSolution& solution,
 
 HighsStatus Highs::writeSolution(const std::string filename,
                                  const HighsInt style) {
-  this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   FILE* file;
@@ -2371,13 +2303,11 @@ HighsStatus Highs::writeSolution(const std::string filename,
 
 HighsStatus Highs::readSolution(const std::string filename,
                                 const HighsInt style) {
-  this->logHeader();
   return readSolutionFile(filename, options_, model_.lp_, basis_, solution_,
                           style);
 }
 
 HighsStatus Highs::checkSolutionFeasibility() {
-  this->logHeader();
   checkLpSolutionFeasibility(options_, model_.lp_, solution_);
   return HighsStatus::kOk;
 }


### PR DESCRIPTION
printing the log header for all public functions is a bit overkill and produces unnessary overhead by adding an additional conditional branch for mundane things like changing a bound of a column. The intention of the change was to print the log header in the library and in the binary in the same way. Hence it should appear when a function is called that produces info output. There is info output for presolve(), run(), and a report on the model size for readModel(). For all other functions a `logHeader()` call does not seem necessary. This way the header should now be printed whenever a HiGHS instance is used to do something.

One thing that popped my eye is the crossover function. It uses cout where it should probably use `highsLogUser()`? Maybe there should be a call for the crossover function that accepts a solution too. The runCrossover call also contains uses of cout.