### PR TITLE
Api function to release global resources

### DIFF
--- a/src/Highs.h
+++ b/src/Highs.h
@@ -895,6 +895,19 @@ class Highs {
     return HighsStatus::kOk;
   }
 
+  /**
+   * @brief Releases all resources held by the global scheduler instance. It is
+   * not thread-safe to call this function while calling run() or presolve() on
+   * any other Highs instance in any thread. After this function has terminated
+   * it is guaranteed that eventually all previously created scheduler threads
+   * will terminate and allocated memory will be released. After this function
+   * has returned the option value for the number of threads may be altered to a
+   * new value before the next call to run() or presolve(). If the given bool
+   * parameter has value true, then the function will not return until all
+   * memory is freed, which might be desirable when debugging heap memory.
+   */
+  static void resetGlobalScheduler(bool blocking = false);
+
 #ifdef OSI_FOUND
   friend class OsiHiGHSSolverInterface;
 #endif

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -904,7 +904,9 @@ class Highs {
    * has returned the option value for the number of threads may be altered to a
    * new value before the next call to run() or presolve(). If the given bool
    * parameter has value true, then the function will not return until all
-   * memory is freed, which might be desirable when debugging heap memory.
+   * memory is freed, which might be desirable when debugging heap memory but
+   * requires the calling thread to wait for all scheduler threads to wake-up
+   * which is usually not necessary.
    */
   static void resetGlobalScheduler(bool blocking = false);
 

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -923,6 +923,10 @@ HighsInt Highs_crossover_set(void* highs, const int num_col, const int num_row,
   return (HighsInt)((Highs*)highs)->crossover(solution);
 }
 
+void Highs_resetGlobalScheduler(HighsInt blocking) {
+  Highs::resetGlobalScheduler(blocking);
+}
+
 // *********************
 // * Deprecated methods*
 // *********************

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -1560,6 +1560,26 @@ HighsInt Highs_crossover_set(void* highs, const int num_col, const int num_row,
                              double* col_value, double* col_dual,
                              double* row_dual);
 
+/**
+ * Releases all resources held by the global scheduler instance. It is
+ * not thread-safe to call this function while calling Highs_run()/Highs_*call()
+ * on any other Highs instance in any thread. After this function has terminated
+ * it is guaranteed that eventually all previously created scheduler threads
+ * will terminate and allocated memory will be released. After this function
+ * has returned the option value for the number of threads may be altered to a
+ * new value before the next call to Highs_run()/Highs_*call(). If the given
+ * parameter has a nonzero value, then the function will not return until all
+ * memory is freed, which might be desirable when debugging heap memory but
+ * requires the calling thread to wait for all scheduler threads to wake-up
+ * which is usually not necessary.
+ *
+ * @returns No status is returned since the function call cannot fail. Calling
+ * this function while any Highs instance is in use on any thread is
+ * undefined behavior and may cause crashes, but cannot be detected and hence
+ * is fully in the callers responsibility.
+ */
+void Highs_resetGlobalScheduler(const HighsInt blocking);
+
 // *********************
 // * Deprecated methods*
 // *********************

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -593,6 +593,19 @@ HighsStatus Highs::presolve() {
     model_presolve_status_ = HighsPresolveStatus::kNotReduced;
   } else {
     const bool force_presolve = true;
+    // make sure global scheduler is initialized before calling presolve, since
+    // MIP presolve may use parallelism
+    highs::parallel::initialize_scheduler(options_.threads);
+    max_threads = highs::parallel::num_threads();
+    if (options_.threads != 0 && max_threads != options_.threads) {
+      highsLogUser(
+          options_.log_options, HighsLogType::kError,
+          "Option 'threads' is set to %d but global scheduler has already been "
+          "initialized to use %d threads. The previous scheduler instance can "
+          "be destroyed by calling Highs::resetGlobalScheduler().\n",
+          (int)options_.threads, max_threads);
+      return HighsStatus::kError;
+    }
     model_presolve_status_ = runPresolve(force_presolve);
   }
 
@@ -698,8 +711,8 @@ HighsStatus Highs::run() {
     highsLogUser(
         options_.log_options, HighsLogType::kError,
         "Option 'threads' is set to %d but global scheduler has already been "
-        "initialized to use %d threads. The previous scheduler instance can be "
-        "destroyed by calling HighsTaskExecutor::shutdown().\n",
+        "initialized to use %d threads. The previous scheduler instance can "
+        "be destroyed by calling Highs::resetGlobalScheduler().\n",
         (int)options_.threads, max_threads);
     return HighsStatus::kError;
   }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3294,3 +3294,7 @@ HighsStatus Highs::openLogFile(const std::string log_file) {
   highsOpenLogFile(options_.log_options, options_.records, log_file);
   return HighsStatus::kOk;
 }
+
+void Highs::resetGlobalScheduler(bool blocking) {
+  HighsTaskExecutor::shutdown(blocking);
+}

--- a/src/parallel/HighsTaskExecutor.h
+++ b/src/parallel/HighsTaskExecutor.h
@@ -137,7 +137,7 @@ class HighsTaskExecutor {
     }
   }
 
-  static void shutdown() {
+  static void shutdown(bool blocking = false) {
     if (globalExecutor) {
       // first spin until every worker has acquired its executor reference
       while (globalExecutor.use_count() != globalExecutor->workerDeques.size())
@@ -148,6 +148,11 @@ class HighsTaskExecutor {
       for (auto& workerDeque : globalExecutor->workerDeques)
         workerDeque->injectTaskAndNotify(nullptr);
       // finally release the global executor reference
+      if (blocking) {
+        while (globalExecutor.use_count() != 1)
+          HighsSpinMutex::yieldProcessor();
+      }
+
       globalExecutor.reset();
     }
   }


### PR DESCRIPTION
I added an API function in the Highs class and the C API to allow resetting the global scheduler.

This is needed if the user wants to release all memory held by the highs library and is also needed for changing the number of threads after the scheduler has been initialized by a previous Highs call.