### PR TITLE
Fix 938

### DIFF
--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -245,7 +245,7 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
     if (coef != 0.0) {
       this->writeToFile(file, "%+g ", coef);
       if (has_col_names) {
-	this->writeToFile(file, "%s ", lp.col_names_[iCol]);
+	this->writeToFile(file, "%s ", lp.col_names_[iCol].c_str());
       } else {
 	this->writeToFile(file, "x%" HIGHSINT_FORMAT " ", (iCol + 1));
       }
@@ -263,8 +263,8 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
           if (coef != 0.0) {
             this->writeToFile(file, "%+g ", coef);
 	    if (has_col_names) {
-	      this->writeToFile(file, "%s ", lp.col_names_[iCol]);
-	      this->writeToFile(file, " * %s ", lp.col_names_[iRow]);
+	      this->writeToFile(file, "%s ", lp.col_names_[iCol].c_str());
+	      this->writeToFile(file, " * %s ", lp.col_names_[iRow].c_str());
 	    } else {
 	      this->writeToFile(file, " x%" HIGHSINT_FORMAT, (iCol + 1));
 	      this->writeToFile(file, " * x%" HIGHSINT_FORMAT " ", (iRow + 1));

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -317,6 +317,8 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
     }
     this->writeToFile(file, "  ]/2 "); // ToDo Surely needs only to be one space
   }
+  double coef = lp.offset_;
+  if (coef != 0) this->writeToFileValue(file, coef);
   this->writeToFileLineend(file);
 
   // write constraint section, lower & upper bounds are one constraint

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -352,7 +352,7 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
       this->writeToFile(file, ":");
       this->writeToFileMatrixRow(file, iRow, ar_matrix, lp.col_names_);
       this->writeToFile(file, " =");
-      this->writeToFileValue(file, lp.row_lower_[iRow]);
+      this->writeToFileValue(file, lp.row_lower_[iRow], true);
       this->writeToFileLineend(file);
     } else {
       if (lp.row_lower_[iRow] > -kHighsInf) {
@@ -365,7 +365,7 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
         this->writeToFile(file, "lo:");
         this->writeToFileMatrixRow(file, iRow, ar_matrix, lp.col_names_);
         this->writeToFile(file, " >=");
-        this->writeToFileValue(file, lp.row_lower_[iRow]);
+        this->writeToFileValue(file, lp.row_lower_[iRow], true);
         this->writeToFileLineend(file);
       }
       if (lp.row_upper_[iRow] < kHighsInf) {
@@ -378,7 +378,7 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
         this->writeToFile(file, "up:");
         this->writeToFileMatrixRow(file, iRow, ar_matrix, lp.col_names_);
         this->writeToFile(file, " <=");
-        this->writeToFileValue(file, lp.row_upper_[iRow]);
+        this->writeToFileValue(file, lp.row_upper_[iRow], true);
         this->writeToFileLineend(file);
       }
     }

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -24,7 +24,7 @@
 #include "lp_data/HighsLpUtils.h"
 
 const bool original_double_format = false;
-const bool allow_mps_names = false;
+const bool allow_model_names = false;
 
 FilereaderRetcode FilereaderLp::readModelFromFile(const HighsOptions& options,
                                                   const std::string filename,
@@ -229,7 +229,12 @@ void FilereaderLp::writeToFileValue(FILE* file, const double value, const bool f
   if (original_double_format) {
     this->writeToFile(file, " %+g", value);
   } else {
-    this->writeToFile(file, " %+.15g", value);
+    // As for writeModelAsMps
+    if (force_plus) {
+      this->writeToFile(file, " %+.15g", value);
+    } else {
+      this->writeToFile(file, " %.15g", value);
+    }
   }
 }
 
@@ -250,7 +255,7 @@ void FilereaderLp::writeToFileMatrixRow(FILE* file, const HighsInt iRow,
 					const HighsSparseMatrix ar_matrix,
 					const std::vector<string> col_names) {
   assert(ar_matrix.isRowwise());
-  const bool has_col_names = allow_mps_names && col_names.size() > 0;
+  const bool has_col_names = allow_model_names && col_names.size() > 0;
   
   for (HighsInt iEl = ar_matrix.start_[iRow];
        iEl < ar_matrix.start_[iRow + 1]; iEl++) {
@@ -273,8 +278,8 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
   HighsSparseMatrix ar_matrix = lp.a_matrix_;
   ar_matrix.ensureRowwise();
   
-  const bool has_col_names = allow_mps_names && lp.col_names_.size() == lp.num_col_;
-  const bool has_row_names = allow_mps_names && lp.row_names_.size() == lp.num_row_;
+  const bool has_col_names = allow_model_names && lp.col_names_.size() == lp.num_col_;
+  const bool has_row_names = allow_model_names && lp.row_names_.size() == lp.num_row_;
   FILE* file = fopen(filename.c_str(), "w");
 
   // write comment at the start of the file

--- a/src/io/FilereaderLp.h
+++ b/src/io/FilereaderLp.h
@@ -43,6 +43,12 @@ class FilereaderLp : public Filereader {
   HighsInt linelength;
   void writeToFile(FILE* file, const char* format, ...);
   void writeToFileLineend(FILE* file);
+  void writeToFileValue(FILE* file, const double value);
+  void writeToFileVar(FILE* file, const HighsInt var_index);
+  void writeToFileVar(FILE* file, const std::string var_name);
+  void writeToFileMatrixRow(FILE* file, const HighsInt iRow,
+			    const HighsSparseMatrix ar_matrix,
+			    const std::vector<string> col_names);
 };
 
 #endif

--- a/src/io/FilereaderLp.h
+++ b/src/io/FilereaderLp.h
@@ -46,6 +46,7 @@ class FilereaderLp : public Filereader {
   void writeToFileValue(FILE* file, const double value, const bool force_plus = true);
   void writeToFileVar(FILE* file, const HighsInt var_index);
   void writeToFileVar(FILE* file, const std::string var_name);
+  void writeToFileCon(FILE* file, const HighsInt con_index);
   void writeToFileMatrixRow(FILE* file, const HighsInt iRow,
 			    const HighsSparseMatrix ar_matrix,
 			    const std::vector<string> col_names);

--- a/src/io/FilereaderLp.h
+++ b/src/io/FilereaderLp.h
@@ -43,13 +43,14 @@ class FilereaderLp : public Filereader {
   HighsInt linelength;
   void writeToFile(FILE* file, const char* format, ...);
   void writeToFileLineend(FILE* file);
-  void writeToFileValue(FILE* file, const double value, const bool force_plus = true);
+  void writeToFileValue(FILE* file, const double value,
+                        const bool force_plus = true);
   void writeToFileVar(FILE* file, const HighsInt var_index);
   void writeToFileVar(FILE* file, const std::string var_name);
   void writeToFileCon(FILE* file, const HighsInt con_index);
   void writeToFileMatrixRow(FILE* file, const HighsInt iRow,
-			    const HighsSparseMatrix ar_matrix,
-			    const std::vector<string> col_names);
+                            const HighsSparseMatrix ar_matrix,
+                            const std::vector<string> col_names);
 };
 
 #endif

--- a/src/io/FilereaderLp.h
+++ b/src/io/FilereaderLp.h
@@ -43,7 +43,7 @@ class FilereaderLp : public Filereader {
   HighsInt linelength;
   void writeToFile(FILE* file, const char* format, ...);
   void writeToFileLineend(FILE* file);
-  void writeToFileValue(FILE* file, const double value);
+  void writeToFileValue(FILE* file, const double value, const bool force_plus = true);
   void writeToFileVar(FILE* file, const HighsInt var_index);
   void writeToFileVar(FILE* file, const std::string var_name);
   void writeToFileMatrixRow(FILE* file, const HighsInt iRow,

--- a/src/io/FilereaderLp.h
+++ b/src/io/FilereaderLp.h
@@ -26,7 +26,7 @@
 #define LP_MAX_LINE_LENGTH 560
 #define LP_MAX_NAME_LENGTH 255
 
-#define LP_COMMENT_FILESTART ("File written by Highs .lp filereader")
+#define LP_COMMENT_FILESTART ("File written by HiGHS .lp file handler")
 
 class FilereaderLp : public Filereader {
  public:

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -31,7 +31,7 @@ void highsLogHeader(const HighsLogOptions& log_options) {
                "Copyright (c) 2022 ERGO-Code under MIT licence terms\n");
 }
 
-std::array<char, 32> highsDoubleToString(double val, double tolerance) {
+std::array<char, 32> highsDoubleToString(const double val, const double tolerance) {
   std::array<char, 32> printString;
   double l =
       std::abs(val) == kHighsInf

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -31,7 +31,8 @@ void highsLogHeader(const HighsLogOptions& log_options) {
                "Copyright (c) 2022 ERGO-Code under MIT licence terms\n");
 }
 
-std::array<char, 32> highsDoubleToString(const double val, const double tolerance) {
+std::array<char, 32> highsDoubleToString(const double val,
+                                         const double tolerance) {
   std::array<char, 32> printString;
   double l =
       std::abs(val) == kHighsInf

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -59,7 +59,7 @@ void highsLogHeader(const HighsLogOptions& log_options);
 /**
  * @brief Convert a double number to a string using given tolerance
  */
-std::array<char, 32> highsDoubleToString(double val, double tolerance);
+std::array<char, 32> highsDoubleToString(const double val, const double tolerance);
 
 /**
  * @brief For _single-line_ user logging with message type notification

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -59,7 +59,8 @@ void highsLogHeader(const HighsLogOptions& log_options);
 /**
  * @brief Convert a double number to a string using given tolerance
  */
-std::array<char, 32> highsDoubleToString(const double val, const double tolerance);
+std::array<char, 32> highsDoubleToString(const double val,
+                                         const double tolerance);
 
 /**
  * @brief For _single-line_ user logging with message type notification

--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -232,6 +232,12 @@ const HighsInt kHighsIllegalErrorIndex = -1;
 // Maximum upper bound on semi-variables
 const double kMaxSemiVariableUpper = 1e5;
 
+// Tolerance values for highsDoubleToString
+const double kModelValueToStringTolerance = 1e-15;
+const double kRangingValueToStringTolerance = 1e-13;
+const double kHighsSolutionValueToStringTolerance = 1e-13;
+const double kGlpsolSolutionValueToStringTolerance = 1e-12;
+
 // Termination link in linked lists
 const HighsInt kNoLink = -1;
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2776,18 +2776,17 @@ HighsStatus Highs::callSolveQp() {
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "QpSolver");
   if (return_status == HighsStatus::kError) return return_status;
-  model_status_ =
-      runtime.status == ProblemStatus::OPTIMAL
-          ? HighsModelStatus::kOptimal
-          : runtime.status == ProblemStatus::UNBOUNDED
-                ? HighsModelStatus::kUnbounded
-                : runtime.status == ProblemStatus::INFEASIBLE
+  model_status_ = runtime.status == ProblemStatus::OPTIMAL
+                      ? HighsModelStatus::kOptimal
+                  : runtime.status == ProblemStatus::UNBOUNDED
+                      ? HighsModelStatus::kUnbounded
+                  : runtime.status == ProblemStatus::INFEASIBLE
                       ? HighsModelStatus::kInfeasible
-                      : runtime.status == ProblemStatus::ITERATIONLIMIT
-                            ? HighsModelStatus::kIterationLimit
-                            : runtime.status == ProblemStatus::TIMELIMIT
-                                  ? HighsModelStatus::kTimeLimit
-                                  : HighsModelStatus::kNotset;
+                  : runtime.status == ProblemStatus::ITERATIONLIMIT
+                      ? HighsModelStatus::kIterationLimit
+                  : runtime.status == ProblemStatus::TIMELIMIT
+                      ? HighsModelStatus::kTimeLimit
+                      : HighsModelStatus::kNotset;
   solution_.col_value.resize(lp.num_col_);
   solution_.col_dual.resize(lp.num_col_);
   const double objective_multiplier = lp.sense_ == ObjSense::kMinimize ? 1 : -1;

--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -227,8 +227,8 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     fprintf(file, "Objective %s\n", objStr.data());
     fprintf(file, "# Columns %" HIGHSINT_FORMAT "\n", lp.num_col_);
     for (HighsInt ix = 0; ix < lp.num_col_; ix++) {
-      std::array<char, 32> valStr =
-          highsDoubleToString(solution.col_value[ix], kHighsSolutionValueToStringTolerance);
+      std::array<char, 32> valStr = highsDoubleToString(
+          solution.col_value[ix], kHighsSolutionValueToStringTolerance);
       // Create a column name
       ss.str(std::string());
       ss << "C" << ix;
@@ -237,8 +237,8 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     }
     fprintf(file, "# Rows %" HIGHSINT_FORMAT "\n", lp.num_row_);
     for (HighsInt ix = 0; ix < lp.num_row_; ix++) {
-      std::array<char, 32> valStr =
-          highsDoubleToString(solution.row_value[ix], kHighsSolutionValueToStringTolerance);
+      std::array<char, 32> valStr = highsDoubleToString(
+          solution.row_value[ix], kHighsSolutionValueToStringTolerance);
       // Create a row name
       ss.str(std::string());
       ss << "R" << ix;
@@ -258,8 +258,8 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     }
     fprintf(file, "# Columns %" HIGHSINT_FORMAT "\n", lp.num_col_);
     for (HighsInt ix = 0; ix < lp.num_col_; ix++) {
-      std::array<char, 32> valStr =
-          highsDoubleToString(solution.col_dual[ix], kHighsSolutionValueToStringTolerance);
+      std::array<char, 32> valStr = highsDoubleToString(
+          solution.col_dual[ix], kHighsSolutionValueToStringTolerance);
       ss.str(std::string());
       ss << "C" << ix;
       const std::string name = have_col_names ? lp.col_names_[ix] : ss.str();
@@ -267,8 +267,8 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     }
     fprintf(file, "# Rows %" HIGHSINT_FORMAT "\n", lp.num_row_);
     for (HighsInt ix = 0; ix < lp.num_row_; ix++) {
-      std::array<char, 32> valStr =
-          highsDoubleToString(solution.row_dual[ix], kHighsSolutionValueToStringTolerance);
+      std::array<char, 32> valStr = highsDoubleToString(
+          solution.row_dual[ix], kHighsSolutionValueToStringTolerance);
       ss.str(std::string());
       ss << "R" << ix;
       const std::string name = have_row_names ? lp.row_names_[ix] : ss.str();
@@ -373,8 +373,9 @@ void writeSolutionFile(FILE* file, const HighsOptions& options,
                             have_basis, basis.row_status);
     fprintf(file, "\nModel status: %s\n",
             utilModelStatusToString(model_status).c_str());
-    std::array<char, 32> objStr = highsDoubleToString(
-        (double)info.objective_function_value, kHighsSolutionValueToStringTolerance);
+    std::array<char, 32> objStr =
+        highsDoubleToString((double)info.objective_function_value,
+                            kHighsSolutionValueToStringTolerance);
     fprintf(file, "\nObjective value: %s\n", objStr.data());
   } else if (style == kSolutionStyleGlpsolRaw ||
              style == kSolutionStyleGlpsolPretty) {
@@ -393,8 +394,8 @@ void writeGlpsolCostRow(FILE* file, const bool raw, const bool is_mip,
                         const double objective_function_value) {
   if (raw) {
     double double_value = objective_function_value;
-    std::array<char, 32> double_string =
-        highsDoubleToString(double_value, kGlpsolSolutionValueToStringTolerance);
+    std::array<char, 32> double_string = highsDoubleToString(
+        double_value, kGlpsolSolutionValueToStringTolerance);
     // Last term of 0 for dual should (also) be blank when not MIP
     fprintf(file, "i %d %s%s%s\n", (int)row_id, is_mip ? "" : "b ",
             double_string.data(), is_mip ? "" : " 0");
@@ -678,8 +679,8 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       if (is_mip) {
         // Complete the line if for a MIP
         double double_value = solution.row_value[iRow];
-        std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
+        std::array<char, 32> double_string = highsDoubleToString(
+            double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s\n", double_string.data());
         continue;
       }
@@ -727,8 +728,8 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (raw) {
       fprintf(file, "%s ", status_char.c_str());
       double double_value = solution.row_value[iRow];
-      std::array<char, 32> double_string =
-          highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
+      std::array<char, 32> double_string = highsDoubleToString(
+          double_value, kHighsSolutionValueToStringTolerance);
       fprintf(file, "%s ", double_string.data());
     } else {
       fprintf(file, "%s ", status_text.c_str());
@@ -745,8 +746,8 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (have_dual) {
       if (raw) {
         double double_value = solution.row_dual[iRow];
-        std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
+        std::array<char, 32> double_string = highsDoubleToString(
+            double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s", double_string.data());
       } else {
         // If the row is known to be basic, don't print the dual
@@ -793,8 +794,8 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       fprintf(file, "%s%d ", line_prefix.c_str(), (int)(iCol + 1));
       if (is_mip) {
         double double_value = solution.col_value[iCol];
-        std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
+        std::array<char, 32> double_string = highsDoubleToString(
+            double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s\n", double_string.data());
         continue;
       }
@@ -845,8 +846,8 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (raw) {
       fprintf(file, "%s ", status_char.c_str());
       double double_value = solution.col_value[iCol];
-      std::array<char, 32> double_string =
-          highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
+      std::array<char, 32> double_string = highsDoubleToString(
+          double_value, kHighsSolutionValueToStringTolerance);
       fprintf(file, "%s ", double_string.data());
     } else {
       fprintf(file, "%s ", status_text.c_str());
@@ -863,8 +864,8 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (have_dual) {
       if (raw) {
         double double_value = solution.col_dual[iCol];
-        std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
+        std::array<char, 32> double_string = highsDoubleToString(
+            double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s", double_string.data());
       } else {
         // If the column is known to be basic, don't print the dual
@@ -913,13 +914,11 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
   fprintf(file, "        max.rel.err = %.2e on row %d\n", relative_error_value,
           absolute_error_index == 0 ? 0 : (int)relative_error_index);
   fprintf(file, "%8s%s\n", "",
-          relative_error_value <= kGlpsolHighQuality
-              ? "High quality"
-              : relative_error_value <= kGlpsolMediumQuality
-                    ? "Medium quality"
-                    : relative_error_value <= kGlpsolLowQuality
-                          ? "Low quality"
-                          : "PRIMAL SOLUTION IS WRONG");
+          relative_error_value <= kGlpsolHighQuality     ? "High quality"
+          : relative_error_value <= kGlpsolMediumQuality ? "Medium quality"
+          : relative_error_value <= kGlpsolLowQuality
+              ? "Low quality"
+              : "PRIMAL SOLUTION IS WRONG");
   fprintf(file, "\n");
 
   // Primal infeasibility
@@ -942,13 +941,11 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
               ? (int)relative_error_index
               : (int)(relative_error_index - lp.num_col_));
   fprintf(file, "%8s%s\n", "",
-          relative_error_value <= kGlpsolHighQuality
-              ? "High quality"
-              : relative_error_value <= kGlpsolMediumQuality
-                    ? "Medium quality"
-                    : relative_error_value <= kGlpsolLowQuality
-                          ? "Low quality"
-                          : "PRIMAL SOLUTION IS INFEASIBLE");
+          relative_error_value <= kGlpsolHighQuality     ? "High quality"
+          : relative_error_value <= kGlpsolMediumQuality ? "Medium quality"
+          : relative_error_value <= kGlpsolLowQuality
+              ? "Low quality"
+              : "PRIMAL SOLUTION IS INFEASIBLE");
   fprintf(file, "\n");
 
   if (have_dual) {
@@ -964,13 +961,11 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     fprintf(file, "        max.rel.err = %.2e on column %d\n",
             relative_error_value, (int)relative_error_index);
     fprintf(file, "%8s%s\n", "",
-            relative_error_value <= kGlpsolHighQuality
-                ? "High quality"
-                : relative_error_value <= kGlpsolMediumQuality
-                      ? "Medium quality"
-                      : relative_error_value <= kGlpsolLowQuality
-                            ? "Low quality"
-                            : "DUAL SOLUTION IS WRONG");
+            relative_error_value <= kGlpsolHighQuality     ? "High quality"
+            : relative_error_value <= kGlpsolMediumQuality ? "Medium quality"
+            : relative_error_value <= kGlpsolLowQuality
+                ? "Low quality"
+                : "DUAL SOLUTION IS WRONG");
     fprintf(file, "\n");
 
     // Dual infeasibility
@@ -994,13 +989,11 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
                 ? (int)relative_error_index
                 : (int)(relative_error_index - lp.num_col_));
     fprintf(file, "%8s%s\n", "",
-            relative_error_value <= kGlpsolHighQuality
-                ? "High quality"
-                : relative_error_value <= kGlpsolMediumQuality
-                      ? "Medium quality"
-                      : relative_error_value <= kGlpsolLowQuality
-                            ? "Low quality"
-                            : "DUAL SOLUTION IS INFEASIBLE");
+            relative_error_value <= kGlpsolHighQuality     ? "High quality"
+            : relative_error_value <= kGlpsolMediumQuality ? "Medium quality"
+            : relative_error_value <= kGlpsolLowQuality
+                ? "Low quality"
+                : "DUAL SOLUTION IS INFEASIBLE");
     fprintf(file, "\n");
   }
   fprintf(file, "End of output\n");

--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -21,15 +21,8 @@
 #include <sstream>
 #include <vector>
 
-//#include "model/HighsModel.h"
-//#include "HConfig.h"
-//#include "io/HighsIO.h"
-//#include "lp_data/HConst.h"
 #include "lp_data/HighsSolution.h"
 #include "util/stringutil.h"
-
-const double kHighsDoubleTolerance = 1e-13;
-const double kGlpsolDoubleTolerance = 1e-12;
 
 void analyseModelBounds(const HighsLogOptions& log_options, const char* message,
                         HighsInt numBd, const std::vector<double>& lower,
@@ -230,12 +223,12 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     for (HighsInt i = 0; i < lp.num_col_; ++i)
       objective_function_value += lp.col_cost_[i] * solution.col_value[i];
     std::array<char, 32> objStr = highsDoubleToString(
-        (double)objective_function_value, kHighsDoubleTolerance);
+        (double)objective_function_value, kHighsSolutionValueToStringTolerance);
     fprintf(file, "Objective %s\n", objStr.data());
     fprintf(file, "# Columns %" HIGHSINT_FORMAT "\n", lp.num_col_);
     for (HighsInt ix = 0; ix < lp.num_col_; ix++) {
       std::array<char, 32> valStr =
-          highsDoubleToString(solution.col_value[ix], kHighsDoubleTolerance);
+          highsDoubleToString(solution.col_value[ix], kHighsSolutionValueToStringTolerance);
       // Create a column name
       ss.str(std::string());
       ss << "C" << ix;
@@ -245,7 +238,7 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     fprintf(file, "# Rows %" HIGHSINT_FORMAT "\n", lp.num_row_);
     for (HighsInt ix = 0; ix < lp.num_row_; ix++) {
       std::array<char, 32> valStr =
-          highsDoubleToString(solution.row_value[ix], kHighsDoubleTolerance);
+          highsDoubleToString(solution.row_value[ix], kHighsSolutionValueToStringTolerance);
       // Create a row name
       ss.str(std::string());
       ss << "R" << ix;
@@ -266,7 +259,7 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     fprintf(file, "# Columns %" HIGHSINT_FORMAT "\n", lp.num_col_);
     for (HighsInt ix = 0; ix < lp.num_col_; ix++) {
       std::array<char, 32> valStr =
-          highsDoubleToString(solution.col_dual[ix], kHighsDoubleTolerance);
+          highsDoubleToString(solution.col_dual[ix], kHighsSolutionValueToStringTolerance);
       ss.str(std::string());
       ss << "C" << ix;
       const std::string name = have_col_names ? lp.col_names_[ix] : ss.str();
@@ -275,7 +268,7 @@ void writeModelSolution(FILE* file, const HighsLp& lp,
     fprintf(file, "# Rows %" HIGHSINT_FORMAT "\n", lp.num_row_);
     for (HighsInt ix = 0; ix < lp.num_row_; ix++) {
       std::array<char, 32> valStr =
-          highsDoubleToString(solution.row_dual[ix], kHighsDoubleTolerance);
+          highsDoubleToString(solution.row_dual[ix], kHighsSolutionValueToStringTolerance);
       ss.str(std::string());
       ss << "R" << ix;
       const std::string name = have_row_names ? lp.row_names_[ix] : ss.str();
@@ -381,7 +374,7 @@ void writeSolutionFile(FILE* file, const HighsOptions& options,
     fprintf(file, "\nModel status: %s\n",
             utilModelStatusToString(model_status).c_str());
     std::array<char, 32> objStr = highsDoubleToString(
-        (double)info.objective_function_value, kHighsDoubleTolerance);
+        (double)info.objective_function_value, kHighsSolutionValueToStringTolerance);
     fprintf(file, "\nObjective value: %s\n", objStr.data());
   } else if (style == kSolutionStyleGlpsolRaw ||
              style == kSolutionStyleGlpsolPretty) {
@@ -401,7 +394,7 @@ void writeGlpsolCostRow(FILE* file, const bool raw, const bool is_mip,
   if (raw) {
     double double_value = objective_function_value;
     std::array<char, 32> double_string =
-        highsDoubleToString(double_value, kGlpsolDoubleTolerance);
+        highsDoubleToString(double_value, kGlpsolSolutionValueToStringTolerance);
     // Last term of 0 for dual should (also) be blank when not MIP
     fprintf(file, "i %d %s%s%s\n", (int)row_id, is_mip ? "" : "b ",
             double_string.data(), is_mip ? "" : " 0");
@@ -653,7 +646,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     }
     double double_value = has_objective ? info.objective_function_value : 0;
     std::array<char, 32> double_string =
-        highsDoubleToString(double_value, kHighsDoubleTolerance);
+        highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
     fprintf(file, " %s\n", double_string.data());
   }
   if (!raw) {
@@ -686,7 +679,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
         // Complete the line if for a MIP
         double double_value = solution.row_value[iRow];
         std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsDoubleTolerance);
+            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s\n", double_string.data());
         continue;
       }
@@ -735,7 +728,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       fprintf(file, "%s ", status_char.c_str());
       double double_value = solution.row_value[iRow];
       std::array<char, 32> double_string =
-          highsDoubleToString(double_value, kHighsDoubleTolerance);
+          highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
       fprintf(file, "%s ", double_string.data());
     } else {
       fprintf(file, "%s ", status_text.c_str());
@@ -753,7 +746,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       if (raw) {
         double double_value = solution.row_dual[iRow];
         std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsDoubleTolerance);
+            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s", double_string.data());
       } else {
         // If the row is known to be basic, don't print the dual
@@ -801,7 +794,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       if (is_mip) {
         double double_value = solution.col_value[iCol];
         std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsDoubleTolerance);
+            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s\n", double_string.data());
         continue;
       }
@@ -853,7 +846,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       fprintf(file, "%s ", status_char.c_str());
       double double_value = solution.col_value[iCol];
       std::array<char, 32> double_string =
-          highsDoubleToString(double_value, kHighsDoubleTolerance);
+          highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
       fprintf(file, "%s ", double_string.data());
     } else {
       fprintf(file, "%s ", status_text.c_str());
@@ -871,7 +864,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       if (raw) {
         double double_value = solution.col_dual[iCol];
         std::array<char, 32> double_string =
-            highsDoubleToString(double_value, kHighsDoubleTolerance);
+            highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
         fprintf(file, "%s", double_string.data());
       } else {
         // If the column is known to be basic, don't print the dual

--- a/src/lp_data/HighsRanging.cpp
+++ b/src/lp_data/HighsRanging.cpp
@@ -636,8 +636,8 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
   std::array<char, 32> dn_value;
   std::array<char, 32> up_value;
 
-  std::array<char, 32> objective =
-      highsDoubleToString(objective_function_value, kRangingValueToStringTolerance);
+  std::array<char, 32> objective = highsDoubleToString(
+      objective_function_value, kRangingValueToStringTolerance);
   fprintf(file, "Objective %s\n", objective.data());
   if (pretty) {
     fprintf(file,

--- a/src/lp_data/HighsRanging.cpp
+++ b/src/lp_data/HighsRanging.cpp
@@ -617,7 +617,6 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
     return;
   }
   fprintf(file, "Valid\n");
-  const double double_tolerance = 1e-13;
   std::stringstream ss;
   const bool have_col_names = lp.col_names_.size() > 0;
   const bool have_row_names = lp.row_names_.size() > 0;
@@ -638,7 +637,7 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
   std::array<char, 32> up_value;
 
   std::array<char, 32> objective =
-      highsDoubleToString(objective_function_value, double_tolerance);
+      highsDoubleToString(objective_function_value, kRangingValueToStringTolerance);
   fprintf(file, "Objective %s\n", objective.data());
   if (pretty) {
     fprintf(file,
@@ -664,13 +663,13 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
               ranging.col_cost_up.objective_[iCol], name.c_str());
     } else {
       dn_objective = highsDoubleToString(ranging.col_cost_dn.objective_[iCol],
-                                         double_tolerance);
+                                         kRangingValueToStringTolerance);
       up_objective = highsDoubleToString(ranging.col_cost_up.objective_[iCol],
-                                         double_tolerance);
+                                         kRangingValueToStringTolerance);
       dn_value = highsDoubleToString(ranging.col_cost_dn.value_[iCol],
-                                     double_tolerance);
+                                     kRangingValueToStringTolerance);
       up_value = highsDoubleToString(ranging.col_cost_up.value_[iCol],
-                                     double_tolerance);
+                                     kRangingValueToStringTolerance);
       fprintf(file, raw_cost_format, name.c_str(), dn_objective.data(),
               dn_value.data(), up_value.data(), up_objective.data());
     }
@@ -700,13 +699,13 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
               ranging.col_bound_up.objective_[iCol], name.c_str());
     } else {
       dn_objective = highsDoubleToString(ranging.col_bound_dn.objective_[iCol],
-                                         double_tolerance);
+                                         kRangingValueToStringTolerance);
       up_objective = highsDoubleToString(ranging.col_bound_up.objective_[iCol],
-                                         double_tolerance);
+                                         kRangingValueToStringTolerance);
       dn_value = highsDoubleToString(ranging.col_bound_dn.value_[iCol],
-                                     double_tolerance);
+                                     kRangingValueToStringTolerance);
       up_value = highsDoubleToString(ranging.col_bound_up.value_[iCol],
-                                     double_tolerance);
+                                     kRangingValueToStringTolerance);
       fprintf(file, raw_bound_format, name.c_str(), dn_objective.data(),
               dn_value.data(), up_value.data(), up_objective.data());
     }
@@ -737,13 +736,13 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
               ranging.row_bound_up.objective_[iRow], name.c_str());
     } else {
       dn_objective = highsDoubleToString(ranging.row_bound_dn.objective_[iRow],
-                                         double_tolerance);
+                                         kRangingValueToStringTolerance);
       up_objective = highsDoubleToString(ranging.row_bound_up.objective_[iRow],
-                                         double_tolerance);
+                                         kRangingValueToStringTolerance);
       dn_value = highsDoubleToString(ranging.row_bound_dn.value_[iRow],
-                                     double_tolerance);
+                                     kRangingValueToStringTolerance);
       up_value = highsDoubleToString(ranging.row_bound_up.value_[iRow],
-                                     double_tolerance);
+                                     kRangingValueToStringTolerance);
       fprintf(file, raw_bound_format, name.c_str(), dn_objective.data(),
               dn_value.data(), up_value.data(), up_objective.data());
     }

--- a/src/simplex/HEkkDualRow.cpp
+++ b/src/simplex/HEkkDualRow.cpp
@@ -87,9 +87,9 @@ void HEkkDualRow::choosePossible() {
    * Determine the possible variables - candidates for CHUZC
    * TODO: Check with Qi what this is doing
    */
-  const double Ta = ekk_instance_.info_.update_count < 10
-                        ? 1e-9
-                        : ekk_instance_.info_.update_count < 20 ? 3e-8 : 1e-6;
+  const double Ta = ekk_instance_.info_.update_count < 10   ? 1e-9
+                    : ekk_instance_.info_.update_count < 20 ? 3e-8
+                                                            : 1e-6;
   const double Td = ekk_instance_.options_->dual_feasibility_tolerance;
   const HighsInt move_out = workDelta < 0 ? -1 : 1;
   workTheta = kHighsInf;
@@ -594,9 +594,9 @@ void HEkkDualRow::createFreelist() {
 void HEkkDualRow::createFreemove(HVector* row_ep) {
   // TODO: Check with Qi what this is doing and why it's expensive
   if (!freeList.empty()) {
-    double Ta = ekk_instance_.info_.update_count < 10
-                    ? 1e-9
-                    : ekk_instance_.info_.update_count < 20 ? 3e-8 : 1e-6;
+    double Ta = ekk_instance_.info_.update_count < 10   ? 1e-9
+                : ekk_instance_.info_.update_count < 20 ? 3e-8
+                                                        : 1e-6;
     HighsInt move_out = workDelta < 0 ? -1 : 1;
     set<HighsInt>::iterator sit;
     for (sit = freeList.begin(); sit != freeList.end(); sit++) {

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -1140,8 +1140,9 @@ void HEkkPrimal::phase1ChooseRow() {
   // Collect phase 1 theta lists
   //
 
-  const double dPivotTol =
-      info.update_count < 10 ? 1e-9 : info.update_count < 20 ? 1e-8 : 1e-7;
+  const double dPivotTol = info.update_count < 10   ? 1e-9
+                           : info.update_count < 20 ? 1e-8
+                                                    : 1e-7;
   ph1SorterR.clear();
   ph1SorterT.clear();
   for (HighsInt i = 0; i < col_aq.count; i++) {
@@ -1270,8 +1271,9 @@ void HEkkPrimal::chooseRow() {
   row_out = kNoRowChosen;
 
   // Choose row pass 1
-  double alphaTol =
-      info.update_count < 10 ? 1e-9 : info.update_count < 20 ? 1e-8 : 1e-7;
+  double alphaTol = info.update_count < 10   ? 1e-9
+                    : info.update_count < 20 ? 1e-8
+                                             : 1e-7;
 
   double relaxTheta = 1e100;
   double relaxSpace;

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -812,8 +812,8 @@ class HighsHashTable {
 
   using Entry = HighsHashTableEntry<K, V>;
   using KeyType = K;
-  using ValueType = typename std::remove_reference<decltype(
-      reinterpret_cast<Entry*>(0x1)->value())>::type;
+  using ValueType = typename std::remove_reference<
+      decltype(reinterpret_cast<Entry*>(0x1)->value())>::type;
 
   std::unique_ptr<Entry, OpNewDeleter> entries;
   std::unique_ptr<u8[]> metadata;


### PR DESCRIPTION
Prompted by #937 big error in writing .lp files has been fixed, and gross inefficiency removed. [Matrix entries were written out row-by-row by searching column-by-column for entries in each row; now the matrix is transposed into row-wise format] Model values are now written out using %+.15g (as in MPS files) rather than %+g so that both file formats have the same resolution. All (constructed) row and column names and model values are written out using single methods, allowing simple global switch of format.