### PR TITLE
Introduced kAllowDeveloperAssert 

### DIFF
--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -35,6 +35,7 @@ const HighsInt kHighsMaxStringLength = 512;
 const HighsInt kSimplexConcurrencyLimit = 8;
 const double kRunningAverageMultiplier = 0.05;
 
+const bool kAllowDeveloperAssert = false;
 const bool kExtendInvertWhenAddingRows = false;
 
 enum SimplexScaleStrategy {

--- a/src/mip/HighsDomain.h
+++ b/src/mip/HighsDomain.h
@@ -478,7 +478,9 @@ class HighsDomain {
   }
 
   void fixCol(HighsInt col, double val, Reason reason = Reason::unspecified()) {
-    assert(infeasible_ == 0);
+    if (kAllowDeveloperAssert) {
+      assert(infeasible_ == 0);
+    }
     if (col_lower_[col] < val) {
       changeBound({val, col, HighsBoundType::kLower}, reason);
       if (infeasible_ == 0) propagate();

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -745,7 +745,9 @@ void HEkkPrimal::rebuild() {
   ekk_instance_.computePrimal();
   if (solve_phase == kSolvePhase2) {
     bool correct_primal_ok = correctPrimal();
-    assert(correct_primal_ok);
+    if (kAllowDeveloperAssert) {
+      assert(correct_primal_ok);
+    }
   }
   getBasicPrimalInfeasibility();
   if (info.num_primal_infeasibilities > 0) {
@@ -2100,7 +2102,9 @@ bool HEkkPrimal::correctPrimal(const bool initialise) {
     highsLogDev(ekk_instance_.options_->log_options, HighsLogType::kError,
                 "correctPrimal: Missed %d bound shifts\n",
                 num_primal_correction_skipped);
-    assert(!num_primal_correction_skipped);
+    if (kAllowDeveloperAssert) {
+      assert(!num_primal_correction_skipped);
+    }
     return false;
   }
   if (max_primal_correction > 2 * max_max_primal_correction) {
@@ -2541,6 +2545,9 @@ void HEkkPrimal::updateVerify() {
                 ekk_instance_.iteration_count_, alpha_col,
                 alpha_row_source.c_str(), alpha_row, abs_alpha_diff,
                 numericalTrouble);
+  if (kAllowDeveloperAssert) {
+    assert(numericalTrouble < 1e-3);
+  }
   // Reinvert if the relative difference is large enough, and updates have been
   // performed
   //


### PR DESCRIPTION
Introduced kAllowDeveloperAssert to be false rather than delete three developer asserts in HekkPrimal.pp and assert(infeasible_ == 0); in HighsDomain.h