### PR TITLE
Add cstring to filereaderlp

### DIFF
--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -2,6 +2,7 @@
 
 #include "builder.hpp"
 
+#include <cstring>
 #include <cassert>
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
This is needed because of the use of strdup.

x-ref https://github.com/ERGO-Code/HiGHS/issues/928

Not sure if it's the best fix. An alternative might be to remove the use of `strdup`.

Also needed to get the Julia binaries to compile: https://github.com/JuliaPackaging/Yggdrasil/pull/5713
