### PR TITLE
Fix bell5 unformatted

### DIFF
--- a/examples/call_highs_from_fortran.f90
+++ b/examples/call_highs_from_fortran.f90
@@ -104,7 +104,7 @@ program fortrantest
   integer alt_sense
   integer scale_strategy
 
-  integer, parameter :: default_scale_strategy = 2
+  integer, parameter :: default_scale_strategy = 1
   integer, parameter :: new_scale_strategy = 3
   double precision, parameter ::  dual_tolerance = 1d-6
   logical ( c_bool ) write_solution_to_file
@@ -531,7 +531,7 @@ program fortrantest
         if (col < qp_numcol) then
            to_el = qp_qstart(col+1)-1
         else
-           to_el = qp_hessian_numnz
+           to_el = qp_hessian_numnz-1
         endif
         objective_function_value = &
              objective_function_value + 0.5 * qp_colvalue(col) * qp_qvalue(from_el+1) * qp_colvalue(col)

--- a/examples/call_highs_from_python1.py
+++ b/examples/call_highs_from_python1.py
@@ -1,3 +1,10 @@
+# NB Must have installed highspy, either by using pip install highspy,
+# or by following the instructions on
+# https://github.com/ERGO-Code/HiGHS#python
+#
+# The paths to MPS file instances assumes that this is run in the
+# directory of this file (ie highs/examples) or any other dubdirectory
+# of HiGHS
 import highspy
 import numpy as np
 inf = highspy.kHighsInf
@@ -34,7 +41,7 @@ for icol in range(num_var):
     print(icol, solution.col_value[icol], h.basisStatusToString(basis.col_status[icol]))
 
 # Read in and solve avgas
-h.readModel("check/instances/avgas.mps")
+h.readModel("../check/instances/avgas.mps")
 #h.writeModel("ml.mps")
 h.run()
 lp = h.getLp()
@@ -142,7 +149,7 @@ h.writeSolution("", 1)
 h.clear()
 print('25fv47 as HighsModel')
 
-h.readModel("../../../check/instances/25fv47.mps")
+h.readModel("../check/instances/25fv47.mps")
 h.presolve()
 presolved_lp = h.getPresolvedLp()
 # Create a HiGHS instance to solve the presolved LP

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -56,13 +56,11 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
                   "Exception %s in solveLpIpx\n", exception.what());
       call_status = HighsStatus::kError;
     }
-    // Non-error return requires a primal solution
-    assert(solver_object.solution_.value_valid);
-    // Set the return_status, model status and, for completeness, scaled
-    // model status
     return_status = interpretCallStatus(options.log_options, call_status,
                                         return_status, "solveLpIpx");
     if (return_status == HighsStatus::kError) return return_status;
+    // Non-error return requires a primal solution
+    assert(solver_object.solution_.value_valid);
     // Get the objective and any KKT failures
     solver_object.highs_info_.objective_function_value =
         solver_object.lp_.objectiveValue(solver_object.solution_.col_value);


### PR DESCRIPTION
Moved `assert(solver_object.solution_.value_valid);` to right place so it's not triggered when IPX yields a solver error with `bell5`