### PR TITLE
Add volatile keyword to doubles involved in sorting operations for 32-bit GCC builds

### DIFF
--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -36,7 +36,6 @@
 #define FP_32BIT_VOLATILE
 #endif
 
-
 HighsPrimalHeuristics::HighsPrimalHeuristics(HighsMipSolver& mipsolver)
     : mipsolver(mipsolver),
       lp_iterations(0),


### PR DESCRIPTION
- resolves https://github.com/ERGO-Code/HiGHS/issues/769 and the associated SciPy issues

This is a well-known 32-bit GCC floating point precision ["bug"](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323).  This PR implements a minimal fix as presented in that thread ([link](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323#c87) to the specific comment).

`__i386__` should only be defined by GCC for 32-bit systems as described [here](https://sourceforge.net/p/predef/wiki/Architectures/), so there should be no performance regressions or complications for 64-bit builds.  