### PR TITLE
Fix 1028

### DIFF
--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -338,7 +338,4 @@ TEST_CASE("highs-options", "[highs_options]") {
 
   return_status = highs.setOptionValue("time_limit", 1);
   REQUIRE(return_status == HighsStatus::kOk);
-  
-  
-
 }

--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -335,4 +335,10 @@ TEST_CASE("highs-options", "[highs_options]") {
   REQUIRE(options.allowed_matrix_scale_factor == allowed_matrix_scale_factor);
   REQUIRE(options.mps_parser_type_free == mps_parser_type_free);
   std::remove(options_file.c_str());
+
+  return_status = highs.setOptionValue("time_limit", 1);
+  REQUIRE(return_status == HighsStatus::kOk);
+  
+  
+
 }

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -382,6 +382,11 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
   if (status != OptionStatus::kOk) return status;
   HighsOptionType type = option_records[index]->type;
   if (type != HighsOptionType::kInt) {
+    if (type == HighsOptionType::kDouble) {
+      // Interpret integer as double
+      double use_value = value;
+      return setLocalOptionValue(report_log_options, ((OptionRecordDouble*)option_records[index])[0], use_value);      
+    }
     highsLogUser(
         report_log_options, HighsLogType::kError,
         "setLocalOptionValue: Option \"%s\" cannot be assigned an int\n",

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -385,7 +385,9 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
     if (type == HighsOptionType::kDouble) {
       // Interpret integer as double
       double use_value = value;
-      return setLocalOptionValue(report_log_options, ((OptionRecordDouble*)option_records[index])[0], use_value);      
+      return setLocalOptionValue(
+          report_log_options, ((OptionRecordDouble*)option_records[index])[0],
+          use_value);
     }
     highsLogUser(
         report_log_options, HighsLogType::kError,


### PR DESCRIPTION
This will close issue #1028 

Only a minor change, but if an `int` is passed to Highs::setOptionValue for a `double` option it used to return an error, but it seems reasonable to interpret it as a `double` and update the option value.