### PR TITLE
HConfig.h mods

### DIFF
--- a/check/TestCheckSolution.cpp
+++ b/check/TestCheckSolution.cpp
@@ -4,7 +4,7 @@
 #include "SpecialLps.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 
 void runWriteReadCheckSolution(Highs& highs, const std::string model,
                                const HighsModelStatus require_model_status,

--- a/check/TestInfo.cpp
+++ b/check/TestInfo.cpp
@@ -77,7 +77,7 @@ TEST_CASE("highs-info", "[highs_info]") {
     printf("From getInfo: objective_function_value = %g\n",
            highs_info.objective_function_value);
     printf("From getInfo: ipm_iteration_count = %" HIGHSINT_FORMAT "\n",
-	   highs_info.ipm_iteration_count);
+           highs_info.ipm_iteration_count);
   }
   std::remove(highs_info_file.c_str());
 }

--- a/check/TestInfo.cpp
+++ b/check/TestInfo.cpp
@@ -24,15 +24,8 @@ TEST_CASE("highs-info", "[highs_info]") {
   return_status = highs.writeInfo("");
   REQUIRE(return_status == HighsStatus::kWarning);
 
-  // Only use IPX if and using 32-bit arithmetic
-  bool use_ipx = false;
-#ifndef HIGHSINT64
-  use_ipx = true;
-#endif
-  if (use_ipx) {
-    return_status = highs.setOptionValue("solver", "ipm");
-    REQUIRE(return_status == HighsStatus::kOk);
-  }
+  return_status = highs.setOptionValue("solver", "ipm");
+  REQUIRE(return_status == HighsStatus::kOk);
 
   // Info not valid before run()
   double objective_function_value;
@@ -83,13 +76,8 @@ TEST_CASE("highs-info", "[highs_info]") {
            highs.modelStatusToString(model_status).c_str());
     printf("From getInfo: objective_function_value = %g\n",
            highs_info.objective_function_value);
-    if (use_ipx) {
-      printf("From getInfo: ipm_iteration_count = %" HIGHSINT_FORMAT "\n",
-             highs_info.ipm_iteration_count);
-    } else {
-      printf("From getInfo: simplex_iteration_count = %" HIGHSINT_FORMAT "\n",
-             highs_info.simplex_iteration_count);
-    }
+    printf("From getInfo: ipm_iteration_count = %" HIGHSINT_FORMAT "\n",
+	   highs_info.ipm_iteration_count);
   }
   std::remove(highs_info_file.c_str());
 }

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -221,11 +221,7 @@ void testSolvers(Highs& highs, IterationCount& model_iteration_count,
     model_iteration_count.simplex = simplex_strategy_iteration_count[i];
     testSolver(highs, "simplex", model_iteration_count, i);
   }
-  // Only use IPX with 32-bit arithmetic
-  // ToDo This is no longer true
-#ifndef HIGHSINT64
   testSolver(highs, "ipm", model_iteration_count);
-#endif
 }
 
 // No commas in test case name.

--- a/check/TestSpecialLps.cpp
+++ b/check/TestSpecialLps.cpp
@@ -59,9 +59,7 @@ void distillation(Highs& highs) {
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   // Presolve doesn't reduce the LP
   solve(highs, "on", "simplex", require_model_status, optimal_objective);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status, optimal_objective);
-#endif
 }
 
 void issue272(Highs& highs) {
@@ -76,10 +74,8 @@ void issue272(Highs& highs) {
   // Presolve reduces to empty, so no need to test presolve+IPX
   solve(highs, "on", "simplex", require_model_status, optimal_objective);
   solve(highs, "off", "simplex", require_model_status, optimal_objective);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status, optimal_objective);
   solve(highs, "off", "ipm", require_model_status, optimal_objective);
-#endif
 }
 
 void issue280(Highs& highs) {
@@ -110,10 +106,8 @@ void issue282(Highs& highs) {
   // Presolve reduces to empty, so no real need to test presolve+IPX
   solve(highs, "on", "simplex", require_model_status, optimal_objective);
   solve(highs, "off", "simplex", require_model_status, optimal_objective);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status, optimal_objective);
   solve(highs, "off", "ipm", require_model_status, optimal_objective);
-#endif
 }
 
 void issue285(Highs& highs) {
@@ -128,10 +122,8 @@ void issue285(Highs& highs) {
   // Presolve identifies infeasibility, so no need to test presolve+IPX
   solve(highs, "on", "simplex", require_model_status);
   solve(highs, "off", "simplex", require_model_status);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status);
   solve(highs, "off", "ipm", require_model_status);
-#endif
 }
 
 void issue295(Highs& highs) {
@@ -152,10 +144,8 @@ void issue295(Highs& highs) {
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   solve(highs, "on", "simplex", require_model_status, optimal_objective);
   solve(highs, "off", "simplex", require_model_status, optimal_objective);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status, optimal_objective);
   solve(highs, "off", "ipm", require_model_status, optimal_objective);
-#endif
 }
 
 void issue306(Highs& highs) {
@@ -172,10 +162,8 @@ void issue306(Highs& highs) {
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   solve(highs, "on", "simplex", require_model_status, optimal_objective);
   solve(highs, "off", "simplex", require_model_status, optimal_objective);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status, optimal_objective);
   solve(highs, "off", "ipm", require_model_status, optimal_objective);
-#endif
 }
 
 void issue316(Highs& highs) {
@@ -216,9 +204,7 @@ void issue425(Highs& highs) {
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   solve(highs, "on", "simplex", require_model_status, 0, -1);
   solve(highs, "off", "simplex", require_model_status, 0, 3);
-#ifndef HIGHSINT64
   solve(highs, "off", "ipm", require_model_status, 0, 4);
-#endif
 }
 
 void issue669(Highs& highs) {
@@ -390,10 +376,8 @@ void mpsGalenet(Highs& highs) {
 
   solve(highs, "on", "simplex", require_model_status);
   solve(highs, "off", "simplex", require_model_status);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status);
   solve(highs, "off", "ipm", require_model_status);
-#endif
 }
 
 void primalDualInfeasible1(Highs& highs) {
@@ -482,10 +466,8 @@ void mpsGas11(Highs& highs) {
 
   solve(highs, "on", "simplex", require_model_status);
   solve(highs, "off", "simplex", require_model_status);
-#ifndef HIGHSINT64
   solve(highs, "on", "ipm", require_model_status);
   solve(highs, "off", "ipm", require_model_status);
-#endif
 }
 
 void almostNotUnbounded(Highs& highs) {
@@ -531,9 +513,7 @@ void almostNotUnbounded(Highs& highs) {
   //  REQUIRE(highs.writeModel("epsilon_unbounded.mps") ==
   //  HighsStatus::WARNING);
   solve(highs, "off", "simplex", require_model_status0);
-#ifndef HIGHSINT64
   solve(highs, "off", "ipm", require_model_status0);
-#endif
 
   // LP is feasible on [1+alpha, alpha] with objective -1 so optimal,
   // but has open set of optimal solutions
@@ -542,9 +522,7 @@ void almostNotUnbounded(Highs& highs) {
 
   solve(highs, "off", "simplex", require_model_status1, optimal_objective1);
   special_lps.reportSolution(highs, dev_run);
-#ifndef HIGHSINT64
   solve(highs, "off", "ipm", require_model_status1, optimal_objective1);
-#endif
 
   // LP has bounded feasible region with optimal solution
   // [1+2/epsilon, 2/epsilon] and objective
@@ -556,9 +534,7 @@ void almostNotUnbounded(Highs& highs) {
 
   solve(highs, "off", "simplex", require_model_status2, optimal_objective2);
   special_lps.reportSolution(highs, dev_run);
-#ifndef HIGHSINT64
   solve(highs, "off", "ipm", require_model_status2, optimal_objective2);
-#endif
 }
 
 void singularStartingBasis(Highs& highs) {

--- a/src/HConfig.h.in
+++ b/src/HConfig.h.in
@@ -2,12 +2,10 @@
 #define HCONFIG_H_
 
 #cmakedefine FAST_BUILD
-#cmakedefine SCIP_DEV
-#cmakedefine HiGHSDEV
 #cmakedefine OSI_FOUND
 #cmakedefine ZLIB_FOUND
 #cmakedefine CMAKE_BUILD_TYPE "@CMAKE_BUILD_TYPE@"
-#cmakedefine HiGHSRELEASE
+#cmakedefine CMAKE_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
 #cmakedefine HIGHSINT64
 #cmakedefine HIGHS_HAVE_MM_PAUSE
 #cmakedefine HIGHS_HAVE_BUILTIN_CLZ


### PR DESCRIPTION
Deleted the listing in `HConfig.h` of two redundant macros (`SCIP_DEV`, `HIGHSRELEASE` and `HiGHSDEV`) and added listing of `CMAKE_INSTALL_PREFIX` as it's important to know the setting when installing `highspy`

Took the opportunity to remove unnecessary exclusions on running IPX with 64-bit integers