### PR TITLE
Fix 917

### DIFF
--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -5,7 +5,7 @@
 #include "util/HighsRandom.h"
 #include "util/HighsUtils.h"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double inf = kHighsInf;
 const double double_equal_tolerance = 1e-5;
 void HighsStatusReport(const HighsLogOptions& log_options, std::string message,
@@ -45,44 +45,6 @@ void messageReportLp(const char* message, const HighsLp& lp);
 void messageReportMatrix(const char* message, const HighsInt num_col,
                          const HighsInt num_nz, const HighsInt* start,
                          const HighsInt* index, const double* value);
-
-void test_917(const HighsInt& dim);
-
-void test_917(const HighsInt& dim) {
-  using namespace std::chrono;
-
-  Highs highs;
-  // highs.setOptionValue("output_flag", dev_run);
-  const HighsLp& lp = highs.getLp();
-  high_resolution_clock::time_point t0 = high_resolution_clock::now();
-  std::vector<HighsInt> index(2);
-  std::vector<double> value(2);
-  value[0] = 1;
-  value[1] = -1;
-  for (HighsInt k = 0; k < dim * dim; k++)
-    highs.addCol(0.0, -inf, inf, 0, nullptr, nullptr);
-  for (HighsInt iCol = 0; iCol < dim; iCol++) {
-    for (HighsInt jCol = 1; jCol < dim; jCol++) {
-      index[1] = dim * iCol + jCol;
-      index[0] = index[1] - 1;
-      highs.addRow(-inf, 0.0, 2, &index[0], &value[0]);
-    }
-  }
-  high_resolution_clock::time_point t1 = high_resolution_clock::now();
-  duration<double> time_span = duration_cast<duration<double>>(t1 - t0);
-  printf("LP has %d rows and %d columns\n", (int)lp.num_row_, (int)lp.num_col_);
-  double time = time_span.count();
-  printf("For dim = %5d, time is %11.4g: time/row = %11.4g \n", (int)dim, time, time / lp.num_row_);
-}
-
-// No commas in test case name.
-TEST_CASE("LP-917", "[highs_data]") {
-  HighsInt dim = 100;
-  for (HighsInt k = 0; k < 4; k++) {
-    test_917(dim);
-    dim *= 2;
-  }
-}
 
 TEST_CASE("LP-717-od", "[highs_data]") {
   Highs highs;

--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -5,7 +5,7 @@
 #include "util/HighsRandom.h"
 #include "util/HighsUtils.h"
 
-const bool dev_run = false;
+const bool dev_run = true;
 const double inf = kHighsInf;
 const double double_equal_tolerance = 1e-5;
 void HighsStatusReport(const HighsLogOptions& log_options, std::string message,
@@ -46,15 +46,15 @@ void messageReportMatrix(const char* message, const HighsInt num_col,
                          const HighsInt num_nz, const HighsInt* start,
                          const HighsInt* index, const double* value);
 
-// No commas in test case name.
-TEST_CASE("LP-917", "[highs_data]") {
+void test_917(const HighsInt& dim);
+
+void test_917(const HighsInt& dim) {
   using namespace std::chrono;
 
   Highs highs;
   // highs.setOptionValue("output_flag", dev_run);
   const HighsLp& lp = highs.getLp();
   high_resolution_clock::time_point t0 = high_resolution_clock::now();
-  const HighsInt dim = 200;  // 200;
   std::vector<HighsInt> index(2);
   std::vector<double> value(2);
   value[0] = 1;
@@ -71,7 +71,17 @@ TEST_CASE("LP-917", "[highs_data]") {
   high_resolution_clock::time_point t1 = high_resolution_clock::now();
   duration<double> time_span = duration_cast<duration<double>>(t1 - t0);
   printf("LP has %d rows and %d columns\n", (int)lp.num_row_, (int)lp.num_col_);
-  printf("For dim = %d, time is %g\n", (int)dim, (double)time_span.count());
+  double time = time_span.count();
+  printf("For dim = %5d, time is %11.4g: time/row = %11.4g \n", (int)dim, time, time / lp.num_row_);
+}
+
+// No commas in test case name.
+TEST_CASE("LP-917", "[highs_data]") {
+  HighsInt dim = 100;
+  for (HighsInt k = 0; k < 4; k++) {
+    test_917(dim);
+    dim *= 2;
+  }
 }
 
 TEST_CASE("LP-717-od", "[highs_data]") {

--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -54,12 +54,12 @@ TEST_CASE("LP-917", "[highs_data]") {
   // highs.setOptionValue("output_flag", dev_run);
   const HighsLp& lp = highs.getLp();
   high_resolution_clock::time_point t0 = high_resolution_clock::now();
-  const HighsInt dim = 200;//200;
+  const HighsInt dim = 200;  // 200;
   std::vector<HighsInt> index(2);
   std::vector<double> value(2);
   value[0] = 1;
   value[1] = -1;
-  for (HighsInt k = 0; k < dim*dim; k++)
+  for (HighsInt k = 0; k < dim * dim; k++)
     highs.addCol(0.0, -inf, inf, 0, nullptr, nullptr);
   for (HighsInt iCol = 0; iCol < dim; iCol++) {
     for (HighsInt jCol = 1; jCol < dim; jCol++) {
@@ -69,7 +69,7 @@ TEST_CASE("LP-917", "[highs_data]") {
     }
   }
   high_resolution_clock::time_point t1 = high_resolution_clock::now();
-  duration<double> time_span = duration_cast<duration<double>>(t1-t0);
+  duration<double> time_span = duration_cast<duration<double>>(t1 - t0);
   printf("LP has %d rows and %d columns\n", (int)lp.num_row_, (int)lp.num_col_);
   printf("For dim = %d, time is %g\n", (int)dim, (double)time_span.count());
 }

--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -47,6 +47,33 @@ void messageReportMatrix(const char* message, const HighsInt num_col,
                          const HighsInt* index, const double* value);
 
 // No commas in test case name.
+TEST_CASE("LP-917", "[highs_data]") {
+  using namespace std::chrono;
+
+  Highs highs;
+  // highs.setOptionValue("output_flag", dev_run);
+  const HighsLp& lp = highs.getLp();
+  high_resolution_clock::time_point t0 = high_resolution_clock::now();
+  const HighsInt dim = 200;//200;
+  std::vector<HighsInt> index(2);
+  std::vector<double> value(2);
+  value[0] = 1;
+  value[1] = -1;
+  for (HighsInt k = 0; k < dim*dim; k++)
+    highs.addCol(0.0, -inf, inf, 0, nullptr, nullptr);
+  for (HighsInt iCol = 0; iCol < dim; iCol++) {
+    for (HighsInt jCol = 1; jCol < dim; jCol++) {
+      index[1] = dim * iCol + jCol;
+      index[0] = index[1] - 1;
+      highs.addRow(-inf, 0.0, 2, &index[0], &value[0]);
+    }
+  }
+  high_resolution_clock::time_point t1 = high_resolution_clock::now();
+  duration<double> time_span = duration_cast<duration<double>>(t1-t0);
+  printf("LP has %d rows and %d columns\n", (int)lp.num_row_, (int)lp.num_col_);
+  printf("For dim = %d, time is %g\n", (int)dim, (double)time_span.count());
+}
+
 TEST_CASE("LP-717-od", "[highs_data]") {
   Highs highs;
   if (!dev_run) highs.setOptionValue("output_flag", false);

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -1,5 +1,3 @@
-#include <chrono>
-
 #include "Highs.h"
 #include "catch.hpp"
 

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -1,6 +1,7 @@
+#include <chrono>
+
 #include "Highs.h"
 #include "catch.hpp"
-#include <chrono>
 
 const bool dev_run = false;
 

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -1,5 +1,6 @@
 #include "Highs.h"
 #include "catch.hpp"
+#include <chrono>
 
 const bool dev_run = false;
 

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -3,7 +3,7 @@
 #include "HighsLpUtils.h"
 #include "catch.hpp"
 
-const bool dev_run = false;
+const bool dev_run = true;
 const double inf = kHighsInf;
 
 // No commas in test case name.
@@ -362,6 +362,22 @@ TEST_CASE("LP-validation", "[highs_data]") {
   REQUIRE(check_value == to_value);
 }
 
+TEST_CASE("LP-row-index-duplication", "[highs_data]") {
+  HighsStatus return_status;
+  Highs highs;
+  HighsInt num_col = 10;
+  for (HighsInt iCol = 0; iCol < num_col; iCol++)
+    highs.addVar(0, 1);
+  std::vector<HighsInt> start = {0, 6, 8};
+  std::vector<HighsInt> index = {0, 1, 4, 5, 6, 7, 0, 1, 0, 1, 4, 5, 6, 7, 4};
+  std::vector<double> value =   {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  std::vector<double> lower = {0, 0, 0};
+  std::vector<double> upper = {inf, inf, inf};
+  HighsInt num_nz = index.size();
+  REQUIRE(highs.addRows(3, &lower[0], &upper[0], num_nz, &start[0], &index[0], &value[0]) ==
+          HighsStatus::kError);
+}
+
 TEST_CASE("LP-extreme-coefficient", "[highs_data]") {
   HighsStatus return_status;
   std::string filename;
@@ -446,3 +462,4 @@ TEST_CASE("LP-change-coefficient", "[highs_data]") {
                                     highs.getInfo().objective_function_value);
   REQUIRE(delta_objective_value < 1e-8);
 }
+

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -365,6 +365,7 @@ TEST_CASE("LP-validation", "[highs_data]") {
 TEST_CASE("LP-row-index-duplication", "[highs_data]") {
   HighsStatus return_status;
   Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
   HighsInt num_col = 10;
   for (HighsInt iCol = 0; iCol < num_col; iCol++) highs.addVar(0, 1);
   std::vector<HighsInt> start = {0, 6, 8};

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -366,16 +366,15 @@ TEST_CASE("LP-row-index-duplication", "[highs_data]") {
   HighsStatus return_status;
   Highs highs;
   HighsInt num_col = 10;
-  for (HighsInt iCol = 0; iCol < num_col; iCol++)
-    highs.addVar(0, 1);
+  for (HighsInt iCol = 0; iCol < num_col; iCol++) highs.addVar(0, 1);
   std::vector<HighsInt> start = {0, 6, 8};
   std::vector<HighsInt> index = {0, 1, 4, 5, 6, 7, 0, 1, 0, 1, 4, 5, 6, 7, 4};
-  std::vector<double> value =   {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  std::vector<double> value = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
   std::vector<double> lower = {0, 0, 0};
   std::vector<double> upper = {inf, inf, inf};
   HighsInt num_nz = index.size();
-  REQUIRE(highs.addRows(3, &lower[0], &upper[0], num_nz, &start[0], &index[0], &value[0]) ==
-          HighsStatus::kError);
+  REQUIRE(highs.addRows(3, &lower[0], &upper[0], num_nz, &start[0], &index[0],
+                        &value[0]) == HighsStatus::kError);
 }
 
 TEST_CASE("LP-extreme-coefficient", "[highs_data]") {
@@ -462,4 +461,3 @@ TEST_CASE("LP-change-coefficient", "[highs_data]") {
                                     highs.getInfo().objective_function_value);
   REQUIRE(delta_objective_value < 1e-8);
 }
-

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -3,7 +3,7 @@
 #include "HighsLpUtils.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double inf = kHighsInf;
 
 // No commas in test case name.

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -2,7 +2,7 @@
 #include "SpecialLps.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double double_equal_tolerance = 1e-5;
 
 void solve(Highs& highs, std::string presolve,

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -410,7 +410,7 @@ TEST_CASE("MIP-infeasible-start", "[highs_test_mip_solver]") {
   highs.setOptionValue("output_flag", dev_run);
   const HighsModelStatus& model_status = highs.getModelStatus();
   HighsLp lp;
-  lp.num_col_ = 2;  
+  lp.num_col_ = 2;
   lp.num_row_ = 2;
   lp.col_cost_ = {0, 0};
   lp.col_lower_ = {0, 0};
@@ -418,8 +418,8 @@ TEST_CASE("MIP-infeasible-start", "[highs_test_mip_solver]") {
   lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kInteger};
   const double rhs = 4.0;
   const double delta = 0.99;
-  lp.row_lower_ = {rhs-delta, rhs+delta};
-  lp.row_upper_ = {rhs-delta, rhs+delta};
+  lp.row_lower_ = {rhs - delta, rhs + delta};
+  lp.row_upper_ = {rhs - delta, rhs + delta};
   lp.a_matrix_.start_ = {0, 2, 4};
   lp.a_matrix_.index_ = {0, 1, 0, 1};
   lp.a_matrix_.value_ = {1, 2, 2, 1};
@@ -428,7 +428,8 @@ TEST_CASE("MIP-infeasible-start", "[highs_test_mip_solver]") {
 
   sol.col_value = {1, 1};
   highs.setSolution(sol);
-  //  REQUIRE(highs.setOptionValue("presolve", kHighsOffString) == HighsStatus::kOk);
+  //  REQUIRE(highs.setOptionValue("presolve", kHighsOffString) ==
+  //  HighsStatus::kOk);
   highs.run();
   REQUIRE(model_status == HighsModelStatus::kInfeasible);
 
@@ -437,9 +438,11 @@ TEST_CASE("MIP-infeasible-start", "[highs_test_mip_solver]") {
   filename = std::string(HIGHS_DIR) + "/check/instances/infeasible.mps";
 
   highs.readModel(filename);
-  sol.col_value = {75, 0, 275, 300, 300, 0, 0, 0, 50, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0};
+  sol.col_value = {75, 0, 275, 300, 300, 0, 0, 0, 50, 0, 0,
+                   1,  0, 1,   1,   1,   0, 0, 0, 1,  0, 0};
   highs.setSolution(sol);
-  REQUIRE(highs.setOptionValue("presolve", kHighsOffString) == HighsStatus::kOk);
+  REQUIRE(highs.setOptionValue("presolve", kHighsOffString) ==
+          HighsStatus::kOk);
   highs.run();
   REQUIRE(model_status == HighsModelStatus::kInfeasible);
 }
@@ -509,4 +512,3 @@ void rowlessMIP(Highs& highs) {
   solve(highs, "on", require_model_status, optimal_objective);
   solve(highs, "off", require_model_status, optimal_objective);
 }
-

--- a/src/util/HighsMatrixUtils.cpp
+++ b/src/util/HighsMatrixUtils.cpp
@@ -50,9 +50,8 @@ HighsStatus assessMatrix(const HighsLogOptions& log_options,
 }
 
 void print_map(std::string comment, const std::map<HighsInt, HighsInt>& m) {
-  std::cout << comment ;
-  for (const auto& n : m)
-    std::cout << n.first << " = " << n.second << "; ";
+  std::cout << comment;
+  for (const auto& n : m) std::cout << n.first << " = " << n.second << "; ";
   std::cout << '\n';
 }
 
@@ -152,12 +151,8 @@ HighsStatus assessMatrix(
   double max_large_value = 0;
   double min_large_value = kHighsInf;
   // Use index_map to identify duplicates.
-  //
-  // Note that operator[] with non-existent key returns 0 and always
-  // performs an insert. Hence value associated with the key has to be
-  // positive: use el+1.
   std::map<HighsInt, HighsInt> index_map;
-  
+
   for (HighsInt ix = 0; ix < num_vec; ix++) {
     HighsInt from_el = matrix_start[ix];
     HighsInt to_el = matrix_start[ix + 1];
@@ -188,21 +183,15 @@ HighsStatus assessMatrix(
                      matrix_name.c_str(), ix, el, component, vec_dim);
         return HighsStatus::kError;
       }
-      // Check that the index has not already ocurred. 
-      print_map("index_map: ", index_map);
-      auto search = index_map.find(component);
-      legal_component = search == index_map.end();
-      printf("index_map.find(%d) yields (%d, %d) so legal_component = %d\n", (int)component,
-	     search->first,
-	     search->second,
-	     legal_component);
+      // Check that the index has not already ocurred.
+      legal_component = index_map.find(component) == index_map.end();
       if (!legal_component) {
-	highsLogUser(log_options, HighsLogType::kError,
-		     "%s matrix packed vector %" HIGHSINT_FORMAT
-		     ", entry %" HIGHSINT_FORMAT
-		     ", is duplicate index %" HIGHSINT_FORMAT "\n",
-		     matrix_name.c_str(), ix, el, component);
-	return HighsStatus::kError;
+        highsLogUser(log_options, HighsLogType::kError,
+                     "%s matrix packed vector %" HIGHSINT_FORMAT
+                     ", entry %" HIGHSINT_FORMAT
+                     ", is duplicate index %" HIGHSINT_FORMAT "\n",
+                     matrix_name.c_str(), ix, el, component);
+        return HighsStatus::kError;
       }
       // Check the value
       double abs_value = fabs(matrix_value[el]);
@@ -220,8 +209,8 @@ HighsStatus assessMatrix(
         num_small_values++;
       }
       if (ok_value) {
-	// Record where the index has occurred
-	index_map[component] = num_new_nz;
+        // Record where the index has occurred
+        index_map[component] = num_new_nz;
         // Shift the index and value of the OK entry to the new
         // position in the index and value vectors, and increment
         // the new number of nonzeros
@@ -229,16 +218,9 @@ HighsStatus assessMatrix(
         matrix_value[num_new_nz] = matrix_value[el];
         num_new_nz++;
       }
-    } // Loop from_el; to_el
-    for (HighsInt el = matrix_start[ix]; el < num_new_nz; el++) {
-      HighsInt iX = matrix_index[el];
-      auto search = index_map.find(iX);
-      assert(search != index_map.end());
-      assert(search->first == iX);
-      assert(search->second == el);
-    }
+    }  // Loop from_el; to_el
     index_map.clear();
-  } // Loop 0; num_vec
+  }  // Loop 0; num_vec
   if (num_large_values) {
     highsLogUser(log_options, HighsLogType::kError,
                  "%s matrix packed vector contains %" HIGHSINT_FORMAT

--- a/src/util/HighsMatrixUtils.cpp
+++ b/src/util/HighsMatrixUtils.cpp
@@ -49,12 +49,6 @@ HighsStatus assessMatrix(const HighsLogOptions& log_options,
                       small_matrix_value, large_matrix_value);
 }
 
-void print_map(std::string comment, const std::map<HighsInt, HighsInt>& m) {
-  std::cout << comment;
-  for (const auto& n : m) std::cout << n.first << " = " << n.second << "; ";
-  std::cout << '\n';
-}
-
 HighsStatus assessMatrix(
     const HighsLogOptions& log_options, const std::string matrix_name,
     const HighsInt vec_dim, const HighsInt num_vec, const bool partitioned,


### PR DESCRIPTION
Using a map rather than a full-length vector to check for duplicate entries in `assessMatrix` will close #917 