### PR TITLE
using ctypes.util.find_library

### DIFF
--- a/src/interfaces/highspy/setup.py
+++ b/src/interfaces/highspy/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 import pybind11.setup_helpers
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 import os
-from pyomo.common.fileutils import find_library
+import ctypes.util
 
 
 original_pybind11_setup_helpers_macos = pybind11.setup_helpers.MACOS
 pybind11.setup_helpers.MACOS = False
 
 try:
-    highs_lib = find_library('highs', include_PATH=True)
+    highs_lib = ctypes.util.find_library('highs')
     if highs_lib is None:
         raise RuntimeError('Could not find HiGHS library; Please make sure it is in the LD_LIBRARY_PATH environment variable')
     highs_lib_dir = os.path.dirname(highs_lib)


### PR DESCRIPTION
I'm on Intel macOS 13.1 and Python 3.10.9.

`pyomo.common.fileutils.find_library()` gives me the directory of the binary file `highs`.

When I change this to `ctypes.util.find_library()`, it gives the directory of the library file `libhighs.dylib` as intended.


```python
Python 3.10.9 (main, Dec 15 2022, 18:25:35) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyomo.common.fileutils import find_library
>>> highs_lib = find_library('highs', include_PATH=True)
>>> highs_lib
'/usr/local/bin/highs'
>>> import ctypes.util
>>> ctypes.util.find_library('highs')
'/usr/local/lib/libhighs.dylib'
```