### PR TITLE
Add integrated Webdemo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,6 @@ qjh.mps
 
 *.whl
 bazel*
+
+# webdemo
+build_webdemo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ option(PYTHON "Build Python interface" OFF)
 option(FORTRAN "Build Fortran interface" OFF)
 option(CSHARP "Build CSharp interface" OFF)
 
+# emscripten
+option(EMSCRIPTEN_HTML "Emscripten HTML output" OFF)
+
 # set the correct rpath for OS X
 set(CMAKE_MACOSX_RPATH ON)
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,24 @@ Javascript
 
 HiGHS can be used from javascript directly inside a web browser thanks to [highs-js](https://github.com/lovasoa/highs-js). See the [demo](https://lovasoa.github.io/highs-js/) and the [npm package](https://www.npmjs.com/package/highs).
 
+Alternatively, HiGHS can directly be compiled into a single HTML file and used
+in a browser. This requires `emscripten` to be installed from their website
+(unfortunately, e.g. `sudo apt install emscripten` in Ubuntu Linux is broken):
+
+    https://emscripten.org/docs/getting_started/downloads.html
+
+Then, run
+
+    sh build_webdemo.sh
+
+This will create the file `build_webdemo/bin/highs.html`. For fast edit
+iterations run
+
+    find src app | entr -rs 'make -C build_webdemo highs; echo'
+
+This will rebuild `highs.html` every time a source file is modified (e.g.
+from Visual Studio Code).
+
 Python
 ------
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -10,6 +10,11 @@ endif()
 
 target_link_libraries(highs libhighs)
 
+if(EMSCRIPTEN AND EMSCRIPTEN_HTML)
+        set(CMAKE_EXECUTABLE_SUFFIX ".html")
+        set_target_properties(highs PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/highs_webdemo_shell.html)
+endif()
+
 target_include_directories(highs PRIVATE
         $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/app>  
         )

--- a/app/highs_webdemo_shell.html
+++ b/app/highs_webdemo_shell.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<!-- compare https://github.com/emscripten-core/emscripten/blob/main/src/shell_minimal.html -->
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>HiGHS</title>
+  </head>
+  <body>
+    <div style="display: grid; grid-template-columns: 1fr 1fr">
+      <textarea id="input" style="height: 700px">
+      </textarea>    
+      <textarea id="output"></textarea>    
+      <button id="run">Optimize!</button>
+    </div>
+    {{{ SCRIPT }}}
+    <script type='text/javascript'>
+      main = async () => {
+        const printInTextarea = function(text) {
+          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+          // These replacements are necessary if you render to raw HTML
+          //text = text.replace(/&/g, "&amp;");
+          //text = text.replace(/</g, "&lt;");
+          //text = text.replace(/>/g, "&gt;");
+          //text = text.replace('\n', '<br>', 'g');
+          // console.log(text);
+          if (element) {
+            element.value += text + "\n";
+            element.scrollTop = element.scrollHeight; // focus on bottom
+          }
+        }
+
+        const highs = await HiGHS({
+          print: printInTextarea,
+          printErr: printInTextarea
+        })        
+
+        const inputTextarea = document.getElementById('input');
+        inputTextarea.value = `Maximize 
+ obj: x1 + 2 x2 + 3 x3 + x4
+Subject To
+ c1: - x1 + x2 + x3 + 10 x4 <= 20
+ c2: x1 - 3 x2 + x3 <= 30
+ c3: x2 - 3.5 x4 = 0
+Bounds
+ 0 <= x1 <= 40
+ 2 <= x4 <= 3
+General
+ x4
+End`;
+
+        const element = document.getElementById('output');
+        const clearOutput = (v) => {
+          element.value = v || '';
+        }
+
+        clearOutput('Click on "Optimize!"') // clear browser cache
+
+        const runButton = document.getElementById('run');
+        runButton.addEventListener("click", () => {
+          clearOutput()
+          const inputFilename = 'inputFile.lp'
+          highs.FS.writeFile(inputFilename, inputTextarea.value)
+          highs.callMain([inputFilename])
+        })
+
+      }
+
+      main()
+
+    </script>
+  </body>
+</html>

--- a/build_webdemo.sh
+++ b/build_webdemo.sh
@@ -1,0 +1,25 @@
+script_path=$(realpath $(dirname $0))
+build_dir="build_webdemo"
+
+# interesting for Node.js: -sNODERAWFS=1, allows direct os filesystem access
+LDFLAGS=$(echo $(cat << EOF
+-sINVOKE_RUN=0
+-sMODULARIZE=1
+-sEXPORTED_RUNTIME_METHODS=['FS','callMain']
+-sEXPORT_NAME='HiGHS'
+-sSINGLE_FILE
+-sALLOW_MEMORY_GROWTH=1
+--shell-file ${script_path}/app/highs_webdemo_shell.html
+EOF
+))
+
+# compare https://stackoverflow.com/a/6481016
+physical_cores=$(grep ^cpu\\scores /proc/cpuinfo | uniq | awk '{print $4}')
+
+cd ${script_path} &&
+rm -rf ${build_dir} &&
+mkdir ${build_dir} &&
+cd ${build_dir} &&
+LDFLAGS=$LDFLAGS emcmake cmake .. \
+-DCMAKE_BUILD_TYPE=Release -DEMSCRIPTEN_HTML=on &&
+emmake make -j ${physical_cores}


### PR DESCRIPTION
Hi everybody & happy New Year!

I've added code for compiling a webdemo for HiGHS directly, so it can be run in a browser serverlessly from a single HTML file of around 3.4 MB. This is done with Emscripten, a C/C++ to JavaScript/WebAssembly compiler. The integration with cmake is a little hacky (by design, Emscripten overrides a lot of parameters), so it needs a script to trigger the build. I've wrapped everything up in this pull request.

Basically a copy of the pull request I've added to SoPlex today.

The difference to the existing approach is that only Emscripten is required, which makes it very simple, a baseline so to say. This allows e.g. to integrate the build into automated tests to ensure JavaScript/Webassembly builds don't break and it will also always be up-to-date, as it is integrated with the actual code. Further, this option rather addresses C/C++ programmers that want to build larger applications that contain HiGHS and then optionally compile them to WebAssembly in contrast to using it primarily as a Node.js module. For example, Pyodide is a Python distribution that runs in a browser. If the maintainers wanted to add HiGHS to Pyodide, one needs to ensure it compiles with Emscripten alongside with its Python bindings.

Demo build see [highs.zip](https://github.com/ERGO-Code/HiGHS/files/10369637/highs.zip)
