### PR TITLE
avoid warning on empty loop body from Clang 11

### DIFF
--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -281,7 +281,8 @@ Model Reader::read() {
    // read first NRAWTOKEN token
    // if file ends early, then all remaining tokens are set to FLEND
    for(size_t i = 0; i < NRAWTOKEN; ++i )
-      while( !readnexttoken(rawtokens[i]) ) ;;
+      while( !readnexttoken(rawtokens[i]) )
+      ;
 
    processtokens();
 
@@ -996,19 +997,25 @@ void Reader::nextrawtoken(size_t howmany) {
       case 1: {
          rawtokens[0] = std::move(rawtokens[1]);
          rawtokens[1] = std::move(rawtokens[2]);
-         while( !readnexttoken(rawtokens[2]) ) ;;
+         while( !readnexttoken(rawtokens[2]) )
+         ;
          break;
       }
       case 2: {
          rawtokens[0] = std::move(rawtokens[2]);
-         while( !readnexttoken(rawtokens[1]) ) ;;
-         while( !readnexttoken(rawtokens[2]) ) ;;
+         while( !readnexttoken(rawtokens[1]) )
+         ;
+         while( !readnexttoken(rawtokens[2]) )
+         ;
          break;
       }
       case 3: {
-         while( !readnexttoken(rawtokens[0]) ) ;;
-         while( !readnexttoken(rawtokens[1]) ) ;;
-         while( !readnexttoken(rawtokens[2]) ) ;;
+         while( !readnexttoken(rawtokens[0]) )
+         ;
+         while( !readnexttoken(rawtokens[1]) )
+         ;
+         while( !readnexttoken(rawtokens[2]) )
+         ;
          break;
       }
       default: {
@@ -1020,7 +1027,8 @@ void Reader::nextrawtoken(size_t howmany) {
          for( ; i < NRAWTOKEN ; ++i )
             // call readnexttoken() to overwrite current token
             // if it didn't actually read a token (returns false), then call again
-            while( !readnexttoken(rawtokens[i]) ) ;;
+            while( !readnexttoken(rawtokens[i]) )
+            ;
       }
    }
 }


### PR DESCRIPTION
The warning suggests to put the semicolon onto a separate line, so do this.
Also there is no need for a second semicolon.

The empty body for the loop is intentional. We loop here until readnexttoken() succeeds (returns true). It's a bit unfortunate that the readnexttoken() function does not always actually read a token, but may just skip over whitespace.
But as the end of the file is a token, these loops will terminate eventually (if you read from files with finite length, don't try `/dev/random` or so).