### PR TITLE
Fix EOF detection in LP file reader

### DIFF
--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -50,6 +50,15 @@ TEST_CASE("filereader-edge-cases", "[highs_filereader]") {
   run_status = highs.run();
   REQUIRE(run_status == HighsStatus::kOk);
 
+  // Load an LP file that does not end with a newline
+  model = "no-newline-eof";
+  model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".lp";
+  return_status = highs.readModel(model_file);
+  REQUIRE(return_status == HighsStatus::kOk);
+
+  run_status = highs.run();
+  REQUIRE(run_status == HighsStatus::kOk);
+
   // Load an existing MPS file and run HiGHS
   model = "adlittle";
   model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";

--- a/check/instances/no-newline-eof.lp
+++ b/check/instances/no-newline-eof.lp
@@ -1,0 +1,5 @@
+Minimize
+ x0 + x1
+subject to
+ c1: x0 + x1 <= 1
+End

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -903,8 +903,8 @@ void Reader::readnexttoken(bool& done) {
      this->linebufferpos = 0;
    }
 
-   // if all line has been read and we are at end of file, then stop
-   if (this->linebufferpos == this->linebuffer.size() && this->file.eof()) {
+   // if we are at end of file, then stop
+   if (this->file.eof()) {
      this->rawtokens.push_back(std::unique_ptr<RawToken>(new RawToken(RawTokenType::FLEND)));
      done = true;
      return;

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -892,7 +892,12 @@ void Reader::readnexttoken(bool& done) {
    done = false;
 
    if (this->linebufferpos == this->linebuffer.size()) {
-     // read next line
+     // read next line if any are left. 
+     if (this->file.eof()) {
+         this->rawtokens.push_back(std::unique_ptr<RawToken>(new RawToken(RawTokenType::FLEND)));
+         done = true;
+         return;
+     }
      std::getline(this->file, linebuffer);
 
      // drop \r
@@ -901,13 +906,6 @@ void Reader::readnexttoken(bool& done) {
 
      // reset linebufferpos
      this->linebufferpos = 0;
-   }
-
-   // if we are at end of file, then stop
-   if (this->file.eof()) {
-     this->rawtokens.push_back(std::unique_ptr<RawToken>(new RawToken(RawTokenType::FLEND)));
-     done = true;
-     return;
    }
 
    // check single character tokens


### PR DESCRIPTION
The condition `this->linebufferpos == this->linebuffer.size()` would never be `true` except potentially (but not necessarily) at the end of the file, since whenever an `'\n'` is encountered, `this->linebufferpos` is manually set to correspond to the end of the line (on line 998).

Moreover, the condition would mean that an actual EOF would not be properly handled when the final line of the file is not empty, which would instead cause an infinite loop as the final line is read over and over. In particular, this infinite loop is encountered for the example given in gh-840:

```
4d 69 6e 69 6d 69 7a 65 0a 20 78 30 20 2b 20 78 31 0a 73 75 62 6a 65 63 74 20 74 6f 0a 20 63 31 3a 20 78 30 20 2b 20 78 31 20 3c 3d 20 31 0a 45 6e 64
```

Here we just move the EOF check to before reading a new line.

This closes gh-840.

Now at the same time, it certainly seems like the condition wouldn't be put there for no reason, so maybe I'm missing something.