### PR TITLE
Fix L2CTA3D

### DIFF
--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1254,6 +1254,8 @@ void accommodateAlienBasis(HighsLpSolverObject& solver_object) {
                       kDefaultPivotThreshold, kDefaultPivotTolerance,
                       kHighsDebugLevelMin, &options.log_options);
   HighsInt rank_deficiency = factor.build();
+  // Must not have timed out
+  assert(rank_deficiency >= 0);
   // Deduce the basis from basic_index
   //
   // Set all basic variables to nonbasic

--- a/src/simplex/HSimplexNla.cpp
+++ b/src/simplex/HSimplexNla.cpp
@@ -93,6 +93,8 @@ HighsInt HSimplexNla::invert() {
         analysis_->getThreadFactorTimerClockPtr(thread_id);
   }
   HighsInt rank_deficiency = factor_.build(factor_timer_clock_pointer);
+  // Must not have timed out
+  assert(rank_deficiency >= 0);
   build_synthetic_tick_ = factor_.build_synthetic_tick;
   // Clear any frozen basis updates
   frozenBasisClearAllUpdate();

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -880,6 +880,7 @@ HighsInt HFactor::buildKernel() {
   const bool progress_report = false;  // num_basic != num_row;
   const HighsInt progress_frequency = 10000;
   const HighsInt timer_frequency = 100;
+  const bool check_for_timeout = this->time_limit_ < kHighsInf;
   HighsInt search_k = 0;
 
   const HighsInt check_nwork = -11;
@@ -888,16 +889,10 @@ HighsInt HFactor::buildKernel() {
     if (nwork == check_nwork) {
       reportAsm();
     }
-
-    if (search_k % timer_frequency == 0) {
-      // Detemine whether to return due to excee`<ding the time limit
-      double local_build_time = build_timer_->readRunHighsClock();
-      if (local_build_time > this->time_limit_) {
-        printf("HFactor::local_build_time(buildKernel - search_k = %9d) = %g\n",
-               int(search_k), local_build_time);
+    // Detemine whether to return due to exceeding the time limit
+    if (check_for_timeout && search_k % timer_frequency == 0)
+      if (build_timer_->readRunHighsClock() > this->time_limit_)
         return kBuildKernelReturnTimeout;
-      }
-    }
 
     /**
      * 1. Search for the pivot

--- a/src/util/HFactor.h
+++ b/src/util/HFactor.h
@@ -32,6 +32,8 @@ using std::max;
 // using std::min;
 using std::vector;
 
+const HighsInt kBuildKernelReturnTimeout = -1;
+
 struct InvertibleRepresentation {
   // Factor L
   std::vector<HighsInt> l_pivot_index;
@@ -212,11 +214,11 @@ class HFactor {
    */
   bool setPivotThreshold(
       const double new_pivot_threshold = kDefaultPivotThreshold);
+
   /**
-   * @brief Sets minimum absolute pivot
+   * @brief Sets a time limit
    */
-  bool setMinAbsPivot(
-      const double new_pivot_tolerance = kDefaultPivotTolerance);
+  void setTimeLimit(const double time_limit);
 
   /**
    * @brief Updates instance with respect to new columns in the
@@ -328,6 +330,7 @@ class HFactor {
   double pivot_threshold;
   double pivot_tolerance;
   HighsInt highs_debug_level;
+  double time_limit_;
 
   struct LogData {
     bool output_flag;
@@ -341,6 +344,9 @@ class HFactor {
   bool debug_report_ = false;
   HighsInt basis_matrix_limit_size;
   HighsInt update_method;
+
+  // Internal timing
+  HighsTimer* build_timer_;
 
   // Working buffer
   HighsInt nwork;


### PR DESCRIPTION
Testing on the 51 Mittlemann benchmark LPs, one (karted) takes an excessive time in presolve, and another (L2CTA3D) fails to return from presolve altogether. This is due to the dependent equations check taking too long. 

A timeout has been introduced. Currently it's min(1000, time_limit/100), making it (technically) non-deterministic. In due course it should be replaced by a limit on the existing pseudo-clock that's related to the size of the equation set.