### PR TITLE
Fix header in "Get started" section of documentation

### DIFF
--- a/src/get-started.md
+++ b/src/get-started.md
@@ -12,9 +12,9 @@ Note that HiGHS is still pre-1.0, so the version numbers in the releases do not 
 
 For Windows users: if in doubt, choose the `x86_64-w64-mingw32-cxx11.tar.gz` file
 
-For Mac users: choose the `x86_64-apple-darwin.tar.gz` file.### Build HiGHS from source code using CMake
+For Mac users: choose the `x86_64-apple-darwin.tar.gz` file.
 
-## Build
+### Build HiGHS from source code
 
 HiGHS uses CMake as a build system. The simplest setup is to create a build folder (within the folder into which HiGHS has been downloaded) and then build HiGHS within it. The name of the build folder is arbitrary but, assuming it is HiGHS/build, the full sequence of commands required is as follows
 


### PR DESCRIPTION
Currently, the page looks as follows:

![image](https://user-images.githubusercontent.com/6169306/167599963-db19d2a1-efba-4d9e-acd4-e219a2611730.png)

This change removes the duplicated header and fixes the formatting of the second one.