### PR TITLE
Fix usage of popcnt on unsupported platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,10 @@ endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86\_64|i686)")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcnt")
-  set(FLAG_MPOPCNT_SUPPORTED ON)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64|powerpc64)")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcntd")
-  set(FLAG_MPOPCNT_SUPPORTED ON)
 else()
   message("FLAG_MPOPCNT_SUPPORTED is not available on this architecture")
-  set(FLAG_MPOPCNT_SUPPORTED OFF)
 endif()
 
 option(DEBUGSOL "check the debug solution" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,16 @@ enable_cxx_compiler_flag_if_supported("-Wno-format-truncation")
 enable_cxx_compiler_flag_if_supported("-pedantic")
 endif()
 
-check_cxx_compiler_flag("-mpopcnt" FLAG_MPOPCNT_SUPPORTED)
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -mpopcnt")
-
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86\_64|i686)")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcnt")
+  set(FLAG_MPOPCNT_SUPPORTED ON)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64|powerpc64)")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mpopcntd")
+  set(FLAG_MPOPCNT_SUPPORTED ON)
+else()
+  message("FLAG_MPOPCNT_SUPPORTED is not available on this architecture")
+  set(FLAG_MPOPCNT_SUPPORTED OFF)
+endif()
 
 option(DEBUGSOL "check the debug solution" OFF)
 

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -104,6 +104,8 @@ struct HighsHashHelpers {
 
   static int log2i(uint32_t n) { return 31 - __builtin_clz(n); }
 
+  static int popcnt(uint64_t x) { return __builtin_popcountll(x); }
+
 #elif defined(HIGHS_HAVE_BITSCAN_REVERSE)
   static int log2i(uint64_t n) {
     unsigned long result;
@@ -116,6 +118,8 @@ struct HighsHashHelpers {
     _BitScanReverse(&result, (unsigned long)n);
     return result;
   }
+
+  static int popcnt(uint64_t x) { return __popcnt64(x); }
 #else
   // integer log2 algorithm without floating point arithmetic. It uses an
   // unrolled loop and requires few instructions that can be well optimized.
@@ -157,13 +161,7 @@ struct HighsHashHelpers {
 
     return x;
   }
-#endif
 
-#ifdef FLAG_MPOPCNT_SUPPORTED
-  static int popcnt(uint64_t x) { return __builtin_popcountll(x); }
-#elif defined(HIGHS_HAVE_BITSCAN_REVERSE)
-  static int popcnt(uint64_t x) { return __popcnt64(x); }
-#else
   static int popcnt(uint64_t x) {
     constexpr uint64_t m1 = 0x5555555555555555ull;
     constexpr uint64_t m2 = 0x3333333333333333ull;
@@ -176,6 +174,7 @@ struct HighsHashHelpers {
 
     return (x * h01) >> 56;
   }
+
 #endif
 
   /// compute a * b mod 2^61-1

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -104,8 +104,6 @@ struct HighsHashHelpers {
 
   static int log2i(uint32_t n) { return 31 - __builtin_clz(n); }
 
-  static int popcnt(uint64_t x) { return __builtin_popcountll(x); }
-
 #elif defined(HIGHS_HAVE_BITSCAN_REVERSE)
   static int log2i(uint64_t n) {
     unsigned long result;
@@ -118,8 +116,6 @@ struct HighsHashHelpers {
     _BitScanReverse(&result, (unsigned long)n);
     return result;
   }
-
-  static int popcnt(uint64_t x) { return __popcnt64(x); }
 #else
   // integer log2 algorithm without floating point arithmetic. It uses an
   // unrolled loop and requires few instructions that can be well optimized.
@@ -161,7 +157,13 @@ struct HighsHashHelpers {
 
     return x;
   }
+#endif
 
+#ifdef FLAG_MPOPCNT_SUPPORTED
+  static int popcnt(uint64_t x) { return __builtin_popcountll(x); }
+#elif defined(HIGHS_HAVE_BITSCAN_REVERSE)
+  static int popcnt(uint64_t x) { return __popcnt64(x); }
+#else
   static int popcnt(uint64_t x) {
     constexpr uint64_t m1 = 0x5555555555555555ull;
     constexpr uint64_t m2 = 0x3333333333333333ull;
@@ -174,7 +176,6 @@ struct HighsHashHelpers {
 
     return (x * h01) >> 56;
   }
-
 #endif
 
   /// compute a * b mod 2^61-1


### PR DESCRIPTION
popcnt is not supported on a range of common platforms, including aarch64.

This patch was taken from the Julia binaries:
https://github.com/JuliaPackaging/Yggdrasil/pull/5713


This needs some checking by @lgottwald.  From what I could tell, `FLAG_MPOPCNT_SUPPORTED` wasn't actually used.