### PR TITLE
fixes #958

### DIFF
--- a/src/qpsolver/factor.hpp
+++ b/src/qpsolver/factor.hpp
@@ -74,7 +74,8 @@ class CholeskyFactor {
     std::vector<double> L_old = L;
     L.clear();
     L.resize((new_k_max) * (new_k_max));
-    for (HighsInt i = 0; i < current_k_max; i++) {
+    HighsInt min_k_max = min(new_k_max, current_k_max);
+    for (HighsInt i = 0; i < min_k_max; i++) {
       for (HighsInt j = 0; j < current_k_max; j++) {
         L[i * (new_k_max) + j] = L_old[i * current_k_max + j];
       }


### PR DESCRIPTION
Fixes a bug in the QP solver that appeared when the storage for the reduced hessian factor is resized to something smaller than before.