### PR TITLE
initialize Qdim in HMPSIO

### DIFF
--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -47,6 +47,7 @@ FilereaderRetcode readMps(
   // MPS file buffer
   numRow = 0;
   numCol = 0;
+  Qdim = 0;
   cost_row_location = -1;
   objOffset = 0;
   objSense = ObjSense::kMinimize;


### PR DESCRIPTION
Set it to some sensible value like for `numRow` or `numCol`, in case there are no quadratic terms.