### PR TITLE
Fix 1129

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if(MSVC)
 # This fouls up building HiGHS as part of a larger CMake project: see #1129.
 # Setting it will speed up run-time in debug (and compile-time?)
 #
-    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+#    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 endif()
 
 if (NOT FAST_BUILD OR FORTRAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,11 @@ if(MSVC)
     add_definitions(/wd4018 /wd4061 /wd4100 /wd4101 /wd4127 /wd4189 /wd4244 /wd4245 /wd4267 /wd4324 /wd4365 /wd4389 /wd4456 /wd4457 /wd4458 /wd4459 /wd4514 /wd4701 /wd4820)
     add_definitions(/MP)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+#
+# This fouls up building HiGHS as part of a larger CMake project: see #1129.
+# Setting it will speed up run-time in debug (and compile-time?)
+#
+#    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 endif()
 
 if (NOT FAST_BUILD OR FORTRAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if(MSVC)
 # This fouls up building HiGHS as part of a larger CMake project: see #1129.
 # Setting it will speed up run-time in debug (and compile-time?)
 #
-#    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
 endif()
 
 if (NOT FAST_BUILD OR FORTRAN)

--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -635,12 +635,12 @@ TEST_CASE("AlienBasis-reuse-basis", "[highs_test_alien_basis]") {
   // Add another variable
   vector<HighsInt> new_index = {0, 1, 2};
   vector<double> new_value = {50, 4, 30};
-  highs.addCol(850, 0, inf, 3, &new_index[0], &new_value[0]);
+  highs.addCol(850, 0, inf, 3, new_index.data(), new_value.data());
   // Add a new constraint
   new_value[0] = 15;
   new_value[1] = 24;
   new_value[2] = 30;
-  highs.addRow(-inf, 108, 3, &new_index[0], &new_value[0]);
+  highs.addRow(-inf, 108, 3, new_index.data(), new_value.data());
   const bool singlar_also = true;
   if (singlar_also) {
     const HighsInt from_col = 0;
@@ -656,8 +656,8 @@ TEST_CASE("AlienBasis-reuse-basis", "[highs_test_alien_basis]") {
     vector<HighsInt> get_index(get_num_nz);
     vector<double> get_value(get_num_nz);
     highs.getCols(from_col, to_col, get_num_col, &get_cost, &get_lower,
-                  &get_upper, get_num_nz, &get_start[0], &get_index[0],
-                  &get_value[0]);
+                  &get_upper, get_num_nz, get_start.data(), get_index.data(),
+                  get_value.data());
 
     // Make the first two columns parallel, so that the saved basis is
     // singular, as well as having too few basic variables
@@ -711,6 +711,6 @@ TEST_CASE("AlienBasis-singular-basis", "[highs_test_alien_basis]") {
   highs.setBasis(basis);
   std::vector<HighsInt> basic_variables;
   basic_variables.resize(lp.num_row_);
-  return_status = highs.getBasicVariables(&basic_variables[0]);
+  return_status = highs.getBasicVariables(basic_variables.data());
   REQUIRE(return_status == HighsStatus::kError);
 }

--- a/check/TestBasisSolves.cpp
+++ b/check/TestBasisSolves.cpp
@@ -177,7 +177,7 @@ void testBasisSolve(Highs& highs) {
 
   HighsInt basic_col;
 
-  highs_status = highs.getBasicVariables(&basic_variables[0]);
+  highs_status = highs.getBasicVariables(basic_variables.data());
   REQUIRE(highs_status == HighsStatus::kOk);
 
   for (HighsInt ix = 0; ix < numRow; ix++) known_solution[ix] = 0;
@@ -202,9 +202,10 @@ void testBasisSolve(Highs& highs) {
 
   GetBasisSolvesFormRHS(lp, basic_variables, known_solution, rhs, transpose);
   if (transpose) {
-    highs_status = highs.getBasisTransposeSolve(&rhs[0], &solution_col[0]);
+    highs_status =
+        highs.getBasisTransposeSolve(rhs.data(), solution_col.data());
   } else {
-    highs_status = highs.getBasisSolve(&rhs[0], &solution_col[0]);
+    highs_status = highs.getBasisSolve(rhs.data(), solution_col.data());
   }
   REQUIRE(highs_status == HighsStatus::kOk);
   residual_norm = GetBasisSolvesCheckSolution(lp, basic_variables, rhs,
@@ -243,8 +244,8 @@ void testBasisSolve(Highs& highs) {
         rhs[lp.a_matrix_.index_[el]] = lp.a_matrix_.value_[el];
 
       highs_status =
-          highs.getBasisSolve(&rhs[0], &solution_col[0], &solution_num_nz,
-                              &solution_col_indices[0]);
+          highs.getBasisSolve(rhs.data(), solution_col.data(), &solution_num_nz,
+                              solution_col_indices.data());
       REQUIRE(highs_status == HighsStatus::kOk);
       bool solution_nz_ok = GetBasisSolvesSolutionNzOk(
           numRow, solution_col, &solution_num_nz, solution_col_indices);
@@ -273,8 +274,8 @@ void testBasisSolve(Highs& highs) {
     check_row = k;
     // Determine row check_row of B^{-1}
     highs_status =
-        highs.getBasisInverseRow(check_row, &solution_col[0], &solution_num_nz,
-                                 &solution_col_indices[0]);
+        highs.getBasisInverseRow(check_row, solution_col.data(),
+                                 &solution_num_nz, solution_col_indices.data());
     REQUIRE(highs_status == HighsStatus::kOk);
     bool solution_nz_ok = GetBasisSolvesSolutionNzOk(
         numRow, solution_col, &solution_num_nz, solution_col_indices);
@@ -306,8 +307,8 @@ void testBasisSolve(Highs& highs) {
     check_col = k;
     // Determine col check_col of B^{-1}
     highs_status =
-        highs.getBasisInverseCol(check_col, &solution_col[0], &solution_num_nz,
-                                 &solution_col_indices[0]);
+        highs.getBasisInverseCol(check_col, solution_col.data(),
+                                 &solution_num_nz, solution_col_indices.data());
     REQUIRE(highs_status == HighsStatus::kOk);
     bool solution_nz_ok = GetBasisSolvesSolutionNzOk(
         numRow, solution_col, &solution_num_nz, solution_col_indices);
@@ -337,7 +338,7 @@ void testBasisSolve(Highs& highs) {
   max_residual_norm = 0;
   for (;;) {
     for (HighsInt row = 0; row < numRow; row++) rhs[row] = random.fraction();
-    highs_status = highs.getBasisSolve(&rhs[0], &solution_col[0]);
+    highs_status = highs.getBasisSolve(rhs.data(), solution_col.data());
     REQUIRE(highs_status == HighsStatus::kOk);
     // Check solution
     residual_norm = GetBasisSolvesCheckSolution(lp, basic_variables, rhs,
@@ -361,7 +362,8 @@ void testBasisSolve(Highs& highs) {
   max_residual_norm = 0;
   for (;;) {
     for (HighsInt row = 0; row < numRow; row++) rhs[row] = random.fraction();
-    highs_status = highs.getBasisTransposeSolve(&rhs[0], &solution_col[0]);
+    highs_status =
+        highs.getBasisTransposeSolve(rhs.data(), solution_col.data());
     REQUIRE(highs_status == HighsStatus::kOk);
     // Check solution
     residual_norm = GetBasisSolvesCheckSolution(lp, basic_variables, rhs,
@@ -388,8 +390,8 @@ void testBasisSolve(Highs& highs) {
   for (;;) {
     check_row = k;
     highs_status =
-        highs.getReducedRow(check_row, &solution_row[0], &solution_num_nz,
-                            &solution_row_indices[0]);
+        highs.getReducedRow(check_row, solution_row.data(), &solution_num_nz,
+                            solution_row_indices.data());
     REQUIRE(highs_status == HighsStatus::kOk);
     bool solution_nz_ok = GetBasisSolvesSolutionNzOk(
         numCol, solution_row, &solution_num_nz, solution_row_indices);
@@ -410,8 +412,8 @@ void testBasisSolve(Highs& highs) {
   for (;;) {
     check_col = k;
     highs_status =
-        highs.getReducedColumn(check_col, &solution_col[0], &solution_num_nz,
-                               &solution_col_indices[0]);
+        highs.getReducedColumn(check_col, solution_col.data(), &solution_num_nz,
+                               solution_col_indices.data());
     REQUIRE(highs_status == HighsStatus::kOk);
     // Check solution
     for (HighsInt row = 0; row < numRow; row++) rhs[row] = 0;
@@ -472,10 +474,10 @@ TEST_CASE("Basis-solves", "[highs_basis_solves]") {
   solution_col.resize(numRow);
 
   // Check the NULL pointer trap for RHS
-  highs_status = highs.getBasisSolve(NULL, &solution_col[0]);
+  highs_status = highs.getBasisSolve(NULL, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisSolve(NULL, &solution_col[0]);
+  highs_status = highs.getBasisSolve(NULL, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
   // Check the NULL pointer trap for the basic variables
@@ -489,10 +491,10 @@ TEST_CASE("Basis-solves", "[highs_basis_solves]") {
   highs_status = highs.getBasisInverseCol(0, NULL);
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisSolve(&rhs[0], NULL);
+  highs_status = highs.getBasisSolve(rhs.data(), NULL);
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisTransposeSolve(&rhs[0], NULL);
+  highs_status = highs.getBasisTransposeSolve(rhs.data(), NULL);
   REQUIRE(highs_status == HighsStatus::kError);
 
   highs_status = highs.getReducedRow(0, NULL);
@@ -502,39 +504,39 @@ TEST_CASE("Basis-solves", "[highs_basis_solves]") {
   REQUIRE(highs_status == HighsStatus::kError);
 
   // Check the indexing traps
-  highs_status = highs.getBasisInverseRow(-1, &solution_col[0]);
+  highs_status = highs.getBasisInverseRow(-1, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisInverseRow(numRow, &solution_col[0]);
+  highs_status = highs.getBasisInverseRow(numRow, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisInverseCol(-1, &solution_col[0]);
+  highs_status = highs.getBasisInverseCol(-1, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisInverseCol(numCol, &solution_col[0]);
+  highs_status = highs.getBasisInverseCol(numCol, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
   // Check the no INVERSE traps - these should all work, as the first should
   // force inversion!!!
-  highs_status = highs.getBasicVariables(&basic_variables[0]);
+  highs_status = highs.getBasicVariables(basic_variables.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisInverseRow(0, &solution_col[0]);
+  highs_status = highs.getBasisInverseRow(0, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisInverseCol(0, &solution_col[0]);
+  highs_status = highs.getBasisInverseCol(0, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisSolve(&rhs[0], &solution_col[0]);
+  highs_status = highs.getBasisSolve(rhs.data(), solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getBasisTransposeSolve(&rhs[0], &solution_col[0]);
+  highs_status = highs.getBasisTransposeSolve(rhs.data(), solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getReducedRow(0, &solution_row[0]);
+  highs_status = highs.getReducedRow(0, solution_row.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
-  highs_status = highs.getReducedColumn(0, &solution_col[0]);
+  highs_status = highs.getReducedColumn(0, solution_col.data());
   REQUIRE(highs_status == HighsStatus::kError);
 
   // Solve and perform numerical tests

--- a/check/TestCheckSolution.cpp
+++ b/check/TestCheckSolution.cpp
@@ -253,7 +253,7 @@ TEST_CASE("check-set-rowwise-lp-solution", "[highs_check_solution]") {
     highs.addCol(-1.0, 0.0, 1.0, 0, nullptr, nullptr);
     highs.changeColIntegrality(i, HighsVarType::kInteger);
   }
-  highs.addRow(0.0, 1.0, num_col, &indices[0], &values[0]);
+  highs.addRow(0.0, 1.0, num_col, indices.data(), values.data());
   highs.run();
   double objective1 = highs.getInfo().objective_function_value;
   HighsSolution solution = highs.getSolution();
@@ -265,7 +265,7 @@ TEST_CASE("check-set-rowwise-lp-solution", "[highs_check_solution]") {
     highs.addCol(-1.0, 0.0, 1.0, 0, nullptr, nullptr);
     highs.changeColIntegrality(i, HighsVarType::kInteger);
   }
-  highs.addRow(0.0, 1.0, num_col, &indices[0], &values[0]);
+  highs.addRow(0.0, 1.0, num_col, indices.data(), values.data());
   highs.setSolution(solution);
   highs.run();
   double objective2 = highs.getInfo().objective_function_value;

--- a/check/TestFactor.cpp
+++ b/check/TestFactor.cpp
@@ -351,7 +351,7 @@ bool testSolveDense() {
     unit[iCol] = 1.0;
     rhs_dense.clear();
     for (HighsInt iCol = 0; iCol < num_row; iCol++)
-      rhs_dense[iCol] = lp.a_matrix_.computeDot(unit, basic_set[iCol]);
+      rhs_dense.push_back(lp.a_matrix_.computeDot(unit, basic_set[iCol]));
     factor.btranCall(rhs_dense);
     error_norm = 0;
     for (HighsInt iRow = 0; iRow < num_row; iRow++) {
@@ -369,7 +369,7 @@ bool testSolveDense() {
     // Dense BTRAN
     rhs_dense.clear();
     for (HighsInt iCol = 0; iCol < num_row; iCol++)
-      rhs_dense[iCol] = lp.a_matrix_.computeDot(solution, basic_set[iCol]);
+      rhs_dense.push_back(lp.a_matrix_.computeDot(solution, basic_set[iCol]));
     factor.btranCall(rhs_dense);
     error_norm = 0;
     for (HighsInt iRow = 0; iRow < num_row; iRow++)

--- a/check/TestFactor.cpp
+++ b/check/TestFactor.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Factor-dense-tran", "[highs_test_factor]") {
   highs.run();
   basic_set.resize(num_row);
   // Get the optimal set of basic variables
-  highs.getBasicVariables(&basic_set[0]);
+  highs.getBasicVariables(basic_set.data());
   for (HighsInt iRow = 0; iRow < num_row; iRow++)
     basic_set[iRow] =
         basic_set[iRow] < 0 ? num_col - basic_set[iRow] + 1 : basic_set[iRow];

--- a/check/TestFreezeBasis.cpp
+++ b/check/TestFreezeBasis.cpp
@@ -30,7 +30,7 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
   // Get the integer solution to provide bound tightenings
   vector<HighsVarType> integrality;
   integrality.assign(num_col, HighsVarType::kInteger);
-  highs.changeColsIntegrality(from_col, to_col, &integrality[0]);
+  highs.changeColsIntegrality(from_col, to_col, integrality.data());
 
   highs.setOptionValue("output_flag", false);
   highs.run();
@@ -43,7 +43,7 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
   // Now restore the original integrality and set an explicit logical
   // basis to force reinversion
   integrality.assign(num_col, HighsVarType::kContinuous);
-  highs.changeColsIntegrality(from_col, to_col, &integrality[0]);
+  highs.changeColsIntegrality(from_col, to_col, integrality.data());
   HighsBasis basis;
   for (HighsInt iCol = 0; iCol < num_col; iCol++)
     basis.col_status.push_back(HighsBasisStatus::kLower);
@@ -58,7 +58,7 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
   // Get the basic variables to force INVERT with a logical basis
   vector<HighsInt> basic_variables;
   basic_variables.resize(lp.num_row_);
-  highs.getBasicVariables(&basic_variables[0]);
+  highs.getBasicVariables(basic_variables.data());
 
   // Can freeze a basis now!
   REQUIRE(highs.freezeBasis(frozen_basis_id0) == HighsStatus::kOk);
@@ -77,8 +77,8 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
   if (dev_run) printf("\nSolving with bounds (integer solution, upper)\n");
   local_col_lower = integer_solution;
   local_col_upper = original_col_upper;
-  highs.changeColsBounds(from_col, to_col, &local_col_lower[0],
-                         &local_col_upper[0]);
+  highs.changeColsBounds(from_col, to_col, local_col_lower.data(),
+                         local_col_upper.data());
   if (dev_run) highs.setOptionValue("output_flag", true);
   highs.run();
   // highs.setOptionValue("output_flag", false);
@@ -91,8 +91,8 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
     printf("\nSolving with bounds (integer solution, integer solution)\n");
   local_col_lower = integer_solution;
   local_col_upper = integer_solution;
-  highs.changeColsBounds(from_col, to_col, &local_col_lower[0],
-                         &local_col_upper[0]);
+  highs.changeColsBounds(from_col, to_col, local_col_lower.data(),
+                         local_col_upper.data());
   if (dev_run) highs.setOptionValue("output_flag", true);
   highs.run();
   // highs.setOptionValue("output_flag", false);
@@ -109,8 +109,8 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
   if (dev_run) printf("Change column bounds to (integer solution, upper)\n");
   local_col_lower = integer_solution;
   local_col_upper = original_col_upper;
-  highs.changeColsBounds(from_col, to_col, &local_col_lower[0],
-                         &local_col_upper[0]);
+  highs.changeColsBounds(from_col, to_col, local_col_lower.data(),
+                         local_col_upper.data());
   if (dev_run) printf("Unfreeze basis %d\n", (int)frozen_basis_id2);
   REQUIRE(highs.unfreezeBasis(frozen_basis_id2) == HighsStatus::kOk);
   // Solving the LP should require no iterations
@@ -131,8 +131,8 @@ TEST_CASE("FreezeBasis", "[highs_test_freeze_basis]") {
   if (dev_run) printf("Change column bounds to (lower, upper)\n");
   local_col_lower = original_col_lower;
   local_col_upper = original_col_upper;
-  highs.changeColsBounds(from_col, to_col, &local_col_lower[0],
-                         &local_col_upper[0]);
+  highs.changeColsBounds(from_col, to_col, local_col_lower.data(),
+                         local_col_upper.data());
   if (dev_run) printf("Unfreeze basis %d\n", (int)frozen_basis_id1);
   REQUIRE(highs.unfreezeBasis(frozen_basis_id1) == HighsStatus::kOk);
   // Solving the LP should require no iterations

--- a/check/TestHotStart.cpp
+++ b/check/TestHotStart.cpp
@@ -26,7 +26,7 @@ TEST_CASE("HotStart-avgas", "[highs_test_hot_start]") {
   // Get the integer solution to provide bound tightenings
   vector<HighsVarType> integrality;
   integrality.assign(num_col, HighsVarType::kInteger);
-  highs.changeColsIntegrality(from_col, to_col, &integrality[0]);
+  highs.changeColsIntegrality(from_col, to_col, integrality.data());
 
   highs.setOptionValue("output_flag", false);
   highs.run();
@@ -36,7 +36,7 @@ TEST_CASE("HotStart-avgas", "[highs_test_hot_start]") {
 
   // Now restore the original integrality
   integrality.assign(num_col, HighsVarType::kContinuous);
-  highs.changeColsIntegrality(from_col, to_col, &integrality[0]);
+  highs.changeColsIntegrality(from_col, to_col, integrality.data());
 
   // Solve the continuous problem and get its hot start
   highs.run();
@@ -51,8 +51,8 @@ TEST_CASE("HotStart-avgas", "[highs_test_hot_start]") {
   highs.setBasis();
 
   // Set the integer solution as upper bounds
-  highs.changeColsBounds(from_col, to_col, &original_col_lower[0],
-                         &integer_solution[0]);
+  highs.changeColsBounds(from_col, to_col, original_col_lower.data(),
+                         integer_solution.data());
 
   if (dev_run) printf("\nSolving with bounds (lower, integer solution)\n");
 
@@ -91,7 +91,7 @@ TEST_CASE("HotStart-rgn", "[highs_test_hot_start]") {
   // Now remove integrality
   vector<HighsVarType> integrality;
   integrality.assign(num_col, HighsVarType::kContinuous);
-  highs.changeColsIntegrality(from_col, to_col, &integrality[0]);
+  highs.changeColsIntegrality(from_col, to_col, integrality.data());
 
   // Solve the continuous problem and get its hot start
   highs.run();
@@ -106,8 +106,8 @@ TEST_CASE("HotStart-rgn", "[highs_test_hot_start]") {
   highs.setBasis();
 
   // Set the mip solution as upper bounds
-  highs.changeColsBounds(from_col, to_col, &original_col_lower[0],
-                         &mip_solution[0]);
+  highs.changeColsBounds(from_col, to_col, original_col_lower.data(),
+                         mip_solution.data());
 
   if (dev_run) printf("\nSolving with bounds (lower, mip solution)\n");
 

--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -53,7 +53,8 @@ TEST_CASE("LP-717-od", "[highs_data]") {
           HighsStatus::kOk);
   std::vector<HighsInt> index = {0};
   std::vector<double> value = {1.0};
-  REQUIRE(highs.addRow(2.0, inf, 1, &index[0], &value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRow(2.0, inf, 1, index.data(), value.data()) ==
+          HighsStatus::kOk);
   REQUIRE(highs.addCol(0.0, -inf, inf, 0, nullptr, nullptr) ==
           HighsStatus::kOk);
   REQUIRE(highs.run() == HighsStatus::kOk);
@@ -136,14 +137,14 @@ TEST_CASE("LP-717-full0", "[highs_data]") {
   }
   row_block_num_nz = row_block_index.size();
 
-  REQUIRE(highs.addCols(row_block_num_col, &row_block_col_cost[0],
-                        &row_block_col_lower[0], &row_block_col_upper[0], 0,
-                        nullptr, nullptr, nullptr) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(row_block_num_col, row_block_col_cost.data(),
+                        row_block_col_lower.data(), row_block_col_upper.data(),
+                        0, nullptr, nullptr, nullptr) == HighsStatus::kOk);
 
-  REQUIRE(highs.addRows(row_block_num_row, &row_block_row_lower[0],
-                        &row_block_row_upper[0], row_block_num_nz,
-                        &row_block_start[0], &row_block_index[0],
-                        &row_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(row_block_num_row, row_block_row_lower.data(),
+                        row_block_row_upper.data(), row_block_num_nz,
+                        row_block_start.data(), row_block_index.data(),
+                        row_block_value.data()) == HighsStatus::kOk);
 
   if (dev_run)
     printf("After adding a row-wise matrix, LP matrix has format %d\n",
@@ -155,11 +156,11 @@ TEST_CASE("LP-717-full0", "[highs_data]") {
   std::vector<HighsInt> col_block_start = {0, 2, 4};
   std::vector<HighsInt> col_block_index = {0, 1, 1, 2, 0, 1};
   std::vector<double> col_block_value = {-1, 1, -2, 2, -3, 3};
-  REQUIRE(highs.addCols(col_block_num_col, &col_block_col_cost[0],
-                        &col_block_col_lower[0], &col_block_col_upper[0],
-                        col_block_num_nz, &col_block_start[0],
-                        &col_block_index[0],
-                        &col_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(col_block_num_col, col_block_col_cost.data(),
+                        col_block_col_lower.data(), col_block_col_upper.data(),
+                        col_block_num_nz, col_block_start.data(),
+                        col_block_index.data(),
+                        col_block_value.data()) == HighsStatus::kOk);
   if (dev_run)
     printf("After adding a column-wise matrix, LP matrix has format %d\n",
            (int)highs_lp.a_matrix_.format_);
@@ -248,14 +249,14 @@ TEST_CASE("LP-717-full1", "[highs_data]") {
   }
   row_block_num_nz = row_block_index.size();
 
-  REQUIRE(highs.addCols(row_block_num_col, &row_block_col_cost[0],
-                        &row_block_col_lower[0], &row_block_col_upper[0], 0,
-                        nullptr, nullptr, nullptr) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(row_block_num_col, row_block_col_cost.data(),
+                        row_block_col_lower.data(), row_block_col_upper.data(),
+                        0, nullptr, nullptr, nullptr) == HighsStatus::kOk);
 
-  REQUIRE(highs.addRows(row_block_num_row, &row_block_row_lower[0],
-                        &row_block_row_upper[0], row_block_num_nz,
-                        &row_block_start[0], &row_block_index[0],
-                        &row_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(row_block_num_row, row_block_row_lower.data(),
+                        row_block_row_upper.data(), row_block_num_nz,
+                        row_block_start.data(), row_block_index.data(),
+                        row_block_value.data()) == HighsStatus::kOk);
 
   if (dev_run)
     printf("After adding a row-wise matrix, LP matrix has format %d\n",
@@ -267,11 +268,11 @@ TEST_CASE("LP-717-full1", "[highs_data]") {
   std::vector<HighsInt> col_block_start = {0, 2, 4};
   std::vector<HighsInt> col_block_index = {0, 1, 1, 2, 0, 1};
   std::vector<double> col_block_value = {-1, 1, -2, 2, -3, 3};
-  REQUIRE(highs.addCols(col_block_num_col, &col_block_col_cost[0],
-                        &col_block_col_lower[0], &col_block_col_upper[0],
-                        col_block_num_nz, &col_block_start[0],
-                        &col_block_index[0],
-                        &col_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(col_block_num_col, col_block_col_cost.data(),
+                        col_block_col_lower.data(), col_block_col_upper.data(),
+                        col_block_num_nz, col_block_start.data(),
+                        col_block_index.data(),
+                        col_block_value.data()) == HighsStatus::kOk);
   if (dev_run)
     printf("After adding a column-wise matrix, LP matrix has format %d\n",
            (int)highs_lp.a_matrix_.format_);
@@ -368,14 +369,14 @@ TEST_CASE("LP-717-full2", "[highs_data]") {
   }
   row_block_num_nz = row_block_index.size();
 
-  REQUIRE(highs.addCols(row_block_num_col, &row_block_col_cost[0],
-                        &row_block_col_lower[0], &row_block_col_upper[0], 0,
-                        nullptr, nullptr, nullptr) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(row_block_num_col, row_block_col_cost.data(),
+                        row_block_col_lower.data(), row_block_col_upper.data(),
+                        0, nullptr, nullptr, nullptr) == HighsStatus::kOk);
 
-  REQUIRE(highs.addRows(row_block_num_row, &row_block_row_lower[0],
-                        &row_block_row_upper[0], row_block_num_nz,
-                        &row_block_start[0], &row_block_index[0],
-                        &row_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(row_block_num_row, row_block_row_lower.data(),
+                        row_block_row_upper.data(), row_block_num_nz,
+                        row_block_start.data(), row_block_index.data(),
+                        row_block_value.data()) == HighsStatus::kOk);
 
   if (dev_run)
     printf("After adding a row-wise matrix, LP matrix has format %d\n",
@@ -387,19 +388,19 @@ TEST_CASE("LP-717-full2", "[highs_data]") {
   std::vector<HighsInt> col_block_start = {0, 2, 4};
   std::vector<HighsInt> col_block_index = {0, 1, 1, 2, 0, 1};
   std::vector<double> col_block_value = {-1, 1, -2, 2, -3, 3};
-  REQUIRE(highs.addCols(col_block_num_col, &col_block_col_cost[0],
-                        &col_block_col_lower[0], &col_block_col_upper[0],
-                        col_block_num_nz, &col_block_start[0],
-                        &col_block_index[0],
-                        &col_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(col_block_num_col, col_block_col_cost.data(),
+                        col_block_col_lower.data(), col_block_col_upper.data(),
+                        col_block_num_nz, col_block_start.data(),
+                        col_block_index.data(),
+                        col_block_value.data()) == HighsStatus::kOk);
   if (dev_run)
     printf("After adding a column-wise matrix, LP matrix has format %d\n",
            (int)highs_lp.a_matrix_.format_);
 
-  REQUIRE(highs.addRows(row_block_num_row, &row_block_row_lower[0],
-                        &row_block_row_upper[0], row_block_num_nz,
-                        &row_block_start[0], &row_block_index[0],
-                        &row_block_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(row_block_num_row, row_block_row_lower.data(),
+                        row_block_row_upper.data(), row_block_num_nz,
+                        row_block_start.data(), row_block_index.data(),
+                        row_block_value.data()) == HighsStatus::kOk);
 
   if (dev_run)
     printf("After adding a row-wise matrix, LP matrix has format %d\n",
@@ -467,11 +468,12 @@ TEST_CASE("LP-modification", "[highs_data]") {
                     return_status);
   REQUIRE(return_status == HighsStatus::kOk);
 
-  REQUIRE(avgas_highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0],
-                              0, NULL, NULL, NULL) == HighsStatus::kOk);
-  REQUIRE(avgas_highs.addRows(num_row, &rowLower[0], &rowUpper[0], num_row_nz,
-                              &ARstart[0], &ARindex[0],
-                              &ARvalue[0]) == HighsStatus::kOk);
+  REQUIRE(avgas_highs.addCols(num_col, colCost.data(), colLower.data(),
+                              colUpper.data(), 0, NULL, NULL,
+                              NULL) == HighsStatus::kOk);
+  REQUIRE(avgas_highs.addRows(num_row, rowLower.data(), rowUpper.data(),
+                              num_row_nz, ARstart.data(), ARindex.data(),
+                              ARvalue.data()) == HighsStatus::kOk);
 
   //  return_status = avgas_highs.writeModel("");
 
@@ -494,22 +496,23 @@ TEST_CASE("LP-modification", "[highs_data]") {
   REQUIRE(model_status == HighsModelStatus::kModelEmpty);
 
   // Adding column vectors and matrix to model with no rows returns an error
-  REQUIRE(highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0],
-                        num_col_nz, &Astart[0], &Aindex[0],
-                        &Avalue[0]) == HighsStatus::kError);
+  REQUIRE(highs.addCols(num_col, colCost.data(), colLower.data(),
+                        colUpper.data(), num_col_nz, Astart.data(),
+                        Aindex.data(), Avalue.data()) == HighsStatus::kError);
 
   // Adding column vectors to model with no rows returns OK
-  REQUIRE(highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0], 0,
-                        NULL, NULL, NULL) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(num_col, colCost.data(), colLower.data(),
+                        colUpper.data(), 0, NULL, NULL,
+                        NULL) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
   //  return_status = highs.writeModel("");
 
   // Adding row vectors and matrix to model with columns returns OK
-  REQUIRE(highs.addRows(num_row, &rowLower[0], &rowUpper[0], num_row_nz,
-                        &ARstart[0], &ARindex[0],
-                        &ARvalue[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(num_row, rowLower.data(), rowUpper.data(), num_row_nz,
+                        ARstart.data(), ARindex.data(),
+                        ARvalue.data()) == HighsStatus::kOk);
 
   //  return_status = highs.writeModel("");
 
@@ -593,15 +596,16 @@ TEST_CASE("LP-modification", "[highs_data]") {
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
   // Adding column vectors to model with no rows returns OK
-  REQUIRE(highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0], 0,
-                        NULL, NULL, NULL) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(num_col, colCost.data(), colLower.data(),
+                        colUpper.data(), 0, NULL, NULL,
+                        NULL) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
   // Adding row vectors and matrix to model with columns returns OK
-  REQUIRE(highs.addRows(num_row, &rowLower[0], &rowUpper[0], num_row_nz,
-                        &ARstart[0], &ARindex[0],
-                        &ARvalue[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(num_row, rowLower.data(), rowUpper.data(), num_row_nz,
+                        ARstart.data(), ARindex.data(),
+                        ARvalue.data()) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
@@ -677,8 +681,9 @@ TEST_CASE("LP-modification", "[highs_data]") {
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
   // Adding column vectors to model with no rows returns OK
-  REQUIRE(highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0], 0,
-                        NULL, NULL, NULL) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(num_col, colCost.data(), colLower.data(),
+                        colUpper.data(), 0, NULL, NULL,
+                        NULL) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
@@ -863,15 +868,16 @@ TEST_CASE("LP-modification", "[highs_data]") {
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
   // Adding column vectors to model with no rows returns OK
-  REQUIRE(highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0], 0,
-                        NULL, NULL, NULL) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(num_col, colCost.data(), colLower.data(),
+                        colUpper.data(), 0, NULL, NULL,
+                        NULL) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
   // Adding row vectors and matrix to model with columns returns OK
-  REQUIRE(highs.addRows(num_row, &rowLower[0], &rowUpper[0], num_row_nz,
-                        &ARstart[0], &ARindex[0],
-                        &ARvalue[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(num_row, rowLower.data(), rowUpper.data(), num_row_nz,
+                        ARstart.data(), ARindex.data(),
+                        ARvalue.data()) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
@@ -941,17 +947,17 @@ TEST_CASE("LP-modification", "[highs_data]") {
                                  col1357_upper) == HighsStatus::kOk);
 
   // Return the LP to its original state with a mask
-  REQUIRE(highs.changeColsCost(col1357_col_mask, &colCost[0]) ==
+  REQUIRE(highs.changeColsCost(col1357_col_mask, colCost.data()) ==
           HighsStatus::kOk);
 
   REQUIRE(highs.changeColBounds(2, colLower[2], colUpper[2]) ==
           HighsStatus::kOk);
 
-  REQUIRE(highs.changeColsBounds(col1357_col_mask, &colLower[0],
-                                 &colUpper[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeColsBounds(col1357_col_mask, colLower.data(),
+                                 colUpper.data()) == HighsStatus::kOk);
 
-  REQUIRE(highs.changeRowsBounds(row0135789_row_mask, &rowLower[0],
-                                 &rowUpper[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeRowsBounds(row0135789_row_mask, rowLower.data(),
+                                 rowUpper.data()) == HighsStatus::kOk);
 
   REQUIRE(highs.changeRowBounds(2, rowLower[2], rowUpper[2]) ==
           HighsStatus::kOk);
@@ -1165,18 +1171,18 @@ TEST_CASE("LP-interval-changes", "[highs_data]") {
   set_col2345_cost[1] = 3.0;
   set_col2345_cost[2] = 4.0;
   set_col2345_cost[3] = 5.0;
-  REQUIRE(highs.getCols(from_col, to_col, get_num_col, &og_col2345_cost[0],
+  REQUIRE(highs.getCols(from_col, to_col, get_num_col, og_col2345_cost.data(),
                         NULL, NULL, get_num_nz, NULL, NULL,
                         NULL) == HighsStatus::kOk);
-  REQUIRE(highs.changeColsCost(from_col, to_col, &set_col2345_cost[0]) ==
+  REQUIRE(highs.changeColsCost(from_col, to_col, set_col2345_cost.data()) ==
           HighsStatus::kOk);
-  REQUIRE(highs.getCols(from_col, to_col, get_num_col, &get_col2345_cost[0],
+  REQUIRE(highs.getCols(from_col, to_col, get_num_col, get_col2345_cost.data(),
                         NULL, NULL, get_num_nz, NULL, NULL,
                         NULL) == HighsStatus::kOk);
   REQUIRE(get_num_col == set_num_col);
   for (HighsInt usr_col = 0; usr_col < get_num_col; usr_col++)
     REQUIRE(get_col2345_cost[usr_col] == set_col2345_cost[usr_col]);
-  REQUIRE(highs.changeColsCost(from_col, to_col, &og_col2345_cost[0]) ==
+  REQUIRE(highs.changeColsCost(from_col, to_col, og_col2345_cost.data()) ==
           HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
@@ -1204,18 +1210,18 @@ TEST_CASE("LP-interval-changes", "[highs_data]") {
   set_col01234_lower[3] = 3.0;
   set_col01234_lower[4] = 4.0;
   REQUIRE(highs.getCols(from_col, to_col, get_num_col, NULL,
-                        &og_col01234_lower[0], &og_col01234_upper[0],
+                        og_col01234_lower.data(), og_col01234_upper.data(),
                         get_num_nz, NULL, NULL, NULL) == HighsStatus::kOk);
-  REQUIRE(highs.changeColsBounds(from_col, to_col, &set_col01234_lower[0],
-                                 &og_col01234_upper[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeColsBounds(from_col, to_col, set_col01234_lower.data(),
+                                 og_col01234_upper.data()) == HighsStatus::kOk);
   REQUIRE(highs.getCols(from_col, to_col, get_num_col, NULL,
-                        &get_col01234_lower[0], &og_col01234_upper[0],
+                        get_col01234_lower.data(), og_col01234_upper.data(),
                         get_num_nz, NULL, NULL, NULL) == HighsStatus::kOk);
   REQUIRE(get_num_col == set_num_col);
   for (HighsInt usr_col = 0; usr_col < get_num_col; usr_col++)
     REQUIRE(get_col01234_lower[usr_col] == set_col01234_lower[usr_col]);
-  REQUIRE(highs.changeColsBounds(from_col, to_col, &og_col01234_lower[0],
-                                 &og_col01234_upper[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeColsBounds(from_col, to_col, og_col01234_lower.data(),
+                                 og_col01234_upper.data()) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
@@ -1241,19 +1247,19 @@ TEST_CASE("LP-interval-changes", "[highs_data]") {
   set_row56789_lower[2] = 7.0;
   set_row56789_lower[3] = 8.0;
   set_row56789_lower[4] = 9.0;
-  REQUIRE(highs.getRows(from_row, to_row, get_num_row, &og_row56789_lower[0],
-                        &og_row56789_upper[0], get_num_nz, NULL, NULL,
+  REQUIRE(highs.getRows(from_row, to_row, get_num_row, og_row56789_lower.data(),
+                        og_row56789_upper.data(), get_num_nz, NULL, NULL,
                         NULL) == HighsStatus::kOk);
-  REQUIRE(highs.changeRowsBounds(from_row, to_row, &set_row56789_lower[0],
-                                 &og_row56789_upper[0]) == HighsStatus::kOk);
-  REQUIRE(highs.getRows(from_row, to_row, get_num_row, &get_row56789_lower[0],
-                        &og_row56789_upper[0], get_num_nz, NULL, NULL,
-                        NULL) == HighsStatus::kOk);
+  REQUIRE(highs.changeRowsBounds(from_row, to_row, set_row56789_lower.data(),
+                                 og_row56789_upper.data()) == HighsStatus::kOk);
+  REQUIRE(highs.getRows(from_row, to_row, get_num_row,
+                        get_row56789_lower.data(), og_row56789_upper.data(),
+                        get_num_nz, NULL, NULL, NULL) == HighsStatus::kOk);
   REQUIRE(get_num_row == set_num_row);
   for (HighsInt usr_row = 0; usr_row < get_num_row; usr_row++)
     REQUIRE(get_row56789_lower[usr_row] == set_row56789_lower[usr_row]);
-  REQUIRE(highs.changeRowsBounds(from_row, to_row, &og_row56789_lower[0],
-                                 &og_row56789_upper[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeRowsBounds(from_row, to_row, og_row56789_lower.data(),
+                                 og_row56789_upper.data()) == HighsStatus::kOk);
 
   callRun(highs, options.log_options, "highs.run()", HighsStatus::kOk);
 
@@ -1332,22 +1338,24 @@ TEST_CASE("LP-delete", "[highs_data]") {
   get_value.resize(num_nz);
 
   // Get the set of cols to be removed - so that they can be reintroduced
-  REQUIRE(highs.getCols(&mask[0], get_num_col, &get_cost[0], &get_lower[0],
-                        &get_upper[0], get_num_nz, &get_start[0], &get_index[0],
-                        &get_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.getCols(mask.data(), get_num_col, get_cost.data(),
+                        get_lower.data(), get_upper.data(), get_num_nz,
+                        get_start.data(), get_index.data(),
+                        get_value.data()) == HighsStatus::kOk);
   REQUIRE(get_num_col == rm_num_col);
   get_index.resize(get_num_nz);
   get_value.resize(get_num_nz);
 
   // Remove the set of cols
-  REQUIRE(highs.deleteCols(&mask[0]) == HighsStatus::kOk);
+  REQUIRE(highs.deleteCols(mask.data()) == HighsStatus::kOk);
   REQUIRE(mask == mask_check);
   REQUIRE(lp.num_col_ == num_col - rm_num_col);
 
   // Replace the set of cols
-  REQUIRE(highs.addCols(get_num_col, &get_cost[0], &get_lower[0], &get_upper[0],
-                        get_num_nz, &get_start[0], &get_index[0],
-                        &get_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(get_num_col, get_cost.data(), get_lower.data(),
+                        get_upper.data(), get_num_nz, get_start.data(),
+                        get_index.data(),
+                        get_value.data()) == HighsStatus::kOk);
   REQUIRE(lp.num_col_ == num_col);
 
   callRun(highs, log_options, "highs.run()", HighsStatus::kOk);
@@ -1389,22 +1397,23 @@ TEST_CASE("LP-delete", "[highs_data]") {
   get_value.resize(num_nz);
 
   // Get the set of rows to be removed - so that they can be reintroduced
-  REQUIRE(highs.getRows(&mask[0], get_num_row, &get_lower[0], &get_upper[0],
-                        get_num_nz, &get_start[0], &get_index[0],
-                        &get_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.getRows(mask.data(), get_num_row, get_lower.data(),
+                        get_upper.data(), get_num_nz, get_start.data(),
+                        get_index.data(),
+                        get_value.data()) == HighsStatus::kOk);
   REQUIRE(get_num_row == rm_num_row);
   get_index.resize(get_num_nz);
   get_value.resize(get_num_nz);
 
   // Remove the set of rows
-  REQUIRE(highs.deleteRows(&mask[0]) == HighsStatus::kOk);
+  REQUIRE(highs.deleteRows(mask.data()) == HighsStatus::kOk);
   REQUIRE(mask == mask_check);
   REQUIRE(lp.num_row_ == num_row - rm_num_row);
 
   // Replace the set of rows
-  REQUIRE(highs.addRows(get_num_row, &get_lower[0], &get_upper[0], get_num_nz,
-                        &get_start[0], &get_index[0],
-                        &get_value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(get_num_row, get_lower.data(), get_upper.data(),
+                        get_num_nz, get_start.data(), get_index.data(),
+                        get_value.data()) == HighsStatus::kOk);
   REQUIRE(lp.num_row_ == num_row);
 
   callRun(highs, log_options, "highs.run()", HighsStatus::kOk);
@@ -1630,21 +1639,21 @@ bool areLpEqual(const HighsLp lp0, const HighsLp lp1,
     HighsInt lp0_num_nz = lp0.a_matrix_.start_[lp0.num_col_];
     HighsInt lp1_num_nz = lp1.a_matrix_.start_[lp1.num_col_];
     return_bool = areLpColEqual(
-        lp0.num_col_, &lp0.col_cost_[0], &lp0.col_lower_[0], &lp0.col_upper_[0],
-        lp0_num_nz, &lp0.a_matrix_.start_[0], &lp0.a_matrix_.index_[0],
-        &lp0.a_matrix_.value_[0], lp1.num_col_, &lp1.col_cost_[0],
-        &lp1.col_lower_[0], &lp1.col_upper_[0], lp1_num_nz,
-        &lp1.a_matrix_.start_[0], &lp1.a_matrix_.index_[0],
-        &lp1.a_matrix_.value_[0], infinite_bound);
+        lp0.num_col_, lp0.col_cost_.data(), lp0.col_lower_.data(),
+        lp0.col_upper_.data(), lp0_num_nz, lp0.a_matrix_.start_.data(),
+        lp0.a_matrix_.index_.data(), lp0.a_matrix_.value_.data(), lp1.num_col_,
+        lp1.col_cost_.data(), lp1.col_lower_.data(), lp1.col_upper_.data(),
+        lp1_num_nz, lp1.a_matrix_.start_.data(), lp1.a_matrix_.index_.data(),
+        lp1.a_matrix_.value_.data(), infinite_bound);
     if (!return_bool) return return_bool;
   }
   if (lp0.num_row_ > 0 && lp1.num_row_ > 0) {
     HighsInt lp0_num_nz = 0;
     HighsInt lp1_num_nz = 0;
     return_bool = areLpRowEqual(
-        lp0.num_row_, &lp0.row_lower_[0], &lp0.row_upper_[0], lp0_num_nz, NULL,
-        NULL, NULL, lp1.num_row_, &lp1.row_lower_[0], &lp1.row_upper_[0],
-        lp1_num_nz, NULL, NULL, NULL, infinite_bound);
+        lp0.num_row_, lp0.row_lower_.data(), lp0.row_upper_.data(), lp0_num_nz,
+        NULL, NULL, NULL, lp1.num_row_, lp1.row_lower_.data(),
+        lp1.row_upper_.data(), lp1_num_nz, NULL, NULL, NULL, infinite_bound);
   }
   return return_bool;
 }

--- a/check/TestLpOrientation.cpp
+++ b/check/TestLpOrientation.cpp
@@ -88,18 +88,19 @@ TEST_CASE("LP-orientation", "[lp_orientation]") {
 
   // Clear the internal LP
   highs.clearModel();
-  REQUIRE(highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0], 0,
-                        NULL, NULL, NULL) == HighsStatus::kOk);
-  REQUIRE(highs.addRows(num_row, &rowLower[0], &rowUpper[0], num_row_nz,
-                        &ARstart[0], &ARindex[0],
-                        &ARvalue[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addCols(num_col, colCost.data(), colLower.data(),
+                        colUpper.data(), 0, NULL, NULL,
+                        NULL) == HighsStatus::kOk);
+  REQUIRE(highs.addRows(num_row, rowLower.data(), rowUpper.data(), num_row_nz,
+                        ARstart.data(), ARindex.data(),
+                        ARvalue.data()) == HighsStatus::kOk);
   highs.run();
   REQUIRE(info.objective_function_value == optimal_objective_function_value);
 
   // Clear the internal LP
   highs.clearModel();
-  highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0], 0, NULL, NULL,
-                NULL);
+  highs.addCols(num_col, colCost.data(), colLower.data(), colUpper.data(), 0,
+                NULL, NULL, NULL);
   vector<double> one_row_Lower;
   vector<double> one_row_Upper;
   vector<HighsInt> one_row_start;
@@ -110,9 +111,10 @@ TEST_CASE("LP-orientation", "[lp_orientation]") {
     HighsInt one_row_numrow = 0;
     avgas.row(row, one_row_numrow, one_row_numnz, one_row_Lower, one_row_Upper,
               one_row_start, one_row_index, one_row_value);
-    REQUIRE(highs.addRows(1, &one_row_Lower[0], &one_row_Upper[0],
-                          one_row_numnz, &one_row_start[0], &one_row_index[0],
-                          &one_row_value[0]) == HighsStatus::kOk);
+    REQUIRE(highs.addRows(1, one_row_Lower.data(), one_row_Upper.data(),
+                          one_row_numnz, one_row_start.data(),
+                          one_row_index.data(),
+                          one_row_value.data()) == HighsStatus::kOk);
   }
   highs.run();
   REQUIRE(info.objective_function_value == optimal_objective_function_value);

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -169,13 +169,13 @@ TEST_CASE("LP-validation", "[highs_data]") {
   highs.passOptions(options);
 
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
-  return_status =
-      highs.addRows(num_row, &rowLower[0], &rowUpper[0], 0, NULL, NULL, NULL);
+  return_status = highs.addRows(num_row, rowLower.data(), rowUpper.data(), 0,
+                                NULL, NULL, NULL);
   REQUIRE(return_status == HighsStatus::kOk);
 
   return_status =
-      highs.addCols(num_col, &colCost[0], &colLower[0], &colUpper[0],
-                    num_col_nz, &Astart[0], &Aindex[0], &Avalue[0]);
+      highs.addCols(num_col, colCost.data(), colLower.data(), colUpper.data(),
+                    num_col_nz, Astart.data(), Aindex.data(), Avalue.data());
   REQUIRE(return_status == HighsStatus::kOk);
 
   // Create an empty column
@@ -196,8 +196,8 @@ TEST_CASE("LP-validation", "[highs_data]") {
   vector<double> XAvalue;
   // Add an empty column
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == HighsStatus::kOk);
   XcolUpper[0] = my_infinity;
   //  reportLp(lp, HighsLogType::kVerbose);
@@ -211,14 +211,14 @@ TEST_CASE("LP-validation", "[highs_data]") {
   }
   XcolCost[0] = my_infinity;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == require_return_status);
 
   XcolCost[0] = -my_infinity;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == require_return_status);
 
   // Reset to a legitimate cost
@@ -228,40 +228,40 @@ TEST_CASE("LP-validation", "[highs_data]") {
   XcolLower[0] = 0;
   XcolUpper[0] = -1;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == HighsStatus::kWarning);
 
   // Add a column with bound inconsistency due to lower
   XcolLower[0] = 1;
   XcolUpper[0] = 0;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == HighsStatus::kWarning);
 
   // Add a column with illegal bound due to lower
   XcolLower[0] = my_infinity;
   XcolUpper[0] = 0;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == HighsStatus::kError);
 
   // Add a column with illegal bound due to upper
   XcolLower[0] = 0;
   XcolUpper[0] = -my_infinity;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == HighsStatus::kError);
 
   // Add a legitimate column
   XcolLower[0] = 0;
   XcolUpper[0] = 0;
   return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], NULL, NULL);
+      highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                    XcolUpper.data(), XnumNewNZ, XAstart.data(), NULL, NULL);
   REQUIRE(return_status == HighsStatus::kOk);
 
   //  reportLp(lp, HighsLogType::kVerbose);
@@ -297,17 +297,17 @@ TEST_CASE("LP-validation", "[highs_data]") {
   XAvalue[4] = -1e60;
   XAvalue[5] = 1e100;
   XAvalue[6] = -1;
-  return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], &XAindex[0], &XAvalue[0]);
+  return_status = highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                                XcolUpper.data(), XnumNewNZ, XAstart.data(),
+                                XAindex.data(), XAvalue.data());
   REQUIRE(return_status == HighsStatus::kError);
 
   // Legitimise large matrix entries. Small entries now cause warning
   XAvalue[4] = -1;
   XAvalue[5] = 1;
-  return_status =
-      highs.addCols(XnumNewCol, &XcolCost[0], &XcolLower[0], &XcolUpper[0],
-                    XnumNewNZ, &XAstart[0], &XAindex[0], &XAvalue[0]);
+  return_status = highs.addCols(XnumNewCol, XcolCost.data(), XcolLower.data(),
+                                XcolUpper.data(), XnumNewNZ, XAstart.data(),
+                                XAindex.data(), XAvalue.data());
   REQUIRE(return_status == HighsStatus::kWarning);
 
   if (!dev_run) highs.setOptionValue("output_flag", false);
@@ -374,8 +374,8 @@ TEST_CASE("LP-row-index-duplication", "[highs_data]") {
   std::vector<double> lower = {0, 0, 0};
   std::vector<double> upper = {inf, inf, inf};
   HighsInt num_nz = index.size();
-  REQUIRE(highs.addRows(3, &lower[0], &upper[0], num_nz, &start[0], &index[0],
-                        &value[0]) == HighsStatus::kError);
+  REQUIRE(highs.addRows(3, lower.data(), upper.data(), num_nz, start.data(),
+                        index.data(), value.data()) == HighsStatus::kError);
 }
 
 TEST_CASE("LP-extreme-coefficient", "[highs_data]") {

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -89,9 +89,9 @@ TEST_CASE("MIP-integrality", "[highs_test_mip_solver]") {
     mask[iCol] = 1;
     integrality[ix] = HighsVarType::kInteger;
   }
-  REQUIRE(highs.changeColsIntegrality(from_col0, to_col0, &integrality[0]) ==
+  REQUIRE(highs.changeColsIntegrality(from_col0, to_col0, integrality.data()) ==
           HighsStatus::kOk);
-  REQUIRE(highs.changeColsIntegrality(from_col1, to_col1, &integrality[0]) ==
+  REQUIRE(highs.changeColsIntegrality(from_col1, to_col1, integrality.data()) ==
           HighsStatus::kOk);
   if (dev_run) {
     highs.setOptionValue("log_dev_level", 3);
@@ -122,8 +122,8 @@ TEST_CASE("MIP-integrality", "[highs_test_mip_solver]") {
   highs.clearModel();
   if (!dev_run) highs.setOptionValue("output_flag", false);
   highs.readModel(filename);
-  REQUIRE(highs.changeColsIntegrality(num_set_entries, &set[0],
-                                      &integrality[0]) == HighsStatus::kOk);
+  REQUIRE(highs.changeColsIntegrality(num_set_entries, set.data(),
+                                      integrality.data()) == HighsStatus::kOk);
   if (dev_run) highs.writeModel("");
   highs.run();
   if (dev_run) highs.writeSolution("", kSolutionStylePretty);
@@ -138,7 +138,7 @@ TEST_CASE("MIP-integrality", "[highs_test_mip_solver]") {
   highs.clearModel();
   if (!dev_run) highs.setOptionValue("output_flag", false);
   highs.readModel(filename);
-  REQUIRE(highs.changeColsIntegrality(&mask[0], &integrality[0]) ==
+  REQUIRE(highs.changeColsIntegrality(mask.data(), integrality.data()) ==
           HighsStatus::kOk);
   if (dev_run) highs.writeModel("");
   highs.run();

--- a/check/TestQpSolver.cpp
+++ b/check/TestQpSolver.cpp
@@ -120,7 +120,7 @@ TEST_CASE("qpsolver", "[qpsolver]") {
   HighsInt num_col = highs.getNumCol();
   std::vector<HighsVarType> integrality;
   integrality.assign(num_col, HighsVarType::kInteger);
-  REQUIRE(highs.changeColsIntegrality(0, num_col - 1, &integrality[0]) ==
+  REQUIRE(highs.changeColsIntegrality(0, num_col - 1, integrality.data()) ==
           HighsStatus::kOk);
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kError);
@@ -249,7 +249,8 @@ TEST_CASE("test-qod", "[qpsolver]") {
   // Add the constraint 0.5 <= x0 + x1
   lp.a_matrix_.index_ = {0, 1};
   lp.a_matrix_.value_ = {1, 1};
-  highs.addRow(0.5, inf, 2, &lp.a_matrix_.index_[0], &lp.a_matrix_.value_[0]);
+  highs.addRow(0.5, inf, 2, lp.a_matrix_.index_.data(),
+               lp.a_matrix_.value_.data());
   if (dev_run) highs.writeModel("");
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kOk);

--- a/check/TestRays.cpp
+++ b/check/TestRays.cpp
@@ -238,7 +238,7 @@ void testInfeasibleMps(const std::string model,
   dual_ray_value.resize(lp.num_row_);
   REQUIRE(highs.getDualRay(has_dual_ray) == HighsStatus::kOk);
   REQUIRE(has_dual_ray == has_dual_ray_);
-  REQUIRE(highs.getDualRay(has_dual_ray, &dual_ray_value[0]) ==
+  REQUIRE(highs.getDualRay(has_dual_ray, dual_ray_value.data()) ==
           HighsStatus::kOk);
   checkDualRayValue(highs, dual_ray_value);
   // Check that there is no primal ray
@@ -285,7 +285,7 @@ void testUnboundedMps(const std::string model,
   primal_ray_value.resize(lp.num_col_);
   REQUIRE(highs.getPrimalRay(has_primal_ray) == HighsStatus::kOk);
   REQUIRE(has_primal_ray == true);
-  REQUIRE(highs.getPrimalRay(has_primal_ray, &primal_ray_value[0]) ==
+  REQUIRE(highs.getPrimalRay(has_primal_ray, primal_ray_value.data()) ==
           HighsStatus::kOk);
   checkPrimalRayValue(highs, primal_ray_value);
 }
@@ -323,7 +323,7 @@ TEST_CASE("Rays", "[highs_test_rays]") {
   REQUIRE(highs.getDualRay(has_dual_ray) == HighsStatus::kOk);
   REQUIRE(has_dual_ray == true);
   // Get the dual ray
-  REQUIRE(highs.getDualRay(has_dual_ray, &dual_ray_value[0]) ==
+  REQUIRE(highs.getDualRay(has_dual_ray, dual_ray_value.data()) ==
           HighsStatus::kOk);
   vector<double> expected_dual_ray = {0.5, -1};  // From SCIP
   if (dev_run) {
@@ -370,7 +370,7 @@ TEST_CASE("Rays", "[highs_test_rays]") {
   primal_ray_value.resize(lp.num_col_);
   REQUIRE(highs.getPrimalRay(has_primal_ray) == HighsStatus::kOk);
   REQUIRE(has_primal_ray == true);
-  REQUIRE(highs.getPrimalRay(has_primal_ray, &primal_ray_value[0]) ==
+  REQUIRE(highs.getPrimalRay(has_primal_ray, primal_ray_value.data()) ==
           HighsStatus::kOk);
   vector<double> expected_primal_ray = {0.5, -1};
   if (dev_run) {
@@ -453,7 +453,7 @@ TEST_CASE("Rays-464a", "[highs_test_rays]") {
   REQUIRE(has_ray == true);
   vector<double> ray_value;
   ray_value.assign(2, NAN);
-  highs.getPrimalRay(has_ray, &ray_value[0]);
+  highs.getPrimalRay(has_ray, ray_value.data());
   checkPrimalRayValue(highs, ray_value);
   REQUIRE(has_ray);
   REQUIRE(ray_value[0] == ray_value[1]);
@@ -486,7 +486,7 @@ TEST_CASE("Rays-464b", "[highs_test_rays]") {
   REQUIRE(has_ray == true);
   vector<double> ray_value;
   ray_value.assign(2, NAN);
-  highs.getPrimalRay(has_ray, &ray_value[0]);
+  highs.getPrimalRay(has_ray, ray_value.data());
   checkPrimalRayValue(highs, ray_value);
   REQUIRE(has_ray);
   REQUIRE(ray_value[0] == ray_value[1]);

--- a/check/TestSemiVariables.cpp
+++ b/check/TestSemiVariables.cpp
@@ -170,7 +170,8 @@ TEST_CASE("semi-variable-upper-bound", "[highs_test_semi_variables]") {
   double coeff = 1e6;
   std::vector<HighsInt> index = {0, 1};
   std::vector<double> value = {-1, coeff};
-  REQUIRE(highs.addRow(0, 0, 2, &index[0], &value[0]) == HighsStatus::kOk);
+  REQUIRE(highs.addRow(0, 0, 2, index.data(), value.data()) ==
+          HighsStatus::kOk);
   // Problem is no longer unbounded due to equation linking the
   // semi-variable to the continuous variable. However, optimal value
   // of semi-variable should be 1e6, so it is active at the modified upper

--- a/check/TestSort.cpp
+++ b/check/TestSort.cpp
@@ -24,7 +24,7 @@ void getRandomValues(const HighsInt num_values, vector<double>& values,
 void doFullSort(const HighsInt num_values, vector<double>& values,
                 vector<HighsInt>& indices) {
   // Sort the vector of random number and their corresponding indices
-  maxheapsort(&values[0], &indices[0], num_values);
+  maxheapsort(values.data(), indices.data(), num_values);
 }
 
 void doAddSort(HighsInt& num_values_sorted,
@@ -138,7 +138,7 @@ TEST_CASE("HiGHS_sort", "[highs_data]") {
   int_values.resize(num_values);
   std::make_heap(int_values.begin(), int_values.end());
   std::sort_heap(int_values.begin(), int_values.end());
-  //  maxheapsort(&int_values[0], num_values);
+  //  maxheapsort(int_values.data(), num_values);
 
   bool ok;
   // Check that the values in the vector of doubles are ascending - can do
@@ -208,8 +208,8 @@ TEST_CASE("HiGHS_sort", "[highs_data]") {
   sorted_lb.resize(num_values);
   sorted_ub.resize(num_values);
 
-  sortSetData(num_values, sorted_set, &lb[0], &ub[0], NULL, &sorted_lb[0],
-              &sorted_ub[0], NULL);
+  sortSetData(num_values, sorted_set, lb.data(), ub.data(), NULL,
+              sorted_lb.data(), sorted_ub.data(), NULL);
 
   HighsInt prev_ix = -kHighsIInf;
   for (HighsInt k0 = 0; k0 < num_values; k0++) {

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -690,7 +690,7 @@ HighsInt Highs_changeColsIntegralityByRange(void* highs,
     }
   }
   return (HighsInt)((Highs*)highs)
-      ->changeColsIntegrality(from_col, to_col, &pass_integrality[0]);
+      ->changeColsIntegrality(from_col, to_col, pass_integrality.data());
 }
 
 HighsInt Highs_changeColsIntegralityBySet(void* highs,
@@ -705,7 +705,7 @@ HighsInt Highs_changeColsIntegralityBySet(void* highs,
     }
   }
   return (HighsInt)((Highs*)highs)
-      ->changeColsIntegrality(num_set_entries, set, &pass_integrality[0]);
+      ->changeColsIntegrality(num_set_entries, set, pass_integrality.data());
 }
 
 HighsInt Highs_changeColsIntegralityByMask(void* highs, const HighsInt* mask,
@@ -719,7 +719,7 @@ HighsInt Highs_changeColsIntegralityByMask(void* highs, const HighsInt* mask,
     }
   }
   return (HighsInt)((Highs*)highs)
-      ->changeColsIntegrality(mask, &pass_integrality[0]);
+      ->changeColsIntegrality(mask, pass_integrality.data());
 }
 
 HighsInt Highs_changeColCost(void* highs, const HighsInt col,
@@ -969,13 +969,13 @@ HighsInt Highs_getModel(const void* highs, const HighsInt a_format,
   *num_col = lp.num_col_;
   *num_row = lp.num_row_;
   if (*num_col > 0) {
-    memcpy(col_cost, &lp.col_cost_[0], *num_col * sizeof(double));
-    memcpy(col_lower, &lp.col_lower_[0], *num_col * sizeof(double));
-    memcpy(col_upper, &lp.col_upper_[0], *num_col * sizeof(double));
+    memcpy(col_cost, lp.col_cost_.data(), *num_col * sizeof(double));
+    memcpy(col_lower, lp.col_lower_.data(), *num_col * sizeof(double));
+    memcpy(col_upper, lp.col_upper_.data(), *num_col * sizeof(double));
   }
   if (*num_row > 0) {
-    memcpy(row_lower, &lp.row_lower_[0], *num_row * sizeof(double));
-    memcpy(row_upper, &lp.row_upper_[0], *num_row * sizeof(double));
+    memcpy(row_lower, lp.row_lower_.data(), *num_row * sizeof(double));
+    memcpy(row_upper, lp.row_upper_.data(), *num_row * sizeof(double));
   }
 
   // Save the original orientation so that it is recovered
@@ -995,16 +995,16 @@ HighsInt Highs_getModel(const void* highs, const HighsInt a_format,
 
   if (*num_col > 0 && *num_row > 0) {
     *num_nz = lp.a_matrix_.numNz();
-    memcpy(a_start, &lp.a_matrix_.start_[0],
+    memcpy(a_start, lp.a_matrix_.start_.data(),
            num_start_entries * sizeof(HighsInt));
-    memcpy(a_index, &lp.a_matrix_.index_[0], *num_nz * sizeof(HighsInt));
-    memcpy(a_value, &lp.a_matrix_.value_[0], *num_nz * sizeof(double));
+    memcpy(a_index, lp.a_matrix_.index_.data(), *num_nz * sizeof(HighsInt));
+    memcpy(a_value, lp.a_matrix_.value_.data(), *num_nz * sizeof(double));
   }
   if (hessian.dim_ > 0) {
     *q_num_nz = hessian.start_[*num_col];
-    memcpy(q_start, &hessian.start_[0], *num_col * sizeof(HighsInt));
-    memcpy(q_index, &hessian.index_[0], *q_num_nz * sizeof(HighsInt));
-    memcpy(q_value, &hessian.value_[0], *q_num_nz * sizeof(double));
+    memcpy(q_start, hessian.start_.data(), *num_col * sizeof(HighsInt));
+    memcpy(q_index, hessian.index_.data(), *q_num_nz * sizeof(HighsInt));
+    memcpy(q_value, hessian.value_.data(), *q_num_nz * sizeof(double));
   }
   if ((HighsInt)lp.integrality_.size()) {
     for (int iCol = 0; iCol < *num_col; iCol++)

--- a/src/ipm/IpxWrapper.cpp
+++ b/src/ipm/IpxWrapper.cpp
@@ -130,8 +130,8 @@ HighsStatus solveLpIpx(const HighsOptions& options,
                num_row, num_col, Ap[num_col]);
 
   ipx::Int load_status =
-      lps.LoadModel(num_col, &objective[0], &col_lb[0], &col_ub[0], num_row,
-                    &Ap[0], &Ai[0], &Av[0], &rhs[0], &constraint_type[0]);
+    lps.LoadModel(num_col, objective.data(), col_lb.data(), col_ub.data(), num_row,
+		  Ap.data(), Ai.data(), Av.data(), rhs.data(), constraint_type.data());
 
   if (load_status) {
     model_status = HighsModelStatus::kSolveError;
@@ -303,10 +303,9 @@ HighsStatus solveLpIpx(const HighsOptions& options,
     ipx_solution.ipx_row_dual.resize(num_row);
     ipx_solution.ipx_row_status.resize(num_row);
     ipx_solution.ipx_col_status.resize(num_col);
-    ipx::Int errflag = lps.GetBasicSolution(
-        &ipx_solution.ipx_col_value[0], &ipx_solution.ipx_row_value[0],
-        &ipx_solution.ipx_row_dual[0], &ipx_solution.ipx_col_dual[0],
-        &ipx_solution.ipx_row_status[0], &ipx_solution.ipx_col_status[0]);
+    ipx::Int errflag = lps.GetBasicSolution(ipx_solution.ipx_col_value.data(), ipx_solution.ipx_row_value.data(),
+					    ipx_solution.ipx_row_dual.data(), ipx_solution.ipx_col_dual.data(),
+					    ipx_solution.ipx_row_status.data(), ipx_solution.ipx_col_status.data());
     if (errflag != 0) {
       highsLogUser(options.log_options, HighsLogType::kError,
 		   "IPX crossover getting basic solution: flag = %d\n",
@@ -815,8 +814,8 @@ void getHighsNonVertexSolution(const HighsOptions& options,
   std::vector<double> slack(num_row);
   std::vector<double> y(num_row);
 
-  lps.GetInteriorSolution(&x[0], &xl[0], &xu[0], &slack[0], &y[0], &zl[0],
-                          &zu[0]);
+  lps.GetInteriorSolution(x.data(), xl.data(), xu.data(), slack.data(), y.data(), zl.data(),
+                          zu.data());
 
   ipxSolutionToHighsSolution(options, lp, rhs, constraint_type, num_col,
                              num_row, x, slack, y, zl, zu,

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1664,8 +1664,8 @@ HighsStatus Highs::getReducedRow(const HighsInt row, double* row_vector,
     rhs[row] = 1;
     basis_inverse_row.resize(num_row, 0);
     // Form B^{-T}e_{row}
-    basisSolveInterface(rhs, &basis_inverse_row[0], NULL, NULL, true);
-    basis_inverse_row_vector = &basis_inverse_row[0];
+    basisSolveInterface(rhs, basis_inverse_row.data(), NULL, NULL, true);
+    basis_inverse_row_vector = basis_inverse_row.data();
   }
   bool return_indices = row_num_nz != NULL;
   if (return_indices) *row_num_nz = 0;
@@ -1939,7 +1939,7 @@ HighsStatus Highs::addVars(const HighsInt num_new_var, const double* lower,
   if (num_new_var <= 0) returnFromHighs(return_status);
   std::vector<double> cost;
   cost.assign(num_new_var, 0);
-  return addCols(num_new_var, &cost[0], lower, upper, 0, nullptr, nullptr,
+  return addCols(num_new_var, cost.data(), lower, upper, 0, nullptr, nullptr,
                  nullptr);
 }
 
@@ -2022,13 +2022,14 @@ HighsStatus Highs::changeColsIntegrality(const HighsInt num_set_entries,
   std::vector<HighsVarType> local_integrality{integrality,
                                               integrality + num_set_entries};
   std::vector<HighsInt> local_set{set, set + num_set_entries};
-  sortSetData(num_set_entries, local_set, integrality, &local_integrality[0]);
+  sortSetData(num_set_entries, local_set, integrality,
+              local_integrality.data());
   HighsIndexCollection index_collection;
   const bool create_ok = create(index_collection, num_set_entries,
-                                &local_set[0], model_.lp_.num_col_);
+                                local_set.data(), model_.lp_.num_col_);
   assert(create_ok);
   HighsStatus call_status =
-      changeIntegralityInterface(index_collection, &local_integrality[0]);
+      changeIntegralityInterface(index_collection, local_integrality.data());
   HighsStatus return_status = HighsStatus::kOk;
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "changeIntegrality");
@@ -2083,14 +2084,14 @@ HighsStatus Highs::changeColsCost(const HighsInt num_set_entries,
   // Ensure that the set and data are in ascending order
   std::vector<double> local_cost{cost, cost + num_set_entries};
   std::vector<HighsInt> local_set{set, set + num_set_entries};
-  sortSetData(num_set_entries, local_set, cost, NULL, NULL, &local_cost[0],
+  sortSetData(num_set_entries, local_set, cost, NULL, NULL, local_cost.data(),
               NULL, NULL);
   HighsIndexCollection index_collection;
   const bool create_ok = create(index_collection, num_set_entries,
-                                &local_set[0], model_.lp_.num_col_);
+                                local_set.data(), model_.lp_.num_col_);
   assert(create_ok);
   HighsStatus call_status =
-      changeCostsInterface(index_collection, &local_cost[0]);
+      changeCostsInterface(index_collection, local_cost.data());
   HighsStatus return_status = HighsStatus::kOk;
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "changeCosts");
@@ -2154,14 +2155,14 @@ HighsStatus Highs::changeColsBounds(const HighsInt num_set_entries,
   std::vector<double> local_lower{lower, lower + num_set_entries};
   std::vector<double> local_upper{upper, upper + num_set_entries};
   std::vector<HighsInt> local_set{set, set + num_set_entries};
-  sortSetData(num_set_entries, local_set, lower, upper, NULL, &local_lower[0],
-              &local_upper[0], NULL);
+  sortSetData(num_set_entries, local_set, lower, upper, NULL,
+              local_lower.data(), local_upper.data(), NULL);
   HighsIndexCollection index_collection;
   const bool create_ok = create(index_collection, num_set_entries,
-                                &local_set[0], model_.lp_.num_col_);
+                                local_set.data(), model_.lp_.num_col_);
   assert(create_ok);
   HighsStatus call_status = changeColBoundsInterface(
-      index_collection, &local_lower[0], &local_upper[0]);
+      index_collection, local_lower.data(), local_upper.data());
   HighsStatus return_status = HighsStatus::kOk;
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "changeColBounds");
@@ -2227,14 +2228,14 @@ HighsStatus Highs::changeRowsBounds(const HighsInt num_set_entries,
   std::vector<double> local_lower{lower, lower + num_set_entries};
   std::vector<double> local_upper{upper, upper + num_set_entries};
   std::vector<HighsInt> local_set{set, set + num_set_entries};
-  sortSetData(num_set_entries, local_set, lower, upper, NULL, &local_lower[0],
-              &local_upper[0], NULL);
+  sortSetData(num_set_entries, local_set, lower, upper, NULL,
+              local_lower.data(), local_upper.data(), NULL);
   HighsIndexCollection index_collection;
   const bool create_ok = create(index_collection, num_set_entries,
-                                &local_set[0], model_.lp_.num_row_);
+                                local_set.data(), model_.lp_.num_row_);
   assert(create_ok);
   HighsStatus call_status = changeRowBoundsInterface(
-      index_collection, &local_lower[0], &local_upper[0]);
+      index_collection, local_lower.data(), local_upper.data());
   HighsStatus return_status = HighsStatus::kOk;
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "changeRowBounds");
@@ -3172,8 +3173,8 @@ void Highs::reportModel() {
   if (model_.hessian_.dim_) {
     const HighsInt dim = model_.hessian_.dim_;
     reportHessian(options_.log_options, dim, model_.hessian_.start_[dim],
-                  &model_.hessian_.start_[0], &model_.hessian_.index_[0],
-                  &model_.hessian_.value_[0]);
+                  model_.hessian_.start_.data(), model_.hessian_.index_.data(),
+                  model_.hessian_.value_.data());
   }
 }
 

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -646,8 +646,8 @@ HighsStatus Highs::changeColBoundsInterface(
   // set and data are in ascending order
   if (index_collection.is_set_)
     sortSetData(index_collection.set_num_entries_, index_collection.set_,
-                col_lower, col_upper, NULL, &local_colLower[0],
-                &local_colUpper[0], NULL);
+                col_lower, col_upper, NULL, local_colLower.data(),
+                local_colUpper.data(), NULL);
   HighsStatus return_status = HighsStatus::kOk;
   return_status = interpretCallStatus(
       options_.log_options,
@@ -691,7 +691,8 @@ HighsStatus Highs::changeRowBoundsInterface(
   // set and data are in ascending order
   if (index_collection.is_set_)
     sortSetData(index_collection.set_num_entries_, index_collection.set_, lower,
-                upper, NULL, &local_rowLower[0], &local_rowUpper[0], NULL);
+                upper, NULL, local_rowLower.data(), local_rowUpper.data(),
+                NULL);
   HighsStatus return_status = HighsStatus::kOk;
   return_status = interpretCallStatus(
       options_.log_options,
@@ -1420,7 +1421,7 @@ HighsStatus Highs::getPrimalRayInterface(bool& has_primal_ray,
       rhs[col - num_col] = primal_ray_sign;
     }
     HighsInt* column_num_nz = 0;
-    basisSolveInterface(rhs, &column[0], column_num_nz, NULL, false);
+    basisSolveInterface(rhs, column.data(), column_num_nz, NULL, false);
     // Now zero primal_ray_value and scatter the column according to
     // the basic variables.
     for (HighsInt iCol = 0; iCol < num_col; iCol++) primal_ray_value[iCol] = 0;

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -1872,12 +1872,12 @@ void reportLpColMatrix(const HighsLogOptions& log_options, const HighsLp& lp) {
     // With postitive number of rows, can assume that there are index and value
     // vectors to pass
     reportMatrix(log_options, "Column", lp.num_col_,
-                 lp.a_matrix_.start_[lp.num_col_], &lp.a_matrix_.start_[0],
-                 &lp.a_matrix_.index_[0], &lp.a_matrix_.value_[0]);
+                 lp.a_matrix_.start_[lp.num_col_], lp.a_matrix_.start_.data(),
+                 lp.a_matrix_.index_.data(), lp.a_matrix_.value_.data());
   } else {
     // With no rows, can's assume that there are index and value vectors to pass
     reportMatrix(log_options, "Column", lp.num_col_,
-                 lp.a_matrix_.start_[lp.num_col_], &lp.a_matrix_.start_[0],
+                 lp.a_matrix_.start_[lp.num_col_], lp.a_matrix_.start_.data(),
                  NULL, NULL);
   }
 }

--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -455,6 +455,9 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (lp.col_cost_[iCol]) num_nz++;
   const bool empty_cost_row = num_nz == lp.a_matrix_.numNz();
   const bool has_objective = !empty_cost_row || model.hessian_.dim_;
+  // Writes the solution using the GLPK raw style (defined in
+  // api/wrsol.c) or pretty style (defined in api/prsol.c)
+  //
   // When writing out the row information (and hence the number of
   // rows and nonzeros), the case of the cost row is tricky
   // (particularly if it's empty) if HiGHS is to be able to reproduce

--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -375,10 +375,10 @@ void writeSolutionFile(FILE* file, const HighsOptions& options,
   if (style == kSolutionStyleOldRaw) {
     writeOldRawSolution(file, lp, basis, solution);
   } else if (style == kSolutionStylePretty) {
-    writeModelBoundSolution(file, true, lp.num_col_, lp.col_lower_,
-                            lp.col_upper_, lp.col_names_, have_primal,
-                            solution.col_value, have_dual, solution.col_dual,
-                            have_basis, basis.col_status, lp.integrality_.data());
+    writeModelBoundSolution(
+        file, true, lp.num_col_, lp.col_lower_, lp.col_upper_, lp.col_names_,
+        have_primal, solution.col_value, have_dual, solution.col_dual,
+        have_basis, basis.col_status, lp.integrality_.data());
     writeModelBoundSolution(file, false, lp.num_row_, lp.row_lower_,
                             lp.row_upper_, lp.row_names_, have_primal,
                             solution.row_value, have_dual, solution.row_dual,

--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -375,12 +375,10 @@ void writeSolutionFile(FILE* file, const HighsOptions& options,
   if (style == kSolutionStyleOldRaw) {
     writeOldRawSolution(file, lp, basis, solution);
   } else if (style == kSolutionStylePretty) {
-    const HighsVarType* integrality_ptr =
-        lp.integrality_.size() > 0 ? &lp.integrality_[0] : NULL;
     writeModelBoundSolution(file, true, lp.num_col_, lp.col_lower_,
                             lp.col_upper_, lp.col_names_, have_primal,
                             solution.col_value, have_dual, solution.col_dual,
-                            have_basis, basis.col_status, integrality_ptr);
+                            have_basis, basis.col_status, lp.integrality_.data());
     writeModelBoundSolution(file, false, lp.num_row_, lp.row_lower_,
                             lp.row_upper_, lp.row_names_, have_primal,
                             solution.row_value, have_dual, solution.row_dual,

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1258,7 +1258,7 @@ void accommodateAlienBasis(HighsLpSolverObject& solver_object) {
   }
   HighsInt num_basic_variables = basic_index.size();
   HFactor factor;
-  factor.setupGeneral(&lp.a_matrix_, num_basic_variables, &basic_index[0],
+  factor.setupGeneral(&lp.a_matrix_, num_basic_variables, basic_index.data(),
                       kDefaultPivotThreshold, kDefaultPivotTolerance,
                       kHighsDebugLevelMin, &options.log_options);
   HighsInt rank_deficiency = factor.build();

--- a/src/presolve/ICrashX.cpp
+++ b/src/presolve/ICrashX.cpp
@@ -52,8 +52,8 @@ HighsStatus callCrossover(const HighsOptions& options, const HighsLp& lp,
   lps.SetParameters(parameters);
 
   ipx::Int load_status =
-      lps.LoadModel(num_col, &objective[0], &col_lb[0], &col_ub[0], num_row,
-                    &Ap[0], &Ai[0], &Av[0], &rhs[0], &constraint_type[0]);
+    lps.LoadModel(num_col, objective.data(), col_lb.data(), col_ub.data(), num_row,
+		  Ap.data(), Ai.data(), Av.data(), rhs.data(), constraint_type.data());
   if (load_status != 0) {
     highsLogUser(log_options, HighsLogType::kError,
                  "Error loading ipx model\n");
@@ -91,14 +91,13 @@ HighsStatus callCrossover(const HighsOptions& options, const HighsLp& lp,
       (HighsInt)highs_solution.row_dual.size() == num_row) {
     highsLogUser(log_options, HighsLogType::kInfo,
                  "Calling IPX crossover with primal and dual values\n");
-    crossover_status = lps.CrossoverFromStartingPoint(
-        &x[0], &slack[0], &highs_solution.row_dual[0],
-        &highs_solution.col_dual[0]);
+    crossover_status = lps.CrossoverFromStartingPoint(x.data(), slack.data(), highs_solution.row_dual.data(),
+						      highs_solution.col_dual.data());
   } else {
     highsLogUser(log_options, HighsLogType::kInfo,
                  "Calling IPX crossover with only primal values\n");
     crossover_status =
-        lps.CrossoverFromStartingPoint(&x[0], &slack[0], nullptr, nullptr);
+      lps.CrossoverFromStartingPoint(x.data(), slack.data(), nullptr, nullptr);
   }
 
   if (crossover_status != 0) {
@@ -133,10 +132,9 @@ HighsStatus callCrossover(const HighsOptions& options, const HighsLp& lp,
   ipx_solution.ipx_row_dual.resize(num_row);
   ipx_solution.ipx_row_status.resize(num_row);
   ipx_solution.ipx_col_status.resize(num_col);
-  ipx::Int errflag = lps.GetBasicSolution(
-      &ipx_solution.ipx_col_value[0], &ipx_solution.ipx_row_value[0],
-      &ipx_solution.ipx_row_dual[0], &ipx_solution.ipx_col_dual[0],
-      &ipx_solution.ipx_row_status[0], &ipx_solution.ipx_col_status[0]);
+  ipx::Int errflag = lps.GetBasicSolution(ipx_solution.ipx_col_value.data(), ipx_solution.ipx_row_value.data(),
+					  ipx_solution.ipx_row_dual.data(), ipx_solution.ipx_col_dual.data(),
+					  ipx_solution.ipx_row_status.data(), ipx_solution.ipx_col_status.data());
   if (errflag != 0) {
     highsLogUser(log_options, HighsLogType::kError,
                  "IPX crossover getting basic solution: flag = %d\n",

--- a/src/presolve/ICrashX.cpp
+++ b/src/presolve/ICrashX.cpp
@@ -51,9 +51,9 @@ HighsStatus callCrossover(const HighsOptions& options, const HighsLp& lp,
   ipx::LpSolver lps;
   lps.SetParameters(parameters);
 
-  ipx::Int load_status =
-    lps.LoadModel(num_col, objective.data(), col_lb.data(), col_ub.data(), num_row,
-		  Ap.data(), Ai.data(), Av.data(), rhs.data(), constraint_type.data());
+  ipx::Int load_status = lps.LoadModel(
+      num_col, objective.data(), col_lb.data(), col_ub.data(), num_row,
+      Ap.data(), Ai.data(), Av.data(), rhs.data(), constraint_type.data());
   if (load_status != 0) {
     highsLogUser(log_options, HighsLogType::kError,
                  "Error loading ipx model\n");
@@ -91,13 +91,14 @@ HighsStatus callCrossover(const HighsOptions& options, const HighsLp& lp,
       (HighsInt)highs_solution.row_dual.size() == num_row) {
     highsLogUser(log_options, HighsLogType::kInfo,
                  "Calling IPX crossover with primal and dual values\n");
-    crossover_status = lps.CrossoverFromStartingPoint(x.data(), slack.data(), highs_solution.row_dual.data(),
-						      highs_solution.col_dual.data());
+    crossover_status = lps.CrossoverFromStartingPoint(
+        x.data(), slack.data(), highs_solution.row_dual.data(),
+        highs_solution.col_dual.data());
   } else {
     highsLogUser(log_options, HighsLogType::kInfo,
                  "Calling IPX crossover with only primal values\n");
-    crossover_status =
-      lps.CrossoverFromStartingPoint(x.data(), slack.data(), nullptr, nullptr);
+    crossover_status = lps.CrossoverFromStartingPoint(x.data(), slack.data(),
+                                                      nullptr, nullptr);
   }
 
   if (crossover_status != 0) {
@@ -132,9 +133,10 @@ HighsStatus callCrossover(const HighsOptions& options, const HighsLp& lp,
   ipx_solution.ipx_row_dual.resize(num_row);
   ipx_solution.ipx_row_status.resize(num_row);
   ipx_solution.ipx_col_status.resize(num_col);
-  ipx::Int errflag = lps.GetBasicSolution(ipx_solution.ipx_col_value.data(), ipx_solution.ipx_row_value.data(),
-					  ipx_solution.ipx_row_dual.data(), ipx_solution.ipx_col_dual.data(),
-					  ipx_solution.ipx_row_status.data(), ipx_solution.ipx_col_status.data());
+  ipx::Int errflag = lps.GetBasicSolution(
+      ipx_solution.ipx_col_value.data(), ipx_solution.ipx_row_value.data(),
+      ipx_solution.ipx_row_dual.data(), ipx_solution.ipx_col_dual.data(),
+      ipx_solution.ipx_row_status.data(), ipx_solution.ipx_col_status.data());
   if (errflag != 0) {
     highsLogUser(log_options, HighsLogType::kError,
                  "IPX crossover getting basic solution: flag = %d\n",

--- a/src/qpsolver/basis.cpp
+++ b/src/qpsolver/basis.cpp
@@ -55,9 +55,9 @@ void Basis::build() {
     Atran.index.resize(1);
     Atran.value.resize(1);
   }
-  basisfactor.setup(Atran.num_col, Atran.num_row, (HighsInt*)&Atran.start[0],
-                    (HighsInt*)&Atran.index[0], (const double*)&Atran.value[0],
-                    (HighsInt*)&baseindex[0]);
+  basisfactor.setup(Atran.num_col, Atran.num_row, Atran.start.data(),
+                    Atran.index.data(), Atran.value.data(),
+                    baseindex.data());
   basisfactor.build();
 
   for (size_t i = 0;

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1307,7 +1307,8 @@ void HEkk::addRows(const HighsLp& lp,
   //  if (valid_simplex_lp)
   //    assert(ekk_instance_.lp_.dimensionsOk("addRows - simplex"));
   if (kExtendInvertWhenAddingRows && this->status_.has_nla) {
-    this->simplex_nla_.addRows(&lp, basis_.basicIndex_.data(), &scaled_ar_matrix);
+    this->simplex_nla_.addRows(&lp, basis_.basicIndex_.data(),
+                               &scaled_ar_matrix);
     setNlaPointersForTrans(lp);
     this->debugNlaCheckInvert("HEkk::addRows - on entry",
                               kHighsDebugLevelExpensive + 1);
@@ -1515,19 +1516,19 @@ HighsStatus HEkk::initialiseSimplexLpBasisAndFactor(
   //
   if (this->status_.has_nla) {
     assert(lpFactorRowCompatible());
-    this->simplex_nla_.setPointers(&(this->lp_), local_scaled_a_matrix,
-                                   this->basis_.basicIndex_.data(), this->options_,
-                                   this->timer_, &(this->analysis_));
+    this->simplex_nla_.setPointers(
+        &(this->lp_), local_scaled_a_matrix, this->basis_.basicIndex_.data(),
+        this->options_, this->timer_, &(this->analysis_));
   } else {
     // todo @ Julian: this fails on glass4
     assert(info_.factor_pivot_threshold >= options_->factor_pivot_threshold);
-    simplex_nla_.setup(&(this->lp_),                  //&lp_,
-                       this->basis_.basicIndex_.data(),  //basis_.basicIndex_.data(),
-                       this->options_,                // options_,
-                       this->timer_,                  // timer_,
-                       &(this->analysis_),            //&analysis_,
-                       local_scaled_a_matrix,
-                       this->info_.factor_pivot_threshold);
+    simplex_nla_.setup(
+        &(this->lp_),                     //&lp_,
+        this->basis_.basicIndex_.data(),  // basis_.basicIndex_.data(),
+        this->options_,                   // options_,
+        this->timer_,                     // timer_,
+        &(this->analysis_),               //&analysis_,
+        local_scaled_a_matrix, this->info_.factor_pivot_threshold);
     status_.has_nla = true;
   }
 
@@ -2298,7 +2299,8 @@ void HEkk::resetSyntheticClock() {
 void HEkk::initialisePartitionedRowwiseMatrix() {
   if (status_.has_ar_matrix) return;
   analysis_.simplexTimerStart(matrixSetupClock);
-  ar_matrix_.createRowwisePartitioned(lp_.a_matrix_, basis_.nonbasicFlag_.data());
+  ar_matrix_.createRowwisePartitioned(lp_.a_matrix_,
+                                      basis_.nonbasicFlag_.data());
   assert(ar_matrix_.debugPartitionOk(basis_.nonbasicFlag_.data()));
   analysis_.simplexTimerStop(matrixSetupClock);
   status_.has_ar_matrix = true;

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -410,7 +410,7 @@ void HEkk::setNlaPointersForTrans(const HighsLp& lp) {
   assert(status_.has_nla);
   assert(status_.has_basis);
   simplex_nla_.setLpAndScalePointers(&lp);
-  simplex_nla_.basic_index_ = &basis_.basicIndex_[0];
+  simplex_nla_.basic_index_ = basis_.basicIndex_.data();
 }
 
 void HEkk::setNlaRefactorInfo() {
@@ -1307,7 +1307,7 @@ void HEkk::addRows(const HighsLp& lp,
   //  if (valid_simplex_lp)
   //    assert(ekk_instance_.lp_.dimensionsOk("addRows - simplex"));
   if (kExtendInvertWhenAddingRows && this->status_.has_nla) {
-    this->simplex_nla_.addRows(&lp, &basis_.basicIndex_[0], &scaled_ar_matrix);
+    this->simplex_nla_.addRows(&lp, basis_.basicIndex_.data(), &scaled_ar_matrix);
     setNlaPointersForTrans(lp);
     this->debugNlaCheckInvert("HEkk::addRows - on entry",
                               kHighsDebugLevelExpensive + 1);
@@ -1516,13 +1516,13 @@ HighsStatus HEkk::initialiseSimplexLpBasisAndFactor(
   if (this->status_.has_nla) {
     assert(lpFactorRowCompatible());
     this->simplex_nla_.setPointers(&(this->lp_), local_scaled_a_matrix,
-                                   &this->basis_.basicIndex_[0], this->options_,
+                                   this->basis_.basicIndex_.data(), this->options_,
                                    this->timer_, &(this->analysis_));
   } else {
     // todo @ Julian: this fails on glass4
     assert(info_.factor_pivot_threshold >= options_->factor_pivot_threshold);
     simplex_nla_.setup(&(this->lp_),                  //&lp_,
-                       &this->basis_.basicIndex_[0],  //&basis_.basicIndex_[0],
+                       this->basis_.basicIndex_.data(),  //basis_.basicIndex_.data(),
                        this->options_,                // options_,
                        this->timer_,                  // timer_,
                        &(this->analysis_),            //&analysis_,
@@ -2122,8 +2122,8 @@ void HEkk::updateDualSteepestEdgeWeights(
 
   const HighsInt num_row = lp_.num_row_;
   const HighsInt column_count = column->count;
-  const HighsInt* variable_index = &column->index[0];
-  const double* column_array = &column->array[0];
+  const HighsInt* variable_index = column->index.data();
+  const double* column_array = column->array.data();
 
   const double col_aq_scale = simplex_nla_.variableScaleFactor(variable_in);
   const double col_ap_scale = simplex_nla_.basicColScaleFactor(row_out);
@@ -2266,8 +2266,8 @@ void HEkk::updateDualDevexWeights(const HVector* column,
 
   const HighsInt num_row = lp_.num_row_;
   const HighsInt column_count = column->count;
-  const HighsInt* variable_index = &column->index[0];
-  const double* column_array = &column->array[0];
+  const HighsInt* variable_index = column->index.data();
+  const double* column_array = column->array.data();
 
   if ((HighsInt)dual_edge_weight_.size() < num_row) {
     printf(
@@ -2298,8 +2298,8 @@ void HEkk::resetSyntheticClock() {
 void HEkk::initialisePartitionedRowwiseMatrix() {
   if (status_.has_ar_matrix) return;
   analysis_.simplexTimerStart(matrixSetupClock);
-  ar_matrix_.createRowwisePartitioned(lp_.a_matrix_, &basis_.nonbasicFlag_[0]);
-  assert(ar_matrix_.debugPartitionOk(&basis_.nonbasicFlag_[0]));
+  ar_matrix_.createRowwisePartitioned(lp_.a_matrix_, basis_.nonbasicFlag_.data());
+  assert(ar_matrix_.debugPartitionOk(basis_.nonbasicFlag_.data()));
   analysis_.simplexTimerStop(matrixSetupClock);
   status_.has_ar_matrix = true;
 }
@@ -2894,7 +2894,7 @@ void HEkk::tableauRowPrice(const bool quad_precision, const HVector& row_ep,
     // Column-wise PRICE computes components corresponding to basic
     // variables, so zero these by exploiting the fact that, for basic
     // variables, nonbasicFlag[*]=0
-    const int8_t* nonbasicFlag = &basis_.nonbasicFlag_[0];
+    const int8_t* nonbasicFlag = basis_.nonbasicFlag_.data();
     for (HighsInt iCol = 0; iCol < solver_num_col; iCol++)
       row_ap.array[iCol] *= nonbasicFlag[iCol];
   }
@@ -3214,7 +3214,7 @@ void HEkk::updateMatrix(const HighsInt variable_in,
                         const HighsInt variable_out) {
   analysis_.simplexTimerStart(UpdateMatrixClock);
   ar_matrix_.update(variable_in, variable_out, lp_.a_matrix_);
-  //  assert(ar_matrix_.debugPartitionOk(&basis_.nonbasicFlag_[0]));
+  //  assert(ar_matrix_.debugPartitionOk(basis_.nonbasicFlag_.data()));
   analysis_.simplexTimerStop(UpdateMatrixClock);
 }
 
@@ -3631,8 +3631,8 @@ double HEkk::computeBasisCondition() {
   HVector row_ep;
   row_ep.setup(solver_num_row);
 
-  const HighsInt* Astart = &lp_.a_matrix_.start_[0];
-  const double* Avalue = &lp_.a_matrix_.value_[0];
+  const HighsInt* Astart = lp_.a_matrix_.start_.data();
+  const double* Avalue = lp_.a_matrix_.value_.data();
   // Compute the Hager condition number estimate for the basis matrix
   const double expected_density = 1;
   bs_cond_x.resize(solver_num_row);
@@ -3788,7 +3788,7 @@ HighsStatus HEkk::unfreezeBasis(const HighsInt frozen_basis_id) {
   // The pointers to simplex basis components have changed, so have to
   // tell simplex NLA to refresh the use of the pointer to the basic
   // indices
-  this->simplex_nla_.setBasicIndexPointers(&basis_.basicIndex_[0]);
+  this->simplex_nla_.setBasicIndexPointers(basis_.basicIndex_.data());
   updateStatus(LpAction::kNewBounds);
   // Indicate whether there is a valid factorization after unfreezing
   this->status_.has_invert = will_have_invert;

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -1036,7 +1036,7 @@ void HEkkDual::rebuild() {
     assert(info.backtracking_);
     ekk_instance_.initialisePartitionedRowwiseMatrix();
     assert(ekk_instance_.ar_matrix_.debugPartitionOk(
-						     ekk_instance_.basis_.nonbasicFlag_.data()));
+        ekk_instance_.basis_.nonbasicFlag_.data()));
   }
   // Record whether the update objective value should be tested. If
   // the objective value is known, then the updated objective value

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -413,13 +413,13 @@ void HEkkDual::initialiseInstance() {
   analysis = &ekk_instance_.analysis_;
 
   // Copy pointers
-  jMove = &ekk_instance_.basis_.nonbasicMove_[0];
-  workDual = &ekk_instance_.info_.workDual_[0];
-  workValue = &ekk_instance_.info_.workValue_[0];
-  workRange = &ekk_instance_.info_.workRange_[0];
-  baseLower = &ekk_instance_.info_.baseLower_[0];
-  baseUpper = &ekk_instance_.info_.baseUpper_[0];
-  baseValue = &ekk_instance_.info_.baseValue_[0];
+  jMove = ekk_instance_.basis_.nonbasicMove_.data();
+  workDual = ekk_instance_.info_.workDual_.data();
+  workValue = ekk_instance_.info_.workValue_.data();
+  workRange = ekk_instance_.info_.workRange_.data();
+  baseLower = ekk_instance_.info_.baseLower_.data();
+  baseUpper = ekk_instance_.info_.baseUpper_.data();
+  baseValue = ekk_instance_.info_.baseValue_.data();
 
   // Setup local vectors
   col_DSE.setup(solver_num_row);
@@ -502,9 +502,9 @@ void HEkkDual::initSlice(const HighsInt initial_num_slice) {
   }
 
   // Alias to the matrix
-  const HighsInt* Astart = &a_matrix->start_[0];
-  const HighsInt* Aindex = &a_matrix->index_[0];
-  const double* Avalue = &a_matrix->value_[0];
+  const HighsInt* Astart = a_matrix->start_.data();
+  const HighsInt* Aindex = a_matrix->index_.data();
+  const double* Avalue = a_matrix->value_.data();
   const HighsInt AcountX = Astart[solver_num_col];
 
   // Figure out partition weight
@@ -1036,7 +1036,7 @@ void HEkkDual::rebuild() {
     assert(info.backtracking_);
     ekk_instance_.initialisePartitionedRowwiseMatrix();
     assert(ekk_instance_.ar_matrix_.debugPartitionOk(
-        &ekk_instance_.basis_.nonbasicFlag_[0]));
+						     ekk_instance_.basis_.nonbasicFlag_.data()));
   }
   // Record whether the update objective value should be tested. If
   // the objective value is known, then the updated objective value
@@ -2144,7 +2144,7 @@ void HEkkDual::updatePrimal(HVector* DSE_Vector) {
     const double Kai = -2 / pivot_in_scaled_space;
     ekk_instance_.updateDualSteepestEdgeWeights(row_out, variable_in, &col_aq,
                                                 new_pivotal_edge_weight, Kai,
-                                                &DSE_Vector->array[0]);
+                                                DSE_Vector->array.data());
     edge_weight[row_out] = new_pivotal_edge_weight;
   } else if (edge_weight_mode == EdgeWeightMode::kDevex) {
     // Pivotal row is for the current basis: weights are required for

--- a/src/simplex/HEkkDualMulti.cpp
+++ b/src/simplex/HEkkDualMulti.cpp
@@ -87,9 +87,9 @@ void HEkkDual::majorChooseRow() {
 
     // Call the hyper-graph method, but partSwitch=0 so just uses
     // choose_multi_global
-    dualRHS.chooseMultiHyperGraphAuto(&choiceIndex[0], &initialCount,
+    dualRHS.chooseMultiHyperGraphAuto(choiceIndex.data(), &initialCount,
                                       multi_num);
-    // dualRHS.chooseMultiGlobal(&choiceIndex[0], &initialCount, multi_num);
+    // dualRHS.chooseMultiGlobal(choiceIndex.data(), &initialCount, multi_num);
     if (initialCount == 0 && dualRHS.workCutoff == 0) {
       // OPTIMAL
       return;
@@ -585,7 +585,7 @@ void HEkkDual::majorUpdateFtranPrepare() {
     // Update this buffer by previous Row_ep
     for (HighsInt jFn = iFn - 1; jFn >= 0; jFn--) {
       MFinish* jFinish = &multi_finish[jFn];
-      double* jRow_epArray = &jFinish->row_ep->array[0];
+      double* jRow_epArray = jFinish->row_ep->array.data();
       double pivotX = 0;
       for (HighsInt k = 0; k < Vec->count; k++) {
         HighsInt iRow = Vec->index[k];
@@ -700,12 +700,12 @@ void HEkkDual::majorUpdateFtranFinal() {
     for (HighsInt iFn = 0; iFn < multi_nFinish; iFn++) {
       multi_finish[iFn].col_aq->count = -1;
       multi_finish[iFn].row_ep->count = -1;
-      double* myCol = &multi_finish[iFn].col_aq->array[0];
-      double* myRow = &multi_finish[iFn].row_ep->array[0];
+      double* myCol = multi_finish[iFn].col_aq->array.data();
+      double* myRow = multi_finish[iFn].row_ep->array.data();
       for (HighsInt jFn = 0; jFn < iFn; jFn++) {
         HighsInt pivotRow = multi_finish[jFn].row_out;
         const double pivotAlpha = multi_finish[jFn].alpha_row;
-        const double* pivotArray = &multi_finish[jFn].col_aq->array[0];
+        const double* pivotArray = multi_finish[jFn].col_aq->array.data();
         double pivotX1 = myCol[pivotRow];
         double pivotX2 = myRow[pivotRow];
 
@@ -770,8 +770,8 @@ void HEkkDual::majorUpdatePrimal() {
   if (updatePrimal_inDense) {
     // Dense update of primal values, infeasibility list and
     // non-pivotal edge weights
-    const double* mixArray = &col_BFRT.array[0];
-    double* local_work_infeasibility = &dualRHS.work_infeasibility[0];
+    const double* mixArray = col_BFRT.array.data();
+    double* local_work_infeasibility = dualRHS.work_infeasibility.data();
     // #pragma omp parallel for schedule(static)
     highs::parallel::for_each(
         0, solver_num_row,
@@ -798,10 +798,10 @@ void HEkkDual::majorUpdatePrimal() {
         // multi_finish[iFn].EdWt has already been transformed to correspond to
         // the new basis
         const double new_pivotal_edge_weight = multi_finish[iFn].EdWt;
-        const double* colArray = &multi_finish[iFn].col_aq->array[0];
+        const double* colArray = multi_finish[iFn].col_aq->array.data();
         if (edge_weight_mode == EdgeWeightMode::kSteepestEdge) {
           // Update steepest edge weights
-          const double* dseArray = &multi_finish[iFn].row_ep->array[0];
+          const double* dseArray = multi_finish[iFn].row_ep->array.data();
           const double Kai = -2 / multi_finish[iFn].alpha_row;
           // #pragma omp parallel for schedule(static)
           highs::parallel::for_each(
@@ -848,7 +848,7 @@ void HEkkDual::majorUpdatePrimal() {
         double Kai = -2 / finish->alpha_row;
         ekk_instance_.updateDualSteepestEdgeWeights(row_out, variable_in, Col,
                                                     new_pivotal_edge_weight,
-                                                    Kai, &Row->array[0]);
+                                                    Kai, Row->array.data());
       } else if (edge_weight_mode == EdgeWeightMode::kDevex &&
                  !new_devex_framework) {
         // Update Devex weights
@@ -874,12 +874,12 @@ void HEkkDual::majorUpdatePrimal() {
     for (HighsInt iFn = 0; iFn < multi_nFinish; iFn++) {
       const HighsInt iRow = multi_finish[iFn].row_out;
       const double new_pivotal_edge_weight = multi_finish[iFn].EdWt;
-      const double* colArray = &multi_finish[iFn].col_aq->array[0];
+      const double* colArray = multi_finish[iFn].col_aq->array.data();
       // The weight for this pivot is known, but weights for rows
       // pivotal earlier need to be updated
       if (edge_weight_mode == EdgeWeightMode::kSteepestEdge) {
         // Steepest edge
-        const double* dseArray = &multi_finish[iFn].row_ep->array[0];
+        const double* dseArray = multi_finish[iFn].row_ep->array.data();
         double Kai = -2 / multi_finish[iFn].alpha_row;
         for (HighsInt jFn = 0; jFn < iFn; jFn++) {
           HighsInt jRow = multi_finish[jFn].row_out;

--- a/src/simplex/HEkkDualRHS.cpp
+++ b/src/simplex/HEkkDualRHS.cpp
@@ -315,13 +315,13 @@ void HEkkDualRHS::updatePrimal(HVector* column, double theta) {
 
   const HighsInt numRow = ekk_instance_.lp_.num_row_;
   const HighsInt columnCount = column->count;
-  const HighsInt* variable_index = &column->index[0];
-  const double* columnArray = &column->array[0];
+  const HighsInt* variable_index = column->index.data();
+  const double* columnArray = column->array.data();
 
-  const double* baseLower = &ekk_instance_.info_.baseLower_[0];
-  const double* baseUpper = &ekk_instance_.info_.baseUpper_[0];
+  const double* baseLower = ekk_instance_.info_.baseLower_.data();
+  const double* baseUpper = ekk_instance_.info_.baseUpper_.data();
   const double Tp = ekk_instance_.options_->primal_feasibility_tolerance;
-  double* baseValue = &ekk_instance_.info_.baseValue_[0];
+  double* baseValue = ekk_instance_.info_.baseValue_.data();
 
   bool updatePrimal_inDense = columnCount < 0 || columnCount > 0.4 * numRow;
 
@@ -372,7 +372,7 @@ void HEkkDualRHS::updatePivots(const HighsInt iRow, const double value) {
 
 void HEkkDualRHS::updateInfeasList(HVector* column) {
   const HighsInt columnCount = column->count;
-  const HighsInt* variable_index = &column->index[0];
+  const HighsInt* variable_index = column->index.data();
 
   // DENSE mode: disabled
   if (workCount < 0) return;
@@ -409,9 +409,9 @@ void HEkkDualRHS::updateInfeasList(HVector* column) {
 
 void HEkkDualRHS::createArrayOfPrimalInfeasibilities() {
   HighsInt numRow = ekk_instance_.lp_.num_row_;
-  const double* baseValue = &ekk_instance_.info_.baseValue_[0];
-  const double* baseLower = &ekk_instance_.info_.baseLower_[0];
-  const double* baseUpper = &ekk_instance_.info_.baseUpper_[0];
+  const double* baseValue = ekk_instance_.info_.baseValue_.data();
+  const double* baseLower = ekk_instance_.info_.baseLower_.data();
+  const double* baseUpper = ekk_instance_.info_.baseUpper_.data();
   const double Tp = ekk_instance_.options_->primal_feasibility_tolerance;
   for (HighsInt i = 0; i < numRow; i++) {
     // @primal_infeasibility calculation
@@ -433,10 +433,10 @@ void HEkkDualRHS::createArrayOfPrimalInfeasibilities() {
 
 void HEkkDualRHS::createInfeasList(double columnDensity) {
   HighsInt numRow = ekk_instance_.lp_.num_row_;
-  double* dwork = &ekk_instance_.scattered_dual_edge_weight_[0];
+  double* dwork = ekk_instance_.scattered_dual_edge_weight_.data();
 
   // 1. Build the full list
-  fill_n(&workMark[0], numRow, 0);
+  fill_n(workMark.data(), numRow, 0);
   workCount = 0;
   workCutoff = 0;
   for (HighsInt iRow = 0; iRow < numRow; iRow++) {
@@ -463,7 +463,7 @@ void HEkkDualRHS::createInfeasList(double columnDensity) {
     workCutoff = min(maxMerit * 0.99999, cutMerit * 1.00001);
 
     // Create again
-    fill_n(&workMark[0], numRow, 0);
+    fill_n(workMark.data(), numRow, 0);
     workCount = 0;
     for (HighsInt iRow = 0; iRow < numRow; iRow++) {
       if (work_infeasibility[iRow] >= edge_weight[iRow] * workCutoff) {

--- a/src/simplex/HEkkDualRow.cpp
+++ b/src/simplex/HEkkDualRow.cpp
@@ -29,10 +29,10 @@ using std::set;
 
 void HEkkDualRow::setupSlice(HighsInt size) {
   workSize = size;
-  workMove = &ekk_instance_.basis_.nonbasicMove_[0];
-  workDual = &ekk_instance_.info_.workDual_[0];
-  workRange = &ekk_instance_.info_.workRange_[0];
-  work_devex_index = &ekk_instance_.info_.devex_index_[0];
+  workMove = ekk_instance_.basis_.nonbasicMove_.data();
+  workDual = ekk_instance_.info_.workDual_.data();
+  workRange = ekk_instance_.info_.workRange_.data();
+  work_devex_index = ekk_instance_.info_.devex_index_.data();
 
   // Allocate spaces
   packCount = 0;
@@ -49,7 +49,7 @@ void HEkkDualRow::setup() {
   const HighsInt numTot =
       ekk_instance_.lp_.num_col_ + ekk_instance_.lp_.num_row_;
   setupSlice(numTot);
-  workNumTotPermutation = &ekk_instance_.info_.numTotPermutation_[0];
+  workNumTotPermutation = ekk_instance_.info_.numTotPermutation_.data();
 
   // deleteFreelist() is being called in Phase 1 and Phase 2 since
   // it's in updatePivots(), but create_Freelist() is only called in
@@ -70,8 +70,8 @@ void HEkkDualRow::chooseMakepack(const HVector* row, const HighsInt offset) {
    * Offset of numCol is used when packing row_ep
    */
   const HighsInt rowCount = row->count;
-  const HighsInt* rowIndex = &row->index[0];
-  const double* rowArray = &row->array[0];
+  const HighsInt* rowIndex = row->index.data();
+  const double* rowArray = row->array.data();
   for (HighsInt i = 0; i < rowCount; i++) {
     const HighsInt index = rowIndex[i];
     const double value = rowArray[index];
@@ -111,7 +111,7 @@ void HEkkDualRow::chooseJoinpack(const HEkkDualRow* otherRow) {
    * candidates in otherRow
    */
   const HighsInt otherCount = otherRow->workCount;
-  const pair<HighsInt, double>* otherData = &otherRow->workData[0];
+  const pair<HighsInt, double>* otherData = otherRow->workData.data();
   copy(otherData, otherData + otherCount, &workData[workCount]);
   workCount = workCount + otherCount;
   workTheta = min(workTheta, otherRow->workTheta);
@@ -463,7 +463,7 @@ bool HEkkDualRow::chooseFinalWorkGroupHeap() {
       heap_v[heap_num_en] = ratio;
     }
   }
-  maxheapsort(&heap_v[0], &heap_i[0], heap_num_en);
+  maxheapsort(heap_v.data(), heap_i.data(), heap_num_en);
 
   alt_workCount = 0;
   alt_workGroup.clear();
@@ -541,7 +541,7 @@ void HEkkDualRow::chooseFinalLargeAlpha(
 }
 
 void HEkkDualRow::updateFlip(HVector* bfrtColumn) {
-  double* workDual = &ekk_instance_.info_.workDual_[0];
+  double* workDual = ekk_instance_.info_.workDual_.data();
   double dual_objective_value_change = 0;
   bfrtColumn->clear();
   for (HighsInt i = 0; i < workCount; i++) {
@@ -559,7 +559,7 @@ void HEkkDualRow::updateFlip(HVector* bfrtColumn) {
 
 void HEkkDualRow::updateDual(double theta) {
   analysis->simplexTimerStart(UpdateDualClock);
-  double* workDual = &ekk_instance_.info_.workDual_[0];
+  double* workDual = ekk_instance_.info_.workDual_.data();
   double dual_objective_value_change = 0;
   for (HighsInt i = 0; i < packCount; i++) {
     workDual[packIndex[i]] -= theta * packValue[i];

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -733,7 +733,7 @@ void HEkkPrimal::rebuild() {
     assert(info.backtracking_);
     ekk_instance_.initialisePartitionedRowwiseMatrix();
     assert(ekk_instance_.ar_matrix_.debugPartitionOk(
-        &ekk_instance_.basis_.nonbasicFlag_[0]));
+						     ekk_instance_.basis_.nonbasicFlag_.data()));
   }
 
   if (info.backtracking_) {
@@ -2469,7 +2469,7 @@ void HEkkPrimal::updateDualSteepestEdgeWeights() {
   const double Kai = -2 / pivot_in_scaled_space;
   ekk_instance_.updateDualSteepestEdgeWeights(row_out, variable_in, &col_aq,
                                               new_pivotal_edge_weight, Kai,
-                                              &col_steepest_edge.array[0]);
+                                              col_steepest_edge.array.data());
   edge_weight[row_out] = new_pivotal_edge_weight;
 }
 

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -733,7 +733,7 @@ void HEkkPrimal::rebuild() {
     assert(info.backtracking_);
     ekk_instance_.initialisePartitionedRowwiseMatrix();
     assert(ekk_instance_.ar_matrix_.debugPartitionOk(
-						     ekk_instance_.basis_.nonbasicFlag_.data()));
+        ekk_instance_.basis_.nonbasicFlag_.data()));
   }
 
   if (info.backtracking_) {

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -2541,7 +2541,6 @@ void HEkkPrimal::updateVerify() {
                 ekk_instance_.iteration_count_, alpha_col,
                 alpha_row_source.c_str(), alpha_row, abs_alpha_diff,
                 numericalTrouble);
-  assert(numericalTrouble < 1e-3);
   // Reinvert if the relative difference is large enough, and updates have been
   // performed
   //

--- a/src/simplex/HSimplexNla.cpp
+++ b/src/simplex/HSimplexNla.cpp
@@ -36,8 +36,8 @@ void HSimplexNla::setup(const HighsLp* lp, HighsInt* basic_index,
   this->report_ = false;
   this->factor_.setupGeneral(
       this->lp_->num_col_, this->lp_->num_row_, this->lp_->num_row_,
-      &factor_a_matrix->start_[0], &factor_a_matrix->index_[0],
-      &factor_a_matrix->value_[0], this->basic_index_, factor_pivot_threshold,
+      factor_a_matrix->start_.data(), factor_a_matrix->index_.data(),
+      factor_a_matrix->value_.data(), this->basic_index_, factor_pivot_threshold,
       this->options_->factor_pivot_tolerance, this->options_->highs_debug_level,
       &(this->options_->log_options));
   assert(debugCheckData("After HSimplexNla::setup") == HighsDebugStatus::kOk);
@@ -485,9 +485,9 @@ HighsDebugStatus HSimplexNla::debugCheckData(const std::string message) const {
   const double* factor_Avalue = factor_.getAvalue();
 
   if (scale_ == NULL) {
-    if (factor_Astart != &(lp_->a_matrix_.start_[0])) error0_found = true;
-    if (factor_Aindex != &(lp_->a_matrix_.index_[0])) error1_found = true;
-    if (factor_Avalue != &(lp_->a_matrix_.value_[0])) error2_found = true;
+    if (factor_Astart != lp_->a_matrix_.start_.data()) error0_found = true;
+    if (factor_Aindex != lp_->a_matrix_.index_.data()) error1_found = true;
+    if (factor_Avalue != lp_->a_matrix_.value_.data()) error2_found = true;
     error_found = error0_found || error1_found || error2_found;
     if (error_found) {
       highsLogUser(options_->log_options, HighsLogType::kError,
@@ -496,7 +496,7 @@ HighsDebugStatus HSimplexNla::debugCheckData(const std::string message) const {
                    message.c_str(), scale_status.c_str());
       if (error0_found)
         printf("a_matrix_.start_ pointer error: %p vs %p\n",
-               (void*)factor_Astart, (void*)&(lp_->a_matrix_.start_[0]));
+               (void*)factor_Astart, (void*)lp_->a_matrix_.start_.data());
       if (error1_found) printf("a_matrix_.index pointer error\n");
       if (error2_found) printf("a_matrix_.value pointer error\n");
       assert(!error_found);

--- a/src/simplex/HSimplexNla.cpp
+++ b/src/simplex/HSimplexNla.cpp
@@ -37,9 +37,9 @@ void HSimplexNla::setup(const HighsLp* lp, HighsInt* basic_index,
   this->factor_.setupGeneral(
       this->lp_->num_col_, this->lp_->num_row_, this->lp_->num_row_,
       factor_a_matrix->start_.data(), factor_a_matrix->index_.data(),
-      factor_a_matrix->value_.data(), this->basic_index_, factor_pivot_threshold,
-      this->options_->factor_pivot_tolerance, this->options_->highs_debug_level,
-      &(this->options_->log_options));
+      factor_a_matrix->value_.data(), this->basic_index_,
+      factor_pivot_threshold, this->options_->factor_pivot_tolerance,
+      this->options_->highs_debug_level, &(this->options_->log_options));
   assert(debugCheckData("After HSimplexNla::setup") == HighsDebugStatus::kOk);
 }
 

--- a/src/simplex/HighsSimplexAnalysis.cpp
+++ b/src/simplex/HighsSimplexAnalysis.cpp
@@ -301,7 +301,7 @@ void HighsSimplexAnalysis::setupFactorTime(const HighsOptions& options) {
       clock.timer_pointer_ = timer_;
       thread_factor_clocks.push_back(clock);
     }
-    pointer_serial_factor_clocks = &thread_factor_clocks[0];
+    pointer_serial_factor_clocks = thread_factor_clocks.data();
     FactorTimer factor_timer;
     for (HighsTimerClock& clock : thread_factor_clocks)
       factor_timer.initialiseFactorClocks(clock);

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -67,14 +67,14 @@ static void solveHyper(const HighsInt h_size, const HighsInt* h_lookup,
                        const HighsInt* h_end, const HighsInt* h_index,
                        const double* h_value, HVector* rhs) {
   HighsInt rhs_count = rhs->count;
-  HighsInt* rhs_index = &rhs->index[0];
-  double* rhs_array = &rhs->array[0];
+  HighsInt* rhs_index = rhs->index.data();
+  double* rhs_array = rhs->array.data();
 
   // Take count
 
   // Build list
-  char* list_mark = &rhs->cwork[0];
-  HighsInt* list_index = &rhs->iwork[0];
+  char* list_mark = rhs->cwork.data();
+  HighsInt* list_index = rhs->iwork.data();
   HighsInt* list_stack = &rhs->iwork[h_size];
   HighsInt list_count = 0;
 
@@ -169,7 +169,7 @@ void HFactor::setup(const HighsSparseMatrix& a_matrix,
   // Nothing to do if basic index has no entries, and mustn't try to
   // pass the pointer to entry 0 of a vector of size 0.
   if (basic_index_size <= 0) return;
-  this->setupGeneral(&a_matrix, basic_index_size, &basic_index[0],
+  this->setupGeneral(&a_matrix, basic_index_size, basic_index.data(),
                      pivot_threshold, pivot_tolerance, highs_debug_level,
                      log_options);
   return;
@@ -181,10 +181,11 @@ void HFactor::setupGeneral(const HighsSparseMatrix* a_matrix,
                            const double pivot_tolerance,
                            const HighsInt highs_debug_level,
                            const HighsLogOptions* log_options) {
-  this->setupGeneral(
-      a_matrix->num_col_, a_matrix->num_row_, num_basic, &a_matrix->start_[0],
-      &a_matrix->index_[0], &a_matrix->value_[0], basic_index, pivot_threshold,
-      pivot_tolerance, highs_debug_level, log_options, true, kUpdateMethodFt);
+  this->setupGeneral(a_matrix->num_col_, a_matrix->num_row_, num_basic,
+                     a_matrix->start_.data(), a_matrix->index_.data(),
+                     a_matrix->value_.data(), basic_index, pivot_threshold,
+                     pivot_tolerance, highs_debug_level, log_options, true,
+                     kUpdateMethodFt);
 }
 
 void HFactor::setup(
@@ -350,7 +351,8 @@ void HFactor::setupMatrix(const HighsInt* a_start_, const HighsInt* a_index_,
 }
 
 void HFactor::setupMatrix(const HighsSparseMatrix* a_matrix) {
-  setupMatrix(&a_matrix->start_[0], &a_matrix->index_[0], &a_matrix->value_[0]);
+  setupMatrix(a_matrix->start_.data(), a_matrix->index_.data(),
+              a_matrix->value_.data());
 }
 
 HighsInt HFactor::build(HighsTimerClock* factor_timer_clock_pointer) {
@@ -582,7 +584,7 @@ void HFactor::buildSimple() {
   const bool report_anything =
       report_unit || report_singletons || report_markowitz;
   HighsInt BcountX = 0;
-  fill_n(&mr_count_before[0], num_row, 0);
+  fill_n(mr_count_before.data(), num_row, 0);
   nwork = 0;
   if (report_anything) printf("\nFactor\n");
   // Compile a vector iwork of the indices within basic_index of the
@@ -1543,13 +1545,12 @@ void HFactor::ftranL(HVector& rhs, const double expected_density,
   if (sparse_solve) {
     factor_timer.start(FactorFtranLowerSps, factor_timer_clock_pointer);
     // Alias to RHS
-    HighsInt* rhs_index = &rhs.index[0];
-    double* rhs_array = &rhs.array[0];
+    HighsInt* rhs_index = rhs.index.data();
+    double* rhs_array = rhs.array.data();
     // Alias to factor L
-    const HighsInt* l_start = &this->l_start[0];
-    const HighsInt* l_index =
-        this->l_index.size() > 0 ? &this->l_index[0] : NULL;
-    const double* l_value = this->l_value.size() > 0 ? &this->l_value[0] : NULL;
+    const HighsInt* l_start = this->l_start.data();
+    const HighsInt* l_index = this->l_index.data();
+    const double* l_value = this->l_value.data();
     // Local accumulation of RHS count
     HighsInt rhs_count = 0;
     // Transform
@@ -1571,11 +1572,10 @@ void HFactor::ftranL(HVector& rhs, const double expected_density,
   } else {
     // Hyper-sparse solve
     factor_timer.start(FactorFtranLowerHyper, factor_timer_clock_pointer);
-    const HighsInt* l_index =
-        this->l_index.size() > 0 ? &this->l_index[0] : NULL;
-    const double* l_value = this->l_value.size() > 0 ? &this->l_value[0] : NULL;
-    solveHyper(num_row, &l_pivot_lookup[0], &l_pivot_index[0], 0, &l_start[0],
-               &l_start[1], &l_index[0], &l_value[0], &rhs);
+    const HighsInt* l_index = this->l_index.data();
+    const double* l_value = this->l_value.data();
+    solveHyper(num_row, l_pivot_lookup.data(), l_pivot_index.data(), 0,
+               l_start.data(), &l_start[1], &l_index[0], &l_value[0], &rhs);
     factor_timer.stop(FactorFtranLowerHyper, factor_timer_clock_pointer);
   }
   factor_timer.stop(FactorFtranLower, factor_timer_clock_pointer);
@@ -1593,14 +1593,12 @@ void HFactor::btranL(HVector& rhs, const double expected_density,
   if (sparse_solve) {
     factor_timer.start(FactorBtranLowerSps, factor_timer_clock_pointer);
     // Alias to RHS
-    HighsInt* rhs_index = &rhs.index[0];
-    double* rhs_array = &rhs.array[0];
+    HighsInt* rhs_index = rhs.index.data();
+    double* rhs_array = rhs.array.data();
     // Alias to factor L
-    const HighsInt* lr_start = &this->lr_start[0];
-    const HighsInt* lr_index =
-        this->lr_index.size() > 0 ? &this->lr_index[0] : NULL;
-    const double* lr_value =
-        this->lr_value.size() > 0 ? &this->lr_value[0] : NULL;
+    const HighsInt* lr_start = this->lr_start.data();
+    const HighsInt* lr_index = this->lr_index.data();
+    const double* lr_value = this->lr_value.data();
     // Local accumulation of RHS count
     HighsInt rhs_count = 0;
     // Transform
@@ -1623,12 +1621,10 @@ void HFactor::btranL(HVector& rhs, const double expected_density,
   } else {
     // Hyper-sparse solve
     factor_timer.start(FactorBtranLowerHyper, factor_timer_clock_pointer);
-    const HighsInt* lr_index =
-        this->lr_index.size() > 0 ? &this->lr_index[0] : NULL;
-    const double* lr_value =
-        this->lr_value.size() > 0 ? &this->lr_value[0] : NULL;
-    solveHyper(num_row, &l_pivot_lookup[0], &l_pivot_index[0], 0, &lr_start[0],
-               &lr_start[1], &lr_index[0], &lr_value[0], &rhs);
+    const HighsInt* lr_index = this->lr_index.data();
+    const double* lr_value = this->lr_value.data();
+    solveHyper(num_row, l_pivot_lookup.data(), l_pivot_index.data(), 0,
+               lr_start.data(), &lr_start[1], &lr_index[0], &lr_value[0], &rhs);
     factor_timer.stop(FactorBtranLowerHyper, factor_timer_clock_pointer);
   }
 
@@ -1683,14 +1679,13 @@ void HFactor::ftranU(HVector& rhs, const double expected_density,
     // Alias to non constant
     double rhs_synthetic_tick = 0;
     // Alias to RHS
-    HighsInt* rhs_index = &rhs.index[0];
-    double* rhs_array = &rhs.array[0];
+    HighsInt* rhs_index = rhs.index.data();
+    double* rhs_array = rhs.array.data();
     // Alias to factor U
-    const HighsInt* u_start = &this->u_start[0];
-    const HighsInt* u_end = &this->u_last_p[0];
-    const HighsInt* u_index =
-        this->u_index.size() > 0 ? &this->u_index[0] : NULL;
-    const double* u_value = this->u_value.size() > 0 ? &this->u_value[0] : NULL;
+    const HighsInt* u_start = this->u_start.data();
+    const HighsInt* u_end = this->u_last_p.data();
+    const HighsInt* u_index = this->u_index.data();
+    const double* u_value = this->u_value.data();
     // Local accumulation of RHS count
     HighsInt rhs_count = 0;
     // Transform
@@ -1742,12 +1737,11 @@ void HFactor::ftranU(HVector& rhs, const double expected_density,
     else
       use_clock = FactorFtranUpperHyper0;
     factor_timer.start(use_clock, factor_timer_clock_pointer);
-    const HighsInt* u_index =
-        this->u_index.size() > 0 ? &this->u_index[0] : NULL;
-    const double* u_value = this->u_value.size() > 0 ? &this->u_value[0] : NULL;
-    solveHyper(num_row, &u_pivot_lookup[0], &u_pivot_index[0],
-               &u_pivot_value[0], &u_start[0], &u_last_p[0], &u_index[0],
-               &u_value[0], &rhs);
+    const HighsInt* u_index = this->u_index.data();
+    const double* u_value = this->u_value.data();
+    solveHyper(num_row, u_pivot_lookup.data(), u_pivot_index.data(),
+               u_pivot_value.data(), u_start.data(), u_last_p.data(),
+               &u_index[0], &u_value[0], &rhs);
     factor_timer.stop(use_clock, factor_timer_clock_pointer);
   }
   if (update_method == kUpdateMethodPf) {
@@ -1783,13 +1777,13 @@ void HFactor::btranU(HVector& rhs, const double expected_density,
     // Alias to non constant
     double rhs_synthetic_tick = 0;
     // Alias to RHS
-    double* rhs_array = &rhs.array[0];
-    HighsInt* rhs_index = &rhs.index[0];
+    double* rhs_array = rhs.array.data();
+    HighsInt* rhs_index = rhs.index.data();
     // Alias to factor U
-    const HighsInt* ur_start = &this->ur_start[0];
-    const HighsInt* ur_end = &this->ur_lastp[0];
-    const HighsInt* ur_index = &this->ur_index[0];
-    const double* ur_value = &this->ur_value[0];
+    const HighsInt* ur_start = this->ur_start.data();
+    const HighsInt* ur_end = this->ur_lastp.data();
+    const HighsInt* ur_index = this->ur_index.data();
+    const double* ur_value = this->ur_value.data();
     // Local accumulation of RHS count
     HighsInt rhs_count = 0;
     // Transform
@@ -1821,9 +1815,9 @@ void HFactor::btranU(HVector& rhs, const double expected_density,
     factor_timer.stop(FactorBtranUpperSps, factor_timer_clock_pointer);
   } else {
     factor_timer.start(FactorBtranUpperHyper, factor_timer_clock_pointer);
-    solveHyper(num_row, &u_pivot_lookup[0], &u_pivot_index[0],
-               &u_pivot_value[0], &ur_start[0], &ur_lastp[0], &ur_index[0],
-               &ur_value[0], &rhs);
+    solveHyper(num_row, u_pivot_lookup.data(), u_pivot_index.data(),
+               u_pivot_value.data(), &ur_start[0], ur_lastp.data(),
+               &ur_index[0], &ur_value[0], &rhs);
     factor_timer.stop(FactorBtranUpperHyper, factor_timer_clock_pointer);
   }
 
@@ -1853,20 +1847,14 @@ void HFactor::ftranFT(HVector& vector) const {
   // Alias to non constant
   assert(vector.count >= 0);
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
   // Alias to PF buffer
   const HighsInt pf_pivot_count = pf_pivot_index.size();
-  HighsInt* pf_pivot_index = NULL;
-  if (this->pf_pivot_index.size() > 0)
-    pf_pivot_index = (HighsInt*)&this->pf_pivot_index[0];
-
-  const HighsInt* pf_start =
-      this->pf_start.size() > 0 ? &this->pf_start[0] : NULL;
-  const HighsInt* pf_index =
-      this->pf_index.size() > 0 ? &this->pf_index[0] : NULL;
-  const double* pf_value =
-      this->pf_value.size() > 0 ? &this->pf_value[0] : NULL;
+  const HighsInt* pf_pivot_index = this->pf_pivot_index.data();
+  const HighsInt* pf_start = this->pf_start.data();
+  const HighsInt* pf_index = this->pf_index.data();
+  const double* pf_value = this->pf_value.data();
   for (HighsInt i = 0; i < pf_pivot_count; i++) {
     HighsInt iRow = pf_pivot_index[i];
     double value0 = rhs_array[iRow];
@@ -1893,18 +1881,14 @@ void HFactor::btranFT(HVector& vector) const {
   // Alias to non constant
   assert(vector.count >= 0);
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
   // Alias to PF buffer
   const HighsInt pf_pivot_count = pf_pivot_index.size();
-  const HighsInt* pf_pivot_index =
-      this->pf_pivot_index.size() > 0 ? &this->pf_pivot_index[0] : NULL;
-  const HighsInt* pf_start =
-      this->pf_start.size() > 0 ? &this->pf_start[0] : NULL;
-  const HighsInt* pf_index =
-      this->pf_index.size() > 0 ? &this->pf_index[0] : NULL;
-  const double* pf_value =
-      this->pf_value.size() > 0 ? &this->pf_value[0] : NULL;
+  const HighsInt* pf_pivot_index = this->pf_pivot_index.data();
+  const HighsInt* pf_start = this->pf_start.data();
+  const HighsInt* pf_index = this->pf_index.data();
+  const double* pf_value = this->pf_value.data();
   // Apply row ETA backward
   double rhs_synthetic_tick = 0;
   for (HighsInt i = pf_pivot_count - 1; i >= 0; i--) {
@@ -1931,16 +1915,16 @@ void HFactor::btranFT(HVector& vector) const {
 void HFactor::ftranPF(HVector& vector) const {
   // Alias to PF buffer
   const HighsInt pf_pivot_count = pf_pivot_index.size();
-  const HighsInt* pf_pivot_index = &this->pf_pivot_index[0];
-  const double* pf_pivot_value = &this->pf_pivot_value[0];
-  const HighsInt* pf_start = &this->pf_start[0];
-  const HighsInt* pf_index = &this->pf_index[0];
-  const double* pf_value = &this->pf_value[0];
+  const HighsInt* pf_pivot_index = this->pf_pivot_index.data();
+  const double* pf_pivot_value = this->pf_pivot_value.data();
+  const HighsInt* pf_start = this->pf_start.data();
+  const HighsInt* pf_index = this->pf_index.data();
+  const double* pf_value = this->pf_value.data();
 
   // Alias to non constant
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
 
   // Forwardly
   for (HighsInt i = 0; i < pf_pivot_count; i++) {
@@ -1966,16 +1950,16 @@ void HFactor::ftranPF(HVector& vector) const {
 void HFactor::btranPF(HVector& vector) const {
   // Alias to PF buffer
   const HighsInt pf_pivot_count = pf_pivot_index.size();
-  const HighsInt* pf_pivot_index = &this->pf_pivot_index[0];
-  const double* pf_pivot_value = &this->pf_pivot_value[0];
-  const HighsInt* pf_start = &this->pf_start[0];
-  const HighsInt* pf_index = &this->pf_index[0];
-  const double* pf_value = &this->pf_value[0];
+  const HighsInt* pf_pivot_index = this->pf_pivot_index.data();
+  const double* pf_pivot_value = this->pf_pivot_value.data();
+  const HighsInt* pf_start = this->pf_start.data();
+  const HighsInt* pf_index = this->pf_index.data();
+  const double* pf_value = this->pf_value.data();
 
   // Alias to non constant
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
 
   // Backwardly
   for (HighsInt i = pf_pivot_count - 1; i >= 0; i--) {
@@ -1997,14 +1981,14 @@ void HFactor::btranPF(HVector& vector) const {
 void HFactor::ftranMPF(HVector& vector) const {
   // Alias to non constant
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
 
   // Forwardly
   HighsInt pf_pivot_count = pf_pivot_value.size();
   for (HighsInt i = 0; i < pf_pivot_count; i++) {
     solveMatrixT(pf_start[i * 2 + 1], pf_start[i * 2 + 2], pf_start[i * 2],
-                 pf_start[i * 2 + 1], &pf_index[0], &pf_value[0],
+                 pf_start[i * 2 + 1], pf_index.data(), pf_value.data(),
                  pf_pivot_value[i], &rhs_count, rhs_index, rhs_array);
   }
 
@@ -2015,13 +1999,13 @@ void HFactor::ftranMPF(HVector& vector) const {
 void HFactor::btranMPF(HVector& vector) const {
   // Alias to non constant
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
 
   // Backwardly
   for (HighsInt i = pf_pivot_value.size() - 1; i >= 0; i--) {
     solveMatrixT(pf_start[i * 2], pf_start[i * 2 + 1], pf_start[i * 2 + 1],
-                 pf_start[i * 2 + 2], &pf_index[0], &pf_value[0],
+                 pf_start[i * 2 + 2], pf_index.data(), pf_value.data(),
                  pf_pivot_value[i], &rhs_count, rhs_index, rhs_array);
   }
 
@@ -2032,14 +2016,14 @@ void HFactor::btranMPF(HVector& vector) const {
 void HFactor::ftranAPF(HVector& vector) const {
   // Alias to non constant
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
 
   // Backwardly
   HighsInt pf_pivot_count = pf_pivot_value.size();
   for (HighsInt i = pf_pivot_count - 1; i >= 0; i--) {
     solveMatrixT(pf_start[i * 2 + 1], pf_start[i * 2 + 2], pf_start[i * 2],
-                 pf_start[i * 2 + 1], &pf_index[0], &pf_value[0],
+                 pf_start[i * 2 + 1], pf_index.data(), pf_value.data(),
                  pf_pivot_value[i], &rhs_count, rhs_index, rhs_array);
   }
 
@@ -2050,14 +2034,14 @@ void HFactor::ftranAPF(HVector& vector) const {
 void HFactor::btranAPF(HVector& vector) const {
   // Alias to non constant
   HighsInt rhs_count = vector.count;
-  HighsInt* rhs_index = &vector.index[0];
-  double* rhs_array = &vector.array[0];
+  HighsInt* rhs_index = vector.index.data();
+  double* rhs_array = vector.array.data();
 
   // Forwardly
   HighsInt pf_pivot_count = pf_pivot_value.size();
   for (HighsInt i = 0; i < pf_pivot_count; i++) {
     solveMatrixT(pf_start[i * 2], pf_start[i * 2 + 1], pf_start[i * 2 + 1],
-                 pf_start[i * 2 + 2], &pf_index[0], &pf_value[0],
+                 pf_start[i * 2 + 2], pf_index.data(), pf_value.data(),
                  pf_pivot_value[i], &rhs_count, rhs_index, rhs_array);
   }
   vector.count = rhs_count;
@@ -2433,8 +2417,8 @@ void HFactor::updateFT(HVector* aq, HVector* ep, HighsInt iRow
 void HFactor::updatePF(HVector* aq, HighsInt iRow, HighsInt* hint) {
   // Check space
   const HighsInt column_count = aq->packCount;
-  const HighsInt* variable_index = &aq->packIndex[0];
-  const double* columnArray = &aq->packValue[0];
+  const HighsInt* variable_index = aq->packIndex.data();
+  const double* columnArray = aq->packValue.data();
 
   // Copy the pivotal column
   for (HighsInt i = 0; i < column_count; i++) {

--- a/src/util/HighsSort.cpp
+++ b/src/util/HighsSort.cpp
@@ -330,8 +330,8 @@ void sortSetData(const HighsInt num_entries, vector<HighsInt>& set,
   vector<HighsInt> sort_set_vec(1 + num_entries);
   vector<HighsInt> perm_vec(1 + num_entries);
 
-  HighsInt* sort_set = &sort_set_vec[0];
-  HighsInt* perm = &perm_vec[0];
+  HighsInt* sort_set = sort_set_vec.data();
+  HighsInt* perm = perm_vec.data();
 
   for (HighsInt ix = 0; ix < num_entries; ix++) {
     sort_set[1 + ix] = set[ix];
@@ -352,8 +352,8 @@ void sortSetData(const HighsInt num_entries, vector<HighsInt>& set,
   vector<HighsInt> sort_set_vec(1 + num_entries);
   vector<HighsInt> perm_vec(1 + num_entries);
 
-  HighsInt* sort_set = &sort_set_vec[0];
-  HighsInt* perm = &perm_vec[0];
+  HighsInt* sort_set = sort_set_vec.data();
+  HighsInt* perm = perm_vec.data();
 
   for (HighsInt ix = 0; ix < num_entries; ix++) {
     sort_set[1 + ix] = set[ix];


### PR DESCRIPTION
Contains the two successful fixes for #1129, and many replacements of `&vector[0]` by `vector.data()` that were inspired by an observation in #1129 