### PR TITLE
Allow LP file parse to handle var*var in expressions

### DIFF
--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -43,6 +43,7 @@ set(TEST_SOURCES
     TestHighsModel.cpp
     TestHSet.cpp
     TestLogging.cpp
+    TestLPFileFormat.cpp
     TestLpValidation.cpp
     TestLpModification.cpp
     TestLpOrientation.cpp

--- a/check/TestLPFileFormat.cpp
+++ b/check/TestLPFileFormat.cpp
@@ -1,0 +1,13 @@
+
+#include "catch.hpp"
+#include "Highs.h"
+#include "../extern/filereaderlp/reader.hpp"
+
+
+TEST_CASE("highs can load .lp files that contain quadratic terms without a space") {
+    std::string filename = std::string(HIGHS_DIR) + "/check/instances/quadratic.lp";
+    Highs highs;
+    REQUIRE(highs.readModel(filename) == HighsStatus::kOk);
+
+    // todo: read the coefficients/variables off the highs model
+}

--- a/check/instances/quadratic.lp
+++ b/check/instances/quadratic.lp
@@ -1,0 +1,5 @@
+Minimize
+ 10 x1 + [ 6 x0*x1 ] / 2
+subject to
+ c1: 10 x1 + [ x0 * x1 ] <= 10
+End

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -1014,7 +1014,7 @@ void Reader::readnexttoken(bool& done) {
    }
 
    // assume it's an (section/variable/constraint) identifier
-   auto endpos = this->linebuffer.find_first_of("\t\n\\:+<>^= /-", this->linebufferpos);
+   auto endpos = this->linebuffer.find_first_of("\t\n\\:+<>^= /-*", this->linebufferpos);
    if( endpos == std::string::npos )
       endpos = this->linebuffer.size();  // take complete rest of string
    if( endpos > this->linebufferpos ) {


### PR DESCRIPTION
Previously LP files with the format
```
Minimize
 10 x1 + [ 6 x0*x1 ] / 2
End
```
would have `x0*x1` treated as a variable, rather than as a multiplication of two variables.

I used the LP reader code as a basis for another project (https://github.com/dwavesystems/dimod/pull/1182). Would have loved to just use y'all as a submodule, but we needed to make pretty invasive changes. Nonetheless, while doing so discovered this bug, so thought I would make the change upstream as well.