### PR TITLE
Added  `| !options.log_to_console` to line 81 of IpxWrapper.cpp

### DIFF
--- a/src/ipm/IpxWrapper.cpp
+++ b/src/ipm/IpxWrapper.cpp
@@ -78,7 +78,7 @@ HighsStatus solveLpIpx(const HighsOptions& options,
   //
   // Set display according to output
   parameters.display = 1;
-  if (!options.output_flag) parameters.display = 0;
+  if (!options.output_flag | !options.log_to_console) parameters.display = 0;
   // Modify parameters.debug according to log_dev_level
   parameters.debug = 0;
   if (options.log_dev_level == kHighsLogDevLevelDetailed) {


### PR DESCRIPTION
This is the modification in `odow-patch-1`. 

It will prevent logging to the console if `log_to_console` is false, but doesn't fix the current inconsistency in which logging from IPX can't go to the logging file.

Unfortunately the logging mechanism of IPX is incompatible with the rest of HiGHS, and would require a lot of editing to bring it into line. Indeed, it's  much easier to make the logging for HiGHS consistent with that of IPX, and this should be considered when adding desired features to HiGHS logging.