### PR TITLE
Fix log_to_console option in the ipm solver

### DIFF
--- a/src/ipm/IpxWrapper.cpp
+++ b/src/ipm/IpxWrapper.cpp
@@ -78,7 +78,7 @@ HighsStatus solveLpIpx(const HighsOptions& options,
   //
   // Set display according to output
   parameters.display = 1;
-  if (!options.output_flag) parameters.display = 0;
+  if (!options.output_flag | !options.log_to_console) parameters.display = 0;
   // Modify parameters.debug according to log_dev_level
   parameters.debug = 0;
   if (options.log_dev_level == kHighsLogDevLevelDetailed) {


### PR DESCRIPTION
A trivial patch for https://github.com/ERGO-Code/HiGHS/issues/967. I didn't dig deeply into the code to understand if this is the correct place to patch, but it works for me.

```
oscar@Oscars-MBP HiGHS % cat /tmp/options
log_to_console=false

oscar@Oscars-MBP HiGHS % cat /tmp/model.lp 
\ File written by HiGHS .lp file handler
min
 obj: +12 x1 +20 x2 
st
 con1lo: +6 x1 +8 x2 >= +100
 con2lo: +7 x1 +12 x2 >= +120
bounds

 x2 <= 3
end
oscar@Oscars-MBP HiGHS % build/bin/highs --options_file=/tmp/options /tmp/model.lp 

oscar@Oscars-MBP HiGHS % build/bin/highs --options_file=/tmp/options --solver=ipm /tmp/model.lp

oscar@Oscars-MBP HiGHS % build/bin/highs --solver=ipm /tmp/model.lp 
Running HiGHS 1.5.0 [date: 2022-12-20, git hash: 33cc544f7-dirty]
Copyright (c) 2022 HiGHS under MIT licence terms
LP   model has 2 rows; 2 cols; 4 nonzeros
Presolving model
2 rows, 2 cols, 4 nonzeros
2 rows, 2 cols, 4 nonzeros
Presolve : Reductions: rows 2(-0); columns 2(-0); elements 4(-0) - Not reduced
Problem not reduced by presolve: solving the LP
IPX model has 2 rows, 2 columns and 4 nonzeros
Input
    Number of variables:                                2
    Number of free variables:                           0
    Number of constraints:                              2
    Number of equality constraints:                     0
    Number of matrix entries:                           4
    Matrix range:                                       [6e+00, 1e+01]
    RHS range:                                          [1e+02, 1e+02]
    Objective range:                                    [1e+01, 2e+01]
    Bounds range:                                       [3e+00, 3e+00]
Preprocessing
    Dualized model:                                     no
    Number of dense columns:                            0
    Range of scaling factors:                           [5.00e-01, 1.00e+00]
IPX version 1.0
Interior Point Solve
 Iter     P.res    D.res            P.obj           D.obj        mu     Time
   0   8.85e+00 2.66e+00   2.03715741e+02  1.90309850e+02  3.67e+01       0s
   1   8.85e-06 2.66e-06   2.15808217e+02  1.93588563e+02  4.44e+00       0s
   2   7.84e-07 5.20e-07   2.05317615e+02  2.02113669e+02  6.41e-01       0s
   3   7.85e-13 4.53e-08   2.05209034e+02  2.04938729e+02  5.41e-02       0s
   4   6.58e-15 4.53e-14   2.05000287e+02  2.04999555e+02  1.46e-04       0s
   5*  6.49e-15 1.78e-15   2.05000000e+02  2.05000000e+02  5.76e-10       0s
 Constructing starting basis...
Running crossover as requested
    Primal residual before push phase:                  8.01e-10
    Dual residual before push phase:                    1.03e-10
    Number of dual pushes required:                     0
    Number of primal pushes required:                   0
Summary
    Runtime:                                            0.00s
    Status interior point solve:                        optimal
    Status crossover:                                   optimal
    objective value:                                    2.05000000e+02
    interior solution primal residual (abs/rel):        1.42e-14 / 1.17e-16
    interior solution dual residual (abs/rel):          1.78e-15 / 8.46e-17
    interior solution objective gap (abs/rel):          2.88e-09 / 1.40e-11
    basic solution primal infeasibility:                0.00e+00
    basic solution dual infeasibility:                  0.00e+00
Ipx: IPM       optimal
Ipx: Crossover optimal
Model   status      : Optimal
IPM       iterations: 5
Objective value     :  2.0500000000e+02
HiGHS run time      :          0.00
```