### PR TITLE
fix warnings for shadowing

### DIFF
--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -58,7 +58,7 @@ class HighsPostsolveStack {
     HighsInt index;
     double value;
 
-    Nonzero(HighsInt index, double value) : index(index), value(value) {}
+    Nonzero(HighsInt index_, double value_) : index(index_), value(value_) {}
     Nonzero() = default;
   };
 

--- a/src/util/HighsCDouble.h
+++ b/src/util/HighsCDouble.h
@@ -61,7 +61,7 @@ class HighsCDouble {
     y = a2 * b2 - (((x - a1 * b1) - a2 * b1) - a1 * b2);
   }
 
-  HighsCDouble(double hi, double lo) : hi(hi), lo(lo) {}
+  HighsCDouble(double hi_, double lo_) : hi(hi_), lo(lo_) {}
 
  public:
   HighsCDouble() = default;

--- a/src/util/HighsDataStack.h
+++ b/src/util/HighsDataStack.h
@@ -80,7 +80,7 @@ class HighsDataStack {
     }
   }
 
-  void setPosition(HighsInt position) { this->position = position; }
+  void setPosition(HighsInt position_) { this->position = position_; }
 
   HighsInt getCurrentDataSize() const { return data.size(); }
 };

--- a/src/util/HighsHash.h
+++ b/src/util/HighsHash.h
@@ -926,8 +926,8 @@ class HighsHashTable {
     using pointer = IterType*;
     using reference = IterType&;
     using iterator_category = std::forward_iterator_tag;
-    HashTableIterator(u8* pos, u8* end, Entry* entryEnd)
-        : pos(pos), end(end), entryEnd(entryEnd) {}
+    HashTableIterator(u8* pos_, u8* end_, Entry* entryEnd_)
+        : pos(pos_), end(end_), entryEnd(entryEnd_) {}
     HashTableIterator() = default;
 
     HashTableIterator<IterType> operator++(int) {

--- a/src/util/HighsMatrixSlice.h
+++ b/src/util/HighsMatrixSlice.h
@@ -107,8 +107,8 @@ class HighsMatrixSlice<HighsCompressedSlice> {
     }
   };
 
-  HighsMatrixSlice(const HighsInt* index, const double* value, HighsInt len)
-      : index(index), value(value), len(len) {}
+  HighsMatrixSlice(const HighsInt* index_, const double* value_, HighsInt len_)
+      : index(index_), value(value_), len(len_) {}
   iterator begin() const { return iterator{index, value}; }
   iterator end() const { return iterator{index + len, nullptr}; }
 };
@@ -131,8 +131,8 @@ class HighsMatrixSlice<HighsIndexedSlice> {
     using pointer = const HighsSliceNonzero*;
     using reference = const HighsSliceNonzero&;
 
-    iterator(const HighsInt* index, const double* denseValues)
-        : pos_(index, denseValues), denseValues(denseValues) {}
+    iterator(const HighsInt* index_, const double* denseValues_)
+        : pos_(index_, denseValues_), denseValues(denseValues_) {}
     iterator() = default;
 
     iterator operator++(int) {


### PR DESCRIPTION
Some warnings are appearing because constructors accept arguments with the same names as the members. See below for examples when building with cmake a tad stricter.

A potential fix I propose here, which is the least amount of change, is changing the constructor argument and not the members


```
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h: In constructor ‘HighsMatrixSlice<HighsIndexedSlice>::iterator::iterator(const HighsInt*, const double*)’:
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:135:63: warning: declaration of ‘denseValues’ shadows a member of ‘HighsMatrixSlice<HighsIndexedSlice>::iterator’ [-Wshadow]
  135 |         : pos_(index, denseValues), denseValues(denseValues) {}
      |                                                               ^
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:125:19: note: shadowed declaration is here
  125 |     const double* denseValues;
      |                   ^~~~~~~~~~~
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h: In constructor ‘HighsMatrixSlice<HighsIndexedSlice>::iterator::iterator(const HighsInt*, const double*)’:
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:135:63: warning: declaration of ‘denseValues’ shadows a member of ‘HighsMatrixSlice<HighsIndexedSlice>::iterator’ [-Wshadow]
  135 |         : pos_(index, denseValues), denseValues(denseValues) {}
      |                                                               ^
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:125:19: note: shadowed declaration is here
  125 |     const double* denseValues;
      |                   ^~~~~~~~~~~
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h: In constructor ‘HighsMatrixSlice<HighsIndexedSlice>::HighsMatrixSlice(const HighsInt*, const double*, HighsInt)’:
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:176:7: warning: declaration of ‘len’ shadows a member of ‘HighsMatrixSlice<HighsIndexedSlice>’ [-Wshadow]
  176 |       : index(index), denseValues(denseValues), len(len) {}
      |       ^
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:120:12: note: shadowed declaration is here
  120 |   HighsInt len;
      |            ^~~
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:176:7: warning: declaration of ‘denseValues’ shadows a member of ‘HighsMatrixSlice<HighsIndexedSlice>’ [-Wshadow]
  176 |       : index(index), denseValues(denseValues), len(len) {}
      |       ^
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:119:17: note: shadowed declaration is here
  119 |   const double* denseValues;
      |                 ^~~~~~~~~~~
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:176:7: warning: declaration of ‘index’ shadows a member of ‘HighsMatrixSlice<HighsIndexedSlice>’ [-Wshadow]
  176 |       : index(index), denseValues(denseValues), len(len) {}
      |       ^
/home/mbesancon/Documents/crptests/highs/src/util/HighsMatrixSlice.h:118:19: note: shadowed declaration is here
  118 |   const HighsInt* index;
```