### PR TITLE
Highs::getRowsInterface now returns get_num_nz when row_matrix_start is nullptr

### DIFF
--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -22,6 +22,7 @@ void reportModelStatsOrError(const HighsLogOptions& log_options,
 int main(int argc, char** argv) {
   // Create the Highs instance
   Highs highs;
+  highs.writeOptions("Options.set");
   const HighsOptions& options = highs.getOptions();
   const HighsLogOptions& log_options = options.log_options;
 

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <string.h>
 
-const HighsInt dev_run = 0;
+const HighsInt dev_run = 1;
 const double double_equal_tolerance = 1e-5;
 
 HighsInt intArraysEqual(const HighsInt dim, const HighsInt* array0, const HighsInt* array1) {
@@ -614,6 +614,67 @@ void full_api_lp() {
   if (dev_run)
     printf("LP problem has old objective sense = %"HIGHSINT_FORMAT"\n", sense);
   assert( sense == kHighsObjSenseMinimize );
+
+
+
+  // fetch column data (just first column)
+  {
+    const HighsInt get_col = 0;
+    const HighsInt num_get_col = 1;
+    HighsInt get_num_col = 0;
+    double* get_costs = (double*)malloc(sizeof(double) * num_get_col);
+    double* get_lower = (double*)malloc(sizeof(double) * num_get_col);
+    double* get_upper = (double*)malloc(sizeof(double) * num_get_col);
+    HighsInt get_num_nz = 0;
+
+    return_status = Highs_getColsByRange(highs, get_col, get_col,
+					 &get_num_col, get_costs, get_lower, get_upper, &get_num_nz,
+					 NULL, NULL, NULL);
+    assert( return_status == kHighsStatusOk );
+
+    assertIntValuesEqual("getCols get_num_col", get_num_col, num_get_col);
+    assertDoubleValuesEqual("getCols get_costs", get_costs[0], col_cost[get_col]);
+    assertDoubleValuesEqual("getCols get_lower", get_lower[0], col_lower[get_col]);
+    assertDoubleValuesEqual("getCols get_upper", get_upper[0], col_upper[get_col]);
+    assertIntValuesEqual("getCols get_num_nz", get_num_nz, 2);
+
+      // could also check coefficients by calling again...
+
+    free(get_upper);
+    free(get_lower);
+    free(get_costs);
+  }
+
+  // fetch row data (just 2nd row: 10 <=  x_0 + 2x_1 <= 14)
+  {
+    const HighsInt get_row = 1;
+    const HighsInt num_get_row = 1;
+    HighsInt get_num_row = 0;
+    double* get_lower = (double*)malloc(sizeof(double) * num_get_row);
+    double* get_upper = (double*)malloc(sizeof(double) * num_get_row);
+    HighsInt get_num_nz = 0;
+
+    assertIntValuesEqual("getNumRows", Highs_getNumRows(highs), num_row);
+
+    return_status = Highs_getRowsByRange(highs, get_row, get_row,
+					 &get_num_row, get_lower, get_upper, &get_num_nz,
+					 NULL, NULL, NULL);
+    assert( return_status == kHighsStatusOk );
+
+    assertIntValuesEqual("getRows get_num_row", get_num_row, num_get_row);
+    assertDoubleValuesEqual("getRows get_lower", get_lower[0], row_lower[get_row]);
+    assertDoubleValuesEqual("getRows get_upper", get_upper[0], row_upper[get_row]);
+    assertIntValuesEqual("getRows get_num_nz", get_num_nz, 2);
+
+      // could also check coefficients by calling again...
+
+    free(get_upper);
+    free(get_lower);
+  }
+
+  
+
+
 
   return_status = Highs_setBoolOptionValue(highs, "output_flag", 0);
   assert( return_status == kHighsStatusOk );

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -8,7 +8,7 @@
 #include <math.h>
 #include <string.h>
 
-const HighsInt dev_run = 1;
+const HighsInt dev_run = 0;
 const double double_equal_tolerance = 1e-5;
 
 HighsInt intArraysEqual(const HighsInt dim, const HighsInt* array0, const HighsInt* array1) {
@@ -424,7 +424,7 @@ void full_api_options() {
   void* highs;
 
   highs = Highs_create();
-  // Highs_setBoolOptionValue(highs, "output_flag", dev_run);
+  Highs_setBoolOptionValue(highs, "output_flag", dev_run);
 
   const double kHighsInf = Highs_getInfinity(highs);
   HighsInt simplex_scale_strategy;
@@ -534,7 +534,7 @@ void full_api_options() {
   HighsInt num_options = Highs_getNumOptions(highs);
   char current_string_value[512];
  
-  //  if (dev_run)
+  if (dev_run)
     printf("\nString options are:\n");
   for (HighsInt index = 0; index < num_options; index++) {
     Highs_getOptionName(highs, index, &option);
@@ -542,9 +542,9 @@ void full_api_options() {
     if (type != kHighsOptionTypeString) continue;
     Highs_getStringOptionValues(highs, option, current_string_value, NULL);
     num_string_option++;
-    //      if (dev_run)
-    printf("%"HIGHSINT_FORMAT": %-24s \"%s\"\n",
-	   num_string_option, option, current_string_value);    
+    if (dev_run)
+      printf("%"HIGHSINT_FORMAT": %-24s \"%s\"\n",
+	     num_string_option, option, current_string_value);    
   }
 
 }

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -510,15 +510,13 @@ void Highs::getRowsInterface(const HighsIndexCollection& index_collection,
       if (row_upper != NULL) row_upper[new_iRow] = lp.row_upper_[iRow];
     }
   }
-  // bail out if no matrix is to be extracted
   const bool extract_start = row_matrix_start != NULL;
   const bool extract_index = row_matrix_index != NULL;
   const bool extract_value = row_matrix_value != NULL;
   const bool extract_matrix = extract_index || extract_value;
-  // Someone might just want the values, but to get them makes use of
-  // the starts so tough!
-  if (!extract_start) return;
-  // Allocate an array of lengths for the row-wise matrix to be extracted
+  // Allocate an array of lengths for the row-wise matrix to be
+  // extracted: necessary even if just the number of nonzeros is
+  // required
   vector<HighsInt> row_matrix_length;
   row_matrix_length.assign(get_num_row, 0);
   // Identify the lengths of the rows in the row-wise matrix to be extracted
@@ -530,6 +528,14 @@ void Highs::getRowsInterface(const HighsIndexCollection& index_collection,
       if (new_iRow >= 0) row_matrix_length[new_iRow]++;
     }
   }
+  if (!extract_start) {
+    // bail out if no matrix starts are to be extracted, but only after
+    // computing the number of nonzeros
+    for (HighsInt iRow = 0; iRow < get_num_row; iRow++)
+      get_num_nz += row_matrix_length[iRow];
+    return;
+  }
+  // Allocate an array of lengths for the row-wise matrix to be extracted
   row_matrix_start[0] = 0;
   for (HighsInt iRow = 0; iRow < get_num_row - 1; iRow++) {
     row_matrix_start[iRow + 1] =


### PR DESCRIPTION
Fixed a bug in `Highs::getRowsInterface` which always returned `get_num_nz=0` when `row_matrix_start` was `nullptr`