### PR TITLE
Fix a few broken links in "Interfaces" section of documentation

### DIFF
--- a/src/man/interfaces.md
+++ b/src/man/interfaces.md
@@ -1,6 +1,6 @@
 ### Language interfaces
 
-There are HiGHS interfaces for C, C#, FORTRAN, Julia and Python in [`HiGHS/interfaces`]( https://github.com/ERGO-Code/HiGHS/tree/master/src/interfaces), with example driver files in [`HiGHS/examples/`](https://github.com/ERGO-Code/HiGHS/tree/master/src/examples). 
+There are HiGHS interfaces for C, C#, FORTRAN, Julia and Python in [`HiGHS/interfaces`](https://github.com/ERGO-Code/HiGHS/tree/master/src/interfaces), with example driver files in [`HiGHS/examples`](https://github.com/ERGO-Code/HiGHS/tree/master/examples). 
 
 Julia
 -----


### PR DESCRIPTION
This fixes two issues:

1. The leading space in the link to HiGHS/interfaces would cause the link to be broken and instead refer to https://ergo-code.github.io/HiGHS/man/man/%20https:/github.com/ERGO-Code/HiGHS/tree/master/src/interfaces
2. The link to HiGHS/examples would also 404 due to the "src/".