### PR TITLE
Use vsnsprintf instead of vsprintf

### DIFF
--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -17,6 +17,7 @@
 #include "io/FilereaderLp.h"
 
 #include <cstdarg>
+#include <cstdio>
 #include <exception>
 #include <map>
 
@@ -211,7 +212,7 @@ void FilereaderLp::writeToFile(FILE* file, const char* format, ...) {
   va_list argptr;
   va_start(argptr, format);
   char stringbuffer[LP_MAX_LINE_LENGTH + 1];
-  HighsInt tokenlength = vsprintf(stringbuffer, format, argptr);
+  HighsInt tokenlength = vsnprintf(stringbuffer, sizeof stringbuffer, format, argptr);
   if (this->linelength + tokenlength >= LP_MAX_LINE_LENGTH) {
     fprintf(file, "\n");
     fprintf(file, "%s", stringbuffer);


### PR DESCRIPTION
This fixes a security warning generated by Apple Clang 14.

The following warning is generated when compiling HiGHS with Apple Clang 14 on MacOS 13.

```
warning: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Wdeprecated-declarations]
  HighsInt tokenlength = vsprintf(stringbuffer, format, argptr);
                         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:207:1: note: 'vsprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead.")
^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 warning generated.
```