### PR TITLE
Install extern headers inside "include" directory.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,6 +384,9 @@ set_target_properties(highs PROPERTIES INSTALL_RPATH
 # install the header files of highs
 foreach ( file ${headers} )
     get_filename_component( dir ${file} DIRECTORY )
+    if ( NOT dir STREQUAL "" )
+        string( REPLACE ../extern/ "" dir ${dir} )
+    endif ()
     install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir} )
 endforeach()
 install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -732,6 +735,9 @@ set_target_properties(libhighs PROPERTIES INSTALL_RPATH
 # install the header files of highs
 foreach ( file ${headers_fast_build_} )
     get_filename_component( dir ${file} DIRECTORY )
+    if ( NOT dir STREQUAL "" )
+        string( REPLACE ../extern/ "" dir ${dir} )
+    endif ()
     install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir} )
 endforeach()
 install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
When installing HiGHS with `cmake --install .`, some headers are installed outside the `include` folder.
By default, these headers are installed in a folder `extern` directly in the installation prefix.

Currently, all of these headers are installed in a sub-folder named `filereaderlp` inside that `extern` folder.

It is not clear to me where those headers should be installed (or whether they should be installed at all). But they very likely shouldn't be installed outside the `include` folder.

With the proposed change these headers are installed in the folder `filereaderlp` in the `include` folder (no `extern` folder anymore).