### PR TITLE
Install headers in subfolder "highs".

### DIFF
--- a/.github/workflows/test-c-example.yml
+++ b/.github/workflows/test-c-example.yml
@@ -30,6 +30,6 @@ jobs:
       run: |
         g++ $GITHUB_WORKSPACE/examples/call_highs_from_c.c \
           -o c_example \
-          -I install/include \
+          -I install/include/highs \
           -L install/lib -lhighs
         LD_LIBRARY_PATH=install/lib ./c_example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,7 +508,7 @@ install(TARGETS libhighs EXPORT highs-targets
     LIBRARY
     ARCHIVE
     RUNTIME
-    PUBLIC_HEADER)
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
 
 endif()

--- a/highs.pc.in
+++ b/highs.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/highs
 
 Name: HiGHS
 Description: Linear Optimization Software

--- a/osi-highs.pc.in
+++ b/osi-highs.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/highs
 
 Name: OsiHiGHS
 Description: COIN-OR Open Solver Interface for HiGHS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -360,7 +360,7 @@ if (OSI_FOUND)
         LIBRARY
         ARCHIVE
         RUNTIME
-        INCLUDES)
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
     set_target_properties(OsiHighs PROPERTIES INSTALL_RPATH
         "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
@@ -387,9 +387,9 @@ foreach ( file ${headers} )
     if ( NOT dir STREQUAL "" )
         string( REPLACE ../extern/ "" dir ${dir} )
     endif ()
-    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir} )
+    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/${dir} )
 endforeach()
-install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
 if (UNIX)
     #target_compile_options(libhighs PRIVATE "-Wno-defaulted-function-deleted")
@@ -414,7 +414,7 @@ install(TARGETS libhighs EXPORT highs-targets
     LIBRARY
     ARCHIVE
     RUNTIME
-    INCLUDES)
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
 # Add library targets to the build-tree export set
 export(TARGETS libhighs
@@ -429,7 +429,7 @@ configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
     "${HIGHS_BINARY_DIR}/highs-config.cmake" @ONLY)
 
 # Configure the config file for the install
-set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR}")
+set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR}/highs")
 configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
     "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake" @ONLY)
 
@@ -738,9 +738,9 @@ foreach ( file ${headers_fast_build_} )
     if ( NOT dir STREQUAL "" )
         string( REPLACE ../extern/ "" dir ${dir} )
     endif ()
-    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${dir} )
+    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/${dir} )
 endforeach()
-install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
 
 # target_compile_options(libhighs PRIVATE "-Wall")
@@ -772,9 +772,9 @@ if(FORTRAN_FOUND)
         LIBRARY
         ARCHIVE
         RUNTIME
-        INCLUDES
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs
         MODULES DESTINATION modules)
-    install(FILES ${HIGHS_BINARY_DIR}/modules/highs_fortran_api.mod DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fortran)
+    install(FILES ${HIGHS_BINARY_DIR}/modules/highs_fortran_api.mod DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/fortran)
     set_target_properties(FortranHighs PROPERTIES INSTALL_RPATH
         "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif(FORTRAN_FOUND)

--- a/src/interfaces/highspy/setup.py
+++ b/src/interfaces/highspy/setup.py
@@ -14,7 +14,7 @@ try:
         raise RuntimeError('Could not find HiGHS library; Please make sure it is in the LD_LIBRARY_PATH environment variable')
     highs_lib_dir = os.path.dirname(highs_lib)
     highs_build_dir = os.path.dirname(highs_lib_dir)
-    highs_include_dir = os.path.join(highs_build_dir, 'include')
+    highs_include_dir = os.path.join(highs_build_dir, 'include', 'highs')
     if not os.path.exists(os.path.join(highs_include_dir, 'Highs.h')):
         raise RuntimeError('Could not find HiGHS include directory')
     


### PR DESCRIPTION
When installing HiGHS, a series of sub-folders are installed in the `include` folder. Some of these have pretty generic names (e.g., `io`, `test`, or `util`).
When HiGHS is installed at the default prefix, some of those folder might collide with folders of other packages. In the best case, this leads to the confusing situation that it is unclear to a user which of these headers belong to which package. In the worst case, header files could collide and it would not be possible to install HiGHS at the same time as those other packages.

The proposed change moves HiGHS' header files to a subfolder `highs` inside the `include` directory.
For projects that use HiGHS via its .pc or .cmake files this change would probably go unnoticed. For other projects that add the path to the HiGHS headers manually, they would need to adapt their `-I` flags accordingly.
