### PR TITLE
fix processing of semi section in .lp reader

### DIFF
--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -663,7 +663,7 @@ void Reader::processgensec() {
 }
 
 void Reader::processsemisec() {
-   if(!sectiontokens.count(LpSectionKeyword::GEN))
+   if(!sectiontokens.count(LpSectionKeyword::SEMI))
       return;
    std::vector<ProcessedToken>::iterator& begin(sectiontokens[LpSectionKeyword::SEMI].first);
    std::vector<ProcessedToken>::iterator& end(sectiontokens[LpSectionKeyword::SEMI].second);


### PR DESCRIPTION
`Semi` section was ignored if there were no general integer variables due to a stupid copy-paste-bug.