### PR TITLE
Fix 987

### DIFF
--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -216,7 +216,6 @@ TEST_CASE("filereader-integrality-constraints", "[highs_filereader]") {
 TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   double objective_value;
   const double optimal_objective_value = 0;
-  REQUIRE(optimal_objective_value == 0);
   std::string model_file =
       std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
   printf("Test Case %s\n", model_file.c_str());
@@ -224,9 +223,11 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   REQUIRE(optimal_objective_value == 0);
   printf("Test Case filereader-fixed-integer\n");
   fflush(stdout);
-  //  highs.setOptionValue("output_flag", dev_run);
+  highs.setOptionValue("output_flag", dev_run);
 
   REQUIRE(highs.readModel(model_file) == HighsStatus::kOk);
+  const HighsLp& internal_lp = highs.getLp();
+  REQUIRE(internal_lp.num_col_==1);
   REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -9,7 +9,7 @@
 #include "lp_data/HighsLp.h"
 #include "lp_data/HighsLpUtils.h"
 
-const bool dev_run = true;
+const bool dev_run = false;
 
 TEST_CASE("filereader-edge-cases", "[highs_filereader]") {
   std::string model = "";

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -9,7 +9,7 @@
 #include "lp_data/HighsLp.h"
 #include "lp_data/HighsLpUtils.h"
 
-const bool dev_run = true;
+const bool dev_run = false;
 
 TEST_CASE("filereader-edge-cases", "[highs_filereader]") {
   std::string model = "";
@@ -231,8 +231,6 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("0: objective_value = %g\n", objective_value);
-  fflush(stdout);
   highs.clearModel();
 
   const std::string lp_file = "ml.lp";
@@ -252,24 +250,18 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   highs.run();
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("1: objective_value = %g\n", objective_value);
-  fflush(stdout);
   highs.clearModel();
 
   highs.readModel(lp_file);
   highs.run();
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("2: objective_value = %g\n", objective_value);
-  fflush(stdout);
   highs.clearModel();
 
   highs.readModel(mps_file);
   highs.run();
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("3: objective_value = %g\n", objective_value);
-  fflush(stdout);
   highs.clearModel();
 
   std::remove(lp_file.c_str());

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -216,15 +216,22 @@ TEST_CASE("filereader-integrality-constraints", "[highs_filereader]") {
 TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   double objective_value;
   const double optimal_objective_value = 0;
+  REQUIRE(optimal_objective_value == 0);
   std::string model_file =
       std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
+  printf("Test Case %s\n", model_file.c_str());
   Highs highs;
-  highs.setOptionValue("output_flag", dev_run);
-  highs.readModel(model_file);
-  highs.run();
+  REQUIRE(optimal_objective_value == 0);
+  printf("Test Case filereader-fixed-integer\n");
+  fflush(stdout);
+  //  highs.setOptionValue("output_flag", dev_run);
+
+  REQUIRE(highs.readModel(model_file) == HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("0: objective_value = %g\n", objective_value);fflush(stdout);
+  printf("0: objective_value = %g\n", objective_value);
+  fflush(stdout);
   highs.clearModel();
 
   const std::string lp_file = "ml.lp";
@@ -244,21 +251,24 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   highs.run();
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("1: objective_value = %g\n", objective_value);fflush(stdout);
+  printf("1: objective_value = %g\n", objective_value);
+  fflush(stdout);
   highs.clearModel();
 
   highs.readModel(lp_file);
   highs.run();
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("2: objective_value = %g\n", objective_value);fflush(stdout);
+  printf("2: objective_value = %g\n", objective_value);
+  fflush(stdout);
   highs.clearModel();
 
   highs.readModel(mps_file);
   highs.run();
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
-  printf("3: objective_value = %g\n", objective_value);fflush(stdout);
+  printf("3: objective_value = %g\n", objective_value);
+  fflush(stdout);
   highs.clearModel();
 
   std::remove(lp_file.c_str());

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -247,8 +247,7 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   REQUIRE(objective_value == optimal_objective_value);
   highs.clearModel();
 
-  REQUIRE(highs.readModel("not_lp_file.lp") == HighsStatus::kError);
-  //			  lp_file) == HighsStatus::kOk);
+  REQUIRE(highs.readModel(lp_file) == HighsStatus::kOk);
   REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -9,7 +9,7 @@
 #include "lp_data/HighsLp.h"
 #include "lp_data/HighsLpUtils.h"
 
-const bool dev_run = false;
+const bool dev_run = true;
 
 TEST_CASE("filereader-edge-cases", "[highs_filereader]") {
   std::string model = "";
@@ -214,6 +214,7 @@ TEST_CASE("filereader-integrality-constraints", "[highs_filereader]") {
 }
 
 TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
+  double objective_value;
   const double optimal_objective_value = 0;
   std::string model_file =
       std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
@@ -221,7 +222,9 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   highs.setOptionValue("output_flag", dev_run);
   highs.readModel(model_file);
   highs.run();
-  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  objective_value = highs.getInfo().objective_function_value;
+  REQUIRE(objective_value == optimal_objective_value);
+  printf("0: objective_value = %g\n", objective_value);fflush(stdout);
   highs.clearModel();
 
   const std::string lp_file = "ml.lp";
@@ -239,17 +242,23 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   highs.writeModel(mps_file);
 
   highs.run();
-  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  objective_value = highs.getInfo().objective_function_value;
+  REQUIRE(objective_value == optimal_objective_value);
+  printf("1: objective_value = %g\n", objective_value);fflush(stdout);
   highs.clearModel();
 
   highs.readModel(lp_file);
   highs.run();
-  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  objective_value = highs.getInfo().objective_function_value;
+  REQUIRE(objective_value == optimal_objective_value);
+  printf("2: objective_value = %g\n", objective_value);fflush(stdout);
   highs.clearModel();
 
   highs.readModel(mps_file);
   highs.run();
-  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  objective_value = highs.getInfo().objective_function_value;
+  REQUIRE(objective_value == optimal_objective_value);
+  printf("3: objective_value = %g\n", objective_value);fflush(stdout);
   highs.clearModel();
 
   std::remove(lp_file.c_str());

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -218,16 +218,11 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   const double optimal_objective_value = 0;
   std::string model_file =
       std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
-  printf("Test Case %s\n", model_file.c_str());
   Highs highs;
-  REQUIRE(optimal_objective_value == 0);
-  printf("Test Case filereader-fixed-integer\n");
-  fflush(stdout);
   highs.setOptionValue("output_flag", dev_run);
 
   REQUIRE(highs.readModel(model_file) == HighsStatus::kOk);
   const HighsLp& internal_lp = highs.getLp();
-  REQUIRE(internal_lp.num_col_==1);
   REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
@@ -243,23 +238,24 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   lp.col_upper_ = {0};
   lp.integrality_ = {HighsVarType::kInteger};
 
-  highs.passModel(lp);
-  highs.writeModel(lp_file);
-  highs.writeModel(mps_file);
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  REQUIRE(highs.writeModel(lp_file) == HighsStatus::kOk);
+  REQUIRE(highs.writeModel(mps_file) == HighsStatus::kWarning);
 
-  highs.run();
+  REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
   highs.clearModel();
 
-  highs.readModel(lp_file);
-  highs.run();
+  REQUIRE(highs.readModel("not_lp_file.lp") == HighsStatus::kError);
+  //			  lp_file) == HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
   highs.clearModel();
 
-  highs.readModel(mps_file);
-  highs.run();
+  REQUIRE(highs.readModel(mps_file) == HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
   objective_value = highs.getInfo().objective_function_value;
   REQUIRE(objective_value == optimal_objective_value);
   highs.clearModel();

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -9,7 +9,7 @@
 #include "lp_data/HighsLp.h"
 #include "lp_data/HighsLpUtils.h"
 
-const bool dev_run = false;
+const bool dev_run = true;
 
 TEST_CASE("filereader-edge-cases", "[highs_filereader]") {
   std::string model = "";
@@ -211,4 +211,46 @@ TEST_CASE("filereader-integrality-constraints", "[highs_filereader]") {
 
   bool are_the_same = lp_free == lp_fixed;
   REQUIRE(are_the_same);
+}
+
+TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
+
+  const std::string lp_file = "ml.lp";
+  const std::string mps_file = "ml.mps";
+  HighsLp lp;
+  lp.num_col_ = 1;
+  lp.num_row_ = 0;
+  lp.col_cost_ = {-1};
+  lp.col_lower_ = {0};
+  lp.col_upper_ = {0};
+  lp.integrality_ = {HighsVarType::kInteger};
+  double optimal_objective_value = 0;
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.passModel(lp);
+  highs.writeModel(lp_file);
+  highs.writeModel(mps_file);
+
+  highs.run();
+  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  highs.clearModel();
+
+  highs.readModel(lp_file);
+  highs.run();
+  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  highs.clearModel();
+  
+  highs.readModel(mps_file);
+  highs.run();
+  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  highs.clearModel();
+
+  std::string model_file = std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
+  highs.readModel(model_file);
+  highs.run();
+  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  highs.clearModel();
+  
+  
+  
 }

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -214,6 +214,15 @@ TEST_CASE("filereader-integrality-constraints", "[highs_filereader]") {
 }
 
 TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
+  const double optimal_objective_value = 0;
+  std::string model_file =
+      std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.readModel(model_file);
+  highs.run();
+  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
+  highs.clearModel();
 
   const std::string lp_file = "ml.lp";
   const std::string mps_file = "ml.mps";
@@ -224,9 +233,7 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   lp.col_lower_ = {0};
   lp.col_upper_ = {0};
   lp.integrality_ = {HighsVarType::kInteger};
-  double optimal_objective_value = 0;
-  Highs highs;
-  highs.setOptionValue("output_flag", dev_run);
+
   highs.passModel(lp);
   highs.writeModel(lp_file);
   highs.writeModel(mps_file);
@@ -239,18 +246,12 @@ TEST_CASE("filereader-fixed-integer", "[highs_filereader]") {
   highs.run();
   REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
   highs.clearModel();
-  
+
   highs.readModel(mps_file);
   highs.run();
   REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
   highs.clearModel();
 
-  std::string model_file = std::string(HIGHS_DIR) + "/check/instances/fixed-binary.lp";
-  highs.readModel(model_file);
-  highs.run();
-  REQUIRE(highs.getInfo().objective_function_value == optimal_objective_value);
-  highs.clearModel();
-  
-  
-  
+  std::remove(lp_file.c_str());
+  std::remove(mps_file.c_str());
 }

--- a/check/instances/fixed-binary.lp
+++ b/check/instances/fixed-binary.lp
@@ -1,0 +1,11 @@
+\ File written by HiGHS .lp file handler
+min
+ obj: -1 x1 
+st
+bounds
+ x1 = 0
+bin
+gen
+ x1
+semi
+end

--- a/check/instances/fixed-binary.lp
+++ b/check/instances/fixed-binary.lp
@@ -5,7 +5,7 @@ st
 bounds
  x1 = 0
 bin
-gen
  x1
+gen
 semi
 end

--- a/extern/filereaderlp/def.hpp
+++ b/extern/filereaderlp/def.hpp
@@ -4,9 +4,12 @@
 #include <stdexcept>
 #include <string>
 
-void inline lpassert(bool condition) {
+void inline lpassert(const bool condition, const std::string message = "") {
    if (!condition) {
-      throw std::invalid_argument("File not existent or illegal file format.");
+     const std::string feedback = "LP file or format error" +
+       message == "" ? "" : ": for " + message;
+     printf("lpassert fails%s\n", (message == "" ? "" : (" for " + message).c_str()));
+      throw std::invalid_argument(feedback);
    }
 }
 

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -235,7 +235,7 @@ public:
 #else
       file.open(filename);
 #endif
-      lpassert(file.is_open());
+      lpassert(file.is_open(), "file.is_open()");
    };
 
    ~Reader() {

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -303,7 +303,7 @@ Model Reader::read() {
 }
 
 void Reader::processnonesec() {
-   lpassert(sectiontokens.count(LpSectionKeyword::NONE) == 0);
+  lpassert(sectiontokens.count(LpSectionKeyword::NONE) == 0, "sectiontokens.count(LpSectionKeyword::NONE) == 0");
 }
 
 void Reader::parseexpression(std::vector<ProcessedToken>::iterator& it, std::vector<ProcessedToken>::iterator end, std::shared_ptr<Expression> expr, bool isobj) {
@@ -371,7 +371,7 @@ void Reader::parseexpression(std::vector<ProcessedToken>::iterator& it, std::vec
             && next3->type == ProcessedTokenType::CONST) {
                std::string name = next1->name;
 
-               lpassert (next3->value == 2.0);
+               lpassert(next3->value == 2.0, "next3->value == 2.0");
 
                std::shared_ptr<QuadTerm> quadterm = std::shared_ptr<QuadTerm>(new QuadTerm());
                quadterm->coef = it->value;
@@ -390,7 +390,7 @@ void Reader::parseexpression(std::vector<ProcessedToken>::iterator& it, std::vec
             && next2->type == ProcessedTokenType::CONST) {
                std::string name = it->name;
 
-               lpassert (next2->value == 2.0);
+               lpassert(next2->value == 2.0, "next2->value == 2.0");
 
                std::shared_ptr<QuadTerm> quadterm = std::shared_ptr<QuadTerm>(new QuadTerm());
                quadterm->coef = 1.0;
@@ -447,16 +447,16 @@ void Reader::parseexpression(std::vector<ProcessedToken>::iterator& it, std::vec
            ++next1; ++next2;
            if( next1 != end ) ++next2;
 
-           lpassert(next2 != end);
-           lpassert(it->type == ProcessedTokenType::BRKCL);
-           lpassert(next1->type == ProcessedTokenType::SLASH);
-           lpassert(next2->type == ProcessedTokenType::CONST);
-           lpassert(next2->value == 2.0);
+           lpassert(next2 != end, "next2 != end");
+           lpassert(it->type == ProcessedTokenType::BRKCL, "it->type == ProcessedTokenType::BRKCL");
+           lpassert(next1->type == ProcessedTokenType::SLASH, "next1->type == ProcessedTokenType::SLASH");
+           lpassert(next2->type == ProcessedTokenType::CONST, "next2->type == ProcessedTokenType::CONST");
+           lpassert(next2->value == 2.0, "next2->value == 2.0");
            it = ++next2;
          }
          else {
-           lpassert(it != end);
-           lpassert(it->type == ProcessedTokenType::BRKCL);
+           lpassert(it != end, "it != end");
+           lpassert(it->type == ProcessedTokenType::BRKCL, "it->type == ProcessedTokenType::BRKCL");
            ++it;
          }
          continue;
@@ -472,13 +472,13 @@ void Reader::processobjsec() {
    {
       builder.model.sense = ObjectiveSense::MIN;
       parseexpression(sectiontokens[LpSectionKeyword::OBJMIN].first, sectiontokens[LpSectionKeyword::OBJMIN].second, builder.model.objective, true);
-      lpassert(sectiontokens[LpSectionKeyword::OBJMIN].first == sectiontokens[LpSectionKeyword::OBJMIN].second); // all section tokens should have been processed
+      lpassert(sectiontokens[LpSectionKeyword::OBJMIN].first == sectiontokens[LpSectionKeyword::OBJMIN].second, "sectiontokens[LpSectionKeyword::OBJMIN].first == sectiontokens[LpSectionKeyword::OBJMIN].second"); // all section tokens should have been processed
    }
    else if( sectiontokens.count(LpSectionKeyword::OBJMAX) )
    {
       builder.model.sense = ObjectiveSense::MAX;
       parseexpression(sectiontokens[LpSectionKeyword::OBJMAX].first, sectiontokens[LpSectionKeyword::OBJMAX].second, builder.model.objective, true);
-      lpassert(sectiontokens[LpSectionKeyword::OBJMAX].first == sectiontokens[LpSectionKeyword::OBJMAX].second); // all section tokens should have been processed
+      lpassert(sectiontokens[LpSectionKeyword::OBJMAX].first == sectiontokens[LpSectionKeyword::OBJMAX].second, "sectiontokens[LpSectionKeyword::OBJMAX].first == sectiontokens[LpSectionKeyword::OBJMAX].second"); // all section tokens should have been processed
    }
 }
 
@@ -491,14 +491,14 @@ void Reader::processconsec() {
       std::shared_ptr<Constraint> con = std::shared_ptr<Constraint>(new Constraint);
       parseexpression(begin, end, con->expr, false);
       // should not be at end of section yet, but a comparison operator should be next
-      lpassert(begin != sectiontokens[LpSectionKeyword::CON].second);
-      lpassert(begin->type == ProcessedTokenType::COMP);
+      lpassert(begin != sectiontokens[LpSectionKeyword::CON].second, "begin != sectiontokens[LpSectionKeyword::CON].second");
+      lpassert(begin->type == ProcessedTokenType::COMP, "begin->type == ProcessedTokenType::COMP");
       LpComparisonType dir = begin->dir;
       ++begin;
 
       // should still not be at end of section yet, but a right-hand-side value should be next
-      lpassert(begin != sectiontokens[LpSectionKeyword::CON].second);
-      lpassert(begin->type == ProcessedTokenType::CONST);
+      lpassert(begin != sectiontokens[LpSectionKeyword::CON].second, "begin != sectiontokens[LpSectionKeyword::CON].second");
+      lpassert(begin->type == ProcessedTokenType::CONST, "begin->type == ProcessedTokenType::CONST");
       switch (dir) {
          case LpComparisonType::EQ:
             con->lowerbound = con->upperbound = begin->value;
@@ -510,7 +510,7 @@ void Reader::processconsec() {
             con->lowerbound = begin->value;
             break;
          default:
-            lpassert(false);
+	   lpassert(false, "LpComparisonType not recognised");
       }
       builder.model.constraints.push_back(con);
       ++begin;
@@ -552,8 +552,8 @@ void Reader::processboundssec() {
 		  && next2->type == ProcessedTokenType::VARID
 		  && next3->type == ProcessedTokenType::COMP
 		  && next4->type == ProcessedTokenType::CONST) {
-		  lpassert(next1->dir == LpComparisonType::LEQ);
-		  lpassert(next3->dir == LpComparisonType::LEQ);
+	    lpassert(next1->dir == LpComparisonType::LEQ, "next1->dir == LpComparisonType::LEQ");
+	    lpassert(next3->dir == LpComparisonType::LEQ, "next3->dir == LpComparisonType::LEQ");
 
 		  double lb = begin->value;
 		  double ub = next4->value;
@@ -578,7 +578,7 @@ void Reader::processboundssec() {
          std::shared_ptr<Variable> var = builder.getvarbyname(name);
          LpComparisonType dir = next1->dir;
 
-         lpassert(dir != LpComparisonType::L && dir != LpComparisonType::G);
+         lpassert(dir != LpComparisonType::L && dir != LpComparisonType::G, "dir != LpComparisonType::L && dir != LpComparisonType::G");
 
          switch (dir) {
             case LpComparisonType::LEQ:
@@ -591,7 +591,7 @@ void Reader::processboundssec() {
                var->lowerbound = var->upperbound = value;
                break;
             default:
-               lpassert(false);
+	      lpassert(false, "LpComparisonType not recognised");
          }
          begin = next3;
          continue;
@@ -607,7 +607,7 @@ void Reader::processboundssec() {
          std::shared_ptr<Variable> var = builder.getvarbyname(name);
          LpComparisonType dir = next1->dir;
 
-         lpassert(dir != LpComparisonType::L && dir != LpComparisonType::G);
+         lpassert(dir != LpComparisonType::L && dir != LpComparisonType::G, "dir != LpComparisonType::L && dir != LpComparisonType::G");
 
          switch (dir) {
             case LpComparisonType::LEQ:
@@ -620,13 +620,13 @@ void Reader::processboundssec() {
                var->lowerbound = var->upperbound = value;
                break;
             default:
-               lpassert(false);
+	      lpassert(false, "LpComparisonType not recognised");
          }
          begin = next3;
          continue;
       }
       
-	  lpassert(false);
+      lpassert(false, "In processboundssec");
    }
 }
 
@@ -636,7 +636,7 @@ void Reader::processbinsec() {
    std::vector<ProcessedToken>::iterator& begin(sectiontokens[LpSectionKeyword::BIN].first);
    std::vector<ProcessedToken>::iterator& end(sectiontokens[LpSectionKeyword::BIN].second);
    for (; begin != end; ++begin) {
-      lpassert(begin->type == ProcessedTokenType::VARID);
+     lpassert(begin->type == ProcessedTokenType::VARID, "begin->type == ProcessedTokenType::VARID");
       std::string name = begin->name;
       std::shared_ptr<Variable> var = builder.getvarbyname(name);
       var->type = VariableType::BINARY;
@@ -651,7 +651,7 @@ void Reader::processgensec() {
    std::vector<ProcessedToken>::iterator& begin(sectiontokens[LpSectionKeyword::GEN].first);
    std::vector<ProcessedToken>::iterator& end(sectiontokens[LpSectionKeyword::GEN].second);
    for (; begin != end; ++begin) {
-      lpassert(begin->type == ProcessedTokenType::VARID);
+     lpassert(begin->type == ProcessedTokenType::VARID, "begin->type == ProcessedTokenType::VARID");
       std::string name = begin->name;
       std::shared_ptr<Variable> var = builder.getvarbyname(name);
       if (var->type == VariableType::SEMICONTINUOUS) {
@@ -668,7 +668,7 @@ void Reader::processsemisec() {
    std::vector<ProcessedToken>::iterator& begin(sectiontokens[LpSectionKeyword::SEMI].first);
    std::vector<ProcessedToken>::iterator& end(sectiontokens[LpSectionKeyword::SEMI].second);
    for (; begin != end; ++begin) {
-      lpassert(begin->type == ProcessedTokenType::VARID);
+     lpassert(begin->type == ProcessedTokenType::VARID, "begin->type == ProcessedTokenType::VARID");
       std::string name = begin->name;
       std::shared_ptr<Variable> var = builder.getvarbyname(name);
       if (var->type == VariableType::GENERAL) {
@@ -690,13 +690,13 @@ void Reader::processsossec() {
       // sos1: S1 :: x1 : 1  x2 : 2  x3 : 3
 
       // name of SOS is mandatory
-      lpassert(begin->type == ProcessedTokenType::CONID);
+      lpassert(begin->type == ProcessedTokenType::CONID, "begin->type == ProcessedTokenType::CONID");
       sos->name = begin->name;
       ++begin;
 
       // SOS type
-      lpassert(begin != end);
-      lpassert(begin->type == ProcessedTokenType::SOSTYPE);
+      lpassert(begin != end, "begin != end");
+      lpassert(begin->type == ProcessedTokenType::SOSTYPE, "begin->type == ProcessedTokenType::SOSTYPE");
       sos->type = begin->sostype == SosType::SOS1 ? 1 : 2;
       ++begin;
 
@@ -727,7 +727,7 @@ void Reader::processsossec() {
 }
 
 void Reader::processendsec() {
-   lpassert(sectiontokens.count(LpSectionKeyword::END) == 0);
+  lpassert(sectiontokens.count(LpSectionKeyword::END) == 0, "sectiontokens.count(LpSectionKeyword::END) == 0");
 }
 
 void Reader::processsections() {
@@ -752,7 +752,7 @@ void Reader::splittokens() {
          currentsection = it->keyword;
 
          // make sure this section did not yet occur
-         lpassert(sectiontokens.count(currentsection) == 0);
+         lpassert(sectiontokens.count(currentsection) == 0, "sectiontokens.count(currentsection) == 0");
 
          std::vector<ProcessedToken>::iterator next = it;
          ++next;
@@ -827,9 +827,9 @@ void Reader::processtokens() {
 
       // sos type identifier? "S1 ::" or "S2 ::"
       if (rawtokens[0].istype(RawTokenType::STR) && rawtokens[1].istype(RawTokenType::COLON) && rawtokens[2].istype(RawTokenType::COLON)) {
-         lpassert(rawtokens[0].svalue.length() == 2);
-         lpassert(rawtokens[0].svalue[0] == 'S' || rawtokens[0].svalue[0] == 's');
-         lpassert(rawtokens[0].svalue[1] == '1' || rawtokens[0].svalue[1] == '2');
+	lpassert(rawtokens[0].svalue.length() == 2, "rawtokens[0].svalue.length() == 2");
+	lpassert(rawtokens[0].svalue[0] == 'S' || rawtokens[0].svalue[0] == 's', "rawtokens[0].svalue[0] == 'S' || rawtokens[0].svalue[0] == 's'");
+	lpassert(rawtokens[0].svalue[1] == '1' || rawtokens[0].svalue[1] == '2', "rawtokens[0].svalue[1] == '1' || rawtokens[0].svalue[1] == '2'");
          processedtokens.emplace_back(rawtokens[0].svalue[1] == '1' ? SosType::SOS1 : SosType::SOS2);
          nextrawtoken(3);
          continue;
@@ -890,7 +890,7 @@ void Reader::processtokens() {
 
          // - [, + - [, - + [
          if (rawtokens[0].istype(RawTokenType::BRKOP))
-            lpassert(false);
+	   lpassert(false, "- [, + - [, - + [");
 
          // +/- variable name
          if (rawtokens[0].istype(RawTokenType::STR)) {
@@ -899,12 +899,12 @@ void Reader::processtokens() {
          }
 
          // +/- (possibly twice) followed by something that isn't a constant, opening bracket, or string (variable name)
-         lpassert(false);
+         lpassert(false, "+/- (possibly twice)");
       }
 
       // constant [
       if (rawtokens[0].istype(RawTokenType::CONS) && rawtokens[1].istype(RawTokenType::BRKOP)) {
-         lpassert(false);
+	lpassert(false, "constant [");
       }
 
       // constant
@@ -988,7 +988,7 @@ void Reader::processtokens() {
       assert(!rawtokens[0].istype(RawTokenType::FLEND));
 
       // catch all unknown symbols
-      lpassert(false);
+      lpassert(false, "known symbol");
       break;
    }
 }
@@ -1168,6 +1168,6 @@ bool Reader::readnexttoken(RawToken& t) {
       return true;
    }
    
-   lpassert(false);
+   lpassert(false, "readnexttoken");
    return false;
 }

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -192,6 +192,7 @@ struct ProcessedToken {
 // set to how many tokens we may need to look ahead
 #define NRAWTOKEN 3
 
+const double kHighsInf = std::numeric_limits<double>::infinity();
 class Reader {
 private:
 #ifdef ZLIB_FOUND
@@ -531,8 +532,8 @@ void Reader::processboundssec() {
          && next1->type == ProcessedTokenType::FREE) {
          std::string name = begin->name;
          std::shared_ptr<Variable> var = builder.getvarbyname(name);
-         var->lowerbound = -std::numeric_limits<double>::infinity(); 
-         var->upperbound = std::numeric_limits<double>::infinity();
+         var->lowerbound = -kHighsInf; 
+         var->upperbound = kHighsInf;
          begin = ++next1;
 		 continue;
       }
@@ -639,8 +640,8 @@ void Reader::processbinsec() {
       std::string name = begin->name;
       std::shared_ptr<Variable> var = builder.getvarbyname(name);
       var->type = VariableType::BINARY;
-      var->lowerbound = 0.0;
-      var->upperbound = 1.0;
+      // Respect any bounds already declared
+      if (var->upperbound == kHighsInf) var->upperbound = 1.0;
    }
 }
 
@@ -850,7 +851,7 @@ void Reader::processtokens() {
 
       // check if infinity
       if (rawtokens[0].istype(RawTokenType::STR) && iskeyword(svalue_lc, LP_KEYWORD_INF, LP_KEYWORD_INF_N)) {
-         processedtokens.emplace_back(std::numeric_limits<double>::infinity());
+         processedtokens.emplace_back(kHighsInf);
          nextrawtoken();
          continue;
       }

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -410,9 +410,9 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
     } else if (lp.col_lower_[iCol] != 0 || lp.col_upper_[iCol] < kHighsInf) {
       // Non-default bound
       if (lp.col_lower_[iCol] != 0) {
-	// Nonzero lower bound
-	this->writeToFileValue(file, lp.col_lower_[iCol], false);
-	this->writeToFile(file, " <=");
+        // Nonzero lower bound
+        this->writeToFileValue(file, lp.col_lower_[iCol], false);
+        this->writeToFile(file, " <=");
       }
       if (has_col_names) {
         this->writeToFileVar(file, lp.col_names_[iCol]);
@@ -420,9 +420,9 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
         this->writeToFileVar(file, iCol);
       }
       if (lp.col_upper_[iCol] < kHighsInf) {
-	// Finite upper bound
-	this->writeToFile(file, " <=");
-	this->writeToFileValue(file, lp.col_upper_[iCol], false);
+        // Finite upper bound
+        this->writeToFile(file, " <=");
+        this->writeToFileValue(file, lp.col_upper_[iCol], false);
       }
     }
     this->writeToFileLineend(file);

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -391,26 +391,42 @@ HighsStatus FilereaderLp::writeModelToFile(const HighsOptions& options,
   this->writeToFileLineend(file);
   for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
     if (lp.col_lower_[iCol] <= -kHighsInf && lp.col_upper_[iCol] >= kHighsInf) {
+      // Free variable
       if (has_col_names) {
         this->writeToFileVar(file, lp.col_names_[iCol]);
       } else {
         this->writeToFileVar(file, iCol);
       }
       this->writeToFile(file, " free");
-    } else {
-      this->writeToFileValue(file, lp.col_lower_[iCol], false);
-      this->writeToFile(file, " <=");
+    } else if (lp.col_lower_[iCol] == lp.col_upper_[iCol]) {
+      // Fixed variable
       if (has_col_names) {
         this->writeToFileVar(file, lp.col_names_[iCol]);
       } else {
         this->writeToFileVar(file, iCol);
       }
-      this->writeToFile(file, " <=");
+      this->writeToFile(file, " =");
       this->writeToFileValue(file, lp.col_upper_[iCol], false);
+    } else if (lp.col_lower_[iCol] != 0 || lp.col_upper_[iCol] < kHighsInf) {
+      // Non-default bound
+      if (lp.col_lower_[iCol] != 0) {
+	// Nonzero lower bound
+	this->writeToFileValue(file, lp.col_lower_[iCol], false);
+	this->writeToFile(file, " <=");
+      }
+      if (has_col_names) {
+        this->writeToFileVar(file, lp.col_names_[iCol]);
+      } else {
+        this->writeToFileVar(file, iCol);
+      }
+      if (lp.col_upper_[iCol] < kHighsInf) {
+	// Finite upper bound
+	this->writeToFile(file, " <=");
+	this->writeToFileValue(file, lp.col_upper_[iCol], false);
+      }
     }
     this->writeToFileLineend(file);
   }
-
   if (lp.integrality_.size() > 0) {
     // write binary section
     this->writeToFile(file, "bin");


### PR DESCRIPTION
.lp file reader now respects non-default bounds in binary section
.lp file writer only specifies non-default bounds, and writes fixed variables explicitly
Tested in TestFileTeader.cpp
This will close  #987 
