### PR TITLE
Fix highs node queue clear

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if(MSVC)
 # This fouls up building HiGHS as part of a larger CMake project: see #1129.
 # Setting it will speed up run-time in debug (and compile-time?)
 #
-    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+#    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 endif()
 
 if (NOT FAST_BUILD OR FORTRAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if(MSVC)
 # This fouls up building HiGHS as part of a larger CMake project: see #1129.
 # Setting it will speed up run-time in debug (and compile-time?)
 #
-#    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 endif()
 
 if (NOT FAST_BUILD OR FORTRAN)

--- a/src/mip/HighsNodeQueue.cpp
+++ b/src/mip/HighsNodeQueue.cpp
@@ -422,7 +422,25 @@ HighsInt HighsNodeQueue::getBestBoundDomchgStackSize() const {
 }
 
 void HighsNodeQueue::clear() {
+  const bool original = false;
   HighsNodeQueue nodequeue;
   nodequeue.setNumCol(numCol);
-  *this = std::move(nodequeue);
+  if (original) {
+    *this = std::move(nodequeue);
+  } else {
+    (*this).allocatorState = std::move(nodequeue.allocatorState);
+    (*this).nodes = std::move(nodequeue.nodes);
+    (*this).freeslots = std::move(nodequeue.freeslots);
+    (*this).colLowerNodesPtr = std::move(nodequeue.colLowerNodesPtr);
+    (*this).colUpperNodesPtr = std::move(nodequeue.colUpperNodesPtr);
+    (*this).lowerRoot = nodequeue.lowerRoot;
+    (*this).lowerMin = nodequeue.lowerMin;
+    (*this).hybridEstimRoot = nodequeue.hybridEstimRoot;
+    (*this).hybridEstimMin = nodequeue.hybridEstimMin;
+    (*this).suboptimalRoot = nodequeue.suboptimalRoot;
+    (*this).suboptimalMin = nodequeue.suboptimalMin;
+    (*this).numSuboptimal = nodequeue.numSuboptimal;
+    (*this).optimality_limit = nodequeue.optimality_limit;
+    (*this).numCol = nodequeue.numCol;
+  }
 }

--- a/src/mip/HighsNodeQueue.cpp
+++ b/src/mip/HighsNodeQueue.cpp
@@ -430,7 +430,8 @@ void HighsNodeQueue::clear() {
   } else {
     (*this).allocatorState = std::move(nodequeue.allocatorState);
     (*this).nodes = std::move(nodequeue.nodes);
-    (*this).freeslots = std::move(nodequeue.freeslots);
+    //    (*this).freeslots = std::move(nodequeue.freeslots);
+    (*this).freeslots = nodequeue.freeslots;
     (*this).colLowerNodesPtr = std::move(nodequeue.colLowerNodesPtr);
     (*this).colUpperNodesPtr = std::move(nodequeue.colUpperNodesPtr);
     (*this).lowerRoot = nodequeue.lowerRoot;

--- a/src/mip/HighsNodeQueue.cpp
+++ b/src/mip/HighsNodeQueue.cpp
@@ -428,12 +428,11 @@ void HighsNodeQueue::clear() {
   if (original) {
     *this = std::move(nodequeue);
   } else {
-    (*this).allocatorState = std::move(nodequeue.allocatorState);
-    (*this).nodes = std::move(nodequeue.nodes);
-    //    (*this).freeslots = std::move(nodequeue.freeslots);
-    (*this).freeslots = nodequeue.freeslots;
-    (*this).colLowerNodesPtr = std::move(nodequeue.colLowerNodesPtr);
-    (*this).colUpperNodesPtr = std::move(nodequeue.colUpperNodesPtr);
+    (*this).nodes.clear();
+    (*this).colLowerNodesPtr.reset();
+    (*this).colUpperNodesPtr.reset();
+    while (!(*this).freeslots.empty()) (*this).freeslots.pop();
+    (*this).allocatorState.reset();
     (*this).lowerRoot = nodequeue.lowerRoot;
     (*this).lowerMin = nodequeue.lowerMin;
     (*this).hybridEstimRoot = nodequeue.hybridEstimRoot;

--- a/src/mip/HighsNodeQueue.cpp
+++ b/src/mip/HighsNodeQueue.cpp
@@ -428,11 +428,11 @@ void HighsNodeQueue::clear() {
   if (original) {
     *this = std::move(nodequeue);
   } else {
-    (*this).nodes.clear();
-    (*this).colLowerNodesPtr.reset();
-    (*this).colUpperNodesPtr.reset();
-    while (!(*this).freeslots.empty()) (*this).freeslots.pop();
-    (*this).allocatorState.reset();
+    (*this).nodes = std::move(nodequeue.nodes);
+    (*this).colLowerNodesPtr = std::move(nodequeue.colLowerNodesPtr);
+    (*this).colUpperNodesPtr = std::move(nodequeue.colUpperNodesPtr);
+    (*this).freeslots = std::move(nodequeue.freeslots);
+    (*this).allocatorState = std::move(nodequeue.allocatorState);
     (*this).lowerRoot = nodequeue.lowerRoot;
     (*this).lowerMin = nodequeue.lowerMin;
     (*this).hybridEstimRoot = nodequeue.hybridEstimRoot;

--- a/src/mip/HighsNodeQueue.cpp
+++ b/src/mip/HighsNodeQueue.cpp
@@ -420,3 +420,9 @@ HighsInt HighsNodeQueue::getBestBoundDomchgStackSize() const {
   return std::min(HighsInt(nodes[suboptimalMin].domchgstack.size()),
                   domchgStackSize);
 }
+
+void HighsNodeQueue::clear() {
+  HighsNodeQueue nodequeue;
+  nodequeue.setNumCol(numCol);
+  *this = std::move(nodequeue);
+}

--- a/src/mip/HighsNodeQueue.h
+++ b/src/mip/HighsNodeQueue.h
@@ -286,11 +286,7 @@ class HighsNodeQueue {
 
   HighsInt getBestBoundDomchgStackSize() const;
 
-  void clear() {
-    HighsNodeQueue nodequeue;
-    nodequeue.setNumCol(numCol);
-    *this = std::move(nodequeue);
-  }
+  void clear();
 
   int64_t numNodes() const { return nodes.size() - freeslots.size(); }
 


### PR DESCRIPTION
`HighsNodeQueue::clear()` was written originally as 

> HighsNodeQueue::clear() 
{
  HighsNodeQueue nodequeue;
  nodequeue.setNumCol(numCol);
  *this = std::move(nodequeue);
}

However, on Windows _without_

-D_ITERATOR_DEBUG_LEVEL=0

a segfault occurs in `std::move(nodequeue);`. This seems to be fixed by performing `std::move` operations in the right order!