### PR TITLE
dataSize now std::size_t in HighsDataStack::push

### DIFF
--- a/src/util/HighsDataStack.h
+++ b/src/util/HighsDataStack.h
@@ -39,7 +39,7 @@ class HighsDataStack {
   template <typename T,
             typename std::enable_if<IS_TRIVIALLY_COPYABLE(T), int>::type = 0>
   void push(const T& r) {
-    HighsInt dataSize = data.size();
+    std::size_t dataSize = data.size();
     data.resize(dataSize + sizeof(T));
     std::memcpy(data.data() + dataSize, &r, sizeof(T));
   }


### PR DESCRIPTION
Declaring `HighsInt dataSize = data.size();` in `HighsDataStack::push` led to overflow with `dlr2` (when 30M columns were removed by presolve) and then vector length error when `dataSize` used in `data.resize(dataSize + sizeof(T));`

Need to declare `size_t dataSize = data.size();` 