### PR TITLE
Fixed bug due to not initialising multi_choice[*].row_out and immediate optimality in dual Phase 1

### DIFF
--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -458,6 +458,7 @@ void HEkkDual::initialiseInstanceParallel(HEkk& simplex) {
     if (multi_num > kSimplexConcurrencyLimit)
       multi_num = kSimplexConcurrencyLimit;
     for (HighsInt i = 0; i < multi_num; i++) {
+      multi_choice[i].row_out = -1;
       multi_choice[i].row_ep.setup(solver_num_row);
       multi_choice[i].col_aq.setup(solver_num_row);
       multi_choice[i].col_BFRT.setup(solver_num_row);


### PR DESCRIPTION
Trivial one-line fix that only affects parallel dual simplex