### PR TITLE
first round on improving performance of .lp reader

### DIFF
--- a/extern/filereaderlp/builder.hpp
+++ b/extern/filereaderlp/builder.hpp
@@ -1,14 +1,14 @@
 #ifndef __READERLP_BUILDER_HPP__
 #define __READERLP_BUILDER_HPP__
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <string>
 
 #include "model.hpp"
 
 struct Builder { 
-   std::map<std::string, std::shared_ptr<Variable>> variables; 
+   std::unordered_map<std::string, std::shared_ptr<Variable>> variables;
 
    Model model;
 

--- a/extern/filereaderlp/builder.hpp
+++ b/extern/filereaderlp/builder.hpp
@@ -12,12 +12,14 @@ struct Builder {
 
    Model model;
 
-   std::shared_ptr<Variable> getvarbyname(std::string name) {
-      if (variables.count(name) == 0) {
-         variables[name] = std::shared_ptr<Variable>(new Variable(name));
-         model.variables.push_back(variables[name]);
-      }
-      return variables[name];
+   std::shared_ptr<Variable> getvarbyname(const std::string& name) {
+      auto it = variables.find(name);
+      if (it != variables.end())
+         return it->second;
+      auto newvar = std::shared_ptr<Variable>(new Variable(name));
+      variables.insert(std::make_pair(name, newvar));
+      model.variables.push_back(newvar);
+      return newvar;
    }
 };
 

--- a/extern/filereaderlp/def.hpp
+++ b/extern/filereaderlp/def.hpp
@@ -10,28 +10,10 @@ void inline lpassert(bool condition) {
    }
 }
 
-const std::string LP_KEYWORD_MIN[] = {"minimize", "min", "minimum"};
-const std::string LP_KEYWORD_MAX[] = {"maximize", "max", "maximum"};
-const std::string LP_KEYWORD_ST[] = {"subject to", "such that", "st", "s.t."};
-const std::string LP_KEYWORD_BOUNDS[] = {"bounds", "bound"};
 const std::string LP_KEYWORD_INF[] = {"infinity", "inf"};
 const std::string LP_KEYWORD_FREE[] = {"free"};
-const std::string LP_KEYWORD_GEN[] = {"general", "generals", "gen"};
-const std::string LP_KEYWORD_BIN[] = {"binary", "binaries", "bin"};
-const std::string LP_KEYWORD_SEMI[] = {"semi-continuous", "semi", "semis"};
-const std::string LP_KEYWORD_SOS[] = {"sos"};
-const std::string LP_KEYWORD_END[] = {"end"};
 
-const unsigned int LP_KEYWORD_MIN_N = 3;
-const unsigned int LP_KEYWORD_MAX_N = 3;
-const unsigned int LP_KEYWORD_ST_N = 4;
-const unsigned int LP_KEYWORD_BOUNDS_N = 2;
 const unsigned int LP_KEYWORD_INF_N = 2;
 const unsigned int LP_KEYWORD_FREE_N = 1;
-const unsigned int LP_KEYWORD_GEN_N = 3;
-const unsigned int LP_KEYWORD_BIN_N = 3;
-const unsigned int LP_KEYWORD_SEMI_N = 3;
-const unsigned int LP_KEYWORD_SOS_N = 1;
-const unsigned int LP_KEYWORD_END_N = 1;
 
 #endif

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -38,54 +38,27 @@ enum class RawTokenType {
 };
 
 struct RawToken {
-private:
-   void clear() {
-      if( type == RawTokenType::STR )
-         free(svalue);
-      type = RawTokenType::NONE;
-   }
-public:
-   RawTokenType type;
-   union {
-      char* svalue;
-      double dvalue = 0.0;
-   };
+   RawTokenType type = RawTokenType::NONE;
+   std::string svalue;
+   double dvalue = 0.0;
 
    inline bool istype(RawTokenType t) const {
       return this->type == t;
    }
 
-   RawToken(const RawToken&) = delete;
-   RawToken() : type(RawTokenType::NONE), dvalue(0.0) {}
-//   RawToken(RawToken&& t) : type(t.type) {
-//      if( type == RawTokenType::STR )
-//      {
-//         svalue = t.svalue;
-//         t.type = RawTokenType::NONE;
-//      }
-//      else
-//         dvalue = t.dvalue;
-//   }
    RawToken& operator=(RawTokenType t) {
-      clear();
       type = t;
       return *this;
    }
    RawToken& operator=(const std::string& v) {
-      clear();
-      svalue = strdup(v.c_str());
+      svalue = v;
       type = RawTokenType::STR;
       return *this;
    }
    RawToken& operator=(const double v) {
-      clear();
       dvalue = v;
       type = RawTokenType::CONS;
       return *this;
-   }
-
-   ~RawToken() {
-      clear();
    }
 };
 
@@ -815,7 +788,7 @@ void Reader::processtokens() {
 
       // long section keyword semi-continuous
       if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::MINUS) && rawtoken(2).istype(RawTokenType::STR)) {
-         std::string temp = std::string(rawtoken().svalue) + "-" + rawtoken(2).svalue;
+         std::string temp = rawtoken().svalue + "-" + rawtoken(2).svalue;
          LpSectionKeyword keyword = parsesectionkeyword(temp);
          if (keyword != LpSectionKeyword::NONE) {
             processedtokens.emplace_back(keyword);
@@ -826,7 +799,7 @@ void Reader::processtokens() {
 
       // long section keyword subject to/such that
       if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::STR)) {
-         std::string temp = std::string(rawtoken().svalue) + " " + rawtoken(1).svalue;
+         std::string temp = rawtoken().svalue + " " + rawtoken(1).svalue;
          LpSectionKeyword keyword = parsesectionkeyword(temp);
          if (keyword != LpSectionKeyword::NONE) {
             processedtokens.emplace_back(keyword);
@@ -847,7 +820,7 @@ void Reader::processtokens() {
 
       // sos type identifier? "S1 ::" or "S2 ::"
       if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::COLON) && rawtoken(2).istype(RawTokenType::COLON)) {
-         lpassert(strlen(rawtoken().svalue) == 2);
+         lpassert(rawtoken().svalue.length() == 2);
          lpassert(rawtoken().svalue[0] == 'S' || rawtoken().svalue[0] == 's');
          lpassert(rawtoken().svalue[1] == '1' || rawtoken().svalue[1] == '2');
          processedtokens.emplace_back(rawtoken().svalue[1] == '1' ? SosType::SOS1 : SosType::SOS2);

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -168,13 +168,12 @@ private:
 #else
    std::ifstream file;
 #endif
+   std::string linebuffer;
+   std::size_t linebufferpos;
    std::vector<RawToken> rawtokens;
    std::vector<ProcessedToken> processedtokens;
    // store for each section a pointer to its begin and end (pointer to element after last)
    std::map<LpSectionKeyword, std::pair<std::vector<ProcessedToken>::iterator, std::vector<ProcessedToken>::iterator> > sectiontokens;
-   
-   std::string linebuffer;
-   std::size_t linebufferpos;
 
    Builder builder;
 
@@ -282,10 +281,23 @@ LpSectionKeyword parsesectionkeyword(const std::string& str) {
 }
 
 Model Reader::read() {
+   //std::clog << "Reading input, tokenizing..." << std::endl;
    tokenize();
+   linebuffer.clear();
+   linebuffer.shrink_to_fit();
+
+   //std::clog << "Processing tokens..." << std::endl;
    processtokens();
+   rawtokens.clear();
+   rawtokens.shrink_to_fit();
+
+   //std::clog << "Splitting tokens..." << std::endl;
    splittokens();
+
+   //std::clog << "Setting up model..." << std::endl;
    processsections();
+   processedtokens.clear();
+   processedtokens.shrink_to_fit();
 
    return builder.model;
 }

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -208,10 +208,6 @@ private:
    Builder builder;
 
    bool readnexttoken(RawToken&);
-   inline const RawToken& rawtoken(size_t offset = 0) const {
-      assert(offset < NRAWTOKEN);
-      return rawtokens[offset];
-   }
    void nextrawtoken(size_t howmany = 1);
    void processtokens();
    void splittokens();
@@ -768,29 +764,29 @@ void Reader::splittokens() {
 
 void Reader::processtokens() {
    std::string svalue_lc;
-   while(!rawtoken().istype(RawTokenType::FLEND)) {
+   while(!rawtokens[0].istype(RawTokenType::FLEND)) {
       fflush(stdout);
 
       // Slash + asterisk: comment, skip everything up to next asterisk + slash
-      if (rawtoken().istype(RawTokenType::SLASH) && rawtoken(1).istype(RawTokenType::ASTERISK)) {
+      if (rawtokens[0].istype(RawTokenType::SLASH) && rawtokens[1].istype(RawTokenType::ASTERISK)) {
          do
          {
             nextrawtoken(2);
          }
-         while( !(rawtoken().istype(RawTokenType::ASTERISK) && rawtoken(1).istype(RawTokenType::SLASH)) && !rawtoken().istype(RawTokenType::FLEND) );
+         while( !(rawtokens[0].istype(RawTokenType::ASTERISK) && rawtokens[1].istype(RawTokenType::SLASH)) && !rawtokens[0].istype(RawTokenType::FLEND) );
          nextrawtoken(2);
          continue;
       }
 
-      if (rawtoken().istype(RawTokenType::STR))
+      if (rawtokens[0].istype(RawTokenType::STR))
       {
-         svalue_lc = rawtoken().svalue;
+         svalue_lc = rawtokens[0].svalue;
          tolower(svalue_lc);
       }
 
       // long section keyword semi-continuous
-      if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::MINUS) && rawtoken(2).istype(RawTokenType::STR)) {
-         std::string temp = rawtoken(2).svalue;
+      if (rawtokens[0].istype(RawTokenType::STR) && rawtokens[1].istype(RawTokenType::MINUS) && rawtokens[2].istype(RawTokenType::STR)) {
+         std::string temp = rawtokens[2].svalue;
          tolower(temp);
          LpSectionKeyword keyword = parsesectionkeyword(svalue_lc + "-" + temp);
          if (keyword != LpSectionKeyword::NONE) {
@@ -801,8 +797,8 @@ void Reader::processtokens() {
       }
 
       // long section keyword subject to/such that
-      if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::STR)) {
-         std::string temp = rawtoken(1).svalue;
+      if (rawtokens[0].istype(RawTokenType::STR) && rawtokens[1].istype(RawTokenType::STR)) {
+         std::string temp = rawtokens[1].svalue;
          tolower(temp);
          LpSectionKeyword keyword = parsesectionkeyword(svalue_lc + " " + temp);
          if (keyword != LpSectionKeyword::NONE) {
@@ -813,7 +809,7 @@ void Reader::processtokens() {
       }
 
       // other section keyword
-      if (rawtoken().istype(RawTokenType::STR)) {
+      if (rawtokens[0].istype(RawTokenType::STR)) {
          LpSectionKeyword keyword = parsesectionkeyword(svalue_lc);
          if (keyword != LpSectionKeyword::NONE) {
             processedtokens.emplace_back(keyword);
@@ -823,167 +819,167 @@ void Reader::processtokens() {
       }
 
       // sos type identifier? "S1 ::" or "S2 ::"
-      if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::COLON) && rawtoken(2).istype(RawTokenType::COLON)) {
-         lpassert(rawtoken().svalue.length() == 2);
-         lpassert(rawtoken().svalue[0] == 'S' || rawtoken().svalue[0] == 's');
-         lpassert(rawtoken().svalue[1] == '1' || rawtoken().svalue[1] == '2');
-         processedtokens.emplace_back(rawtoken().svalue[1] == '1' ? SosType::SOS1 : SosType::SOS2);
+      if (rawtokens[0].istype(RawTokenType::STR) && rawtokens[1].istype(RawTokenType::COLON) && rawtokens[2].istype(RawTokenType::COLON)) {
+         lpassert(rawtokens[0].svalue.length() == 2);
+         lpassert(rawtokens[0].svalue[0] == 'S' || rawtokens[0].svalue[0] == 's');
+         lpassert(rawtokens[0].svalue[1] == '1' || rawtokens[0].svalue[1] == '2');
+         processedtokens.emplace_back(rawtokens[0].svalue[1] == '1' ? SosType::SOS1 : SosType::SOS2);
          nextrawtoken(3);
          continue;
       }
 
       // constraint identifier?
-      if (rawtoken().istype(RawTokenType::STR) && rawtoken(1).istype(RawTokenType::COLON)) {
-         processedtokens.emplace_back(ProcessedTokenType::CONID, rawtoken().svalue);
+      if (rawtokens[0].istype(RawTokenType::STR) && rawtokens[1].istype(RawTokenType::COLON)) {
+         processedtokens.emplace_back(ProcessedTokenType::CONID, rawtokens[0].svalue);
          nextrawtoken(2);
          continue;
       }
 
       // check if free
-      if (rawtoken().istype(RawTokenType::STR) && iskeyword(svalue_lc, LP_KEYWORD_FREE, LP_KEYWORD_FREE_N)) {
+      if (rawtokens[0].istype(RawTokenType::STR) && iskeyword(svalue_lc, LP_KEYWORD_FREE, LP_KEYWORD_FREE_N)) {
          processedtokens.emplace_back(ProcessedTokenType::FREE);
          nextrawtoken();
          continue;
       }
 
       // check if infinity
-      if (rawtoken().istype(RawTokenType::STR) && iskeyword(svalue_lc, LP_KEYWORD_INF, LP_KEYWORD_INF_N)) {
+      if (rawtokens[0].istype(RawTokenType::STR) && iskeyword(svalue_lc, LP_KEYWORD_INF, LP_KEYWORD_INF_N)) {
          processedtokens.emplace_back(std::numeric_limits<double>::infinity());
          nextrawtoken();
          continue;
       }
 
       // assume var identifier
-      if (rawtoken().istype(RawTokenType::STR)) {
-         processedtokens.emplace_back(ProcessedTokenType::VARID, rawtoken().svalue);
+      if (rawtokens[0].istype(RawTokenType::STR)) {
+         processedtokens.emplace_back(ProcessedTokenType::VARID, rawtokens[0].svalue);
          nextrawtoken();
          continue;
       }
 
       // + Constant
-      if (rawtoken().istype(RawTokenType::PLUS) && rawtoken(1).istype(RawTokenType::CONS)) {
-         processedtokens.emplace_back(rawtoken(1).dvalue);
+      if (rawtokens[0].istype(RawTokenType::PLUS) && rawtokens[1].istype(RawTokenType::CONS)) {
+         processedtokens.emplace_back(rawtokens[1].dvalue);
          nextrawtoken(2);
          continue;
       }
 
       // - constant
-      if (rawtoken().istype(RawTokenType::MINUS) && rawtoken(1).istype(RawTokenType::CONS)) {
-         processedtokens.emplace_back(-rawtoken(1).dvalue);
+      if (rawtokens[0].istype(RawTokenType::MINUS) && rawtokens[1].istype(RawTokenType::CONS)) {
+         processedtokens.emplace_back(-rawtokens[1].dvalue);
          nextrawtoken(2);
          continue;
       }
 
       // + [
-      if (rawtoken().istype(RawTokenType::PLUS) && rawtoken(1).istype(RawTokenType::BRKOP)) {
+      if (rawtokens[0].istype(RawTokenType::PLUS) && rawtokens[1].istype(RawTokenType::BRKOP)) {
          processedtokens.emplace_back(ProcessedTokenType::BRKOP);
          nextrawtoken(2);
          continue;
       }
 
       // - [
-      if (rawtoken().istype(RawTokenType::MINUS) && rawtoken(1).istype(RawTokenType::BRKOP)) {
+      if (rawtokens[0].istype(RawTokenType::MINUS) && rawtokens[1].istype(RawTokenType::BRKOP)) {
          lpassert(false);
       }
 
       // constant [
-      if (rawtoken().istype(RawTokenType::CONS) && rawtoken(1).istype(RawTokenType::BRKOP)) {
+      if (rawtokens[0].istype(RawTokenType::CONS) && rawtokens[1].istype(RawTokenType::BRKOP)) {
          lpassert(false);
       }
 
       // +
-      if (rawtoken().istype(RawTokenType::PLUS)) {
+      if (rawtokens[0].istype(RawTokenType::PLUS)) {
          processedtokens.emplace_back(1.0);
          nextrawtoken();
          continue;
       }
 
       // -
-      if (rawtoken().istype(RawTokenType::MINUS)) {
+      if (rawtokens[0].istype(RawTokenType::MINUS)) {
          processedtokens.emplace_back(-1.0);
          nextrawtoken();
          continue;
       }
 
       // constant
-      if (rawtoken().istype(RawTokenType::CONS)) {
-         processedtokens.emplace_back(rawtoken().dvalue);
+      if (rawtokens[0].istype(RawTokenType::CONS)) {
+         processedtokens.emplace_back(rawtokens[0].dvalue);
          nextrawtoken();
          continue;
       }
 
       // [
-      if (rawtoken().istype(RawTokenType::BRKOP)) {
+      if (rawtokens[0].istype(RawTokenType::BRKOP)) {
          processedtokens.emplace_back(ProcessedTokenType::BRKOP);
          nextrawtoken();
          continue;
       }
 
       // ]
-      if (rawtoken().istype(RawTokenType::BRKCL)) {
+      if (rawtokens[0].istype(RawTokenType::BRKCL)) {
          processedtokens.emplace_back(ProcessedTokenType::BRKCL);
          nextrawtoken();
          continue;
       }
 
       // /
-      if (rawtoken().istype(RawTokenType::SLASH)) {
+      if (rawtokens[0].istype(RawTokenType::SLASH)) {
          processedtokens.emplace_back(ProcessedTokenType::SLASH);
          nextrawtoken();
          continue;
       }
 
       // *
-      if (rawtoken().istype(RawTokenType::ASTERISK)) {
+      if (rawtokens[0].istype(RawTokenType::ASTERISK)) {
          processedtokens.emplace_back(ProcessedTokenType::ASTERISK);
          nextrawtoken();
          continue;
       }
 
       // ^
-      if (rawtoken().istype(RawTokenType::HAT)) {
+      if (rawtokens[0].istype(RawTokenType::HAT)) {
          processedtokens.emplace_back(ProcessedTokenType::HAT);
          nextrawtoken();
          continue;
       }
 
       // <=
-      if (rawtoken().istype(RawTokenType::LESS) && rawtoken(1).istype(RawTokenType::EQUAL)) {
+      if (rawtokens[0].istype(RawTokenType::LESS) && rawtokens[1].istype(RawTokenType::EQUAL)) {
          processedtokens.emplace_back(LpComparisonType::LEQ);
          nextrawtoken(2);
          continue;
       }
 
       // <
-      if (rawtoken().istype(RawTokenType::LESS)) {
+      if (rawtokens[0].istype(RawTokenType::LESS)) {
          processedtokens.emplace_back(LpComparisonType::L);
          nextrawtoken();
          continue;
       }
 
       // >=
-      if (rawtoken().istype(RawTokenType::GREATER) && rawtoken(1).istype(RawTokenType::EQUAL)) {
+      if (rawtokens[0].istype(RawTokenType::GREATER) && rawtokens[1].istype(RawTokenType::EQUAL)) {
          processedtokens.emplace_back(LpComparisonType::GEQ);
          nextrawtoken(2);
          continue;
       }
 
       // >
-      if (rawtoken().istype(RawTokenType::GREATER)) {
+      if (rawtokens[0].istype(RawTokenType::GREATER)) {
          processedtokens.emplace_back(LpComparisonType::G);
          nextrawtoken();
          continue;
       }
 
       // =
-      if (rawtoken().istype(RawTokenType::EQUAL)) {
+      if (rawtokens[0].istype(RawTokenType::EQUAL)) {
          processedtokens.emplace_back(LpComparisonType::EQ);
          nextrawtoken();
          continue;
       }
 
       // FILEEND should have been handled in condition of while()
-      assert(!rawtoken().istype(RawTokenType::FLEND));
+      assert(!rawtokens[0].istype(RawTokenType::FLEND));
 
       // catch all unknown symbols
       lpassert(false);

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -518,6 +518,7 @@ void Reader::processboundssec() {
    std::vector<ProcessedToken>::iterator& end(sectiontokens[LpSectionKeyword::BOUNDS].second);
    while (begin != end) {
       std::vector<ProcessedToken>::iterator next1 = begin;  // token after begin
+      ++next1;
 
       // VAR free
       if (next1 != end
@@ -531,10 +532,9 @@ void Reader::processboundssec() {
 		 continue;
       }
 
-      std::vector<ProcessedToken>::iterator next2 = begin;  // token 2nd-after begin
-      std::vector<ProcessedToken>::iterator next3 = begin;  // token 3rd-after begin
-      std::vector<ProcessedToken>::iterator next4 = begin;  // token 4th-after begin
-      ++next1; ++next2; ++next3; ++next4;
+      std::vector<ProcessedToken>::iterator next2 = next1;  // token 2nd-after begin
+      std::vector<ProcessedToken>::iterator next3 = next1;  // token 3rd-after begin
+      std::vector<ProcessedToken>::iterator next4 = next1;  // token 4th-after begin
       if( next1 != end ) { ++next2; ++next3; ++next4; }
       if( next2 != end ) { ++next3; ++next4; }
       if( next3 != end ) ++next4;

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -701,14 +701,15 @@ void Reader::processsossec() {
          if (begin->type != ProcessedTokenType::CONID)
             break;
          std::string name = begin->name;
-         ++begin;
-         if (begin != end && begin->type == ProcessedTokenType::CONST) {
+         std::vector<ProcessedToken>::iterator next = begin;
+         ++next;
+         if (next != end && next->type == ProcessedTokenType::CONST) {
             auto var = builder.getvarbyname(name);
-            double weight = begin->value;
+            double weight = next->value;
 
             sos->entries.push_back({var, weight});
 
-            ++begin;
+            begin = ++next;
             continue;
          }
 

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -250,13 +250,13 @@ Model readinstance(std::string filename) {
 }
 
 // convert string to lower-case, modifies string
-static
+static inline
 void tolower(std::string& s) {
    std::transform(s.begin(), s.end(), s.begin(),
       [](unsigned char c) { return std::tolower(c); });
 }
 
-static
+static inline
 bool iskeyword(const std::string& str, const std::string* keywords, const int nkeywords) {
    for (int i=0; i<nkeywords; i++) {
       if (str == keywords[i]) {
@@ -266,7 +266,7 @@ bool iskeyword(const std::string& str, const std::string* keywords, const int nk
    return false;
 }
 
-static
+static inline
 LpSectionKeyword parsesectionkeyword(const std::string& str) {
    // look up lower case
    auto it(sectionkeywordmap.find(str));

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -994,15 +994,38 @@ void Reader::processtokens() {
 void Reader::nextrawtoken(size_t howmany) {
    assert(howmany > 0);
    assert(howmany <= NRAWTOKEN);
-   size_t i = 0;
-   // move tokens up
-   for( ; i < NRAWTOKEN - howmany; ++i )
-      rawtokens[i] = std::move(rawtokens[i+howmany]);
-   // read new tokens at end positions
-   for( ; i < NRAWTOKEN ; ++i )
-      // call readnexttoken() to overwrite current token
-      // if it didn't actually read a token (returns false), then call again
-      while( !readnexttoken(rawtokens[i]) ) ;;
+   static_assert(NRAWTOKEN == 3, "code below need to be adjusted if NRAWTOKEN changes");
+   switch( howmany ) {
+      case 1: {
+         rawtokens[0] = std::move(rawtokens[1]);
+         rawtokens[1] = std::move(rawtokens[2]);
+         while( !readnexttoken(rawtokens[2]) ) ;;
+         break;
+      }
+      case 2: {
+         rawtokens[0] = std::move(rawtokens[2]);
+         while( !readnexttoken(rawtokens[1]) ) ;;
+         while( !readnexttoken(rawtokens[2]) ) ;;
+         break;
+      }
+      case 3: {
+         while( !readnexttoken(rawtokens[0]) ) ;;
+         while( !readnexttoken(rawtokens[1]) ) ;;
+         while( !readnexttoken(rawtokens[2]) ) ;;
+         break;
+      }
+      default: {
+         size_t i = 0;
+         // move tokens up
+         for( ; i < NRAWTOKEN - howmany; ++i )
+            rawtokens[i] = std::move(rawtokens[i+howmany]);
+         // read new tokens at end positions
+         for( ; i < NRAWTOKEN ; ++i )
+            // call readnexttoken() to overwrite current token
+            // if it didn't actually read a token (returns false), then call again
+            while( !readnexttoken(rawtokens[i]) ) ;;
+      }
+   }
 }
 
 // return true, if token has been set; return false if skipped over whitespace only

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 #include <array>
+#include <algorithm>
 
 #include "def.hpp"
 
@@ -221,20 +222,9 @@ Model readinstance(std::string filename) {
 }
 
 static
-bool isstrequalnocase(const std::string str1, const std::string str2) {
-   size_t len = str1.size();
-    if (str2.size() != len)
-        return false;
-    for (size_t i = 0; i < len; ++i)
-        if (tolower(str1[i]) != tolower(str2[i]))
-            return false;
-    return true;
-}
-
-static
 bool iskeyword(const std::string str, const std::string* keywords, const int nkeywords) {
    for (int i=0; i<nkeywords; i++) {
-      if (isstrequalnocase(str, keywords[i])) {
+      if (str == keywords[i]) {
          return true;
       }
    }
@@ -242,7 +232,10 @@ bool iskeyword(const std::string str, const std::string* keywords, const int nke
 }
 
 static
-LpSectionKeyword parsesectionkeyword(const std::string& str) {
+LpSectionKeyword parsesectionkeyword(std::string str) {
+   std::transform(str.begin(), str.end(), str.begin(),
+      [](unsigned char c) { return std::tolower(c); });
+
    if (iskeyword(str, LP_KEYWORD_MIN, LP_KEYWORD_MIN_N)) {
       return LpSectionKeyword::OBJMIN;
    }


### PR DESCRIPTION
As discussed in #886, the .lp reader seems to require too much memory and time when reading larger input files.
The huge memory requirement may be caused by having too much data stored simultaneously, in particular, the vector of all raw tokens, the vector of all processed tokens, the vectors of processed tokens for each section, the LP stored in the readers Model class, and finally the LP stored in HiGHS.    
The large time requirement may be due to some inefficient string comparisons or lookups, memory reallocations, or unnecessary polymorphism.

This PR mainly tackles the raw tokens and speeds up some bottlenecks.
In particular,
- raw tokens are read and created while processed tokens are generated; at most 3 raw tokens are stored at a time
- when the vectors of processed tokens for each section are generated, only pointers to the begin and end of each section in the large vector of processed tokens are stored
-  processed tokens are freed after the Model has been generated
- speed up `getvarbyname()` by using a hashmap instead of a tree-based map
- speed up `parsesectionkeyword()` by using a hashmap instead of comparing with each allowed section keyword; convert string that is looked up to lower-case once; as this function is called for every string (e.g., variable and constraint names), it better be fast
- remove polymorphism for RawToken and ProcessedToken; use union for ProcessedToken to save a bit of memory
- simplify handing of objective keyword by distinguishing into min and max early

I've run this on .lp files generated from the MIPLIB2010 MPS files and other .lp files that I found on my disk (quadratics, sos, semi, etc). I've run master and this PR with `bin/highs --write_model_file out/$f.mps --model_file $i --time_limit 0 --presolve off > out/$f.log` and confirmed that the log and MPS files are the same.

This scatter plot compares the runtime for the above command per instance:    
![time](https://user-images.githubusercontent.com/10905411/180219080-e0a046cb-01f6-4258-a525-8a2c1ba26e46.png)

This scatter plot compares the peak memory usage (KB) for the above command per instance:    
![mem](https://user-images.githubusercontent.com/10905411/180219077-b8604d90-a4b7-4c9a-81b2-d4ceb04cc108.png)

There is more to do, but this is now a good place for a first cut.