### PR TITLE
Solve relaxation

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: DoozyX/clang-format-lint-action@v0.14
       with:
-        source: 'app/ src/Highs.h .src/io .src/ipm ./src/lp_data ./src/mip ./src/model ./src/simplex ./src/presolve .src/qpsolver ./src/simplex ./src/util ./src/test'
+        source: 'app/ src/Highs.h ./src/lp_data ./src/mip ./src/model ./src/simplex ./src/presolve  ./src/simplex ./src/util ./src/test'
         #./src/test ./interfaces'
         extensions: 'h,cpp,c'
         clangFormatVersion: 14

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: DoozyX/clang-format-lint-action@v0.14
       with:
-        source: 'app/ src/Highs.h ./src/lp_data ./src/mip ./src/simplex ./src/presolve ./src/util'
+        source: 'app/ src/Highs.h .src/io .src/ipm ./src/lp_data ./src/mip ./src/model ./src/simplex ./src/presolve .src/qpsolver ./src/simplex ./src/util ./src/test'
         #./src/test ./interfaces'
         extensions: 'h,cpp,c'
-        clangFormatVersion: 9
+        clangFormatVersion: 14

--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,4 @@ adlittle.lp
 qjh.mps
 
 *.whl
+bazel*

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -181,8 +181,15 @@ TEST_CASE("MIP-maximize", "[highs_test_mip_solver]") {
           options.mip_abs_gap);
   REQUIRE(std::abs(info.mip_gap) <= options.mip_rel_gap);
 
+  highs.setOptionValue("solve_relaxation", true);
+  optimal_objective = -11.2;
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(std::abs(info.objective_function_value - optimal_objective) <
+          double_equal_tolerance);
+  highs.setOptionValue("solve_relaxation", false);
+
   // Now test with a larger problem
-  const bool use_avgas = false;
+  const bool use_avgas = true;
   const std::string model = use_avgas ? "avgas" : "dcmulti";
   const std::string filename =
       std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";

--- a/check/TestQpSolver.cpp
+++ b/check/TestQpSolver.cpp
@@ -4,7 +4,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = false;
+const bool dev_run = true;
 const double inf = kHighsInf;
 const double double_equal_tolerance = 1e-5;
 
@@ -115,6 +115,20 @@ TEST_CASE("qpsolver", "[qpsolver]") {
   REQUIRE(fabs(solution.col_value[1] - required_x1) < double_equal_tolerance);
   REQUIRE(fabs(solution.col_value[2] - required_x2) < double_equal_tolerance);
   std::remove(filename.c_str());
+
+  // Test that attempting to solve MIQP yields error
+  HighsInt num_col = highs.getNumCol();
+  std::vector<HighsVarType> integrality;
+  integrality.assign(num_col, HighsVarType::kInteger);
+  REQUIRE(highs.changeColsIntegrality(0, num_col-1, &integrality[0]) == HighsStatus::kOk);
+  return_status = highs.run();
+  REQUIRE(return_status == HighsStatus::kError);
+
+  highs.setOptionValue("solve_relaxation", true);
+  return_status = highs.run();
+  REQUIRE(return_status == HighsStatus::kOk);
+
+
 }
 
 TEST_CASE("test-qod", "[qpsolver]") {

--- a/check/TestQpSolver.cpp
+++ b/check/TestQpSolver.cpp
@@ -4,7 +4,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double inf = kHighsInf;
 const double double_equal_tolerance = 1e-5;
 
@@ -120,15 +120,15 @@ TEST_CASE("qpsolver", "[qpsolver]") {
   HighsInt num_col = highs.getNumCol();
   std::vector<HighsVarType> integrality;
   integrality.assign(num_col, HighsVarType::kInteger);
-  REQUIRE(highs.changeColsIntegrality(0, num_col-1, &integrality[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeColsIntegrality(0, num_col - 1, &integrality[0]) ==
+          HighsStatus::kOk);
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kError);
 
+  // Test that attempting to solve MIQP relaxation is OK
   highs.setOptionValue("solve_relaxation", true);
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kOk);
-
-
 }
 
 TEST_CASE("test-qod", "[qpsolver]") {

--- a/check/TestSemiVariables.cpp
+++ b/check/TestSemiVariables.cpp
@@ -126,6 +126,8 @@ TEST_CASE("semi-variable-lower-bound", "[highs_test_semi_variables]") {
       optimal_relaxation_objective_function_value;
   REQUIRE(fabs(info.objective_function_value -
                optimal_objective_function_value) < double_equal_tolerance);
+  // Check that the lower bound of the semi-variable has been restored
+  REQUIRE(highs.getLp().col_lower_[semi_col] == semi_col_lower);
 }
 
 TEST_CASE("semi-variable-upper-bound", "[highs_test_semi_variables]") {

--- a/check/TestSemiVariables.cpp
+++ b/check/TestSemiVariables.cpp
@@ -5,6 +5,11 @@
 const double inf = kHighsInf;
 const bool dev_run = false;
 const double double_equal_tolerance = 1e-5;
+const HighsVarType continuous = HighsVarType::kContinuous;
+const HighsVarType semi_continuous = HighsVarType::kSemiContinuous;
+const HighsVarType semi_integer = HighsVarType::kSemiInteger;
+
+void semiModel0(HighsLp& lp);
 
 TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   Highs highs;
@@ -14,26 +19,12 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   if (!dev_run) highs.setOptionValue("output_flag", false);
   HighsModel model;
   HighsLp& lp = model.lp_;
-  lp.num_col_ = 4;
-  lp.num_row_ = 4;
-  lp.col_cost_ = {1, 2, -4, -3};
-  lp.col_lower_ = {0, 0, 1.1, 0};
-  lp.col_upper_ = {inf, inf, inf, inf};
-  lp.row_lower_ = {-inf, 0, 0, 0.5};
-  lp.row_upper_ = {5, inf, inf, inf};
-  lp.a_matrix_.start_ = {0, 3, 6, 7, 8};
-  lp.a_matrix_.index_ = {0, 1, 2, 0, 1, 2, 3, 3};
-  lp.a_matrix_.value_ = {1, 2, -1, 1, -1, 3, 1, 1};
-  lp.a_matrix_.format_ = MatrixFormat::kColwise;
-  lp.sense_ = ObjSense::kMaximize;
-
-  const HighsVarType continuous = HighsVarType::kContinuous;
-  const HighsVarType semi_continuous = HighsVarType::kSemiContinuous;
-  const HighsVarType semi_integer = HighsVarType::kSemiInteger;
-  lp.integrality_ = {continuous, continuous, semi_continuous, continuous};
+  semiModel0(lp);
   const HighsInt semi_col = 2;
-  const double save_semi_col_lower = lp.col_lower_[semi_col];
-  const double save_semi_col_upper = lp.col_upper_[semi_col];
+  const double semi_col_cost = -4.0;
+  const double semi_col_lower = lp.col_lower_[semi_col];
+  const double semi_col_upper = lp.col_upper_[semi_col];
+  lp.col_cost_[semi_col] = semi_col_cost;
   optimal_objective_function_value = 6.83333;
   // Legal to have infinte upper bounds on semi-variables
   lp.col_upper_[semi_col] = inf;
@@ -45,7 +36,7 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   REQUIRE(fabs(info.objective_function_value -
                optimal_objective_function_value) < double_equal_tolerance);
 
-  // Remove the semi-condition and resolve
+  // Remove the semi-condition and resolve - not the same as relaxation
   highs.changeColIntegrality(semi_col, continuous);
   REQUIRE(highs.run() == HighsStatus::kOk);
   if (dev_run) highs.writeSolution("", kSolutionStylePretty);
@@ -72,7 +63,7 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
 
   // Change to sem-integer, restore the bounds and resolve
   highs.changeColIntegrality(semi_col, semi_integer);
-  highs.changeColBounds(semi_col, save_semi_col_lower, save_semi_col_upper);
+  highs.changeColBounds(semi_col, semi_col_lower, semi_col_upper);
   REQUIRE(highs.run() == HighsStatus::kOk);
   if (dev_run) highs.writeSolution("", kSolutionStylePretty);
   optimal_objective_function_value = 8.13333;
@@ -84,6 +75,55 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   sol.col_value = {0, 0, 0.5, 0};
   highs.setSolution(sol);
   REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(fabs(info.objective_function_value -
+               optimal_objective_function_value) < double_equal_tolerance);
+  //
+}
+
+TEST_CASE("semi-variable-lower-bound", "[highs_test_semi_variables]") {
+  const double optimal_relaxation_objective_function_value = 7.83333;
+  const double optimal_semi_continuous_objective_function_value = 7.23333;
+  double optimal_objective_function_value;
+  Highs highs;
+  const HighsInfo& info = highs.getInfo();
+  highs.setOptionValue("output_flag", dev_run);
+  HighsLp lp;
+  semiModel0(lp);
+  const HighsInt semi_col = 2;
+  const double semi_col_cost = -1.0;
+  const double semi_col_lower = lp.col_lower_[semi_col];
+  lp.col_cost_[semi_col] = semi_col_cost;
+  // Force relaxation directly
+  lp.col_lower_[semi_col] = 0;
+  lp.integrality_[semi_col] = continuous;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  if (dev_run) highs.writeSolution("", kSolutionStylePretty);
+
+  optimal_objective_function_value =
+      optimal_relaxation_objective_function_value;
+  REQUIRE(fabs(info.objective_function_value -
+               optimal_objective_function_value) < double_equal_tolerance);
+
+  // Restore the semi-continuous variable
+  lp.col_lower_[semi_col] = semi_col_lower;
+  lp.integrality_[semi_col] = semi_continuous;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  if (dev_run) highs.writeSolution("", kSolutionStylePretty);
+  optimal_objective_function_value =
+      optimal_semi_continuous_objective_function_value;
+  REQUIRE(fabs(info.objective_function_value -
+               optimal_objective_function_value) < double_equal_tolerance);
+
+  // Now solve the relaxation
+  highs.setOptionValue("solve_relaxation", true);
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  if (dev_run) highs.writeSolution("", kSolutionStylePretty);
+  optimal_objective_function_value =
+      optimal_relaxation_objective_function_value;
   REQUIRE(fabs(info.objective_function_value -
                optimal_objective_function_value) < double_equal_tolerance);
 }
@@ -185,4 +225,20 @@ TEST_CASE("semi-variable-file", "[highs_test_semi_variables]") {
   REQUIRE(highs.run() == HighsStatus::kOk);
   REQUIRE(fabs(info.objective_function_value -
                optimal_objective_function_value) < double_equal_tolerance);
+}
+
+void semiModel0(HighsLp& lp) {
+  lp.num_col_ = 4;
+  lp.num_row_ = 4;
+  lp.col_cost_ = {1, 2, -1, -3};
+  lp.col_lower_ = {0, 0, 1.1, 0};
+  lp.col_upper_ = {inf, inf, inf, inf};
+  lp.row_lower_ = {-inf, 0, 0, 0.5};
+  lp.row_upper_ = {5, inf, inf, inf};
+  lp.a_matrix_.start_ = {0, 3, 6, 7, 8};
+  lp.a_matrix_.index_ = {0, 1, 2, 0, 1, 2, 3, 3};
+  lp.a_matrix_.value_ = {1, 2, -1, 1, -1, 3, 1, 1};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.sense_ = ObjSense::kMaximize;
+  lp.integrality_ = {continuous, continuous, semi_continuous, continuous};
 }

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -80,7 +80,7 @@ struct HighsScale {
 struct HighsLpMods {
   std::vector<HighsInt> save_semi_variable_lower_bound_index;
   std::vector<double> save_semi_variable_lower_bound_value;
-  std::vector<HighsInt> save_semi_variable_upper_bound_index; 
+  std::vector<HighsInt> save_semi_variable_upper_bound_index;
   std::vector<double> save_semi_variable_upper_bound_value;
   void clear();
   bool isClear();

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -78,7 +78,9 @@ struct HighsScale {
 };
 
 struct HighsLpMods {
-  std::vector<HighsInt> save_semi_variable_upper_bound_index;
+  std::vector<HighsInt> save_semi_variable_lower_bound_index;
+  std::vector<double> save_semi_variable_lower_bound_value;
+  std::vector<HighsInt> save_semi_variable_upper_bound_index; 
   std::vector<double> save_semi_variable_upper_bound_value;
   void clear();
   bool isClear();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -799,34 +799,46 @@ HighsStatus Highs::run() {
     return returnFromRun(HighsStatus::kError);
   }
 
-  if (!options_.solver.compare(kHighsChooseString) && !options_.solve_relaxation && model_.isQp()) {
-    // Choosing method according to model class, and model is a QP
-    //
-    // Ensure that it's not MIQP!
-    if (model_.isMip()) {
-      highsLogUser(options_.log_options, HighsLogType::kError,
-                   "Cannot solve MIQP problems with HiGHS\n");
-      return returnFromRun(HighsStatus::kError);
+  if (!options_.solver.compare(kHighsChooseString)) {
+    // Leaving HiGHS to choose method according to model class
+    if (model_.isQp()) {
+      if (model_.isMip()) {
+	if (options_.solve_relaxation) {
+	  // Relax any semi-variables
+	  relaxSemiVariables(model_.lp_);
+	} else {
+	  highsLogUser(options_.log_options, HighsLogType::kError,
+		       "Cannot solve MIQP problems with HiGHS\n");
+	  return returnFromRun(HighsStatus::kError);
+	}
+      }
+      // 
+      // Ensure that its diagonal entries are OK in the context of the
+      // objective sense. It's OK to be semi-definite
+      if (!okHessianDiagonal(options_, model_.hessian_, model_.lp_.sense_)) {
+	highsLogUser(options_.log_options, HighsLogType::kError,
+		     "Cannot solve non-convex QP problems with HiGHS\n");
+	return returnFromRun(HighsStatus::kError);
+      }
+      call_status = callSolveQp();
+      return_status = interpretCallStatus(options_.log_options, call_status,
+					  return_status, "callSolveQp");
+      return returnFromRun(return_status);
+    } else if (model_.isMip() && !options_.solve_relaxation) {
+      // Model is a MIP and not solving just the relaxation
+      call_status = callSolveMip();
+      return_status = interpretCallStatus(options_.log_options, call_status,
+					  return_status, "callSolveMip");
+      return returnFromRun(return_status);
     }
-    // Ensure that its diagonal entries are OK in the context of the
-    // objective sense. It's OK to be semi-definite
-    if (!okHessianDiagonal(options_, model_.hessian_, model_.lp_.sense_)) {
-      highsLogUser(options_.log_options, HighsLogType::kError,
-                   "Cannot solve non-convex QP problems with HiGHS\n");
-      return returnFromRun(HighsStatus::kError);
-    }
-    call_status = callSolveQp();
-    return_status = interpretCallStatus(options_.log_options, call_status,
-                                        return_status, "callSolveQp");
-    return returnFromRun(return_status);
   }
-
-  if (!options_.solver.compare(kHighsChooseString) && model_.isMip()) {
-    // Choosing method according to model class, and model is a MIP
-    call_status = callSolveMip();
-    return_status = interpretCallStatus(options_.log_options, call_status,
-                                        return_status, "callSolveMip");
-    return returnFromRun(return_status);
+  // If model is MIP, must be solving the relaxation or not leaving
+  // HiGHS to choose method according to model class
+  if (model_.isMip()) {
+    assert(options_.solve_relaxation ||
+	   options_.solver.compare(kHighsChooseString));
+    // Relax any semi-variables
+    relaxSemiVariables(model_.lp_);
   }
   // Solve the model as an LP
   HighsLp& incumbent_lp = model_.lp_;

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -803,32 +803,32 @@ HighsStatus Highs::run() {
     // Leaving HiGHS to choose method according to model class
     if (model_.isQp()) {
       if (model_.isMip()) {
-	if (options_.solve_relaxation) {
-	  // Relax any semi-variables
-	  relaxSemiVariables(model_.lp_);
-	} else {
-	  highsLogUser(options_.log_options, HighsLogType::kError,
-		       "Cannot solve MIQP problems with HiGHS\n");
-	  return returnFromRun(HighsStatus::kError);
-	}
+        if (options_.solve_relaxation) {
+          // Relax any semi-variables
+          relaxSemiVariables(model_.lp_);
+        } else {
+          highsLogUser(options_.log_options, HighsLogType::kError,
+                       "Cannot solve MIQP problems with HiGHS\n");
+          return returnFromRun(HighsStatus::kError);
+        }
       }
-      // 
+      //
       // Ensure that its diagonal entries are OK in the context of the
       // objective sense. It's OK to be semi-definite
       if (!okHessianDiagonal(options_, model_.hessian_, model_.lp_.sense_)) {
-	highsLogUser(options_.log_options, HighsLogType::kError,
-		     "Cannot solve non-convex QP problems with HiGHS\n");
-	return returnFromRun(HighsStatus::kError);
+        highsLogUser(options_.log_options, HighsLogType::kError,
+                     "Cannot solve non-convex QP problems with HiGHS\n");
+        return returnFromRun(HighsStatus::kError);
       }
       call_status = callSolveQp();
       return_status = interpretCallStatus(options_.log_options, call_status,
-					  return_status, "callSolveQp");
+                                          return_status, "callSolveQp");
       return returnFromRun(return_status);
     } else if (model_.isMip() && !options_.solve_relaxation) {
       // Model is a MIP and not solving just the relaxation
       call_status = callSolveMip();
       return_status = interpretCallStatus(options_.log_options, call_status,
-					  return_status, "callSolveMip");
+                                          return_status, "callSolveMip");
       return returnFromRun(return_status);
     }
   }
@@ -836,7 +836,7 @@ HighsStatus Highs::run() {
   // HiGHS to choose method according to model class
   if (model_.isMip()) {
     assert(options_.solve_relaxation ||
-	   options_.solver.compare(kHighsChooseString));
+           options_.solver.compare(kHighsChooseString));
     // Relax any semi-variables
     relaxSemiVariables(model_.lp_);
   }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -799,7 +799,7 @@ HighsStatus Highs::run() {
     return returnFromRun(HighsStatus::kError);
   }
 
-  if (!options_.solver.compare(kHighsChooseString) && model_.isQp()) {
+  if (!options_.solver.compare(kHighsChooseString) && !options_.solve_relaxation && model_.isQp()) {
     // Choosing method according to model class, and model is a QP
     //
     // Ensure that it's not MIQP!

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -22,7 +22,7 @@
 
 HighsStatus Highs::basisForSolution() {
   HighsLp& lp = model_.lp_;
-  assert(!lp.isMip());
+  assert(!lp.isMip() || options_.solve_relaxation);
   assert(solution_.value_valid);
   invalidateBasis();
   HighsInt num_basic = 0;

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -588,9 +588,9 @@ void relaxSemiVariables(HighsLp& lp) {
   assert(lp.integrality_.size() == lp.num_col_);
   HighsInt num_modified_lower = 0;
   std::vector<HighsInt>& lower_bound_index =
-    lp.mods_.save_semi_variable_lower_bound_index;
+      lp.mods_.save_semi_variable_lower_bound_index;
   std::vector<double>& lower_bound_value =
-    lp.mods_.save_semi_variable_lower_bound_value;
+      lp.mods_.save_semi_variable_lower_bound_value;
   assert(lower_bound_index.size() == 0);
   for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
     if (lp.integrality_[iCol] == HighsVarType::kSemiContinuous ||

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -58,6 +58,7 @@ HighsStatus assessBounds(const HighsOptions& options, const char* type,
 HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp);
 
 HighsStatus assessIntegrality(HighsLp& lp, const HighsOptions& options);
+void relaxSemiVariables(HighsLp& lp);
 bool activeModifiedUpperBounds(const HighsOptions& options, const HighsLp& lp,
                                const std::vector<double> col_value);
 

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -311,7 +311,7 @@ struct HighsOptionsStruct {
   // Options for IPM solver
   HighsInt ipm_iteration_limit;
   bool run_crossover;
-  
+
   // Advanced options
   HighsInt log_dev_level;
   bool solve_relaxation;
@@ -812,9 +812,9 @@ class HighsOptions : public HighsOptionsStruct {
         &ipm_iteration_limit, 0, kHighsIInf, kHighsIInf);
     records.push_back(record_int);
 
-    record_bool = new OptionRecordBool("run_crossover",
-                                       "Run the crossover routine for IPM solver",
-                                       advanced, &run_crossover, true);
+    record_bool = new OptionRecordBool(
+        "run_crossover", "Run the crossover routine for IPM solver", advanced,
+        &run_crossover, true);
     records.push_back(record_bool);
 
     // Advanced options
@@ -827,10 +827,9 @@ class HighsOptions : public HighsOptionsStruct {
         kHighsLogDevLevelMax);
     records.push_back(record_int);
 
-    record_bool =
-        new OptionRecordBool("solve_relaxation",
-                             "Solve the relaxation of discrete model components",
-                             advanced, &solve_relaxation, false);
+    record_bool = new OptionRecordBool(
+        "solve_relaxation", "Solve the relaxation of discrete model components",
+        advanced, &solve_relaxation, false);
     records.push_back(record_bool);
 
     record_bool =

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -295,7 +295,7 @@ struct HighsOptionsStruct {
   HighsInt simplex_update_limit;
   HighsInt simplex_min_concurrency;
   HighsInt simplex_max_concurrency;
-  HighsInt ipm_iteration_limit;
+
   std::string write_model_file;
   std::string solution_file;
   std::string log_file;
@@ -303,13 +303,18 @@ struct HighsOptionsStruct {
   bool write_solution_to_file;
   HighsInt write_solution_style;
   HighsInt glpsol_cost_row_location;
+
   // Control of HiGHS log
   bool output_flag;
   bool log_to_console;
 
+  // Options for IPM solver
+  HighsInt ipm_iteration_limit;
+  bool run_crossover;
+  
   // Advanced options
   HighsInt log_dev_level;
-  bool run_crossover;
+  bool solve_relaxation;
   bool allow_unbounded_or_infeasible;
   bool use_implied_bounds_from_presolve;
   bool lp_presolve_requires_basis_postsolve;
@@ -598,11 +603,6 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "ipm_iteration_limit", "Iteration limit for IPM solver", advanced,
-        &ipm_iteration_limit, 0, kHighsIInf, kHighsIInf);
-    records.push_back(record_int);
-
-    record_int = new OptionRecordInt(
         "simplex_min_concurrency",
         "Minimum level of concurrency in parallel simplex", advanced,
         &simplex_min_concurrency, 1, 1, kSimplexConcurrencyLimit);
@@ -807,6 +807,16 @@ class HighsOptions : public HighsOptionsStruct {
         advanced, &mip_abs_gap, 0.0, 1e-6, kHighsInf);
     records.push_back(record_double);
 
+    record_int = new OptionRecordInt(
+        "ipm_iteration_limit", "Iteration limit for IPM solver", advanced,
+        &ipm_iteration_limit, 0, kHighsIInf, kHighsIInf);
+    records.push_back(record_int);
+
+    record_bool = new OptionRecordBool("run_crossover",
+                                       "Run the crossover routine for IPM solver",
+                                       advanced, &run_crossover, true);
+    records.push_back(record_bool);
+
     // Advanced options
     advanced = true;
 
@@ -817,9 +827,10 @@ class HighsOptions : public HighsOptionsStruct {
         kHighsLogDevLevelMax);
     records.push_back(record_int);
 
-    record_bool = new OptionRecordBool("run_crossover",
-                                       "Run the crossover routine for IPX",
-                                       advanced, &run_crossover, true);
+    record_bool =
+        new OptionRecordBool("solve_relaxation",
+                             "Solve the relaxation of discrete model components",
+                             advanced, &solve_relaxation, false);
     records.push_back(record_bool);
 
     record_bool =

--- a/src/test/DevKkt.cpp
+++ b/src/test/DevKkt.cpp
@@ -139,8 +139,7 @@ void checkDualFeasibility(const State& state, KktConditionDetails& details) {
       details.checked++;
       double infeas = 0;
       // j not in L or U
-      if (state.colLower[i] <= -kHighsInf &&
-          state.colUpper[i] >= kHighsInf) {
+      if (state.colLower[i] <= -kHighsInf && state.colUpper[i] >= kHighsInf) {
         if (fabs(state.colDual[i]) > tol) {
           if (dev_print == 1)
             std::cout << "Dual feasibility fail: l=-inf, x[" << i


### PR DESCRIPTION
Some LP test problems are read from MPS files containing integrality markers. Hence it's necessary to tell HiGHS to solve the relaxation. Previously this was achieved by setting solver=simplex or solver=ipm. However, in future, concurrent LP solvers will be used when solver=choose, so the solve_relaxation option has been added to force the LP to be solved. Obviously the option is false by default. Code has also been added to modify the lower bound on a semi-variable to zero when solving the LP relaxation. Unit tests have been added to check new code.