### PR TITLE
Add .gitattributes file to override githubs language-detection for al…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Exclude mps/lp files from github language stats
+*.mps linguist-vendored
+*.lp linguist-vendored


### PR DESCRIPTION
Hi,

this PR introduces some overrides to "fix" the current, slightly misleading, language-statistics automatically calculated and shown by github. See attached image fur current status.

![lang_stats_current](https://user-images.githubusercontent.com/8052880/179287300-79277b7c-9ec6-453e-8110-efcfcc2cac4a.png)

I followed the [github-linguist docs](https://github.com/github/linguist/blob/master/docs/overrides.md) and added a `.gitattributes` file designed to completely ignore `.mps` / `.lp` within the whole repository (for this tool only).

I checked it locally and the stats calculated now are the following (which much more reflect the state):

    ~/Tmp/highs_github_linguist/HiGHS$ github-linguist
    49.11%  4780061    C++
    45.38%  4417092    JetBrains MPS
    4.11%   400504     C
    0.58%   56731      CMake
    0.36%   34686      Fortran
    0.25%   24240      C#
    0.21%   20515      Python

