### PR TITLE
Read solution file

### DIFF
--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -36,7 +36,8 @@ int main(int argc, char** argv) {
   loaded_options.log_file = "HiGHS.log";
   // When loading the options file, any messages are reported using
   // the default HighsLogOptions
-  if (!loadOptions(log_options, argc, argv, loaded_options, model_file, read_solution_file))
+  if (!loadOptions(log_options, argc, argv, loaded_options, model_file,
+                   read_solution_file))
     return (int)HighsStatus::kError;
   // Open the app log file - unless output_flag is false, to avoid
   // creating an empty file. It does nothing if its name is "".
@@ -56,7 +57,8 @@ int main(int argc, char** argv) {
   // Possible read a solution file
   if (read_solution_file != "") {
     HighsStatus read_solution_status = highs.readSolution(read_solution_file);
-    if (read_solution_status == HighsStatus::kError) return (int)read_solution_status;
+    if (read_solution_status == HighsStatus::kError)
+      return (int)read_solution_status;
   }
   // Solve the model
   HighsStatus run_status = highs.run();

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -29,13 +29,14 @@ int main(int argc, char** argv) {
 
   // Load user options
   std::string model_file;
+  std::string read_solution_file;
   HighsOptions loaded_options;
   // Set "HiGHS.log" as the default log_file for the app so that
   // log_file has this value if it isn't set in the file
   loaded_options.log_file = "HiGHS.log";
   // When loading the options file, any messages are reported using
   // the default HighsLogOptions
-  if (!loadOptions(log_options, argc, argv, loaded_options, model_file))
+  if (!loadOptions(log_options, argc, argv, loaded_options, model_file, read_solution_file))
     return (int)HighsStatus::kError;
   // Open the app log file - unless output_flag is false, to avoid
   // creating an empty file. It does nothing if its name is "".
@@ -52,6 +53,11 @@ int main(int argc, char** argv) {
   reportModelStatsOrError(log_options, read_status, highs.getModel());
   if (read_status == HighsStatus::kError) return (int)read_status;
 
+  // Possible read a solution file
+  if (read_solution_file != "") {
+    HighsStatus read_solution_status = highs.readSolution(read_solution_file);
+    if (read_solution_status == HighsStatus::kError) return (int)read_solution_status;
+  }
   // Solve the model
   HighsStatus run_status = highs.run();
   if (run_status == HighsStatus::kError) return (int)run_status;

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -57,8 +57,11 @@ int main(int argc, char** argv) {
   // Possible read a solution file
   if (read_solution_file != "") {
     HighsStatus read_solution_status = highs.readSolution(read_solution_file);
-    if (read_solution_status == HighsStatus::kError)
+    if (read_solution_status == HighsStatus::kError) {
+      highsLogUser(log_options, HighsLogType::kInfo,
+                   "Error loading solution file\n");
       return (int)read_solution_status;
+    }
   }
   // Solve the model
   HighsStatus run_status = highs.run();

--- a/check/TestCheckSolution.cpp
+++ b/check/TestCheckSolution.cpp
@@ -74,8 +74,8 @@ TEST_CASE("check-set-mip-solution", "[highs_check_solution]") {
   if (dev_run) printf("Num nodes = %d\n", int(scratch_num_nodes));
 
   std::string solution_file = model + ".sol";
-  //  if (dev_run) return_status = highs.writeSolution("", kSolutionStyleRaw);
-  return_status = highs.writeSolution(solution_file, kSolutionStyleRaw);
+  //  if (dev_run) return_status = highs.writeSolution("");
+  return_status = highs.writeSolution(solution_file);
   REQUIRE(return_status == HighsStatus::kOk);
 
   highs.clear();
@@ -106,7 +106,7 @@ TEST_CASE("check-set-mip-solution", "[highs_check_solution]") {
     highs.setOptionValue("output_flag", dev_run);
     highs.readModel(model_file);
 
-    return_status = highs.readSolution(solution_file, kSolutionStyleRaw);
+    return_status = highs.readSolution(solution_file);
     REQUIRE(return_status == HighsStatus::kOk);
 
     return_status = highs.checkSolutionFeasibility();
@@ -118,7 +118,7 @@ TEST_CASE("check-set-mip-solution", "[highs_check_solution]") {
     highs.clear();
   }
 
-  const bool test2 = true;
+  const bool test2 = false;
   if (test2) {
     if (dev_run)
       printf(
@@ -137,6 +137,28 @@ TEST_CASE("check-set-mip-solution", "[highs_check_solution]") {
     REQUIRE(solution_dl);
 
     return_status = highs.setSolution(solution);
+    REQUIRE(return_status == HighsStatus::kOk);
+
+    return_status = highs.checkSolutionFeasibility();
+    REQUIRE(return_status == HighsStatus::kWarning);
+
+    highs.run();
+    if (dev_run) printf("Num nodes = %d\n", int(info.mip_node_count));
+    REQUIRE(info.mip_node_count < scratch_num_nodes);
+    highs.clear();
+  }
+
+  const bool test3 = true;
+  if (test3) {
+    if (dev_run)
+      printf("\n***************************\nSolving from column solution file\n");
+    std::string column_solution_file =
+      std::string(HIGHS_DIR) + "/check/instances/flugpl_integer.sol";
+
+    highs.setOptionValue("output_flag", dev_run);
+    highs.readModel(model_file);
+
+    return_status = highs.readSolution(column_solution_file);
     REQUIRE(return_status == HighsStatus::kOk);
 
     return_status = highs.checkSolutionFeasibility();
@@ -207,11 +229,11 @@ void runWriteReadCheckSolution(Highs& highs, const std::string model,
   REQUIRE(status == require_model_status);
 
   solution_file = model + ".sol";
-  if (dev_run) return_status = highs.writeSolution("", kSolutionStyleRaw);
-  return_status = highs.writeSolution(solution_file, kSolutionStyleRaw);
+  if (dev_run) return_status = highs.writeSolution("");
+  return_status = highs.writeSolution(solution_file);
   REQUIRE(return_status == HighsStatus::kOk);
 
-  return_status = highs.readSolution(solution_file, kSolutionStyleRaw);
+  return_status = highs.readSolution(solution_file);
   REQUIRE(return_status == HighsStatus::kOk);
 
   const bool value_valid = highs.getSolution().value_valid;

--- a/check/instances/flugpl_illegal_integer.sol
+++ b/check/instances/flugpl_illegal_integer.sol
@@ -1,0 +1,24 @@
+Model status
+Optimal
+
+# Primal solution values
+Feasible
+Objective 1201500
+# Columns 18
+STM1 0
+ANM1 6
+UE1 0
+STM2 60
+ANM2 6
+UE2 0
+STM3 60
+ANM3 16
+UE3 0
+STM4 70
+ANM4 7
+UE4 0
+STM5 70
+ANM5 12
+UE5 0
+STM6 75
+ANM6 0

--- a/check/instances/flugpl_integer.sol
+++ b/check/instances/flugpl_integer.sol
@@ -1,0 +1,25 @@
+Model status
+Optimal
+
+# Primal solution values
+Feasible
+Objective 1201500
+# Columns 18
+STM1 0
+ANM1 6
+UE1 0
+STM2 60
+ANM2 6
+UE2 0
+STM3 60
+ANM3 16
+UE3 0
+STM4 70
+ANM4 7
+UE4 0
+STM5 70
+ANM5 12
+UE5 0
+STM6 75
+ANM6 0
+UE6 0

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -151,7 +151,7 @@ class Highs {
    * @brief Check the feasibility of the current solution. Of value
    * after calling Highs::readSolution
    */
-  HighsStatus checkSolutionFeasibility();
+  HighsStatus checkSolutionFeasibility() const;
 
   /**
    * Methods for HiGHS option input/output

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -140,12 +140,14 @@ class Highs {
   /**
    * @brief Write the current solution to a file in a given style
    */
-  HighsStatus writeSolution(const std::string& filename, const HighsInt style = kSolutionStyleRaw);
+  HighsStatus writeSolution(const std::string& filename,
+                            const HighsInt style = kSolutionStyleRaw);
 
   /**
    * @brief Read a HiGHS solution file in a given style
    */
-  HighsStatus readSolution(const std::string& filename, const HighsInt style = kSolutionStyleRaw);
+  HighsStatus readSolution(const std::string& filename,
+                           const HighsInt style = kSolutionStyleRaw);
 
   /**
    * @brief Check the feasibility of the current solution. Of value

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1118,6 +1118,8 @@ class Highs {
     this->model_.hessian_.exactResize();
   }
 
+  HighsStatus assessContinuousMipSolution();
+
   HighsStatus callSolveLp(HighsLp& lp, const string message);
   HighsStatus callSolveQp();
   HighsStatus callSolveMip();

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -140,12 +140,12 @@ class Highs {
   /**
    * @brief Write the current solution to a file in a given style
    */
-  HighsStatus writeSolution(const std::string& filename, const HighsInt style);
+  HighsStatus writeSolution(const std::string& filename, const HighsInt style = kSolutionStyleRaw);
 
   /**
    * @brief Read a HiGHS solution file in a given style
    */
-  HighsStatus readSolution(const std::string& filename, const HighsInt style);
+  HighsStatus readSolution(const std::string& filename, const HighsInt style = kSolutionStyleRaw);
 
   /**
    * @brief Check the feasibility of the current solution. Of value

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2483,9 +2483,8 @@ HighsStatus Highs::readSolution(const std::string& filename,
                           style);
 }
 
-HighsStatus Highs::checkSolutionFeasibility() {
-  checkLpSolutionFeasibility(options_, model_.lp_, solution_);
-  return HighsStatus::kOk;
+HighsStatus Highs::checkSolutionFeasibility() const {
+  return checkLpSolutionFeasibility(options_, model_.lp_, solution_);
 }
 
 std::string Highs::modelStatusToString(

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2726,6 +2726,9 @@ HighsStatus Highs::assessContinuousMipSolution() {
   basis_.clear();
   // Solve the model
   assert(!model_.isMip());
+  highsLogUser(options_.log_options, HighsLogType::kInfo,
+               "Attempting to find feasible solution of continuous variables "
+               "for user-supplied values of discrete variables\n");
   return_status = this->run();
   // Recover the column bounds and integrality
   lp.col_lower_ = save_col_lower;

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -204,12 +204,17 @@ HighsStatus readSolutionFile(const std::string filename,
 
 HighsStatus readSolutionFileErrorReturn(std::ifstream& in_file);
 HighsStatus readSolutionFileReturn(const HighsStatus status,
-				   HighsSolution& solution,
-				   HighsBasis& basis,
-				   const HighsSolution& read_solution,
-				   const HighsBasis& read_basis,
-				   std::ifstream& in_file);
-				   
+                                   HighsSolution& solution, HighsBasis& basis,
+                                   const HighsSolution& read_solution,
+                                   const HighsBasis& read_basis,
+                                   std::ifstream& in_file);
+bool readSolutionFileIgnoreLineOk(std::ifstream& in_file);
+bool readSolutionFileKeywordLineOk(std::string& keyword,
+                                   std::ifstream& in_file);
+bool readSolutionFileHashKeywordIntLineOk(std::string& keyword, HighsInt& value,
+                                          std::ifstream& in_file);
+bool readSolutionFileIdDoubleLineOk(double& value, std::ifstream& in_file);
+
 HighsStatus checkLpSolutionFeasibility(const HighsOptions& options,
                                        const HighsLp& lp,
                                        const HighsSolution& solution);

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -202,6 +202,14 @@ HighsStatus readSolutionFile(const std::string filename,
                              HighsBasis& basis, HighsSolution& solution,
                              const HighsInt style);
 
+HighsStatus readSolutionFileErrorReturn(std::ifstream& in_file);
+HighsStatus readSolutionFileReturn(const HighsStatus status,
+				   HighsSolution& solution,
+				   HighsBasis& basis,
+				   const HighsSolution& read_solution,
+				   const HighsBasis& read_basis,
+				   std::ifstream& in_file);
+				   
 HighsStatus checkLpSolutionFeasibility(const HighsOptions& options,
                                        const HighsLp& lp,
                                        const HighsSolution& solution);

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -202,9 +202,13 @@ HighsStatus readSolutionFile(const std::string filename,
                              HighsBasis& basis, HighsSolution& solution,
                              const HighsInt style);
 
-void checkLpSolutionFeasibility(const HighsOptions& options, const HighsLp& lp,
-                                const HighsSolution& solution);
+HighsStatus checkLpSolutionFeasibility(const HighsOptions& options,
+                                       const HighsLp& lp,
+                                       const HighsSolution& solution);
 
+HighsStatus calculateRowValues(const HighsLp& lp,
+                               const std::vector<double>& col_value,
+                               std::vector<double>& row_value);
 HighsStatus calculateRowValues(const HighsLp& lp, HighsSolution& solution);
 HighsStatus calculateRowValuesQuad(const HighsLp& lp, HighsSolution& solution);
 HighsStatus calculateColDuals(const HighsLp& lp, HighsSolution& solution);

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -261,6 +261,7 @@ const string kRandomSeedString = "random_seed";
 const string kSolutionFileString = "solution_file";
 const string kRangingString = "ranging";
 const string kWriteModelFileString = "write_model_file";
+const string kReadSolutionFileString = "read_solution_file";
 
 // String for HiGHS log file option
 const string kLogFileString = "log_file";

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -20,7 +20,9 @@
 #include "util/stringutil.h"
 
 bool loadOptions(const HighsLogOptions& report_log_options, int argc,
-                 char** argv, HighsOptions& options, std::string& model_file) {
+                 char** argv, HighsOptions& options,
+		 std::string& model_file,
+		 std::string& read_solution_file) {
   try {
     cxxopts::Options cxx_options(argv[0], "HiGHS options");
     cxx_options.positional_help("[file]").show_positional_help();
@@ -31,6 +33,9 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
         //
         // model file
         (kModelFileString, "File of model to solve.",
+         cxxopts::value<std::vector<std::string>>())
+        // read_solution file
+        (kReadSolutionFileString, "File of solution to read.",
          cxxopts::value<std::vector<std::string>>())
         // options file
         (kOptionsFileString, "File containing HiGHS options.",
@@ -101,6 +106,26 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
         }
       } else {
         model_file = v[0];
+      }
+    }
+    read_solution_file = "";
+    if (result.count(kReadSolutionFileString)) {
+      auto& v = result[kReadSolutionFileString].as<std::vector<std::string>>();
+      if (v.size() > 1) {
+        HighsInt nonEmpty = 0;
+        for (HighsInt i = 0; i < (HighsInt)v.size(); i++) {
+          std::string arg = v[i];
+          if (trim(arg).size() > 0) {
+            nonEmpty++;
+            read_solution_file = arg;
+          }
+        }
+        if (nonEmpty > 1) {
+          std::cout << "Multiple files not implemented.\n";
+          return false;
+        }
+      } else {
+        read_solution_file = v[0];
       }
     }
     // options file

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -20,9 +20,8 @@
 #include "util/stringutil.h"
 
 bool loadOptions(const HighsLogOptions& report_log_options, int argc,
-                 char** argv, HighsOptions& options,
-		 std::string& model_file,
-		 std::string& read_solution_file) {
+                 char** argv, HighsOptions& options, std::string& model_file,
+                 std::string& read_solution_file) {
   try {
     cxxopts::Options cxx_options(argv[0], "HiGHS options");
     cxx_options.positional_help("[file]").show_positional_help();


### PR DESCRIPTION
Following email from user and discussion #979 

Added the command line option --read_solution_file so that such users can specify an initial solution, with greatly enhanced checking of solution file format: must be in HiGHS raw solution format, thinking that users might have written a solution and then want to re-use it, as well as it being logical that both are the same.

For a MIP, if the solution is not feasible - as can happen if users specify values for the discrete values obtained heuristically - then an LP is solved with the discrete variables fixed at their values. If feasible, this is exploited by the MIP solver. Previously it only exploited user-supplied solutions if they were feasible