### PR TITLE
Add volatile keyword to doubles involved in sorting operations for 32-bit GCC builds - PR to latest

### DIFF
--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -36,7 +36,6 @@
 #define FP_32BIT_VOLATILE
 #endif
 
-
 HighsPrimalHeuristics::HighsPrimalHeuristics(HighsMipSolver& mipsolver)
     : mipsolver(mipsolver),
       lp_iterations(0),


### PR DESCRIPTION
This was OK-ed by @galabovaa a few months ago, but the requested PR to latest wasn't made