### PR TITLE
Fix 831

### DIFF
--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -158,7 +158,7 @@ TEST_CASE("filereader-read-mps-ems-lp", "[highs_filereader]") {
 
   double delta =
       std::fabs(mps_objective_function_value - info.objective_function_value);
-  if (delta)
+  if (dev_run && delta)
     printf("TestFilereader: LP-MPS |objective difference| of %g\n", delta);
   REQUIRE(delta < 1e-8);
 

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1114,7 +1114,7 @@ class Highs {
   //
   // Clears all solver data in Highs class members by calling
   // clearModelStatus(), clearSolution(), clearBasis(),
-  // clearInfo() and clearEkk()
+  // clearInfo() and invalidateEkk()
   void clearUserSolverData();
   //
   // Clears the model status, solution_ and info_
@@ -1137,7 +1137,7 @@ class Highs {
   void clearRanging();
 
   // Invalidates ekk_instance_
-  void clearEkk();
+  void invalidateEkk();
 
   HighsStatus returnFromRun(const HighsStatus return_status);
   HighsStatus returnFromHighs(const HighsStatus return_status);

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1111,20 +1111,19 @@ class Highs {
   // before (possibly) updating them with data from trying to solve
   // the inumcumbent model.
   //
-  // Clears all solver data in Highs class members by calling
-  // invalidateModelStatus(), clearSolution(), invalidateBasis(),
+  // Invalidates all solver data in Highs class members by calling
+  // invalidateModelStatus(), invalidateSolution(), invalidateBasis(),
   // invalidateInfo() and invalidateEkk()
-  void clearUserSolverData();
+  void invalidateUserSolverData();
   //
-  // Clears the model status, solution_ and info_
-  void clearModelStatusSolutionAndInfo();
+  // Invalidates the model status, solution_ and info_
+  void invalidateModelStatusSolutionAndInfo();
   //
   // Sets model status to HighsModelStatus::kNotset
   void invalidateModelStatus();
   //
-  // Sets primal and dual solution status to
-  // kSolutionStatusNone, and clears solution_ vectors
-  void clearSolution();
+  // Invalidates primal and dual solution
+  void invalidateSolution();
   //
   // Invalidates basis
   void invalidateBasis();
@@ -1132,8 +1131,8 @@ class Highs {
   // Invalidates info_ and resets the values of its members
   void invalidateInfo();
   //
-  // Invalidates ranging_ and clears its vectors
-  void clearRanging();
+  // Invalidates ranging_
+  void invalidateRanging();
 
   // Invalidates ekk_instance_
   void invalidateEkk();

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1112,15 +1112,15 @@ class Highs {
   // the inumcumbent model.
   //
   // Clears all solver data in Highs class members by calling
-  // clearModelStatus(), clearSolution(), clearBasis(),
-  // clearInfo() and invalidateEkk()
+  // invalidateModelStatus(), clearSolution(), clearBasis(),
+  // invalidateInfo() and invalidateEkk()
   void clearUserSolverData();
   //
   // Clears the model status, solution_ and info_
   void clearModelStatusSolutionAndInfo();
   //
   // Sets model status to HighsModelStatus::kNotset
-  void clearModelStatus();
+  void invalidateModelStatus();
   //
   // Sets primal and dual solution status to
   // kSolutionStatusNone, and clears solution_ vectors
@@ -1130,7 +1130,7 @@ class Highs {
   void clearBasis();
   //
   // Invalidates info_ and resets the values of its members
-  void clearInfo();
+  void invalidateInfo();
   //
   // Invalidates ranging_ and clears its vectors
   void clearRanging();

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1112,7 +1112,7 @@ class Highs {
   // the inumcumbent model.
   //
   // Clears all solver data in Highs class members by calling
-  // invalidateModelStatus(), clearSolution(), clearBasis(),
+  // invalidateModelStatus(), clearSolution(), invalidateBasis(),
   // invalidateInfo() and invalidateEkk()
   void clearUserSolverData();
   //
@@ -1126,8 +1126,8 @@ class Highs {
   // kSolutionStatusNone, and clears solution_ vectors
   void clearSolution();
   //
-  // Invalidates basis and clears basis_ vectors
-  void clearBasis();
+  // Invalidates basis
+  void invalidateBasis();
   //
   // Invalidates info_ and resets the values of its members
   void invalidateInfo();

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -265,7 +265,7 @@ HighsInt Highs_clearModel(void* highs);
  *
  * @returns a `kHighsStatus` constant indicating whether the call succeeded
  */
-HighsInt Highs_clearSolution(void* highs);
+HighsInt Highs_clearSolver(void* highs);
 
 /**
  * Optimize a model. The algorithm used by HiGHS depends on the options that

--- a/src/interfaces/highspy/highspy/tests/test_highspy.py
+++ b/src/interfaces/highspy/highspy/tests/test_highspy.py
@@ -164,8 +164,8 @@ class TestHighsPy(unittest.TestCase):
         self.assertEqual(h.getNumRow(), 2)
         self.assertEqual(h.getNumNz(), 4)
         sol = h.getSolution()
-        self.assertAlmostEqual(sol.col_value[0], 0)
-        self.assertAlmostEqual(sol.col_value[1], 0)
+        self.assertFalse(sol.value_valid)
+        self.assertFalse(sol.dual_valid)
 
         h = self.get_basic_model()
         orig_feas_tol = h.getOptionValue('primal_feasibility_tolerance')

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -34,6 +34,7 @@ struct HighsSolution {
   std::vector<double> col_dual;
   std::vector<double> row_value;
   std::vector<double> row_dual;
+  void invalidate();
   void clear();
 };
 
@@ -62,6 +63,7 @@ struct HighsBasis {
   std::string debug_origin_name = "None";
   std::vector<HighsBasisStatus> col_status;
   std::vector<HighsBasisStatus> row_status;
+  void invalidate();
   void clear();
 };
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -742,7 +742,7 @@ HighsStatus Highs::run() {
   // Initialise the HiGHS model status
   model_status_ = HighsModelStatus::kNotset;
   // Clear the run info
-  clearInfo();
+  invalidateInfo();
   // Zero the iteration counts
   zeroIterationCounts();
   // Start the HiGHS run clock
@@ -2520,21 +2520,21 @@ void Highs::clearPresolve() {
 }
 
 void Highs::clearUserSolverData() {
-  clearModelStatus();
+  invalidateModelStatus();
   clearSolution();
   clearBasis();
   clearRanging();
-  clearInfo();
+  invalidateInfo();
   invalidateEkk();
 }
 
 void Highs::clearModelStatusSolutionAndInfo() {
-  clearModelStatus();
+  invalidateModelStatus();
   clearSolution();
-  clearInfo();
+  invalidateInfo();
 }
 
-void Highs::clearModelStatus() { model_status_ = HighsModelStatus::kNotset; }
+void Highs::invalidateModelStatus() { model_status_ = HighsModelStatus::kNotset; }
 
 void Highs::clearSolution() {
   info_.primal_solution_status = kSolutionStatusNone;
@@ -2553,7 +2553,7 @@ void Highs::clearBasis() {
   this->basis_.clear();
 }
 
-void Highs::clearInfo() { info_.clear(); }
+void Highs::invalidateInfo() { info_.invalidate(); }
 
 void Highs::clearRanging() { ranging_.clear(); }
 
@@ -3001,7 +3001,7 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status) {
     case HighsModelStatus::kPostsolveError:
       // Don't clear the model status!
       //      clearUserSolverData();
-      clearInfo();
+      invalidateInfo();
       clearSolution();
       clearBasis();
       assert(return_status == HighsStatus::kError);
@@ -3009,7 +3009,7 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status) {
 
       // Then consider the OK returns
     case HighsModelStatus::kModelEmpty:
-      clearInfo();
+      invalidateInfo();
       clearSolution();
       clearBasis();
       assert(return_status == HighsStatus::kOk);

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1128,10 +1128,9 @@ HighsStatus Highs::run() {
           solution_ = presolve_.data_.recovered_solution_;
           solution_.value_valid = true;
           if (ipx_no_crossover) {
-            // IPX was used without crossover, so only have a primal solution
+            // IPX was used without crossover, so have a dual solution, but no basis
             solution_.dual_valid = true;
-            basis_.clear();
-            basis_.valid = false;
+            basis_.invalidate();
           } else {
             //
             // Hot-start the simplex solver for the incumbent LP
@@ -1637,7 +1636,7 @@ HighsStatus Highs::setBasis() {
   //
   // Don't set to logical basis since that causes presolve to be
   // skipped
-  basis_.clear();
+  basis_.invalidate();
   // Follow implications of a new HiGHS basis
   newHighsBasis();
   // Can't use returnFromHighs since...
@@ -2522,7 +2521,7 @@ void Highs::clearPresolve() {
 void Highs::clearUserSolverData() {
   invalidateModelStatus();
   clearSolution();
-  clearBasis();
+  invalidateBasis();
   clearRanging();
   invalidateInfo();
   invalidateEkk();
@@ -2548,9 +2547,9 @@ void Highs::clearSolution() {
   this->solution_.clear();
 }
 
-void Highs::clearBasis() {
+void Highs::invalidateBasis() {
   info_.basis_validity = kBasisValidityInvalid;
-  this->basis_.clear();
+  this->basis_.invalidate();
 }
 
 void Highs::invalidateInfo() { info_.invalidate(); }
@@ -2949,7 +2948,7 @@ void Highs::setHighsModelStatusAndClearSolutionAndBasis(
     const HighsModelStatus model_status) {
   model_status_ = model_status;
   clearSolution();
-  clearBasis();
+  invalidateBasis();
   info_.valid = true;
 }
 
@@ -3003,7 +3002,7 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status) {
       //      clearUserSolverData();
       invalidateInfo();
       clearSolution();
-      clearBasis();
+      invalidateBasis();
       assert(return_status == HighsStatus::kError);
       break;
 
@@ -3011,7 +3010,7 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status) {
     case HighsModelStatus::kModelEmpty:
       invalidateInfo();
       clearSolution();
-      clearBasis();
+      invalidateBasis();
       assert(return_status == HighsStatus::kOk);
       break;
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2525,7 +2525,7 @@ void Highs::clearUserSolverData() {
   clearBasis();
   clearRanging();
   clearInfo();
-  clearEkk();
+  invalidateEkk();
 }
 
 void Highs::clearModelStatusSolutionAndInfo() {
@@ -2557,7 +2557,7 @@ void Highs::clearInfo() { info_.clear(); }
 
 void Highs::clearRanging() { ranging_.clear(); }
 
-void Highs::clearEkk() { ekk_instance_.invalidate(); }
+void Highs::invalidateEkk() { ekk_instance_.invalidate(); }
 
 // The method below runs calls solveLp for the given LP
 HighsStatus Highs::callSolveLp(HighsLp& lp, const string message) {

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -19,7 +19,7 @@
 
 #include "lp_data/HighsOptions.h"
 
-void HighsInfo::clear() {
+void HighsInfo::invalidate() {
   valid = false;
   mip_node_count = -1;
   simplex_iteration_count = -1;

--- a/src/lp_data/HighsInfo.h
+++ b/src/lp_data/HighsInfo.h
@@ -183,7 +183,7 @@ class HighsInfo : public HighsInfoStruct {
     if (records.size() > 0) deleteRecords();
   }
 
-  void clear();
+  void invalidate();
 
  private:
   void deleteRecords() {

--- a/src/lp_data/HighsInfoDebug.cpp
+++ b/src/lp_data/HighsInfoDebug.cpp
@@ -132,7 +132,7 @@ HighsDebugStatus debugInfo(const HighsOptions& options, const HighsLp& lp,
 
 HighsDebugStatus debugNoInfo(const HighsInfo& info) {
   HighsInfo no_info;
-  no_info.clear();
+  no_info.invalidate();
   bool error_found = false;
   const std::vector<InfoRecord*>& info_records = info.records;
   const std::vector<InfoRecord*>& no_info_records = no_info.records;

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -596,7 +596,7 @@ HighsStatus Highs::changeIntegralityInterface(
   HighsStatus call_status;
   changeLpIntegrality(model_.lp_, index_collection, local_integrality);
   // Deduce the consequences of new integrality
-  clearModelStatus();
+  invalidateModelStatus();
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -24,7 +24,7 @@ HighsStatus Highs::basisForSolution() {
   HighsLp& lp = model_.lp_;
   assert(!lp.isMip());
   assert(solution_.value_valid);
-  clearBasis();
+  invalidateBasis();
   HighsInt num_basic = 0;
   HighsBasis basis;
   for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -174,7 +174,7 @@ HighsStatus Highs::addColsInterface(
   assert(lpDimensionsOk("addCols", lp, options.log_options));
 
   // Deduce the consequences of adding new columns
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
 
   // Determine any implications for simplex data
   ekk_instance_.addCols(lp, local_a_matrix);
@@ -293,7 +293,7 @@ HighsStatus Highs::addRowsInterface(HighsInt ext_num_new_row,
   assert(lpDimensionsOk("addRows", lp, options.log_options));
 
   // Deduce the consequences of adding new rows
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
   // Determine any implications for simplex data
   ekk_instance_.addRows(lp, local_ar_matrix);
   return return_status;
@@ -322,7 +322,7 @@ void Highs::deleteColsInterface(HighsIndexCollection& index_collection) {
     lp.scale_.num_col = lp.num_col_;
   }
   // Deduce the consequences of deleting columns
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
 
   // Determine any implications for simplex data
   ekk_instance_.deleteCols(index_collection);
@@ -366,7 +366,7 @@ void Highs::deleteRowsInterface(HighsIndexCollection& index_collection) {
     lp.scale_.num_row = lp.num_row_;
   }
   // Deduce the consequences of deleting rows
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
 
   // Determine any implications for simplex data
   ekk_instance_.deleteRows(index_collection);
@@ -619,7 +619,7 @@ HighsStatus Highs::changeCostsInterface(HighsIndexCollection& index_collection,
   if (return_status == HighsStatus::kError) return return_status;
   changeLpCosts(model_.lp_, index_collection, local_colCost);
   // Deduce the consequences of new costs
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
   // Determine any implications for simplex data
   ekk_instance_.updateStatus(LpAction::kNewCosts);
   return HighsStatus::kOk;
@@ -664,7 +664,7 @@ HighsStatus Highs::changeColBoundsInterface(
   // nonbasic variables whose bounds have changed
   setNonbasicStatusInterface(index_collection, true);
   // Deduce the consequences of new col bounds
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
   // Determine any implications for simplex data
   ekk_instance_.updateStatus(LpAction::kNewBounds);
   return HighsStatus::kOk;
@@ -708,7 +708,7 @@ HighsStatus Highs::changeRowBoundsInterface(
   // nonbasic variables whose bounds have changed
   setNonbasicStatusInterface(index_collection, false);
   // Deduce the consequences of new row bounds
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
   // Determine any implications for simplex data
   ekk_instance_.updateStatus(LpAction::kNewBounds);
   return HighsStatus::kOk;
@@ -731,7 +731,7 @@ void Highs::changeCoefficientInterface(const HighsInt ext_row,
   //
   // ToDo: Can do something more intelligent if element is in nonbasic column.
   // Otherwise, treat it as if it's a new row
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
 
   // Determine any implications for simplex data
   ekk_instance_.updateStatus(LpAction::kNewRows);
@@ -775,7 +775,7 @@ HighsStatus Highs::scaleColInterface(const HighsInt col,
     }
   }
   // Deduce the consequences of a scaled column
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
 
   // Determine any implications for simplex data
   ekk_instance_.updateStatus(LpAction::kScaledCol);
@@ -822,7 +822,7 @@ HighsStatus Highs::scaleRowInterface(const HighsInt row,
     }
   }
   // Deduce the consequences of a scaled row
-  clearModelStatusSolutionAndInfo();
+  invalidateModelStatusSolutionAndInfo();
 
   // Determine any implications for simplex data
   ekk_instance_.updateStatus(LpAction::kScaledRow);

--- a/src/lp_data/HighsRanging.cpp
+++ b/src/lp_data/HighsRanging.cpp
@@ -24,8 +24,10 @@
 
 using std::min;
 
+void HighsRanging::invalidate() { valid = false; }
+
 void HighsRanging::clear() {
-  valid = false;
+  this->invalidate();
   this->col_cost_up.value_.clear();
   this->col_cost_up.objective_.clear();
   this->col_cost_up.in_var_.clear();

--- a/src/lp_data/HighsRanging.h
+++ b/src/lp_data/HighsRanging.h
@@ -35,6 +35,7 @@ struct HighsRanging {
   HighsRangingRecord col_bound_dn;
   HighsRangingRecord row_bound_up;
   HighsRangingRecord row_bound_dn;
+  void invalidate();
   void clear();
 };
 

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1206,22 +1206,31 @@ bool isBasisRightSize(const HighsLp& lp, const HighsBasis& basis) {
          (HighsInt)basis.row_status.size() == lp.num_row_;
 }
 
-void HighsSolution::clear() {
-  this->col_value.clear();
-  this->row_value.clear();
+void HighsSolution::invalidate() {
   this->value_valid = false;
-  this->col_dual.clear();
-  this->row_dual.clear();
   this->dual_valid = false;
 }
 
-void HighsBasis::clear() {
+void HighsSolution::clear() {
+  this->invalidate();
+  this->col_value.clear();
+  this->row_value.clear();
+  this->col_dual.clear();
+  this->row_dual.clear();
+}
+
+void HighsBasis::invalidate() {
   this->valid = false;
   this->alien = true;
   this->was_alien = true;
   this->debug_id = -1;
   this->debug_update_count = -1;
   this->debug_origin_name = "None";
+}
+
+void HighsBasis::clear() {
+  this->invalidate();
   this->row_status.clear();
   this->col_status.clear();
 }
+

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1233,4 +1233,3 @@ void HighsBasis::clear() {
   this->row_status.clear();
   this->col_status.clear();
 }
-

--- a/src/qpsolver/feasibility_highs.hpp
+++ b/src/qpsolver/feasibility_highs.hpp
@@ -9,7 +9,7 @@ void computestartingpoint_highs(Runtime& runtime, CrashSolution& result) {
   Highs highs;
 
   // set HiGHS to be silent
-  highs.setOptionValue("output_flag", true);
+  highs.setOptionValue("output_flag", false);
   highs.setOptionValue("presolve", "on");
   highs.setOptionValue("time_limit", runtime.settings.timelimit -
                                          runtime.timer.readRunHighsClock());


### PR DESCRIPTION
This avoids a very obscure unassigned read in HFactor::buildSimple - when the check for a unit column considers a zero column for which all subsequent columns are zero

This will close #831 

The vectors in `Highs::solution_` and `Highs::basis_` were being cleared and then reassigned, rather than leaving the values as they were and just using `value_valid`, `dual_valid` and `valid` to indicate whether the values in the vectors had any meaning. The latter is now done

This will close #830 
