### PR TITLE
add R pkg to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ Rust
 
 - HiGHS can be used from rust through the [`highs` crate](https://crates.io/crates/highs). The rust linear programming modeler [**good_lp**](https://crates.io/crates/good_lp) supports HiGHS. 
 
+R
+------
+
+- An R interface is available through the [`highs` R package](https://cran.r-project.org/package=highs).
+
 Javascript
 ----------
 


### PR DESCRIPTION
Thank you very much for developing the HiGHS software! An R package was recently developed to interface with HiGHS (see https://cran.r-project.org/package=highs), so I thought it might be worth adding this to the README? Since this PR only edits the `README.md` file, the other documentation files might need to be updated using Docsy? I'm sorry, I've never used Docsy before so haven't attempted rebuilding the documentation with Docsy.