### PR TITLE
fix some compiler warnings

### DIFF
--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -13,7 +13,7 @@
 /**@file io/HighsIO.cpp
  * @brief IO methods for HiGHS - currently just print/log messages
  */
-#include "HighsIO.h"
+#include "io/HighsIO.h"
 
 #include <cmath>
 #include <cstdarg>

--- a/src/ipm/ipx/src/iterate.cc
+++ b/src/ipm/ipx/src/iterate.cc
@@ -428,6 +428,7 @@ void Iterate::ResidualsFromDropping(double* pres, double* dres) const {
                     zdrop = zl_[j]-zu_[j]; // inactive
             }
             break;
+        default: ;
         }
         double amax = 0.0;
         for (Int p = AI.begin(j); p < AI.begin(j+1); p++)

--- a/src/ipm/ipx/src/model.cc
+++ b/src/ipm/ipx/src/model.cc
@@ -494,7 +494,7 @@ static int CheckVectors(Int m, Int n, const double* rhs,const char* constr_type,
 
 // Checks if A is a valid m-by-n matrix in CSC format. Returns 0 if OK and a
 // negative value otherwise.
-Int CheckMatrix(Int m, Int n, const Int *Ap, const Int *Ai, const double *Ax) {
+static Int CheckMatrix(Int m, Int n, const Int *Ap, const Int *Ai, const double *Ax) {
     if (Ap[0] != 0)
         return -5;
     for (Int j = 0; j < n; j++)

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -41,7 +41,7 @@ void HighsInfo::invalidate() {
   sum_dual_infeasibilities = kHighsIllegalInfeasibilityMeasure;
 }
 
-std::string infoEntryTypeToString(const HighsInfoType type) {
+static std::string infoEntryTypeToString(const HighsInfoType type) {
   if (type == HighsInfoType::kInt64) {
     return "int64_t";
   } else if (type == HighsInfoType::kInt) {

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -1754,7 +1754,7 @@ void reportLpObjSense(const HighsLogOptions& log_options, const HighsLp& lp) {
                  lp.sense_);
 }
 
-std::string getBoundType(const double lower, const double upper) {
+static std::string getBoundType(const double lower, const double upper) {
   std::string type;
   if (highs_isInfinity(-lower)) {
     if (highs_isInfinity(upper)) {

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -42,7 +42,7 @@ void highsOpenLogFile(HighsLogOptions& log_options,
   option.assignvalue(log_file);
 }
 
-std::string optionEntryTypeToString(const HighsOptionType type) {
+static std::string optionEntryTypeToString(const HighsOptionType type) {
   if (type == HighsOptionType::kBool) {
     return "bool";
   } else if (type == HighsOptionType::kInt) {

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -152,13 +152,13 @@ OptionStatus checkOption(const HighsLogOptions& report_log_options,
                          const OptionRecordDouble& option);
 
 OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
-                              std::vector<OptionRecord*>& option_records,
+                              OptionRecordInt& option_records,
                               const HighsInt value);
 OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
-                              std::vector<OptionRecord*>& option_records,
+                              OptionRecordDouble& option_records,
                               const double value);
 OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
-                              std::vector<OptionRecord*>& option_records,
+                              OptionRecordString& option_records,
                               const std::string value);
 
 OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,

--- a/src/lp_data/HighsRanging.cpp
+++ b/src/lp_data/HighsRanging.cpp
@@ -54,7 +54,7 @@ void HighsRanging::clear() {
   this->row_bound_dn.ou_var_.clear();
 }
 
-double infProduct(double value) {
+static double infProduct(double value) {
   // Multiplying value and kHighsInf
   if (value == 0) {
     return 0;
@@ -63,7 +63,7 @@ double infProduct(double value) {
   }
 }
 
-double possInfProduct(double poss_inf, double value) {
+static double possInfProduct(double poss_inf, double value) {
   // Multiplying something that could be infinite and value
   if (value == 0) {
     return 0;

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -566,6 +566,7 @@ void HighsMipSolverData::runSetup() {
   for (HighsInt i = 0; i != mipsolver.numCol(); ++i) {
     switch (mipsolver.variableType(i)) {
       case HighsVarType::kContinuous:
+      case HighsVarType::kSemiContinuous:  //FIXME
         continuous_cols.push_back(i);
         break;
       case HighsVarType::kImplicitInteger:
@@ -573,6 +574,7 @@ void HighsMipSolverData::runSetup() {
         integral_cols.push_back(i);
         break;
       case HighsVarType::kInteger:
+      case HighsVarType::kSemiInteger:  //FIXME
         integer_cols.push_back(i);
         integral_cols.push_back(i);
         numBin += ((mipsolver.model_->col_lower_[i] == 0.0) &

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -566,7 +566,6 @@ void HighsMipSolverData::runSetup() {
   for (HighsInt i = 0; i != mipsolver.numCol(); ++i) {
     switch (mipsolver.variableType(i)) {
       case HighsVarType::kContinuous:
-      case HighsVarType::kSemiContinuous:  // FIXME
         continuous_cols.push_back(i);
         break;
       case HighsVarType::kImplicitInteger:
@@ -574,11 +573,18 @@ void HighsMipSolverData::runSetup() {
         integral_cols.push_back(i);
         break;
       case HighsVarType::kInteger:
-      case HighsVarType::kSemiInteger:  // FIXME
         integer_cols.push_back(i);
         integral_cols.push_back(i);
         numBin += ((mipsolver.model_->col_lower_[i] == 0.0) &
                    (mipsolver.model_->col_upper_[i] == 1.0));
+        break;
+      case HighsVarType::kSemiContinuous:
+      case HighsVarType::kSemiInteger:
+        highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kError,
+                     "Semicontinuous or semiinteger variables should have been "
+                     "reformulated away before HighsMipSolverData::runSetup() "
+                     "is called.");
+        throw std::logic_error("Unexpected variable type");
     }
   }
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -566,7 +566,7 @@ void HighsMipSolverData::runSetup() {
   for (HighsInt i = 0; i != mipsolver.numCol(); ++i) {
     switch (mipsolver.variableType(i)) {
       case HighsVarType::kContinuous:
-      case HighsVarType::kSemiContinuous:  //FIXME
+      case HighsVarType::kSemiContinuous:  // FIXME
         continuous_cols.push_back(i);
         break;
       case HighsVarType::kImplicitInteger:
@@ -574,7 +574,7 @@ void HighsMipSolverData::runSetup() {
         integral_cols.push_back(i);
         break;
       case HighsVarType::kInteger:
-      case HighsVarType::kSemiInteger:  //FIXME
+      case HighsVarType::kSemiInteger:  // FIXME
         integer_cols.push_back(i);
         integral_cols.push_back(i);
         numBin += ((mipsolver.model_->col_lower_[i] == 0.0) &

--- a/src/presolve/HighsPostsolveStack.cpp
+++ b/src/presolve/HighsPostsolveStack.cpp
@@ -14,9 +14,9 @@
 
 #include <numeric>
 
-#include "util/HighsCDouble.h"
 #include "lp_data/HConst.h"
 #include "lp_data/HighsOptions.h"
+#include "util/HighsCDouble.h"
 
 namespace presolve {
 
@@ -598,7 +598,7 @@ void HighsPostsolveStack::DuplicateColumn::undo(const HighsOptions& options,
         return;
       }
       case HighsBasisStatus::kBasic:
-      case HighsBasisStatus::kNonbasic: ;
+      case HighsBasisStatus::kNonbasic:;
     }
 
     assert(basis.col_status[col] == HighsBasisStatus::kBasic);

--- a/src/presolve/HighsPostsolveStack.cpp
+++ b/src/presolve/HighsPostsolveStack.cpp
@@ -14,7 +14,7 @@
 
 #include <numeric>
 
-#include "HighsCDouble.h"
+#include "util/HighsCDouble.h"
 #include "lp_data/HConst.h"
 #include "lp_data/HighsOptions.h"
 
@@ -597,6 +597,8 @@ void HighsPostsolveStack::DuplicateColumn::undo(const HighsOptions& options,
         // nothing else to do
         return;
       }
+      case HighsBasisStatus::kBasic:
+      case HighsBasisStatus::kNonbasic: ;
     }
 
     assert(basis.col_status[col] == HighsBasisStatus::kBasic);

--- a/src/qpsolver/feasibility_highs.hpp
+++ b/src/qpsolver/feasibility_highs.hpp
@@ -4,7 +4,7 @@
 #include "Highs.h"
 #include "crashsolution.hpp"
 
-void computestartingpoint_highs(Runtime& runtime, CrashSolution& result) {
+static void computestartingpoint_highs(Runtime& runtime, CrashSolution& result) {
   // compute initial feasible point
   Highs highs;
 

--- a/src/qpsolver/quass.cpp
+++ b/src/qpsolver/quass.cpp
@@ -52,7 +52,7 @@ void Quass::loginformation(Runtime& rt, Basis& basis, CholeskyFactor& factor) {
   rt.statistics.density_nullspace.push_back(0.0);
 }
 
-void tidyup(Vector& p, Vector& rowmove, Basis& basis, Runtime& runtime) {
+static void tidyup(Vector& p, Vector& rowmove, Basis& basis, Runtime& runtime) {
   for (unsigned acon : basis.getactive()) {
     if (acon >= runtime.instance.num_con) {
       p.value[acon - runtime.instance.num_con] = 0.0;
@@ -62,9 +62,7 @@ void tidyup(Vector& p, Vector& rowmove, Basis& basis, Runtime& runtime) {
   }
 }
 
-void recomputexatfsep(Runtime& runtime) {}
-
-void computerowmove(Runtime& runtime, Basis& basis, Vector& p,
+static void computerowmove(Runtime& runtime, Basis& basis, Vector& p,
                     Vector& rowmove) {
   runtime.instance.A.mat_vec(p, rowmove);
   return;
@@ -91,7 +89,7 @@ void computerowmove(Runtime& runtime, Basis& basis, Vector& p,
 }
 
 // VECTOR
-Vector& computesearchdirection_minor(Runtime& rt, Basis& bas,
+static Vector& computesearchdirection_minor(Runtime& rt, Basis& bas,
                                      CholeskyFactor& cf,
                                      ReducedGradient& redgrad, Vector& p) {
   Vector g2 = -redgrad.get();
@@ -104,7 +102,7 @@ Vector& computesearchdirection_minor(Runtime& rt, Basis& bas,
 }
 
 // VECTOR
-Vector& computesearchdirection_major(Runtime& runtime, Basis& basis,
+static Vector& computesearchdirection_major(Runtime& runtime, Basis& basis,
                                      CholeskyFactor& factor, const Vector& yp,
                                      Gradient& gradient, Vector& gyp, Vector& l,
                                      Vector& m, Vector& p) {
@@ -132,7 +130,7 @@ Vector& computesearchdirection_major(Runtime& runtime, Basis& basis,
   }
 }
 
-double computemaxsteplength(Runtime& runtime, const Vector& p,
+static double computemaxsteplength(Runtime& runtime, const Vector& p,
                             Gradient& gradient, Vector& buffer_Qp, bool& zcd) {
   double denominator = p * runtime.instance.Q.mat_vec(p, buffer_Qp);
   if (fabs(denominator) > 10E-5) {
@@ -148,7 +146,7 @@ double computemaxsteplength(Runtime& runtime, const Vector& p,
   }
 }
 
-QpSolverStatus reduce(Runtime& rt, Basis& basis, const HighsInt newactivecon,
+static QpSolverStatus reduce(Runtime& rt, Basis& basis, const HighsInt newactivecon,
                       Vector& buffer_d, HighsInt& maxabsd,
                       HighsInt& constrainttodrop) {
   HighsInt idx = indexof(basis.getinactive(), newactivecon);
@@ -183,7 +181,7 @@ QpSolverStatus reduce(Runtime& rt, Basis& basis, const HighsInt newactivecon,
   // return NullspaceReductionResult(idx != -1);
 }
 
-std::unique_ptr<Pricing> getPricing(Runtime& runtime, Basis& basis,
+static std::unique_ptr<Pricing> getPricing(Runtime& runtime, Basis& basis,
                                     ReducedCosts& redcosts) {
   switch (runtime.settings.pricing) {
     case PricingStrategy::Devex:
@@ -195,7 +193,8 @@ std::unique_ptr<Pricing> getPricing(Runtime& runtime, Basis& basis,
   }
   return nullptr;
 }
-void regularize(Runtime& rt) {
+
+static void regularize(Runtime& rt) {
   // add small diagonal to hessian
   for (HighsInt i = 0; i < rt.instance.num_var; i++) {
     for (HighsInt index = rt.instance.Q.mat.start[i];

--- a/src/qpsolver/ratiotest.cpp
+++ b/src/qpsolver/ratiotest.cpp
@@ -98,10 +98,10 @@ RatiotestResult ratiotest(Runtime& runtime, const Vector& p,
                           const Vector& rowmove, double alphastart) {
   switch (runtime.settings.ratiotest) {
     case RatiotestStrategy::Textbook:
-    default:  // to fix -Wreturn-type warning
       return ratiotest_textbook(runtime, p, rowmove, runtime.instance,
                                 alphastart);
     case RatiotestStrategy::TwoPass:
+    default:  // to fix -Wreturn-type warning
       Instance relaxed_instance = runtime.instance;
       for (double& bound : relaxed_instance.con_lo) {
         if (bound != -std::numeric_limits<double>::infinity()) {

--- a/src/qpsolver/ratiotest.cpp
+++ b/src/qpsolver/ratiotest.cpp
@@ -1,6 +1,6 @@
 #include "ratiotest.hpp"
 
-double step(double x, double p, double l, double u, double t) {
+static double step(double x, double p, double l, double u, double t) {
   if (p < -t && l > -std::numeric_limits<double>::infinity()) {
     return (l - x) / p;
   } else if (p > t && u < std::numeric_limits<double>::infinity()) {
@@ -10,7 +10,7 @@ double step(double x, double p, double l, double u, double t) {
   }
 }
 
-RatiotestResult ratiotest_textbook(Runtime& rt, const Vector& p,
+static RatiotestResult ratiotest_textbook(Runtime& rt, const Vector& p,
                                    const Vector& rowmove, Instance& instance,
                                    const double alphastart) {
   RatiotestResult result;
@@ -45,7 +45,7 @@ RatiotestResult ratiotest_textbook(Runtime& rt, const Vector& p,
   return result;
 }
 
-RatiotestResult ratiotest_twopass(Runtime& runtime, const Vector& p,
+static RatiotestResult ratiotest_twopass(Runtime& runtime, const Vector& p,
                                   const Vector& rowmove, Instance& relaxed,
                                   const double alphastart) {
   RatiotestResult res1 =
@@ -98,6 +98,7 @@ RatiotestResult ratiotest(Runtime& runtime, const Vector& p,
                           const Vector& rowmove, double alphastart) {
   switch (runtime.settings.ratiotest) {
     case RatiotestStrategy::Textbook:
+    default:  // to fix -Wreturn-type warning
       return ratiotest_textbook(runtime, p, rowmove, runtime.instance,
                                 alphastart);
     case RatiotestStrategy::TwoPass:

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -38,7 +38,7 @@
 // If possible, it sets the HiGHS basis and solution
 
 inline HighsStatus returnFromSolveLpSimplex(HighsLpSolverObject& solver_object,
-                                     HighsStatus return_status) {
+                                            HighsStatus return_status) {
   HighsOptions& options = solver_object.options_;
   HEkk& ekk_instance = solver_object.ekk_instance_;
   HighsLp& incumbent_lp = solver_object.lp_;

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -37,7 +37,7 @@
 //
 // If possible, it sets the HiGHS basis and solution
 
-HighsStatus returnFromSolveLpSimplex(HighsLpSolverObject& solver_object,
+inline HighsStatus returnFromSolveLpSimplex(HighsLpSolverObject& solver_object,
                                      HighsStatus return_status) {
   HighsOptions& options = solver_object.options_;
   HEkk& ekk_instance = solver_object.ekk_instance_;
@@ -75,7 +75,7 @@ HighsStatus returnFromSolveLpSimplex(HighsLpSolverObject& solver_object,
   return return_status;
 }
 
-HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
+inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   HighsOptions& options = solver_object.options_;

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -13,7 +13,7 @@
 /**@file simplex/HEkkDual.cpp
  * @brief
  */
-#include "HEkkDual.h"
+#include "simplex/HEkkDual.h"
 
 #include <algorithm>
 #include <cassert>

--- a/src/simplex/HEkkDualRHS.cpp
+++ b/src/simplex/HEkkDualRHS.cpp
@@ -13,7 +13,7 @@
 /**@file simplex/HEkkDualRHS.cpp
  * @brief
  */
-#include "HEkkDualRHS.h"
+#include "simplex/HEkkDualRHS.h"
 
 #include <algorithm>
 #include <fstream>

--- a/src/simplex/HSimplexReport.cpp
+++ b/src/simplex/HSimplexReport.cpp
@@ -16,7 +16,7 @@
 
 #include <sstream>
 
-#include "simplex/HSimplex.h"
+#include "simplex/HSimplexReport.h"
 
 void reportSimplexPhaseIterations(const HighsLogOptions& log_options,
                                   const HighsInt iteration_count,

--- a/src/simplex/HSimplexReport.cpp
+++ b/src/simplex/HSimplexReport.cpp
@@ -14,9 +14,9 @@
  * @brief
  */
 
-#include <sstream>
-
 #include "simplex/HSimplexReport.h"
+
+#include <sstream>
 
 void reportSimplexPhaseIterations(const HighsLogOptions& log_options,
                                   const HighsInt iteration_count,

--- a/src/simplex/HSimplexReport.h
+++ b/src/simplex/HSimplexReport.h
@@ -17,6 +17,7 @@
 #define SIMPLEX_HSIMPLEXREPORT_H_
 
 #include "lp_data/HighsOptions.h"
+#include "simplex/HSimplex.h"
 
 void reportSimplexPhaseIterations(const HighsLogOptions& log_options,
                                   const HighsInt iteration_count,

--- a/src/test/DevKkt.cpp
+++ b/src/test/DevKkt.cpp
@@ -19,7 +19,7 @@
 #include <cmath>
 #include <iostream>
 
-#include "HighsCDouble.h"
+#include "util/HighsCDouble.h"
 
 namespace presolve {
 namespace dev_kkt_check {

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -37,10 +37,10 @@ using std::min;
 using std::pair;
 
 static void solveMatrixT(const HighsInt X_Start, const HighsInt x_end,
-                  const HighsInt y_start, const HighsInt y_end,
-                  const HighsInt* t_index, const double* t_value,
-                  const double t_pivot, HighsInt* rhs_count,
-                  HighsInt* rhs_index, double* rhs_array) {
+                         const HighsInt y_start, const HighsInt y_end,
+                         const HighsInt* t_index, const double* t_value,
+                         const double t_pivot, HighsInt* rhs_count,
+                         HighsInt* rhs_index, double* rhs_array) {
   // Collect by X
   double pivot_multiplier = 0;
   for (HighsInt k = X_Start; k < x_end; k++)
@@ -64,9 +64,10 @@ static void solveMatrixT(const HighsInt X_Start, const HighsInt x_end,
 }
 
 static void solveHyper(const HighsInt h_size, const HighsInt* h_lookup,
-                const HighsInt* h_pivot_index, const double* h_pivot_value,
-                const HighsInt* h_start, const HighsInt* h_end,
-                const HighsInt* h_index, const double* h_value, HVector* rhs) {
+                       const HighsInt* h_pivot_index,
+                       const double* h_pivot_value, const HighsInt* h_start,
+                       const HighsInt* h_end, const HighsInt* h_index,
+                       const double* h_value, HVector* rhs) {
   HighsInt rhs_count = rhs->count;
   HighsInt* rhs_index = &rhs->index[0];
   double* rhs_array = &rhs->array[0];

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -36,7 +36,7 @@ using std::make_pair;
 using std::min;
 using std::pair;
 
-void solveMatrixT(const HighsInt X_Start, const HighsInt x_end,
+static void solveMatrixT(const HighsInt X_Start, const HighsInt x_end,
                   const HighsInt y_start, const HighsInt y_end,
                   const HighsInt* t_index, const double* t_value,
                   const double t_pivot, HighsInt* rhs_count,
@@ -63,7 +63,7 @@ void solveMatrixT(const HighsInt X_Start, const HighsInt x_end,
   }
 }
 
-void solveHyper(const HighsInt h_size, const HighsInt* h_lookup,
+static void solveHyper(const HighsInt h_size, const HighsInt* h_lookup,
                 const HighsInt* h_pivot_index, const double* h_pivot_value,
                 const HighsInt* h_start, const HighsInt* h_end,
                 const HighsInt* h_index, const double* h_value, HVector* rhs) {

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -813,7 +813,7 @@ class HighsHashTable {
   using Entry = HighsHashTableEntry<K, V>;
   using KeyType = K;
   using ValueType = typename std::remove_reference<decltype(
-      reinterpret_cast<Entry*>(0)->value())>::type;
+      reinterpret_cast<Entry*>(0x1)->value())>::type;
 
   std::unique_ptr<Entry, OpNewDeleter> entries;
   std::unique_ptr<u8[]> metadata;


### PR DESCRIPTION
I compile HiGHS 1.2.2 with GCC 12 and ` -Wall -Wreturn-type -Wmissing-declarations -Wno-sign-compare -Wno-unused-variable -Wno-format-truncation`. This PR fixes some warnings that still come up.
In particular, functions are declared static if in cpp and local, or the signature in the corresponding declaration is fixed, or is declared inline if in header. Some include paths are fixed. The pretty annoying `-Wnon-null` warning from the hashing code is avoided. All cases are handled in switch statements.

Regarding the last, there seems to be another issue. In `HighsMipSolverData::runSetup()` there was a switch on variable types which doesn't handle the cases of semicontinuous and semiinteger variables. I added that there are handles as if continuous/integer to squash the warning, but, not surprisingly, I get wrong results on a MIP with these variables. It somehow looks as if HiGHS allows to input semicontinuous/integer variables, but does not handle them appropriately further on. Shouldn't it reject such problem instances at least?