### PR TITLE
Modified C API for Highs_version, Highs_githash and Highs_compilation_date

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -46,11 +46,11 @@ void assertLogical(const char* name, const HighsInt is) {
 void version_api() {
   if (dev_run) {
     printf("HiGHS version %s\n", Highs_version());
-    printf("HiGHS version major %d\n", Highs_version_major());
-    printf("HiGHS version minor %d\n", Highs_version_minor());
-    printf("HiGHS version patch %d\n", Highs_version_patch());
+    printf("HiGHS version major %d\n", Highs_versionMajor());
+    printf("HiGHS version minor %d\n", Highs_versionMinor());
+    printf("HiGHS version patch %d\n", Highs_versionPatch());
     printf("HiGHS githash: %s\n", Highs_githash());
-    printf("HiGHS compilation date %s\n", Highs_compilation_date());
+    printf("HiGHS compilation date %s\n", Highs_compilationDate());
   }
 }
 

--- a/check/TestHighsVersion.cpp
+++ b/check/TestHighsVersion.cpp
@@ -8,7 +8,7 @@ const bool dev_run = false;
 
 // No commas in test case name.
 TEST_CASE("HighsVersion", "[highs_version]") {
-  std::string version = highsVersion();
+  std::string version = std::string(highsVersion());
   const HighsInt major = highsVersionMajor();
   const HighsInt minor = highsVersionMinor();
   const HighsInt patch = highsVersionPatch();
@@ -20,8 +20,8 @@ TEST_CASE("HighsVersion", "[highs_version]") {
     printf("HiGHS major version %d\n", int(major));
     printf("HiGHS minor version %d\n", int(minor));
     printf("HiGHS patch version %d\n", int(patch));
-    printf("HiGHS githash: %s\n", highsGithash().c_str());
-    printf("HiGHS compilation date: %s\n", highsCompilationDate().c_str());
+    printf("HiGHS githash: %s\n", highsGithash());
+    printf("HiGHS compilation date: %s\n", highsCompilationDate());
     printf("HiGHS local version: %s\n", local_version.c_str());
   }
   REQUIRE(major == HIGHS_VERSION_MAJOR);

--- a/examples/call_highs_from_c.c
+++ b/examples/call_highs_from_c.c
@@ -301,6 +301,12 @@ void minimal_api_mps() {
 }
 
 void full_api() {
+  printf("\nHiGHS version %s\n", Highs_version());
+  printf("      Major version %d\n", Highs_versionMajor());
+  printf("      Minor version %d\n", Highs_versionMinor());
+  printf("      Patch version %d\n", Highs_versionPatch());
+  printf("      Githash %s\n", Highs_githash());
+  printf("      compilation date %s\n", Highs_compilationDate());
   // This example does exactly the same as the minimal example above,
   // but illustrates the full C API.  It first forms and solves the LP
   //

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -24,9 +24,9 @@
 #include "presolve/PresolveComponent.h"
 
 /**
- * @brief Return the version as a string
+ * @brief Return the version
  */
-std::string highsVersion();
+const char* highsVersion();
 
 /**
  * @brief Return detailed version information, githash and compilation
@@ -35,8 +35,8 @@ std::string highsVersion();
 HighsInt highsVersionMajor();
 HighsInt highsVersionMinor();
 HighsInt highsVersionPatch();
-std::string highsGithash();
-std::string highsCompilationDate();
+const char* highsGithash();
+const char* highsCompilationDate();
 
 /**
  * @brief Class to set parameters and run HiGHS

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -172,12 +172,24 @@ void* Highs_create() { return new Highs(); }
 
 void Highs_destroy(void* highs) { delete (Highs*)highs; }
 
-const char* Highs_version(void) { return highsVersion().c_str(); }
+const char* Highs_version(void) {
+  static std::string version = highsVersion();
+  return version.c_str();
+}
+
 HighsInt Highs_version_major() { return highsVersionMajor(); }
 HighsInt Highs_version_minor() { return highsVersionMinor(); }
 HighsInt Highs_version_patch() { return highsVersionPatch(); }
-const char* Highs_githash() { return highsGithash().c_str(); }
-const char* Highs_compilation_date() { return highsCompilationDate().c_str(); }
+
+const char* Highs_githash() {
+  static std::string githash = highsGithash();
+  return githash.c_str();
+}
+
+const char* Highs_compilation_date() {
+  static std::string compilation_date = highsCompilationDate();
+  return compilation_date.c_str();
+}
 
 HighsInt Highs_run(void* highs) { return (HighsInt)((Highs*)highs)->run(); }
 

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -177,16 +177,16 @@ const char* Highs_version(void) {
   return version.c_str();
 }
 
-HighsInt Highs_version_major() { return highsVersionMajor(); }
-HighsInt Highs_version_minor() { return highsVersionMinor(); }
-HighsInt Highs_version_patch() { return highsVersionPatch(); }
+HighsInt Highs_versionMajor() { return highsVersionMajor(); }
+HighsInt Highs_versionMinor() { return highsVersionMinor(); }
+HighsInt Highs_versionPatch() { return highsVersionPatch(); }
 
 const char* Highs_githash() {
   static std::string githash = highsGithash();
   return githash.c_str();
 }
 
-const char* Highs_compilation_date() {
+const char* Highs_compilationDate() {
   static std::string compilation_date = highsCompilationDate();
   return compilation_date.c_str();
 }

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -172,24 +172,12 @@ void* Highs_create() { return new Highs(); }
 
 void Highs_destroy(void* highs) { delete (Highs*)highs; }
 
-const char* Highs_version(void) {
-  static std::string version = highsVersion();
-  return version.c_str();
-}
-
+const char* Highs_version(void) { return highsVersion(); }
 HighsInt Highs_versionMajor() { return highsVersionMajor(); }
 HighsInt Highs_versionMinor() { return highsVersionMinor(); }
 HighsInt Highs_versionPatch() { return highsVersionPatch(); }
-
-const char* Highs_githash() {
-  static std::string githash = highsGithash();
-  return githash.c_str();
-}
-
-const char* Highs_compilationDate() {
-  static std::string compilation_date = highsCompilationDate();
-  return compilation_date.c_str();
-}
+const char* Highs_githash(void) { return highsGithash(); }
+const char* Highs_compilationDate(void) { return highsCompilationDate(); }
 
 HighsInt Highs_run(void* highs) { return (HighsInt)((Highs*)highs)->run(); }
 

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -246,14 +246,14 @@ HighsInt Highs_version_patch();
  *
  * @returns the HiGHS githash
  */
-const char* Highs_githash();
+const char* Highs_githash(void);
 
 /**
  * Return the HiGHS compilation date
  *
  * @returns the HiGHS compilation date
  */
-const char* Highs_compilation_date();
+const char* Highs_compilation_date(void);
 
 /**
  * Read a model from `filename` into `highs`.

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -225,21 +225,21 @@ const char* Highs_version(void);
  *
  * @returns the HiGHS major version number
  */
-HighsInt Highs_version_major();
+HighsInt Highs_versionMajor();
 
 /**
  * Return the HiGHS minor version number
  *
  * @returns the HiGHS minor version number
  */
-HighsInt Highs_version_minor();
+HighsInt Highs_versionMinor();
 
 /**
  * Return the HiGHS patch version number
  *
  * @returns the HiGHS patch version number
  */
-HighsInt Highs_version_patch();
+HighsInt Highs_versionPatch();
 
 /**
  * Return the HiGHS githash
@@ -253,7 +253,7 @@ const char* Highs_githash(void);
  *
  * @returns the HiGHS compilation date
  */
-const char* Highs_compilation_date(void);
+const char* Highs_compilationDate(void);
 
 /**
  * Read a model from `filename` into `highs`.

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -34,18 +34,17 @@
 #include "util/HighsMatrixPic.h"
 #include "util/HighsSort.h"
 
-std::string highsVersion() {
-  std::stringstream ss;
-  ss << HIGHS_VERSION_MAJOR << "." << HIGHS_VERSION_MINOR << "."
-     << HIGHS_VERSION_PATCH;
-  return ss.str();
+#define STRINGFY(s) STRINGFY0(s)
+#define STRINGFY0(s) #s
+const char* highsVersion() {
+  return STRINGFY(HIGHS_VERSION_MAJOR) "." STRINGFY(
+      HIGHS_VERSION_MINOR) "." STRINGFY(HIGHS_VERSION_PATCH);
 }
-
 HighsInt highsVersionMajor() { return HIGHS_VERSION_MAJOR; }
 HighsInt highsVersionMinor() { return HIGHS_VERSION_MINOR; }
 HighsInt highsVersionPatch() { return HIGHS_VERSION_PATCH; }
-std::string highsGithash() { return HIGHS_GITHASH; }
-std::string highsCompilationDate() { return HIGHS_COMPILATION_DATE; }
+const char* highsGithash() { return HIGHS_GITHASH; }
+const char* highsCompilationDate() { return HIGHS_COMPILATION_DATE; }
 
 Highs::Highs() {}
 


### PR DESCRIPTION
Simple change to these methods so that what's returned doesn't become invalid once the function returns and the string goes away.