### PR TITLE
fix-1129

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,11 @@ if(MSVC)
     add_definitions(/wd4018 /wd4061 /wd4100 /wd4101 /wd4127 /wd4189 /wd4244 /wd4245 /wd4267 /wd4324 /wd4365 /wd4389 /wd4456 /wd4457 /wd4458 /wd4459 /wd4514 /wd4701 /wd4820)
     add_definitions(/MP)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+#
+# This fouls up building HiGHS as part of a larger CMake project: see #1129.
+# Setting it will speed up run-time in debug (and compile-time?)
+#
+#    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 endif()
 
 if (NOT FAST_BUILD OR FORTRAN)


### PR DESCRIPTION
Commented out `add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)` in main `CMakeLists.txt`

This fouls up building HiGHS as part of a larger CMake project: see #1129 

Setting it will speed up run-time in debug (and compile-time?) so leave in `CMakeLists.txt`for local change by developer