### PR TITLE
presolve_rule_logging default now false

### DIFF
--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -996,7 +996,7 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_bool = new OptionRecordBool(
         "presolve_rule_logging", "Log effectiveness of presolve rules for LP",
-        advanced, &presolve_rule_logging, true);
+        advanced, &presolve_rule_logging, false);
     records.push_back(record_bool);
 
     record_int = new OptionRecordInt(


### PR DESCRIPTION
`presolve_rule_logging` default value is now false

This prevents the assert referred to in #1124, unless `presolve_rule_logging` is set to true

Full investigation of why the assert is triggered awaits 

This will close #1124 