### PR TITLE
Fix 842 843a

### DIFF
--- a/check/TestHighsHessian.cpp
+++ b/check/TestHighsHessian.cpp
@@ -31,8 +31,8 @@ TEST_CASE("HighsHessian", "[highs_hessian]") {
   // OK for default assessHessian (minimization) but not for
   // maximization.
   REQUIRE(assessHessian(square_hessian, options) == HighsStatus::kOk);
-  REQUIRE(assessHessian(square_hessian, options, ObjSense::kMaximize) ==
-          HighsStatus::kError);
+  REQUIRE(okHessianDiagonal(options, square_hessian, ObjSense::kMinimize));
+  REQUIRE(!okHessianDiagonal(options, square_hessian, ObjSense::kMaximize));
   if (dev_run) {
     printf("\nReturned square Hessian\n");
     square_hessian.print();
@@ -42,8 +42,8 @@ TEST_CASE("HighsHessian", "[highs_hessian]") {
   // OK for default assessHessian (minimization) but not for
   // maximization.
   REQUIRE(assessHessian(triangular_hessian, options) == HighsStatus::kOk);
-  REQUIRE(assessHessian(triangular_hessian, options, ObjSense::kMaximize) ==
-          HighsStatus::kError);
+  REQUIRE(okHessianDiagonal(options, square_hessian, ObjSense::kMinimize));
+  REQUIRE(!okHessianDiagonal(options, square_hessian, ObjSense::kMaximize));
   if (dev_run) {
     printf("\nReturned triangular Hessian\n");
     triangular_hessian.print();
@@ -73,10 +73,12 @@ TEST_CASE("HighsHessian", "[highs_hessian]") {
   negative_diagonal_hessian.value_[6] = -negative_diagonal_hessian.value_[6];
   negative_diagonal_hessian.value_[8] = -negative_diagonal_hessian.value_[8];
   negative_diagonal_hessian.value_[9] = -negative_diagonal_hessian.value_[9];
-  REQUIRE(assessHessian(negative_diagonal_hessian, options,
-                        ObjSense::kMaximize) == HighsStatus::kOk);
-  REQUIRE(assessHessian(negative_diagonal_hessian, options,
-                        ObjSense::kMinimize) == HighsStatus::kError);
+  REQUIRE(assessHessian(negative_diagonal_hessian, options) ==
+          HighsStatus::kOk);
+  REQUIRE(!okHessianDiagonal(options, negative_diagonal_hessian,
+                             ObjSense::kMinimize));
+  REQUIRE(okHessianDiagonal(options, negative_diagonal_hessian,
+                            ObjSense::kMaximize));
 
   // Square Hessian with only triangular entries - doubled strictly triangular
   // entries.
@@ -129,6 +131,14 @@ TEST_CASE("HighsHessian", "[highs_hessian]") {
     const HighsInt iEl = indefinite.start_[iCol];
     indefinite.value_[iEl] = -indefinite.value_[iEl];
   }
-  REQUIRE(assessHessian(indefinite, options, ObjSense::kMaximize) ==
-          HighsStatus::kOk);
+  if (dev_run) {
+    printf("\nIndefinite\n");
+    indefinite.print();
+  }
+  REQUIRE(assessHessian(indefinite, options) == HighsStatus::kOk);
+  // Can tell that the indefinite Hessian is not OK for minimization
+  REQUIRE(!okHessianDiagonal(options, indefinite, ObjSense::kMinimize));
+  // Cannot tell that the indefinite Hessian is not OK for
+  // maximization since its diagonal entries are in [-4 0)
+  REQUIRE(okHessianDiagonal(options, indefinite, ObjSense::kMaximize));
 }

--- a/check/TestHighsModel.cpp
+++ b/check/TestHighsModel.cpp
@@ -70,5 +70,7 @@ TEST_CASE("HighsModel", "[highs_model]") {
   hessian.value_[0] = illegal_small_hessian_diagonal_entry;
   hessian.value_[1] = illegal_negative_hessian_diagonal_entry;
   status = highs.passModel(model);
+  REQUIRE(status == HighsStatus::kOk);
+  status = highs.run();
   REQUIRE(status == HighsStatus::kError);
 }

--- a/check/TestLPFileFormat.cpp
+++ b/check/TestLPFileFormat.cpp
@@ -1,13 +1,14 @@
 
-#include "catch.hpp"
-#include "Highs.h"
 #include "../extern/filereaderlp/reader.hpp"
+#include "Highs.h"
+#include "catch.hpp"
 
+TEST_CASE(
+    "highs can load .lp files that contain quadratic terms without a space") {
+  std::string filename =
+      std::string(HIGHS_DIR) + "/check/instances/quadratic.lp";
+  Highs highs;
+  REQUIRE(highs.readModel(filename) == HighsStatus::kOk);
 
-TEST_CASE("highs can load .lp files that contain quadratic terms without a space") {
-    std::string filename = std::string(HIGHS_DIR) + "/check/instances/quadratic.lp";
-    Highs highs;
-    REQUIRE(highs.readModel(filename) == HighsStatus::kOk);
-
-    // todo: read the coefficients/variables off the highs model
+  // todo: read the coefficients/variables off the highs model
 }

--- a/examples/call_highs_from_python.py
+++ b/examples/call_highs_from_python.py
@@ -71,18 +71,3 @@ return_status, model_status, col_value, col_dual, row_value, row_dual , col_basi
 print ("return_status = ", return_status)
 print ("model_status = ", model_status)
 print (col_value, col_dual, row_value, row_dual, col_basis, row_basis)
-
-# Illustrate the reading of an MPS file
-#
-return_status, n_col, n_row, sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper, a_start, a_index, a_value = Highs_lpMpsRead()
-
-# Find the continuous solution of the LP
-return_status, model_status, col_value, col_dual, row_value, row_dual , col_basis, row_basis = Highs_lpCall(
-    col_cost, col_lower, col_upper,
-    row_lower, row_upper,
-    a_start, a_index, a_value)
-
-print ("return_status = ", return_status)
-print ("model_status = ", model_status)
-print (col_value)
-

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -282,9 +282,9 @@ HighsStatus Highs::passModel(HighsModel model) {
       options_.log_options, assessLp(lp, options_), return_status, "assessLp");
   if (return_status == HighsStatus::kError) return return_status;
   // Check validity of any Hessian, normalising its entries
-  return_status = interpretCallStatus(
-      options_.log_options, assessHessian(hessian, options_, lp.sense_),
-      return_status, "assessHessian");
+  return_status = interpretCallStatus(options_.log_options,
+                                      assessHessian(hessian, options_),
+                                      return_status, "assessHessian");
   if (return_status == HighsStatus::kError) return return_status;
   if (hessian.dim_) {
     // Clear any zero Hessian
@@ -436,9 +436,9 @@ HighsStatus Highs::passHessian(HighsHessian hessian_) {
   HighsHessian& hessian = model_.hessian_;
   hessian = std::move(hessian_);
   // Check validity of any Hessian, normalising its entries
-  return_status = interpretCallStatus(
-      options_.log_options, assessHessian(hessian, options_, model_.lp_.sense_),
-      return_status, "assessHessian");
+  return_status = interpretCallStatus(options_.log_options,
+                                      assessHessian(hessian, options_),
+                                      return_status, "assessHessian");
   if (return_status == HighsStatus::kError) return return_status;
   if (hessian.dim_) {
     // Clear any zero Hessian
@@ -806,6 +806,13 @@ HighsStatus Highs::run() {
     if (model_.isMip()) {
       highsLogUser(options_.log_options, HighsLogType::kError,
                    "Cannot solve MIQP problems with HiGHS\n");
+      return returnFromRun(HighsStatus::kError);
+    }
+    // Ensure that its diagonal entries are OK in the context of the
+    // objective sense. It's OK to be semi-definite
+    if (!okHessianDiagonal(options_, model_.hessian_, model_.lp_.sense_)) {
+      highsLogUser(options_.log_options, HighsLogType::kError,
+                   "Cannot solve non-convex QP problems with HiGHS\n");
       return returnFromRun(HighsStatus::kError);
     }
     call_status = callSolveQp();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3201,25 +3201,27 @@ void Highs::reportSolvedLpQpStats() {
   HighsLogOptions& log_options = options_.log_options;
   highsLogUser(log_options, HighsLogType::kInfo, "Model   status      : %s\n",
                modelStatusToString(model_status_).c_str());
-  if (info_.simplex_iteration_count)
+  if (info_.valid) {
+    if (info_.simplex_iteration_count)
+      highsLogUser(log_options, HighsLogType::kInfo,
+                   "Simplex   iterations: %" HIGHSINT_FORMAT "\n",
+                   info_.simplex_iteration_count);
+    if (info_.ipm_iteration_count)
+      highsLogUser(log_options, HighsLogType::kInfo,
+                   "IPM       iterations: %" HIGHSINT_FORMAT "\n",
+                   info_.ipm_iteration_count);
+    if (info_.crossover_iteration_count)
+      highsLogUser(log_options, HighsLogType::kInfo,
+                   "Crossover iterations: %" HIGHSINT_FORMAT "\n",
+                   info_.crossover_iteration_count);
+    if (info_.qp_iteration_count)
+      highsLogUser(log_options, HighsLogType::kInfo,
+                   "QP ASM    iterations: %" HIGHSINT_FORMAT "\n",
+                   info_.qp_iteration_count);
     highsLogUser(log_options, HighsLogType::kInfo,
-                 "Simplex   iterations: %" HIGHSINT_FORMAT "\n",
-                 info_.simplex_iteration_count);
-  if (info_.ipm_iteration_count)
-    highsLogUser(log_options, HighsLogType::kInfo,
-                 "IPM       iterations: %" HIGHSINT_FORMAT "\n",
-                 info_.ipm_iteration_count);
-  if (info_.crossover_iteration_count)
-    highsLogUser(log_options, HighsLogType::kInfo,
-                 "Crossover iterations: %" HIGHSINT_FORMAT "\n",
-                 info_.crossover_iteration_count);
-  if (info_.qp_iteration_count)
-    highsLogUser(log_options, HighsLogType::kInfo,
-                 "QP ASM    iterations: %" HIGHSINT_FORMAT "\n",
-                 info_.qp_iteration_count);
-  highsLogUser(log_options, HighsLogType::kInfo,
-               "Objective value     : %17.10e\n",
-               info_.objective_function_value);
+                 "Objective value     : %17.10e\n",
+                 info_.objective_function_value);
+  }
   double run_time = timer_.readRunHighsClock();
   highsLogUser(log_options, HighsLogType::kInfo,
                "HiGHS run time      : %13.2f\n", run_time);

--- a/src/model/HighsHessianUtils.cpp
+++ b/src/model/HighsHessianUtils.cpp
@@ -24,8 +24,7 @@
 
 using std::fabs;
 
-HighsStatus assessHessian(HighsHessian& hessian, const HighsOptions& options,
-                          const ObjSense sense) {
+HighsStatus assessHessian(HighsHessian& hessian, const HighsOptions& options) {
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
 
@@ -88,13 +87,10 @@ HighsStatus assessHessian(HighsHessian& hessian, const HighsOptions& options,
 
   HighsInt hessian_num_nz = hessian.numNz();
   // If the Hessian has nonzeros, complete its diagonal with explicit
-  // zeros if necessary, and then check its diagonal entries in the
-  // context of the objective sense. It's OK to be semi-definite
+  // zeros if necessary
   if (hessian_num_nz) {
     completeHessianDiagonal(options, hessian);
     hessian_num_nz = hessian.numNz();
-    if (!okHessianDiagonal(options, hessian, sense))
-      return_status = HighsStatus::kError;
   }
   // If entries have been removed from the matrix, resize the index
   // and value vectors
@@ -201,17 +197,17 @@ bool okHessianDiagonal(const HighsOptions& options, HighsHessian& hessian,
       num_illegal_diagonal_value > 0;
   if (certainly_not_positive_semidefinite) {
     if (sense == ObjSense::kMinimize) {
-      highsLogUser(
-          options.log_options, HighsLogType::kError,
-          "Hessian has %" HIGHSINT_FORMAT
-          " diagonal entries in [%g, 0) so is not positive semidefinite\n",
-          num_illegal_diagonal_value, min_diagonal_value);
+      highsLogUser(options.log_options, HighsLogType::kError,
+                   "Hessian has %" HIGHSINT_FORMAT
+                   " diagonal entries in [%g, 0) so is not positive "
+                   "semidefinite for minimization\n",
+                   num_illegal_diagonal_value, min_diagonal_value);
     } else {
-      highsLogUser(
-          options.log_options, HighsLogType::kError,
-          "Hessian has %" HIGHSINT_FORMAT
-          " diagonal entries in (0, %g] so is not negative semidefinite\n",
-          num_illegal_diagonal_value, -min_diagonal_value);
+      highsLogUser(options.log_options, HighsLogType::kError,
+                   "Hessian has %" HIGHSINT_FORMAT
+                   " diagonal entries in (0, %g] so is not negative "
+                   "semidefinite for maximization\n",
+                   num_illegal_diagonal_value, -min_diagonal_value);
     }
   }
   return !certainly_not_positive_semidefinite;

--- a/src/model/HighsHessianUtils.h
+++ b/src/model/HighsHessianUtils.h
@@ -27,8 +27,7 @@
 
 using std::vector;
 
-HighsStatus assessHessian(HighsHessian& hessian, const HighsOptions& options,
-                          const ObjSense sense = ObjSense::kMinimize);
+HighsStatus assessHessian(HighsHessian& hessian, const HighsOptions& options);
 HighsStatus assessHessianDimensions(const HighsOptions& options,
                                     HighsHessian& hessian);
 void completeHessianDiagonal(const HighsOptions& options,

--- a/src/util/HighsUtils.cpp
+++ b/src/util/HighsUtils.cpp
@@ -332,8 +332,10 @@ void analyseVectorValues(const HighsLogOptions* log_options,
   for (HighsInt ix = 0; ix < vecDim; ix++) {
     double v = vec[ix];
     double absV = std::fabs(v);
-    min_abs_value = std::min(absV, min_abs_value);
-    max_abs_value = std::max(absV, max_abs_value);
+    if (absV) {
+      min_abs_value = std::min(absV, min_abs_value);
+      max_abs_value = std::max(absV, max_abs_value);
+    }
     HighsInt log10V;
     if (absV > 0) {
       // Nonzero value


### PR DESCRIPTION
Reading/passing a Hessian that has negative diagonal entries is not an error, since the file is read correctly and it's a valid Hessian. It's only an error to try to solve when the optimization sense makes the problem non-convex. Hence the test of Hessian diagonal entries is now performed in Highs::run(). This will close #842 

The horrible MPS read method had been removed from the Python interface some time ago, but is still referenced in `examples/call_highs_from_python.py`. This is now removed and will close #843 
