### PR TITLE
cmake: Allow customizing install directories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ include(Platform/${CMAKE_SYSTEM_NAME}-Determine-CXX OPTIONAL)
 include(Platform/${CMAKE_SYSTEM_NAME}-CXX OPTIONAL)
 set(CMAKE_CXX_COMPILER_NAMES clang++ icpc c++ ${CMAKE_CXX_COMPILER_NAMES})
 
+# use customizable install directories
+include(GNUInstallDirs)
+
 # set default build type before project call, as it otherwise seems to fail for some plattforms
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
@@ -60,15 +63,9 @@ set(CMAKE_MACOSX_RPATH ON)
 option(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS "Export all symbols into the DLL" ON)
 
 
-if (WIN32)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/bin)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/bin)
-else()
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/lib)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/bin)
-endif()
-
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${HIGHS_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 
 include(CheckCXXSourceCompiles)
 
@@ -292,7 +289,7 @@ if(NOT MSVC)
     if (NOT "${OSI_ROOT}" STREQUAL "")
         # if OSI_ROOT is set, then overwrite PKG_CONFIG_PATH
         message(STATUS "OSI root folder set: " ${OSI_ROOT})
-        set(ENV{PKG_CONFIG_PATH}  "${OSI_ROOT}/lib/pkgconfig")
+        set(ENV{PKG_CONFIG_PATH}  "${OSI_ROOT}/${CMAKE_INSTALL_LIBDIR}/pkgconfig")
     endif ()
     unset(OSI_ROOT CACHE)
     find_package(PkgConfig)
@@ -355,7 +352,7 @@ set(CMAKE_SKIP_BUILD_RPATH FALSE)
 # when building, don't use the install RPATH already
 # (but later on when installing)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 
 # Targets
@@ -509,16 +506,11 @@ if (EXP)
 endif()
 
 
-if (UNIX)
-    install(TARGETS libhighs EXPORT highs-targets
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib
-            PUBLIC_HEADER DESTINATION include)
-elseif (WIN32)
-    install(TARGETS libhighs EXPORT highs-targets
-            LIBRARY DESTINATION bin
-            PUBLIC_HEADER DESTINATION include)
-endif()
+install(TARGETS libhighs EXPORT highs-targets
+    LIBRARY
+    ARCHIVE
+    RUNTIME
+    PUBLIC_HEADER)
 
 
 endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(highs libhighs)
 
 # install the binary
 install(TARGETS highs EXPORT highs-targets
-        RUNTIME DESTINATION bin)
+        RUNTIME)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -332,7 +332,7 @@ endif()
 # on UNIX system the 'lib' prefix is automatically added
 set_target_properties(libhighs PROPERTIES
     OUTPUT_NAME "highs"
-    MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 if (OSI_FOUND)
     add_library(OsiHighs interfaces/OsiHiGHSSolverInterface.cpp)
@@ -352,19 +352,19 @@ if (OSI_FOUND)
     endif()
 
     install(TARGETS OsiHighs
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include)
+        LIBRARY
+        ARCHIVE
+        RUNTIME
+        INCLUDES)
 
     set_target_properties(OsiHighs PROPERTIES INSTALL_RPATH
-        "${CMAKE_INSTALL_PREFIX}/lib")
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
     #configure and install the pkg-config file
     configure_file(${HIGHS_SOURCE_DIR}/osi-highs.pc.in
         "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/osi-highs.pc" @ONLY)
     install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/osi-highs.pc"
-        DESTINATION lib/pkgconfig)
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 if (ZLIB_FOUND)
@@ -374,14 +374,14 @@ endif()
 
 # set the install rpath to the installed destination
 set_target_properties(highs PROPERTIES INSTALL_RPATH
-    "${CMAKE_INSTALL_PREFIX}/lib")
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # install the header files of highs
 foreach ( file ${headers} )
     get_filename_component( dir ${file} DIRECTORY )
-    install( FILES ${file} DESTINATION include/${dir} )
+    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir} )
 endforeach()
-install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION include)
+install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if (UNIX)
     #target_compile_options(libhighs PRIVATE "-Wno-defaulted-function-deleted")
@@ -403,14 +403,14 @@ if (UNIX)
 endif()
 
 install(TARGETS libhighs EXPORT highs-targets
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    RUNTIME DESTINATION bin
-    INCLUDES DESTINATION include)
+    LIBRARY
+    ARCHIVE
+    RUNTIME
+    INCLUDES)
 
 # Add library targets to the build-tree export set
 export(TARGETS libhighs
-FILE "${HIGHS_BINARY_DIR}/highs-targets.cmake")
+    FILE "${HIGHS_BINARY_DIR}/highs-targets.cmake")
 
 # Configure the config file for the build tree:
 # Either list all the src/* directories here, or put explicit paths in all the
@@ -433,11 +433,11 @@ configure_file(${HIGHS_SOURCE_DIR}/highs.pc.in
 # cmake-projects can link easily against highs, and the pkg-config flie so that
 # other projects can easily build against highs
 install(EXPORT highs-targets FILE highs-targets.cmake DESTINATION
-    lib/cmake/highs)
+    ${CMAKE_INSTALL_LIBDIR}/cmake/highs)
 install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake"
-    DESTINATION lib/cmake/highs)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/highs)
 install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc"
-    DESTINATION lib/pkgconfig)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 else()
 
@@ -573,11 +573,11 @@ endif()
 # on UNIX system the 'lib' prefix is automatically added
 set_target_properties(libhighs PROPERTIES
     OUTPUT_NAME "highs"
-    MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 if (UNIX)
     set_target_properties(libhighs PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${HIGHS_BINARY_DIR}/lib")
+        LIBRARY_OUTPUT_DIRECTORY "${HIGHS_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 
 set(headers_fast_build_
@@ -717,14 +717,14 @@ set(headers_fast_build_ ${headers_fast_build_} ipm/IpxWrapper.h ${basiclu_header
 
 # set the install rpath to the installed destination
 set_target_properties(libhighs PROPERTIES INSTALL_RPATH
-    "${CMAKE_INSTALL_PREFIX}/lib")
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 # install the header files of highs
 foreach ( file ${headers_fast_build_} )
     get_filename_component( dir ${file} DIRECTORY )
-    install( FILES ${file} DESTINATION include/${dir} )
+    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir} )
 endforeach()
-install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION include)
+install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 
 # target_compile_options(libhighs PRIVATE "-Wall")
@@ -743,7 +743,7 @@ if (UNIX)
 endif()
 
 set_target_properties(libhighs PROPERTIES INSTALL_RPATH
-    "${CMAKE_INSTALL_PREFIX}/lib")
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 endif()
 
@@ -753,14 +753,14 @@ if(FORTRAN_FOUND)
     add_library(FortranHighs interfaces/highs_fortran_api.f90)
     target_link_libraries(FortranHighs PUBLIC libhighs)
     install(TARGETS FortranHighs
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION bin
-        INCLUDES DESTINATION include
+        LIBRARY
+        ARCHIVE
+        RUNTIME
+        INCLUDES
         MODULES DESTINATION modules)
-    install(FILES ${HIGHS_BINARY_DIR}/modules/highs_fortran_api.mod DESTINATION include/fortran)
+    install(FILES ${HIGHS_BINARY_DIR}/modules/highs_fortran_api.mod DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fortran)
     set_target_properties(FortranHighs PROPERTIES INSTALL_RPATH
-        "${CMAKE_INSTALL_PREFIX}/lib")
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif(FORTRAN_FOUND)
 
 if(CSHARP_FOUND)


### PR DESCRIPTION
The installation directories are currently hard-coded in the cmake rules. Some (multi-arch) distributions (e.g. Fedora) prefer to customize the installation directories, e.g., to allow distributing libraries for different architectures.

The proposed change allows defining custom installation directories by taking advantage of `GNUInstallDirs`. As an example, to allow installing the libraries to, e.g., `lib64` a distributor/builder could configure with `-DCMAKE_INSTALL_LIBDIR=lib64`.

See also: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html