### PR TITLE
create a distinct executor for each user thread that initializes the …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,9 +533,6 @@ endif()
 
 endif()
 
-include(GenerateExportHeader)
-generate_export_header(libhighs)
-
 # # Comment out for scaffold/ tests
 # add_subdirectory(scaffold)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -401,7 +401,6 @@ foreach ( file ${headers} )
     install( FILES ${file} DESTINATION include/${dir} )
 endforeach()
 install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION include)
-install(FILES ${HIGHS_BINARY_DIR}/libhighs_export.h DESTINATION include)
 
 if (IPX_ON)
     if (UNIX)
@@ -769,7 +768,6 @@ foreach ( file ${headers_fast_build_} )
     install( FILES ${file} DESTINATION include/${dir} )
 endforeach()
 install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION include)
-install(FILES ${HIGHS_BINARY_DIR}/libhighs_export.h DESTINATION include)
 
 
 # target_compile_options(libhighs PRIVATE "-Wall")

--- a/src/parallel/HighsParallel.h
+++ b/src/parallel/HighsParallel.h
@@ -28,7 +28,9 @@ inline void initialize_scheduler(int numThreads = 0) {
   HighsTaskExecutor::initialize(numThreads);
 }
 
-inline int num_threads() { return HighsTaskExecutor::getNumWorkerThreads(); }
+inline int num_threads() {
+  return HighsTaskExecutor::getThisWorkerDeque()->getNumWorkers();
+}
 
 inline int thread_num() {
   return HighsTaskExecutor::getThisWorkerDeque()->getOwnerId();
@@ -55,7 +57,7 @@ inline void sync(HighsSplitDeque* localDeque) {
       // spawn already
       break;
     case HighsSplitDeque::Status::kStolen:
-      HighsTaskExecutor::getGlobalTaskExecutor()->sync_stolen_task(
+      HighsTaskExecutor::sync_stolen_task(
           localDeque, popResult.second);
       break;
     case HighsSplitDeque::Status::kWork:

--- a/src/parallel/HighsSplitDeque.h
+++ b/src/parallel/HighsSplitDeque.h
@@ -478,6 +478,8 @@ class HighsSplitDeque {
 
   int getOwnerId() const { return ownerData.ownerId; }
 
+  int getNumWorkers() const { return ownerData.numWorkers; }
+
   int getCurrentHead() const { return ownerData.head; }
 
   HighsSplitDeque* getWorkerById(int id) const {

--- a/src/parallel/HighsTaskExecutor.cpp
+++ b/src/parallel/HighsTaskExecutor.cpp
@@ -8,8 +8,7 @@ HighsSplitDeque*& HighsTaskExecutor::threadLocalWorkerDeque() {
   return threadLocalWorkerDequePtr;
 }
 
-static thread_local HighsTaskExecutor::ExecutorHandle
-    HighsTaskExecutor::globalExecutorHandle{};
+static thread_local HighsTaskExecutor::ExecutorHandle globalExecutorHandle{};
 
 HighsTaskExecutor::ExecutorHandle&
 HighsTaskExecutor::threadLocalExecutorHandle() {
@@ -21,3 +20,8 @@ thread_local HighsSplitDeque* HighsTaskExecutor::threadLocalWorkerDequePtr{
 thread_local HighsTaskExecutor::ExecutorHandle
     HighsTaskExecutor::globalExecutorHandle{};
 #endif
+
+HighsTaskExecutor::ExecutorHandle::~ExecutorHandle() {
+  if (ptr && this == ptr->mainWorkerHandle.load(std::memory_order_relaxed))
+    HighsTaskExecutor::shutdown();
+}

--- a/src/parallel/HighsTaskExecutor.cpp
+++ b/src/parallel/HighsTaskExecutor.cpp
@@ -7,12 +7,17 @@ static thread_local HighsSplitDeque* threadLocalWorkerDequePtr{nullptr};
 HighsSplitDeque*& HighsTaskExecutor::threadLocalWorkerDeque() {
   return threadLocalWorkerDequePtr;
 }
+
+static thread_local HighsTaskExecutor::ExecutorHandle
+    HighsTaskExecutor::globalExecutorHandle{};
+
+HighsTaskExecutor::ExecutorHandle&
+HighsTaskExecutor::threadLocalExecutorHandle() {
+  return globalExecutorHandle;
+}
 #else
 thread_local HighsSplitDeque* HighsTaskExecutor::threadLocalWorkerDequePtr{
     nullptr};
+thread_local HighsTaskExecutor::ExecutorHandle
+    HighsTaskExecutor::globalExecutorHandle{};
 #endif
-
-cache_aligned::shared_ptr<HighsTaskExecutor> HighsTaskExecutor::globalExecutor{
-    nullptr};
-
-HighsSpinMutex HighsTaskExecutor::initMutex;

--- a/src/parallel/HighsTaskExecutor.h
+++ b/src/parallel/HighsTaskExecutor.h
@@ -20,7 +20,6 @@
 #include <thread>
 #include <vector>
 
-#include "libhighs_export.h"
 #include "parallel/HighsCacheAlign.h"
 #include "parallel/HighsSplitDeque.h"
 #include "util/HighsInt.h"
@@ -33,23 +32,34 @@ class HighsTaskExecutor {
 
  private:
   using cache_aligned = highs::cache_aligned;
+  struct ExecutorHandle {
+    cache_aligned::shared_ptr<HighsTaskExecutor> ptr{nullptr};
+
+    ~ExecutorHandle() {
+      if (ptr && this == ptr->mainWorkerHandle.load(std::memory_order_relaxed))
+        HighsTaskExecutor::shutdown();
+    }
+  };
 
 #ifdef _WIN32
   static HighsSplitDeque*& threadLocalWorkerDeque();
+  static ExecutorHandle& threadLocalExecutorHandle();
 #else
   static thread_local HighsSplitDeque* threadLocalWorkerDequePtr;
+  static thread_local ExecutorHandle globalExecutorHandle;
+
   static HighsSplitDeque*& threadLocalWorkerDeque() {
     return threadLocalWorkerDequePtr;
   }
-#endif
 
-  static LIBHIGHS_EXPORT cache_aligned::shared_ptr<HighsTaskExecutor>
-      globalExecutor;
-  static LIBHIGHS_EXPORT HighsSpinMutex initMutex;
+  static ExecutorHandle& threadLocalExecutorHandle() {
+    return globalExecutorHandle;
+  }
+#endif
 
   std::vector<cache_aligned::unique_ptr<HighsSplitDeque>> workerDeques;
   cache_aligned::shared_ptr<HighsSplitDeque::WorkerBunk> workerBunk;
-  std::atomic<bool> active;
+  std::atomic<ExecutorHandle*> mainWorkerHandle;
 
   HighsTask* random_steal_loop(HighsSplitDeque* localDeque) {
     const int numWorkers = workerDeques.size();
@@ -82,10 +92,11 @@ class HighsTaskExecutor {
 
   void run_worker(int workerId) {
     // spin until the global executor pointer is set up
-    while (!active.load(std::memory_order_acquire))
+    ExecutorHandle* executor;
+    while (!(executor = mainWorkerHandle.load(std::memory_order_acquire)))
       HighsSpinMutex::yieldProcessor();
     // now acquire a reference count of the global executor
-    auto executor = globalExecutor;
+    threadLocalExecutorHandle() = *executor;
     HighsSplitDeque* localDeque = workerDeques[workerId].get();
     threadLocalWorkerDeque() = localDeque;
     HighsTask* currentTask = workerBunk->waitForNewTask(localDeque);
@@ -102,7 +113,7 @@ class HighsTaskExecutor {
  public:
   HighsTaskExecutor(int numThreads) {
     assert(numThreads > 0);
-    active.store(false, std::memory_order_relaxed);
+    mainWorkerHandle.store(nullptr, std::memory_order_relaxed);
     workerDeques.resize(numThreads);
     workerBunk = cache_aligned::make_shared<HighsSplitDeque::WorkerBunk>();
     for (int i = 0; i < numThreads; ++i)
@@ -118,48 +129,47 @@ class HighsTaskExecutor {
     return threadLocalWorkerDeque();
   }
 
-  static HighsTaskExecutor* getGlobalTaskExecutor() {
-    return globalExecutor.get();
-  }
-
   static int getNumWorkerThreads() {
-    return globalExecutor->workerDeques.size();
+    return threadLocalWorkerDeque()->getNumWorkers();
   }
 
   static void initialize(int numThreads) {
-    if (!globalExecutor) {
-      std::lock_guard<HighsSpinMutex> lg{initMutex};
-      if (!globalExecutor) {
-        globalExecutor =
-            cache_aligned::make_shared<HighsTaskExecutor>(numThreads);
-        globalExecutor->active.store(true, std::memory_order_release);
-      }
+    auto& executorHandle = threadLocalExecutorHandle();
+    if (!executorHandle.ptr) {
+      executorHandle.ptr =
+          cache_aligned::make_shared<HighsTaskExecutor>(numThreads);
+      executorHandle.ptr->mainWorkerHandle.store(&executorHandle,
+                                                 std::memory_order_release);
     }
   }
 
   static void shutdown(bool blocking = false) {
-    if (globalExecutor) {
+    auto& executorHandle = threadLocalExecutorHandle();
+    if (executorHandle.ptr) {
       // first spin until every worker has acquired its executor reference
-      while (globalExecutor.use_count() != globalExecutor->workerDeques.size())
+      while (executorHandle.ptr.use_count() !=
+             executorHandle.ptr->workerDeques.size())
         HighsSpinMutex::yieldProcessor();
       // set the active flag to false first with release ordering
-      globalExecutor->active.store(false, std::memory_order_release);
+      executorHandle.ptr->mainWorkerHandle.store(nullptr,
+                                                 std::memory_order_release);
       // now inject the null task as termination signal to every worker
-      for (auto& workerDeque : globalExecutor->workerDeques)
+      for (auto& workerDeque : executorHandle.ptr->workerDeques)
         workerDeque->injectTaskAndNotify(nullptr);
       // finally release the global executor reference
       if (blocking) {
-        while (globalExecutor.use_count() != 1)
+        while (executorHandle.ptr.use_count() != 1)
           HighsSpinMutex::yieldProcessor();
       }
 
-      globalExecutor.reset();
+      executorHandle.ptr.reset();
     }
   }
 
-  void sync_stolen_task(HighsSplitDeque* localDeque, HighsTask* stolenTask) {
+  static void sync_stolen_task(HighsSplitDeque* localDeque,
+                               HighsTask* stolenTask) {
     if (!localDeque->leapfrogStolenTask(stolenTask)) {
-      const int numWorkers = workerDeques.size();
+      const int numWorkers = localDeque->getNumWorkers();
       int numTries = kNumTryFac * (numWorkers - 1);
 
       auto tStart = std::chrono::high_resolution_clock::now();

--- a/src/parallel/HighsTaskExecutor.h
+++ b/src/parallel/HighsTaskExecutor.h
@@ -30,17 +30,14 @@ class HighsTaskExecutor {
   static constexpr int kMicroSecsBeforeSleep = 5000;
   static constexpr int kMicroSecsBeforeGlobalSync = 1000;
 
- private:
   using cache_aligned = highs::cache_aligned;
   struct ExecutorHandle {
     cache_aligned::shared_ptr<HighsTaskExecutor> ptr{nullptr};
 
-    ~ExecutorHandle() {
-      if (ptr && this == ptr->mainWorkerHandle.load(std::memory_order_relaxed))
-        HighsTaskExecutor::shutdown();
-    }
+    ~ExecutorHandle();
   };
 
+ private:
 #ifdef _WIN32
   static HighsSplitDeque*& threadLocalWorkerDeque();
   static ExecutorHandle& threadLocalExecutorHandle();


### PR DESCRIPTION
…HiGHS scheduler

This should fix the issue in #810 although I need more testing. It means when `Highs::run()` is called from a new thread where it never has been called before, then the scheduler will be initialized for the thread number in that Highs instance and subsequent calls to Highs::run() in that same thread will reuse the scheduler instance. When `Highs::run()` is now called from a different user thread then it will not anymore interact with scheduler instances used on other user threads.

When a user thread exits for which a Highs scheduler was initialized then it should automatically call the shutdown() function causing all background threads attached to that scheduler instance to also exit and all memory to be freed once the last of that scheduler instance exits.

Also this removed the need for the generated export header which I removed from cmake in this branch.