### PR TITLE
Write options

### DIFF
--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
   HighsStatus run_status = highs.run();
   if (run_status == HighsStatus::kError) return (int)run_status;
 
-  //  highs.writeInfo("Info.md");
+  highs.writeInfo("Info.md");
   // Possibly compute the ranging information
   if (options.ranging == kHighsOnString) highs.getRanging();
 

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -46,6 +46,7 @@ int main(int argc, char** argv) {
   // call this first so that printHighsVersionCopyright uses reporting
   // settings defined in any options file.
   highs.passOptions(loaded_options);
+  highs.writeOptions("Options.md");
 
   // Load the model from model_file
   HighsStatus read_status = highs.readModel(model_file);

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -65,6 +65,7 @@ int main(int argc, char** argv) {
   HighsStatus run_status = highs.run();
   if (run_status == HighsStatus::kError) return (int)run_status;
 
+  highs.writeInfo("Info.md");
   // Possibly compute the ranging information
   if (options.ranging == kHighsOnString) highs.getRanging();
 

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
   // call this first so that printHighsVersionCopyright uses reporting
   // settings defined in any options file.
   highs.passOptions(loaded_options);
-  highs.writeOptions("Options.md");
+  //  highs.writeOptions("Options.md");
 
   // Load the model from model_file
   HighsStatus read_status = highs.readModel(model_file);
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
   HighsStatus run_status = highs.run();
   if (run_status == HighsStatus::kError) return (int)run_status;
 
-  highs.writeInfo("Info.md");
+  // highs.writeInfo("Info.md");
   // Possibly compute the ranging information
   if (options.ranging == kHighsOnString) highs.getRanging();
 

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
   HighsStatus run_status = highs.run();
   if (run_status == HighsStatus::kError) return (int)run_status;
 
-  highs.writeInfo("Info.md");
+  //  highs.writeInfo("Info.md");
   // Possibly compute the ranging information
   if (options.ranging == kHighsOnString) highs.getRanging();
 

--- a/check/TestIO.cpp
+++ b/check/TestIO.cpp
@@ -4,7 +4,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = false;
+const bool dev_run = true;
 
 const HighsInt kLogBufferSize = kIoBufferSize;
 

--- a/check/TestIO.cpp
+++ b/check/TestIO.cpp
@@ -19,13 +19,15 @@ using std::strstr;
 
 // Callback that saves message for comparison
 static void myLogCallback(HighsLogType type, const char* message,
-                          void* deprecated // V2.0 remove
-			  ) { strcpy(printed_log, message); }
+                          void* deprecated  // V2.0 remove
+) {
+  strcpy(printed_log, message);
+}
 
 // Callback that provides user logging
 static void userLogCallback(HighsLogType type, const char* message,
-                            void* deprecated // V2.0 remove
-			    ) {
+                            void* deprecated  // V2.0 remove
+) {
   if (dev_run) printf("userLogCallback: %s", message);
 }
 

--- a/check/TestIO.cpp
+++ b/check/TestIO.cpp
@@ -20,14 +20,14 @@ using std::strstr;
 
 // Callback that saves message for comparison
 static void myLogCallback(HighsLogType type, const char* message,
-                          void* log_callback_data) {
+                          void* log_deprecated) {
   strcpy(printed_log, message);
-  received_data = log_callback_data;
+  received_data = log_deprecated;
 }
 
 // Callback that provides user logging
 static void userLogCallback(HighsLogType type, const char* message,
-                            void* log_callback_data) {
+                            void* log_deprecated) {
   if (dev_run) printf("userLogCallback: %s", message);
 }
 
@@ -51,7 +51,7 @@ TEST_CASE("log-callback", "[highs_io]") {
   log_options.log_to_console = &log_to_console;
   log_options.log_dev_level = &log_dev_level;
   log_options.log_callback = myLogCallback;
-  log_options.log_callback_data = (void*)&dummy_data;
+  log_options.log_deprecated = (void*)&dummy_data;
 
   highsLogDev(log_options, HighsLogType::kInfo, "Hi %s!", "HiGHS");
   if (dev_run) printf("Log callback yields \"%s\"\n", printed_log);

--- a/check/TestIO.cpp
+++ b/check/TestIO.cpp
@@ -50,7 +50,7 @@ TEST_CASE("log-callback", "[highs_io]") {
   log_options.output_flag = &output_flag;
   log_options.log_to_console = &log_to_console;
   log_options.log_dev_level = &log_dev_level;
-  log_options.log_callback = myLogCallback;
+  log_options.log_user_callback = myLogCallback;
   log_options.log_deprecated = (void*)&dummy_data;
 
   highsLogDev(log_options, HighsLogType::kInfo, "Hi %s!", "HiGHS");

--- a/check/TestIO.cpp
+++ b/check/TestIO.cpp
@@ -9,7 +9,6 @@ const bool dev_run = true;
 const HighsInt kLogBufferSize = kIoBufferSize;
 
 char printed_log[kLogBufferSize];
-void* received_data = NULL;
 
 using std::memset;
 using std::strcmp;
@@ -20,14 +19,13 @@ using std::strstr;
 
 // Callback that saves message for comparison
 static void myLogCallback(HighsLogType type, const char* message,
-                          void* log_deprecated) {
-  strcpy(printed_log, message);
-  received_data = log_deprecated;
-}
+                          void* deprecated // V2.0 remove
+			  ) { strcpy(printed_log, message); }
 
 // Callback that provides user logging
 static void userLogCallback(HighsLogType type, const char* message,
-                            void* log_deprecated) {
+                            void* deprecated // V2.0 remove
+			    ) {
   if (dev_run) printf("userLogCallback: %s", message);
 }
 
@@ -41,7 +39,6 @@ TEST_CASE("run-callback", "[highs_io]") {
 }
 
 TEST_CASE("log-callback", "[highs_io]") {
-  int dummy_data = 42;
   bool output_flag = true;
   bool log_to_console = false;
   HighsInt log_dev_level = kHighsLogDevLevelInfo;
@@ -51,12 +48,10 @@ TEST_CASE("log-callback", "[highs_io]") {
   log_options.log_to_console = &log_to_console;
   log_options.log_dev_level = &log_dev_level;
   log_options.log_user_callback = myLogCallback;
-  log_options.log_deprecated = (void*)&dummy_data;
 
   highsLogDev(log_options, HighsLogType::kInfo, "Hi %s!", "HiGHS");
   if (dev_run) printf("Log callback yields \"%s\"\n", printed_log);
   REQUIRE(strcmp(printed_log, "Hi HiGHS!") == 0);
-  REQUIRE(received_data == &dummy_data);
 
   // Check that nothing is printed if the type is VERBOSE when
   // log_dev_level is kHighsLogDevLevelInfo;
@@ -78,7 +73,6 @@ TEST_CASE("log-callback", "[highs_io]") {
   highsLogUser(log_options, HighsLogType::kInfo, "Hello %s!\n", "HiGHS");
   REQUIRE(strlen(printed_log) > 9);
   REQUIRE(strcmp(printed_log, "Hello HiGHS!\n") == 0);
-  REQUIRE(received_data == &dummy_data);
 
   {
     char long_message[sizeof(printed_log)];

--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -87,7 +87,8 @@ TEST_CASE("internal-options", "[highs_options]") {
 
   std::string filename = std::string(HIGHS_DIR) + "/check/sample_options_file";
 
-  bool success = loadOptionsFromFile(report_log_options, options, filename) == HighsLoadOptionsStatus::kOk;
+  bool success = loadOptionsFromFile(report_log_options, options, filename) ==
+                 HighsLoadOptionsStatus::kOk;
   REQUIRE(success == true);
   REQUIRE(options.presolve == kHighsOnString);
   REQUIRE(options.small_matrix_value == 0.001);

--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -87,7 +87,7 @@ TEST_CASE("internal-options", "[highs_options]") {
 
   std::string filename = std::string(HIGHS_DIR) + "/check/sample_options_file";
 
-  bool success = loadOptionsFromFile(report_log_options, options, filename);
+  bool success = loadOptionsFromFile(report_log_options, options, filename) == HighsLoadOptionsStatus::kOk;
   REQUIRE(success == true);
   REQUIRE(options.presolve == kHighsOnString);
   REQUIRE(options.small_matrix_value == 0.001);

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1009,8 +1009,9 @@ class Highs {
    * @brief Set the callback method and user data to use for logging
    */
   HighsStatus setLogCallback(void (*log_user_callback)(HighsLogType, const char*,
-                                                  void*),
-                             void* log_deprecated = nullptr);
+                                                  void*)
+                             , void* deprecated = nullptr// V2.0 remove
+			     );
 
   /**
    * @brief Use the HighsBasis passed to set the internal HighsBasis

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1266,7 +1266,7 @@ class Highs {
   HighsPostsolveStatus runPostsolve();
 
   HighsStatus openWriteFile(const string filename, const string method_name,
-                            FILE*& file, bool& html) const;
+                            FILE*& file, HighsFileType& file_type) const;
 
   void reportModel();
   void newHighsBasis();

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1008,7 +1008,7 @@ class Highs {
   /**
    * @brief Set the callback method and user data to use for logging
    */
-  HighsStatus setLogCallback(void (*log_callback)(HighsLogType, const char*,
+  HighsStatus setLogCallback(void (*log_user_callback)(HighsLogType, const char*,
                                                   void*),
                              void* log_deprecated = nullptr);
 

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1008,10 +1008,10 @@ class Highs {
   /**
    * @brief Set the callback method and user data to use for logging
    */
-  HighsStatus setLogCallback(void (*log_user_callback)(HighsLogType, const char*,
-                                                  void*)
-                             , void* deprecated = nullptr// V2.0 remove
-			     );
+  HighsStatus setLogCallback(void (*log_user_callback)(HighsLogType,
+                                                       const char*, void*),
+                             void* deprecated = nullptr  // V2.0 remove
+  );
 
   /**
    * @brief Use the HighsBasis passed to set the internal HighsBasis

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1010,7 +1010,7 @@ class Highs {
    */
   HighsStatus setLogCallback(void (*log_callback)(HighsLogType, const char*,
                                                   void*),
-                             void* log_callback_data = nullptr);
+                             void* log_deprecated = nullptr);
 
   /**
    * @brief Use the HighsBasis passed to set the internal HighsBasis

--- a/src/interfaces/highspy/highspy/highs.py
+++ b/src/interfaces/highspy/highspy/highs.py
@@ -33,7 +33,9 @@ class Highs(_Highs):
         super().__init__()
         self._log_user_callback_tuple = CallbackTuple()
 
-    def setLogCallback(self, func, log_deprecated):
+    def setLogCallback(self, func
+#                       , deprecated// V2.0 remove
+                       ):
         self._log_user_callback_tuple.callback = func
         self._log_user_callback_tuple.log_deprecated = log_deprecated
         super().setLogCallback(self._log_user_callback_tuple)

--- a/src/interfaces/highspy/highspy/highs.py
+++ b/src/interfaces/highspy/highspy/highs.py
@@ -33,7 +33,7 @@ class Highs(_Highs):
         super().__init__()
         self._log_callback_tuple = CallbackTuple()
 
-    def setLogCallback(self, func, callback_data):
+    def setLogCallback(self, func, log_deprecated):
         self._log_callback_tuple.callback = func
-        self._log_callback_tuple.callback_data = callback_data
+        self._log_callback_tuple.log_deprecated = log_deprecated
         super().setLogCallback(self._log_callback_tuple)

--- a/src/interfaces/highspy/highspy/highs.py
+++ b/src/interfaces/highspy/highspy/highs.py
@@ -11,7 +11,6 @@ from .highs_bindings import (
     HighsInfoType,
     HighsStatus,
     HighsLogType,
-    CallbackTuple,
     HighsSparseMatrix,
     HighsLp,
     HighsHessian,
@@ -31,11 +30,3 @@ from .highs_bindings import (
 class Highs(_Highs):
     def __init__(self):
         super().__init__()
-        self._log_user_callback_tuple = CallbackTuple()
-
-    def setLogCallback(self, func
-#                       , deprecated// V2.0 remove
-                       ):
-        self._log_user_callback_tuple.callback = func
-        self._log_user_callback_tuple.log_deprecated = log_deprecated
-        super().setLogCallback(self._log_user_callback_tuple)

--- a/src/interfaces/highspy/highspy/highs.py
+++ b/src/interfaces/highspy/highspy/highs.py
@@ -31,9 +31,9 @@ from .highs_bindings import (
 class Highs(_Highs):
     def __init__(self):
         super().__init__()
-        self._log_callback_tuple = CallbackTuple()
+        self._log_user_callback_tuple = CallbackTuple()
 
     def setLogCallback(self, func, log_deprecated):
-        self._log_callback_tuple.callback = func
-        self._log_callback_tuple.log_deprecated = log_deprecated
-        super().setLogCallback(self._log_callback_tuple)
+        self._log_user_callback_tuple.callback = func
+        self._log_user_callback_tuple.log_deprecated = log_deprecated
+        super().setLogCallback(self._log_user_callback_tuple)

--- a/src/interfaces/highspy/highspy/highs_bindings.cpp
+++ b/src/interfaces/highspy/highspy/highs_bindings.cpp
@@ -431,7 +431,7 @@ public:
   py::object log_deprecated;
 };
 
-void py_log_callback(HighsLogType log_type, const char* msgbuffer, void* log_deprecated)
+void py_log_user_callback(HighsLogType log_type, const char* msgbuffer, void* log_deprecated)
 {
   CallbackTuple* callback_tuple = static_cast<CallbackTuple*>(log_deprecated);
   std::string msg(msgbuffer);
@@ -440,8 +440,8 @@ void py_log_callback(HighsLogType log_type, const char* msgbuffer, void* log_dep
 
 HighsStatus highs_setLogCallback(Highs* h, CallbackTuple* callback_tuple)
 {
-  void (*_log_callback)(HighsLogType, const char*, void*) = &py_log_callback;
-  HighsStatus status = h->setLogCallback(_log_callback, callback_tuple);
+  void (*_log_user_callback)(HighsLogType, const char*, void*) = &py_log_user_callback;
+  HighsStatus status = h->setLogCallback(_log_user_callback, callback_tuple);
   return status;
 }
 

--- a/src/interfaces/highspy/highspy/highs_bindings.cpp
+++ b/src/interfaces/highspy/highspy/highs_bindings.cpp
@@ -425,17 +425,17 @@ double highs_getObjectiveOffset(Highs* h)
 class CallbackTuple {
 public:
   CallbackTuple() = default;
-  CallbackTuple(py::object _callback, py::object _cb_data) : callback(_callback), callback_data(_cb_data) {}
+  CallbackTuple(py::object _callback, py::object _cb_data) : callback(_callback), log_deprecated(_cb_data) {}
   ~CallbackTuple() = default;
   py::object callback;
-  py::object callback_data;
+  py::object log_deprecated;
 };
 
-void py_log_callback(HighsLogType log_type, const char* msgbuffer, void* callback_data)
+void py_log_callback(HighsLogType log_type, const char* msgbuffer, void* log_deprecated)
 {
-  CallbackTuple* callback_tuple = static_cast<CallbackTuple*>(callback_data);
+  CallbackTuple* callback_tuple = static_cast<CallbackTuple*>(log_deprecated);
   std::string msg(msgbuffer);
-  callback_tuple->callback(log_type, msg, callback_tuple->callback_data);
+  callback_tuple->callback(log_type, msg, callback_tuple->log_deprecated);
 }
 
 HighsStatus highs_setLogCallback(Highs* h, CallbackTuple* callback_tuple)
@@ -522,7 +522,7 @@ PYBIND11_MODULE(highs_bindings, m)
     .def(py::init<>())
     .def(py::init<py::object, py::object>())
     .def_readwrite("callback", &CallbackTuple::callback)
-    .def_readwrite("callback_data", &CallbackTuple::callback_data);
+    .def_readwrite("log_deprecated", &CallbackTuple::log_deprecated);
   py::class_<HighsSparseMatrix>(m, "HighsSparseMatrix")
     .def(py::init<>())
     .def_readwrite("format_", &HighsSparseMatrix::format_)

--- a/src/interfaces/highspy/highspy/tests/test_highspy.py
+++ b/src/interfaces/highspy/highspy/tests/test_highspy.py
@@ -267,24 +267,3 @@ class TestHighsPy(unittest.TestCase):
         self.assertEqual(integral, True)
         self.assertEqual(feasible, True)
 
-    def test_log_callback(self):
-        h = self.get_basic_model()
-        h.setOptionValue('log_to_console', True)
-
-        class Foo(object):
-            def __str__(self):
-                return 'an instance of Foo'
-
-            def __repr__(self):
-                return self.__str__()
-
-        def log_callback(log_type, message, data):
-            print('got a log message: ', log_type, data, message)
-
-        h.setLogCallback(log_callback, Foo())
-        out = StringIO()
-        with capture_output(out) as t:
-            h.run()
-        out = out.getvalue()
-        self.assertIn('got a log message:  HighsLogType.kInfo an instance of Foo Presolving model', out)
-

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -240,7 +240,7 @@ const std::string highsBoolToString(const bool b) {
 }
 
 const std::string highsInsertMdEscapes(const std::string from_string) {
-    std::string to_string = "";
+  std::string to_string = "";
   const char* underscore = "_";
   const char* backslash = "\\";
   HighsInt from_string_length = from_string.length();
@@ -253,4 +253,3 @@ const std::string highsInsertMdEscapes(const std::string from_string) {
   }
   return to_string;
 }
-

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -137,7 +137,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_user_callback(type, msgbuffer, log_options_.log_deprecated);
+    log_options_.log_user_callback(type, msgbuffer, nullptr);
   }
   va_end(argptr);
 }
@@ -187,7 +187,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_user_callback(type, msgbuffer, log_options_.log_deprecated);
+    log_options_.log_user_callback(type, msgbuffer, nullptr);
   }
   va_end(argptr);
 }

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -107,7 +107,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
   va_list argptr;
   va_start(argptr, format);
   const bool flush_streams = true;
-  if (!log_options_.log_callback) {
+  if (!log_options_.log_user_callback) {
     // Write to log file stream unless it is NULL
     if (log_options_.log_file_stream) {
       if (prefix)
@@ -137,7 +137,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_callback(type, msgbuffer, log_options_.log_deprecated);
+    log_options_.log_user_callback(type, msgbuffer, log_options_.log_deprecated);
   }
   va_end(argptr);
 }
@@ -165,7 +165,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
   va_list argptr;
   va_start(argptr, format);
   const bool flush_streams = true;
-  if (!log_options_.log_callback) {
+  if (!log_options_.log_user_callback) {
     // Write to log file stream unless it is NULL
     if (log_options_.log_file_stream) {
       // Write to log file stream
@@ -187,7 +187,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_callback(type, msgbuffer, log_options_.log_deprecated);
+    log_options_.log_user_callback(type, msgbuffer, log_options_.log_deprecated);
   }
   va_end(argptr);
 }

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -238,3 +238,19 @@ std::string highsFormatToString(const char* format, ...) {
 const std::string highsBoolToString(const bool b) {
   return b ? "true" : "false";
 }
+
+const std::string highsInsertMdEscapes(const std::string from_string) {
+    std::string to_string = "";
+  const char* underscore = "_";
+  const char* backslash = "\\";
+  HighsInt from_string_length = from_string.length();
+  for (HighsInt p = 0; p < from_string_length; p++) {
+    const char string_ch = from_string[p];
+    if (string_ch == *underscore) {
+      to_string += backslash;
+    }
+    to_string += from_string[p];
+  }
+  return to_string;
+}
+

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -137,7 +137,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_callback(type, msgbuffer, log_options_.log_callback_data);
+    log_options_.log_callback(type, msgbuffer, log_options_.log_deprecated);
   }
   va_end(argptr);
 }
@@ -187,7 +187,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_callback(type, msgbuffer, log_options_.log_callback_data);
+    log_options_.log_callback(type, msgbuffer, log_options_.log_deprecated);
   }
   va_end(argptr);
 }

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -46,7 +46,6 @@ struct HighsLogOptions {
   HighsInt* log_dev_level;
   void (*log_highs_callback)(HighsLogType, const char*, void*) = nullptr;
   void (*log_user_callback)(HighsLogType, const char*, void*) = nullptr;
-  void* log_deprecated = nullptr;
 };
 
 /**

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -90,4 +90,6 @@ std::string highsFormatToString(const char* format, ...);
 
 const std::string highsBoolToString(const bool b);
 
+const std::string highsInsertMdEscapes(const std::string from_string);
+
 #endif

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -44,7 +44,7 @@ struct HighsLogOptions {
   bool* output_flag;
   bool* log_to_console;
   HighsInt* log_dev_level;
-  void (*log_callback)(HighsLogType, const char*, void*) = nullptr;
+  void (*log_user_callback)(HighsLogType, const char*, void*) = nullptr;
   void* log_deprecated = nullptr;
 };
 

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -23,6 +23,8 @@ class HighsOptions;
 
 const HighsInt kIoBufferSize = 1024;  // 65536;
 
+enum class HighsFileType { kNone = 0, kOther, kMps, kLp, kMd, kHtml };
+
 /**
  * @brief IO methods for HiGHS - currently just print/log messages
  */

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -44,6 +44,7 @@ struct HighsLogOptions {
   bool* output_flag;
   bool* log_to_console;
   HighsInt* log_dev_level;
+  void (*log_highs_callback)(HighsLogType, const char*, void*) = nullptr;
   void (*log_user_callback)(HighsLogType, const char*, void*) = nullptr;
   void* log_deprecated = nullptr;
 };

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -45,7 +45,7 @@ struct HighsLogOptions {
   bool* log_to_console;
   HighsInt* log_dev_level;
   void (*log_callback)(HighsLogType, const char*, void*) = nullptr;
-  void* log_callback_data = nullptr;
+  void* log_deprecated = nullptr;
 };
 
 /**

--- a/src/io/LoadOptions.cpp
+++ b/src/io/LoadOptions.cpp
@@ -16,8 +16,9 @@
 
 // For extended options to be parsed from a file. Assuming options file is
 // specified.
-HighsLoadOptionsStatus loadOptionsFromFile(const HighsLogOptions& report_log_options,
-                         HighsOptions& options, const std::string filename) {
+HighsLoadOptionsStatus loadOptionsFromFile(
+    const HighsLogOptions& report_log_options, HighsOptions& options,
+    const std::string filename) {
   if (filename.size() == 0) return HighsLoadOptionsStatus::kEmpty;
 
   string line, option, value;

--- a/src/io/LoadOptions.cpp
+++ b/src/io/LoadOptions.cpp
@@ -16,9 +16,9 @@
 
 // For extended options to be parsed from a file. Assuming options file is
 // specified.
-bool loadOptionsFromFile(const HighsLogOptions& report_log_options,
+HighsLoadOptionsStatus loadOptionsFromFile(const HighsLogOptions& report_log_options,
                          HighsOptions& options, const std::string filename) {
-  if (filename.size() == 0) return false;
+  if (filename.size() == 0) return HighsLoadOptionsStatus::kEmpty;
 
   string line, option, value;
   HighsInt line_count = 0;
@@ -38,7 +38,7 @@ bool loadOptionsFromFile(const HighsLogOptions& report_log_options,
         highsLogUser(report_log_options, HighsLogType::kError,
                      "Error on line %" HIGHSINT_FORMAT " of options file.\n",
                      line_count);
-        return false;
+        return HighsLoadOptionsStatus::kError;
       }
       option = line.substr(0, equals);
       value = line.substr(equals + 1, line.size() - equals);
@@ -46,13 +46,13 @@ bool loadOptionsFromFile(const HighsLogOptions& report_log_options,
       trim(value, non_chars);
       if (setLocalOptionValue(report_log_options, option, options.log_options,
                               options.records, value) != OptionStatus::kOk)
-        return false;
+        return HighsLoadOptionsStatus::kError;
     }
   } else {
     highsLogUser(report_log_options, HighsLogType::kError,
                  "Options file not found.\n");
-    return false;
+    return HighsLoadOptionsStatus::kError;
   }
 
-  return true;
+  return HighsLoadOptionsStatus::kOk;
 }

--- a/src/io/LoadOptions.h
+++ b/src/io/LoadOptions.h
@@ -17,8 +17,10 @@
 
 #include "lp_data/HighsOptions.h"
 
+enum class HighsLoadOptionsStatus { kError = -1, kOk = 0, kEmpty = 1 };
+
 // For extended options to be parsed from filename
-bool loadOptionsFromFile(const HighsLogOptions& report_log_options,
+HighsLoadOptionsStatus loadOptionsFromFile(const HighsLogOptions& report_log_options,
                          HighsOptions& options, const std::string filename);
 
 #endif

--- a/src/io/LoadOptions.h
+++ b/src/io/LoadOptions.h
@@ -20,7 +20,8 @@
 enum class HighsLoadOptionsStatus { kError = -1, kOk = 0, kEmpty = 1 };
 
 // For extended options to be parsed from filename
-HighsLoadOptionsStatus loadOptionsFromFile(const HighsLogOptions& report_log_options,
-                         HighsOptions& options, const std::string filename);
+HighsLoadOptionsStatus loadOptionsFromFile(
+    const HighsLogOptions& report_log_options, HighsOptions& options,
+    const std::string filename);
 
 #endif

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -114,11 +114,11 @@ HighsStatus Highs::readOptions(const std::string& filename) {
   }
   HighsLogOptions report_log_options = options_.log_options;
   switch (loadOptionsFromFile(report_log_options, options_, filename)) {
-  case HighsLoadOptionsStatus::kError:
-  case HighsLoadOptionsStatus::kEmpty:
-    return HighsStatus::kError;
-  default:
-    break;
+    case HighsLoadOptionsStatus::kError:
+    case HighsLoadOptionsStatus::kEmpty:
+      return HighsStatus::kError;
+    default:
+      break;
   }
   return HighsStatus::kOk;
 }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1815,9 +1815,9 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
 
 HighsStatus Highs::setLogCallback(void (*log_callback)(HighsLogType,
                                                        const char*, void*),
-                                  void* log_callback_data) {
+                                  void* log_deprecated) {
   options_.log_options.log_callback = log_callback;
-  options_.log_options.log_callback_data = log_callback_data;
+  options_.log_options.log_deprecated = log_deprecated;
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1813,10 +1813,10 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
   return returnFromHighs(return_status);
 }
 
-HighsStatus Highs::setLogCallback(void (*log_callback)(HighsLogType,
+HighsStatus Highs::setLogCallback(void (*log_user_callback)(HighsLogType,
                                                        const char*, void*),
                                   void* log_deprecated) {
-  options_.log_options.log_callback = log_callback;
+  options_.log_options.log_user_callback = log_user_callback;
   options_.log_options.log_deprecated = log_deprecated;
   return HighsStatus::kOk;
 }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -113,8 +113,13 @@ HighsStatus Highs::readOptions(const std::string& filename) {
     return HighsStatus::kWarning;
   }
   HighsLogOptions report_log_options = options_.log_options;
-  if (!loadOptionsFromFile(report_log_options, options_, filename))
+  switch (loadOptionsFromFile(report_log_options, options_, filename)) {
+  case HighsLoadOptionsStatus::kError:
+  case HighsLoadOptionsStatus::kEmpty:
     return HighsStatus::kError;
+  default:
+    break;
+  }
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -139,19 +139,21 @@ HighsStatus Highs::writeOptions(const std::string& filename,
                                 const bool report_only_deviations) const {
   HighsStatus return_status = HighsStatus::kOk;
   FILE* file;
-  bool html;
+  HighsFileType file_type;
   return_status = interpretCallStatus(
-      options_.log_options, openWriteFile(filename, "writeOptions", file, html),
-      return_status, "openWriteFile");
+      options_.log_options,
+      openWriteFile(filename, "writeOptions", file, file_type), return_status,
+      "openWriteFile");
   if (return_status == HighsStatus::kError) return return_status;
   // Report to user that options are being written to a file
   if (filename != "")
     highsLogUser(options_.log_options, HighsLogType::kInfo,
                  "Writing the option values to %s\n", filename.c_str());
-  return_status = interpretCallStatus(
-      options_.log_options,
-      writeOptionsToFile(file, options_.records, report_only_deviations, html),
-      return_status, "writeOptionsToFile");
+  return_status =
+      interpretCallStatus(options_.log_options,
+                          writeOptionsToFile(file, options_.records,
+                                             report_only_deviations, file_type),
+                          return_status, "writeOptionsToFile");
   if (file != stdout) fclose(file);
   return return_status;
 }
@@ -265,10 +267,11 @@ HighsStatus Highs::getInfoValue(const std::string& info, double& value) const {
 HighsStatus Highs::writeInfo(const std::string& filename) const {
   HighsStatus return_status = HighsStatus::kOk;
   FILE* file;
-  bool html;
-  return_status = interpretCallStatus(
-      options_.log_options, openWriteFile(filename, "writeInfo", file, html),
-      return_status, "openWriteFile");
+  HighsFileType file_type;
+  return_status =
+      interpretCallStatus(options_.log_options,
+                          openWriteFile(filename, "writeInfo", file, file_type),
+                          return_status, "openWriteFile");
   if (return_status == HighsStatus::kError) return return_status;
   // Report to user that options are being written to a file
   if (filename != "")
@@ -276,8 +279,8 @@ HighsStatus Highs::writeInfo(const std::string& filename) const {
                  "Writing the info values to %s\n", filename.c_str());
   return_status = interpretCallStatus(
       options_.log_options,
-      writeInfoToFile(file, info_.valid, info_.records, html), return_status,
-      "writeInfoToFile");
+      writeInfoToFile(file, info_.valid, info_.records, file_type),
+      return_status, "writeInfoToFile");
   if (file != stdout) fclose(file);
   return return_status;
 }
@@ -679,8 +682,8 @@ HighsStatus Highs::writeBasis(const std::string& filename) {
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   FILE* file;
-  bool html;
-  call_status = openWriteFile(filename, "writebasis", file, html);
+  HighsFileType file_type;
+  call_status = openWriteFile(filename, "writebasis", file, file_type);
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "openWriteFile");
   if (return_status == HighsStatus::kError) return return_status;
@@ -2636,8 +2639,8 @@ HighsStatus Highs::writeSolution(const std::string& filename,
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   FILE* file;
-  bool html;
-  call_status = openWriteFile(filename, "writeSolution", file, html);
+  HighsFileType file_type;
+  call_status = openWriteFile(filename, "writeSolution", file, file_type);
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "openWriteFile");
   if (return_status == HighsStatus::kError) return return_status;
@@ -3342,8 +3345,8 @@ void Highs::setBasisValidity() {
 
 HighsStatus Highs::openWriteFile(const string filename,
                                  const string method_name, FILE*& file,
-                                 bool& html) const {
-  html = false;
+                                 HighsFileType& file_type) const {
+  file_type = HighsFileType::kNone;
   if (filename == "") {
     // Empty file name: use stdout
     file = stdout;
@@ -3356,7 +3359,17 @@ HighsStatus Highs::openWriteFile(const string filename,
       return HighsStatus::kError;
     }
     const char* dot = strrchr(filename.c_str(), '.');
-    if (dot && dot != filename) html = strcmp(dot + 1, "html") == 0;
+    if (dot && dot != filename) {
+      if (strcmp(dot + 1, "mps") == 0) {
+        file_type = HighsFileType::kMps;
+      } else if (strcmp(dot + 1, "lp") == 0) {
+        file_type = HighsFileType::kLp;
+      } else if (strcmp(dot + 1, "md") == 0) {
+        file_type = HighsFileType::kMd;
+      } else if (strcmp(dot + 1, "html") == 0) {
+        file_type = HighsFileType::kHtml;
+      }
+    }
   }
   return HighsStatus::kOk;
 }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1814,10 +1814,10 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
 }
 
 HighsStatus Highs::setLogCallback(void (*log_user_callback)(HighsLogType,
-                                                       const char*, void*),
-                                  void* log_deprecated) {
+                                                       const char*, void*)
+                                  , void* deprecated// V2.0 remove
+				  ) {
   options_.log_options.log_user_callback = log_user_callback;
-  options_.log_options.log_deprecated = log_deprecated;
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1814,9 +1814,9 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
 }
 
 HighsStatus Highs::setLogCallback(void (*log_user_callback)(HighsLogType,
-                                                       const char*, void*)
-                                  , void* deprecated// V2.0 remove
-				  ) {
+                                                            const char*, void*),
+                                  void* deprecated  // V2.0 remove
+) {
   options_.log_options.log_user_callback = log_user_callback;
   return HighsStatus::kOk;
 }

--- a/src/lp_data/HighsDeprecated.cpp
+++ b/src/lp_data/HighsDeprecated.cpp
@@ -149,8 +149,8 @@ HighsStatus Highs::writeSolution(const std::string& filename,
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   FILE* file;
-  bool html;
-  call_status = openWriteFile(filename, "writeSolution", file, html);
+  HighsFileType file_type;
+  call_status = openWriteFile(filename, "writeSolution", file, file_type);
   return_status =
       interpretCallStatus(call_status, return_status, "openWriteFile");
   if (return_status == HighsStatus::kError) return return_status;

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -252,9 +252,11 @@ InfoStatus getLocalInfoType(const HighsLogOptions& report_log_options,
 HighsStatus writeInfoToFile(FILE* file, const bool valid,
                             const std::vector<InfoRecord*>& info_records,
                             const HighsFileType file_type) {
-  const bool html = file_type == HighsFileType::kHtml;
-  if (!html && !valid) return HighsStatus::kWarning;
-  if (html) {
+  const bool html_file = file_type == HighsFileType::kHtml;
+  const bool md_file = file_type == HighsFileType::kMd;
+  const bool documentation_file = html_file || md_file;
+  if (!documentation_file && !valid) return HighsStatus::kWarning;
+  if (html_file) {
     fprintf(file, "<!DOCTYPE HTML>\n<html>\n\n<head>\n");
     fprintf(file, "  <title>HiGHS Info</title>\n");
     fprintf(file, "	<meta charset=\"utf-8\" />\n");
@@ -268,8 +270,8 @@ HighsStatus writeInfoToFile(FILE* file, const bool valid,
     fprintf(file, "<h3>HiGHS Info</h3>\n\n");
     fprintf(file, "<ul>\n");
   }
-  if (html || valid) reportInfo(file, info_records, file_type);
-  if (html) {
+  if (html_file || valid) reportInfo(file, info_records, file_type);
+  if (html_file) {
     fprintf(file, "</ul>\n");
     fprintf(file, "</body>\n\n</html>\n");
   }
@@ -278,12 +280,13 @@ HighsStatus writeInfoToFile(FILE* file, const bool valid,
 
 void reportInfo(FILE* file, const std::vector<InfoRecord*>& info_records,
                 const HighsFileType file_type) {
-  const bool html = file_type == HighsFileType::kHtml;
+  const bool html_file = file_type == HighsFileType::kHtml;
+  const bool md_file = file_type == HighsFileType::kMd;
   HighsInt num_info = info_records.size();
   for (HighsInt index = 0; index < num_info; index++) {
     HighsInfoType type = info_records[index]->type;
     // Skip the advanced info when creating HTML
-    if (html && info_records[index]->advanced) continue;
+    if (html_file && info_records[index]->advanced) continue;
     if (type == HighsInfoType::kInt64) {
       reportInfo(file, ((InfoRecordInt64*)info_records[index])[0], file_type);
     } else if (type == HighsInfoType::kInt) {
@@ -296,8 +299,9 @@ void reportInfo(FILE* file, const std::vector<InfoRecord*>& info_records,
 
 void reportInfo(FILE* file, const InfoRecordInt64& info,
                 const HighsFileType file_type) {
-  const bool html = file_type == HighsFileType::kHtml;
-  if (html) {
+  const bool html_file = file_type == HighsFileType::kHtml;
+  const bool md_file = file_type == HighsFileType::kMd;
+  if (html_file) {
     fprintf(file,
             "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
             info.name.c_str());
@@ -315,8 +319,9 @@ void reportInfo(FILE* file, const InfoRecordInt64& info,
 
 void reportInfo(FILE* file, const InfoRecordInt& info,
                 const HighsFileType file_type) {
-  const bool html = file_type == HighsFileType::kHtml;
-  if (html) {
+  const bool html_file = file_type == HighsFileType::kHtml;
+  const bool md_file = file_type == HighsFileType::kMd;
+  if (html_file) {
     fprintf(file,
             "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
             info.name.c_str());
@@ -335,8 +340,9 @@ void reportInfo(FILE* file, const InfoRecordInt& info,
 
 void reportInfo(FILE* file, const InfoRecordDouble& info,
                 const HighsFileType file_type) {
-  const bool html = file_type == HighsFileType::kHtml;
-  if (html) {
+  const bool html_file = file_type == HighsFileType::kHtml;
+  const bool md_file = file_type == HighsFileType::kMd;
+  if (html_file) {
     fprintf(file,
             "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
             info.name.c_str());

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -251,7 +251,8 @@ InfoStatus getLocalInfoType(const HighsLogOptions& report_log_options,
 
 HighsStatus writeInfoToFile(FILE* file, const bool valid,
                             const std::vector<InfoRecord*>& info_records,
-                            const bool html) {
+                            const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (!html && !valid) return HighsStatus::kWarning;
   if (html) {
     fprintf(file, "<!DOCTYPE HTML>\n<html>\n\n<head>\n");
@@ -267,7 +268,7 @@ HighsStatus writeInfoToFile(FILE* file, const bool valid,
     fprintf(file, "<h3>HiGHS Info</h3>\n\n");
     fprintf(file, "<ul>\n");
   }
-  if (html || valid) reportInfo(file, info_records, html);
+  if (html || valid) reportInfo(file, info_records, file_type);
   if (html) {
     fprintf(file, "</ul>\n");
     fprintf(file, "</body>\n\n</html>\n");
@@ -276,23 +277,26 @@ HighsStatus writeInfoToFile(FILE* file, const bool valid,
 }
 
 void reportInfo(FILE* file, const std::vector<InfoRecord*>& info_records,
-                const bool html) {
+                const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   HighsInt num_info = info_records.size();
   for (HighsInt index = 0; index < num_info; index++) {
     HighsInfoType type = info_records[index]->type;
     // Skip the advanced info when creating HTML
     if (html && info_records[index]->advanced) continue;
     if (type == HighsInfoType::kInt64) {
-      reportInfo(file, ((InfoRecordInt64*)info_records[index])[0], html);
+      reportInfo(file, ((InfoRecordInt64*)info_records[index])[0], file_type);
     } else if (type == HighsInfoType::kInt) {
-      reportInfo(file, ((InfoRecordInt*)info_records[index])[0], html);
+      reportInfo(file, ((InfoRecordInt*)info_records[index])[0], file_type);
     } else {
-      reportInfo(file, ((InfoRecordDouble*)info_records[index])[0], html);
+      reportInfo(file, ((InfoRecordDouble*)info_records[index])[0], file_type);
     }
   }
 }
 
-void reportInfo(FILE* file, const InfoRecordInt64& info, const bool html) {
+void reportInfo(FILE* file, const InfoRecordInt64& info,
+                const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (html) {
     fprintf(file,
             "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
@@ -309,7 +313,9 @@ void reportInfo(FILE* file, const InfoRecordInt64& info, const bool html) {
   }
 }
 
-void reportInfo(FILE* file, const InfoRecordInt& info, const bool html) {
+void reportInfo(FILE* file, const InfoRecordInt& info,
+                const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (html) {
     fprintf(file,
             "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
@@ -327,7 +333,9 @@ void reportInfo(FILE* file, const InfoRecordInt& info, const bool html) {
   }
 }
 
-void reportInfo(FILE* file, const InfoRecordDouble& info, const bool html) {
+void reportInfo(FILE* file, const InfoRecordDouble& info,
+                const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (html) {
     fprintf(file,
             "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -303,15 +303,17 @@ void reportInfo(FILE* file, const InfoRecordInt64& info,
   const bool md_file = file_type == HighsFileType::kMd;
   if (html_file) {
     fprintf(file,
-            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: int64_t</li>\n",
+            "<li><tt><font "
+            "size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: "
+            "int64_t</li>\n",
             info.name.c_str(), info.description.c_str());
   } else if (md_file) {
-      fprintf(file, "## %s\n- %s\n- Type: long integer\n\n",
-	      highsInsertMdEscapes(info.name).c_str(),
-	      highsInsertMdEscapes(info.description).c_str());
+    fprintf(file, "## %s\n- %s\n- Type: long integer\n\n",
+            highsInsertMdEscapes(info.name).c_str(),
+            highsInsertMdEscapes(info.description).c_str());
   } else {
     fprintf(file, "\n# %s\n# [type: int64_t]\n%s = %" PRId64 "\n",
-	    info.description.c_str(), info.name.c_str(), *info.value);
+            info.description.c_str(), info.name.c_str(), *info.value);
   }
 }
 
@@ -321,14 +323,17 @@ void reportInfo(FILE* file, const InfoRecordInt& info,
   const bool md_file = file_type == HighsFileType::kMd;
   if (html_file) {
     fprintf(file,
-            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: HighsInt</li>\n",
+            "<li><tt><font "
+            "size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: "
+            "HighsInt</li>\n",
             info.name.c_str(), info.description.c_str());
   } else if (md_file) {
     fprintf(file, "## %s\n- %s\n- Type: integer\n\n",
-	    highsInsertMdEscapes(info.name).c_str(),
-	    highsInsertMdEscapes(info.description).c_str());
+            highsInsertMdEscapes(info.name).c_str(),
+            highsInsertMdEscapes(info.description).c_str());
   } else {
-    fprintf(file, "\n# %s\n# [type: HighsInt]\n%s = %" HIGHSINT_FORMAT "\n", info.description.c_str(), info.name.c_str(), *info.value);
+    fprintf(file, "\n# %s\n# [type: HighsInt]\n%s = %" HIGHSINT_FORMAT "\n",
+            info.description.c_str(), info.name.c_str(), *info.value);
   }
 }
 
@@ -338,13 +343,16 @@ void reportInfo(FILE* file, const InfoRecordDouble& info,
   const bool md_file = file_type == HighsFileType::kMd;
   if (html_file) {
     fprintf(file,
-            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: double\n</li>\n",
+            "<li><tt><font "
+            "size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: "
+            "double\n</li>\n",
             info.name.c_str(), info.description.c_str());
   } else if (md_file) {
     fprintf(file, "## %s\n- %s\n- Type: double\n\n",
-	    highsInsertMdEscapes(info.name).c_str(),
-	    highsInsertMdEscapes(info.description).c_str());
+            highsInsertMdEscapes(info.name).c_str(),
+            highsInsertMdEscapes(info.description).c_str());
   } else {
-    fprintf(file, "\n# %s\n# [type: double]\n%s = %g\n", info.description.c_str(), info.name.c_str(), *info.value);
+    fprintf(file, "\n# %s\n# [type: double]\n%s = %g\n",
+            info.description.c_str(), info.name.c_str(), *info.value);
   }
 }

--- a/src/lp_data/HighsInfo.cpp
+++ b/src/lp_data/HighsInfo.cpp
@@ -270,7 +270,7 @@ HighsStatus writeInfoToFile(FILE* file, const bool valid,
     fprintf(file, "<h3>HiGHS Info</h3>\n\n");
     fprintf(file, "<ul>\n");
   }
-  if (html_file || valid) reportInfo(file, info_records, file_type);
+  if (documentation_file || valid) reportInfo(file, info_records, file_type);
   if (html_file) {
     fprintf(file, "</ul>\n");
     fprintf(file, "</body>\n\n</html>\n");
@@ -303,17 +303,15 @@ void reportInfo(FILE* file, const InfoRecordInt64& info,
   const bool md_file = file_type == HighsFileType::kMd;
   if (html_file) {
     fprintf(file,
-            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
-            info.name.c_str());
-    fprintf(file, "%s<br>\n", info.description.c_str());
-    fprintf(file, "type: HighsInt, advanced: %s\n",
-            highsBoolToString(info.advanced).c_str());
-    fprintf(file, "</li>\n");
+            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: int64_t</li>\n",
+            info.name.c_str(), info.description.c_str());
+  } else if (md_file) {
+      fprintf(file, "## %s\n- %s\n- Type: long integer\n\n",
+	      highsInsertMdEscapes(info.name).c_str(),
+	      highsInsertMdEscapes(info.description).c_str());
   } else {
-    fprintf(file, "\n# %s\n", info.description.c_str());
-    fprintf(file, "# [type: HighsInt, advanced: %s]\n",
-            highsBoolToString(info.advanced).c_str());
-    fprintf(file, "%s = %" PRId64 "\n", info.name.c_str(), *info.value);
+    fprintf(file, "\n# %s\n# [type: int64_t]\n%s = %" PRId64 "\n",
+	    info.description.c_str(), info.name.c_str(), *info.value);
   }
 }
 
@@ -323,18 +321,14 @@ void reportInfo(FILE* file, const InfoRecordInt& info,
   const bool md_file = file_type == HighsFileType::kMd;
   if (html_file) {
     fprintf(file,
-            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
-            info.name.c_str());
-    fprintf(file, "%s<br>\n", info.description.c_str());
-    fprintf(file, "type: HighsInt, advanced: %s\n",
-            highsBoolToString(info.advanced).c_str());
-    fprintf(file, "</li>\n");
+            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: HighsInt</li>\n",
+            info.name.c_str(), info.description.c_str());
+  } else if (md_file) {
+    fprintf(file, "## %s\n- %s\n- Type: integer\n\n",
+	    highsInsertMdEscapes(info.name).c_str(),
+	    highsInsertMdEscapes(info.description).c_str());
   } else {
-    fprintf(file, "\n# %s\n", info.description.c_str());
-    fprintf(file, "# [type: HighsInt, advanced: %s]\n",
-            highsBoolToString(info.advanced).c_str());
-    fprintf(file, "%s = %" HIGHSINT_FORMAT "\n", info.name.c_str(),
-            *info.value);
+    fprintf(file, "\n# %s\n# [type: HighsInt]\n%s = %" HIGHSINT_FORMAT "\n", info.description.c_str(), info.name.c_str(), *info.value);
   }
 }
 
@@ -344,16 +338,13 @@ void reportInfo(FILE* file, const InfoRecordDouble& info,
   const bool md_file = file_type == HighsFileType::kMd;
   if (html_file) {
     fprintf(file,
-            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
-            info.name.c_str());
-    fprintf(file, "%s<br>\n", info.description.c_str());
-    fprintf(file, "type: double, advanced: %s\n",
-            highsBoolToString(info.advanced).c_str());
-    fprintf(file, "</li>\n");
+            "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n%s<br>\ntype: double\n</li>\n",
+            info.name.c_str(), info.description.c_str());
+  } else if (md_file) {
+    fprintf(file, "## %s\n- %s\n- Type: double\n\n",
+	    highsInsertMdEscapes(info.name).c_str(),
+	    highsInsertMdEscapes(info.description).c_str());
   } else {
-    fprintf(file, "\n# %s\n", info.description.c_str());
-    fprintf(file, "# [type: double, advanced: %s]\n",
-            highsBoolToString(info.advanced).c_str());
-    fprintf(file, "%s = %g\n", info.name.c_str(), *info.value);
+    fprintf(file, "\n# %s\n# [type: double]\n%s = %g\n", info.description.c_str(), info.name.c_str(), *info.value);
   }
 }

--- a/src/lp_data/HighsInfo.h
+++ b/src/lp_data/HighsInfo.h
@@ -115,16 +115,17 @@ InfoStatus getLocalInfoType(const HighsLogOptions& report_log_options,
                             const std::vector<InfoRecord*>& info_records,
                             HighsInfoType& type);
 
-HighsStatus writeInfoToFile(FILE* file, const bool valid,
-                            const std::vector<InfoRecord*>& info_records,
-                            const bool html = false);
+HighsStatus writeInfoToFile(
+    FILE* file, const bool valid, const std::vector<InfoRecord*>& info_records,
+    const HighsFileType file_type = HighsFileType::kOther);
 void reportInfo(FILE* file, const std::vector<InfoRecord*>& info_records,
-                const bool html = false);
+                const HighsFileType file_type = HighsFileType::kOther);
 void reportInfo(FILE* file, const InfoRecordInt64& info,
-                const bool html = false);
-void reportInfo(FILE* file, const InfoRecordInt& info, const bool html = false);
+                const HighsFileType file_type = HighsFileType::kOther);
+void reportInfo(FILE* file, const InfoRecordInt& info,
+                const HighsFileType file_type = HighsFileType::kOther);
 void reportInfo(FILE* file, const InfoRecordDouble& info,
-                const bool html = false);
+                const HighsFileType file_type = HighsFileType::kOther);
 
 // For now, but later change so HiGHS properties are string based so that new
 // info (for debug and testing too) can be added easily. The info below

--- a/src/lp_data/HighsInfo.h
+++ b/src/lp_data/HighsInfo.h
@@ -199,8 +199,7 @@ class HighsInfo : public HighsInfoStruct {
     InfoRecordInt64* record_int64;
     InfoRecordInt* record_int;
     InfoRecordDouble* record_double;
-    bool advanced;
-    advanced = false;
+    const bool advanced = false; // Not used
 
     record_int = new InfoRecordInt("simplex_iteration_count",
                                    "Iteration count for simplex solver",

--- a/src/lp_data/HighsInfo.h
+++ b/src/lp_data/HighsInfo.h
@@ -199,7 +199,7 @@ class HighsInfo : public HighsInfoStruct {
     InfoRecordInt64* record_int64;
     InfoRecordInt* record_int;
     InfoRecordDouble* record_double;
-    const bool advanced = false; // Not used
+    const bool advanced = false;  // Not used
 
     record_int = new InfoRecordInt("simplex_iteration_count",
                                    "Iteration count for simplex solver",

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -846,7 +846,7 @@ void reportOption(FILE* file, const OptionRecordBool& option,
     } else if (md_file) {
       fprintf(file,
               "## %s\n- %s\n- Type: boolean\n- Default: \"%s\"\n\n",
-	      option.name.c_str(),
+	      highsInsertMdEscapes(option.name).c_str(),
 	      option.description.c_str(),
 	      highsBoolToString(option.default_value).c_str());
     } else {
@@ -883,7 +883,7 @@ void reportOption(FILE* file, const OptionRecordInt& option,
       fprintf(file,
 	      "## %s\n- %s\n- Type: integer\n- Range: {%" HIGHSINT_FORMAT
               ", %" HIGHSINT_FORMAT "}\n- Default: %" HIGHSINT_FORMAT "\n\n",
-	      option.name.c_str(),
+	      highsInsertMdEscapes(option.name).c_str(),
 	      option.description.c_str(),
 	      option.lower_bound,
 	      option.upper_bound, option.default_value);
@@ -919,7 +919,7 @@ void reportOption(FILE* file, const OptionRecordDouble& option,
     } else if (md_file) {
       fprintf(file,
 	      "## %s\n- %s\n- Type: double\n- Range: [%g, %g]\n- Default: %g\n\n",
-	      option.name.c_str(),
+	      highsInsertMdEscapes(option.name).c_str(),
 	      option.description.c_str(),
 	      option.lower_bound,
 	      option.upper_bound, option.default_value);
@@ -957,7 +957,7 @@ void reportOption(FILE* file, const OptionRecordString& option,
     } else if (md_file) {
       fprintf(file,
               "## %s\n- %s\n- Type: string\n- Default: \"%s\"\n\n",
-	      option.name.c_str(),
+	      highsInsertMdEscapes(option.name).c_str(),
 	      option.description.c_str(),
 	      option.default_value.c_str());
     } else {

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -807,7 +807,7 @@ void reportOptions(FILE* file, const std::vector<OptionRecord*>& option_records,
   for (HighsInt index = 0; index < num_options; index++) {
     HighsOptionType type = option_records[index]->type;
     // Only report non-advanced options
-    if (option_records[index]->advanced) {// && (html_file || md_file)) {
+    if (option_records[index]->advanced) {  // && (html_file || md_file)) {
       // Possibly the advanced options when creating HTML or Md file
       if (!kAdvancedInDocumentation) continue;
     }
@@ -844,11 +844,10 @@ void reportOption(FILE* file, const OptionRecordBool& option,
               highsBoolToString(option.default_value).c_str());
       fprintf(file, "</li>\n");
     } else if (md_file) {
-      fprintf(file,
-              "## %s\n- %s\n- Type: boolean\n- Default: \"%s\"\n\n",
-	      highsInsertMdEscapes(option.name).c_str(),
-	      highsInsertMdEscapes(option.description).c_str(),
-	      highsBoolToString(option.default_value).c_str());
+      fprintf(file, "## %s\n- %s\n- Type: boolean\n- Default: \"%s\"\n\n",
+              highsInsertMdEscapes(option.name).c_str(),
+              highsInsertMdEscapes(option.description).c_str(),
+              highsBoolToString(option.default_value).c_str());
     } else {
       fprintf(file, "\n# %s\n", option.description.c_str());
       fprintf(
@@ -881,12 +880,11 @@ void reportOption(FILE* file, const OptionRecordInt& option,
       fprintf(file, "</li>\n");
     } else if (md_file) {
       fprintf(file,
-	      "## %s\n- %s\n- Type: integer\n- Range: {%" HIGHSINT_FORMAT
+              "## %s\n- %s\n- Type: integer\n- Range: {%" HIGHSINT_FORMAT
               ", %" HIGHSINT_FORMAT "}\n- Default: %" HIGHSINT_FORMAT "\n\n",
-	      highsInsertMdEscapes(option.name).c_str(),
-	      highsInsertMdEscapes(option.description).c_str(),
-	      option.lower_bound,
-	      option.upper_bound, option.default_value);
+              highsInsertMdEscapes(option.name).c_str(),
+              highsInsertMdEscapes(option.description).c_str(),
+              option.lower_bound, option.upper_bound, option.default_value);
     } else {
       fprintf(file, "\n# %s\n", option.description.c_str());
       fprintf(file,
@@ -908,21 +906,21 @@ void reportOption(FILE* file, const OptionRecordDouble& option,
   if (!report_only_deviations || option.default_value != *option.value) {
     if (html_file) {
       fprintf(file,
-	      "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
-	      option.name.c_str());
+              "<li><tt><font size=\"+2\"><strong>%s</strong></font></tt><br>\n",
+              option.name.c_str());
       fprintf(file, "%s<br>\n", option.description.c_str());
       fprintf(file,
-	      "type: double, advanced: %s, range: [%g, %g], default: %g\n",
-	      highsBoolToString(option.advanced).c_str(), option.lower_bound,
-	      option.upper_bound, option.default_value);
+              "type: double, advanced: %s, range: [%g, %g], default: %g\n",
+              highsBoolToString(option.advanced).c_str(), option.lower_bound,
+              option.upper_bound, option.default_value);
       fprintf(file, "</li>\n");
     } else if (md_file) {
-      fprintf(file,
-	      "## %s\n- %s\n- Type: double\n- Range: [%g, %g]\n- Default: %g\n\n",
-	      highsInsertMdEscapes(option.name).c_str(),
-	      highsInsertMdEscapes(option.description).c_str(),
-	      option.lower_bound,
-	      option.upper_bound, option.default_value);
+      fprintf(
+          file,
+          "## %s\n- %s\n- Type: double\n- Range: [%g, %g]\n- Default: %g\n\n",
+          highsInsertMdEscapes(option.name).c_str(),
+          highsInsertMdEscapes(option.description).c_str(), option.lower_bound,
+          option.upper_bound, option.default_value);
     } else {
       fprintf(file, "\n# %s\n", option.description.c_str());
       fprintf(file,
@@ -955,11 +953,10 @@ void reportOption(FILE* file, const OptionRecordString& option,
               option.default_value.c_str());
       fprintf(file, "</li>\n");
     } else if (md_file) {
-      fprintf(file,
-              "## %s\n- %s\n- Type: string\n- Default: \"%s\"\n\n",
-	      highsInsertMdEscapes(option.name).c_str(),
-	      highsInsertMdEscapes(option.description).c_str(),
-	      option.default_value.c_str());
+      fprintf(file, "## %s\n- %s\n- Type: string\n- Default: \"%s\"\n\n",
+              highsInsertMdEscapes(option.name).c_str(),
+              highsInsertMdEscapes(option.description).c_str(),
+              option.default_value.c_str());
     } else {
       fprintf(file, "\n# %s\n", option.description.c_str());
       fprintf(file, "# [type: string, advanced: %s, default: \"%s\"]\n",

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -773,7 +773,8 @@ void resetLocalOptions(std::vector<OptionRecord*>& option_records) {
 HighsStatus writeOptionsToFile(FILE* file,
                                const std::vector<OptionRecord*>& option_records,
                                const bool report_only_deviations,
-                               const bool html) {
+                               const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (html) {
     fprintf(file, "<!DOCTYPE HTML>\n<html>\n\n<head>\n");
     fprintf(file, "  <title>HiGHS Options</title>\n");
@@ -788,7 +789,7 @@ HighsStatus writeOptionsToFile(FILE* file,
     fprintf(file, "<h3>HiGHS Options</h3>\n\n");
     fprintf(file, "<ul>\n");
   }
-  reportOptions(file, option_records, report_only_deviations, html);
+  reportOptions(file, option_records, report_only_deviations, file_type);
   if (html) {
     fprintf(file, "</ul>\n");
     fprintf(file, "</body>\n\n</html>\n");
@@ -797,7 +798,9 @@ HighsStatus writeOptionsToFile(FILE* file,
 }
 
 void reportOptions(FILE* file, const std::vector<OptionRecord*>& option_records,
-                   const bool report_only_deviations, const bool html) {
+                   const bool report_only_deviations,
+                   const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   HighsInt num_options = option_records.size();
   for (HighsInt index = 0; index < num_options; index++) {
     HighsOptionType type = option_records[index]->type;
@@ -806,22 +809,24 @@ void reportOptions(FILE* file, const std::vector<OptionRecord*>& option_records,
     if (html && option_records[index]->advanced) continue;
     if (type == HighsOptionType::kBool) {
       reportOption(file, ((OptionRecordBool*)option_records[index])[0],
-                   report_only_deviations, html);
+                   report_only_deviations, file_type);
     } else if (type == HighsOptionType::kInt) {
       reportOption(file, ((OptionRecordInt*)option_records[index])[0],
-                   report_only_deviations, html);
+                   report_only_deviations, file_type);
     } else if (type == HighsOptionType::kDouble) {
       reportOption(file, ((OptionRecordDouble*)option_records[index])[0],
-                   report_only_deviations, html);
+                   report_only_deviations, file_type);
     } else {
       reportOption(file, ((OptionRecordString*)option_records[index])[0],
-                   report_only_deviations, html);
+                   report_only_deviations, file_type);
     }
   }
 }
 
 void reportOption(FILE* file, const OptionRecordBool& option,
-                  const bool report_only_deviations, const bool html) {
+                  const bool report_only_deviations,
+                  const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (!report_only_deviations || option.default_value != *option.value) {
     if (html) {
       fprintf(file,
@@ -847,7 +852,9 @@ void reportOption(FILE* file, const OptionRecordBool& option,
 }
 
 void reportOption(FILE* file, const OptionRecordInt& option,
-                  const bool report_only_deviations, const bool html) {
+                  const bool report_only_deviations,
+                  const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (!report_only_deviations || option.default_value != *option.value) {
     if (html) {
       fprintf(file,
@@ -874,7 +881,9 @@ void reportOption(FILE* file, const OptionRecordInt& option,
 }
 
 void reportOption(FILE* file, const OptionRecordDouble& option,
-                  const bool report_only_deviations, const bool html) {
+                  const bool report_only_deviations,
+                  const HighsFileType file_type) {
+  const bool html = file_type == HighsFileType::kHtml;
   if (!report_only_deviations || option.default_value != *option.value) {
     if (html) {
       fprintf(file,
@@ -898,8 +907,10 @@ void reportOption(FILE* file, const OptionRecordDouble& option,
 }
 
 void reportOption(FILE* file, const OptionRecordString& option,
-                  const bool report_only_deviations, const bool html) {
+                  const bool report_only_deviations,
+                  const HighsFileType file_type) {
   // Don't report for the options file if writing to an options file
+  const bool html = file_type == HighsFileType::kHtml;
   if (option.name == kOptionsFileString) return;
   if (!report_only_deviations || option.default_value != *option.value) {
     if (html) {

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -806,8 +806,8 @@ void reportOptions(FILE* file, const std::vector<OptionRecord*>& option_records,
   HighsInt num_options = option_records.size();
   for (HighsInt index = 0; index < num_options; index++) {
     HighsOptionType type = option_records[index]->type;
-    //    fprintf(file, "\n# Option %1" HIGHSINT_FORMAT "\n", index);
-    if (option_records[index]->advanced && (html_file || md_file)) {
+    // Only report non-advanced options
+    if (option_records[index]->advanced) {// && (html_file || md_file)) {
       // Possibly the advanced options when creating HTML or Md file
       if (!kAdvancedInDocumentation) continue;
     }
@@ -847,7 +847,7 @@ void reportOption(FILE* file, const OptionRecordBool& option,
       fprintf(file,
               "## %s\n- %s\n- Type: boolean\n- Default: \"%s\"\n\n",
 	      highsInsertMdEscapes(option.name).c_str(),
-	      option.description.c_str(),
+	      highsInsertMdEscapes(option.description).c_str(),
 	      highsBoolToString(option.default_value).c_str());
     } else {
       fprintf(file, "\n# %s\n", option.description.c_str());
@@ -884,7 +884,7 @@ void reportOption(FILE* file, const OptionRecordInt& option,
 	      "## %s\n- %s\n- Type: integer\n- Range: {%" HIGHSINT_FORMAT
               ", %" HIGHSINT_FORMAT "}\n- Default: %" HIGHSINT_FORMAT "\n\n",
 	      highsInsertMdEscapes(option.name).c_str(),
-	      option.description.c_str(),
+	      highsInsertMdEscapes(option.description).c_str(),
 	      option.lower_bound,
 	      option.upper_bound, option.default_value);
     } else {
@@ -920,7 +920,7 @@ void reportOption(FILE* file, const OptionRecordDouble& option,
       fprintf(file,
 	      "## %s\n- %s\n- Type: double\n- Range: [%g, %g]\n- Default: %g\n\n",
 	      highsInsertMdEscapes(option.name).c_str(),
-	      option.description.c_str(),
+	      highsInsertMdEscapes(option.description).c_str(),
 	      option.lower_bound,
 	      option.upper_bound, option.default_value);
     } else {
@@ -958,7 +958,7 @@ void reportOption(FILE* file, const OptionRecordString& option,
       fprintf(file,
               "## %s\n- %s\n- Type: string\n- Default: \"%s\"\n\n",
 	      highsInsertMdEscapes(option.name).c_str(),
-	      option.description.c_str(),
+	      highsInsertMdEscapes(option.description).c_str(),
 	      option.default_value.c_str());
     } else {
       fprintf(file, "\n# %s\n", option.description.c_str());

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -1058,7 +1058,6 @@ class HighsOptions : public HighsOptionsStruct {
     log_options.log_dev_level = &log_dev_level;
     log_options.log_highs_callback = nullptr;
     log_options.log_user_callback = nullptr;
-    log_options.log_deprecated = nullptr;
   }
 
   void deleteRecords() {

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -231,21 +231,25 @@ OptionStatus getLocalOptionType(
 
 void resetLocalOptions(std::vector<OptionRecord*>& option_records);
 
-HighsStatus writeOptionsToFile(FILE* file,
-                               const std::vector<OptionRecord*>& option_records,
-                               const bool report_only_deviations = false,
-                               const bool html = false);
+HighsStatus writeOptionsToFile(
+    FILE* file, const std::vector<OptionRecord*>& option_records,
+    const bool report_only_deviations = false,
+    const HighsFileType file_type = HighsFileType::kOther);
 void reportOptions(FILE* file, const std::vector<OptionRecord*>& option_records,
                    const bool report_only_deviations = true,
-                   const bool html = false);
+                   const HighsFileType file_type = HighsFileType::kOther);
 void reportOption(FILE* file, const OptionRecordBool& option,
-                  const bool report_only_deviations, const bool html);
+                  const bool report_only_deviations,
+                  const HighsFileType file_type);
 void reportOption(FILE* file, const OptionRecordInt& option,
-                  const bool report_only_deviations, const bool html);
+                  const bool report_only_deviations,
+                  const HighsFileType file_type);
 void reportOption(FILE* file, const OptionRecordDouble& option,
-                  const bool report_only_deviations, const bool html);
+                  const bool report_only_deviations,
+                  const HighsFileType file_type);
 void reportOption(FILE* file, const OptionRecordString& option,
-                  const bool report_only_deviations, const bool html);
+                  const bool report_only_deviations,
+                  const HighsFileType file_type);
 
 const string kSimplexString = "simplex";
 const string kIpmString = "ipm";

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -1057,7 +1057,7 @@ class HighsOptions : public HighsOptionsStruct {
     log_options.log_to_console = &log_to_console;
     log_options.log_dev_level = &log_dev_level;
     log_options.log_callback = nullptr;
-    log_options.log_callback_data = nullptr;
+    log_options.log_deprecated = nullptr;
   }
 
   void deleteRecords() {

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -1056,7 +1056,7 @@ class HighsOptions : public HighsOptionsStruct {
     log_options.output_flag = &output_flag;
     log_options.log_to_console = &log_to_console;
     log_options.log_dev_level = &log_dev_level;
-    log_options.log_callback = nullptr;
+    log_options.log_user_callback = nullptr;
     log_options.log_deprecated = nullptr;
   }
 

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -453,8 +453,8 @@ class HighsOptions : public HighsOptionsStruct {
     OptionRecordInt* record_int;
     OptionRecordDouble* record_double;
     OptionRecordString* record_string;
-    bool advanced;
-    advanced = false;
+    bool advanced = false;
+    const bool now_advanced = true;
     // Options read from the command line
     record_string = new OptionRecordString(
         kPresolveString, "Presolve option: \"off\", \"choose\" or \"on\"",
@@ -546,23 +546,23 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_double);
 
     record_int =
-        new OptionRecordInt(kRandomSeedString, "random seed used in HiGHS",
+        new OptionRecordInt(kRandomSeedString, "Random seed used in HiGHS",
                             advanced, &random_seed, 0, 0, kHighsIInf);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "threads", "number of threads used by HiGHS (0: automatic)", advanced,
+        "threads", "Number of threads used by HiGHS (0: automatic)", advanced,
         &threads, 0, 0, kHighsIInf);
     records.push_back(record_int);
 
     record_int =
         new OptionRecordInt("highs_debug_level", "Debugging level in HiGHS",
-                            advanced, &highs_debug_level, kHighsDebugLevelMin,
+                            now_advanced, &highs_debug_level, kHighsDebugLevelMin,
                             kHighsDebugLevelMin, kHighsDebugLevelMax);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "highs_analysis_level", "Analysis level in HiGHS", advanced,
+        "highs_analysis_level", "Analysis level in HiGHS", now_advanced,
         &highs_analysis_level, kHighsAnalysisLevelMin, kHighsAnalysisLevelMin,
         kHighsAnalysisLevelMax);
     records.push_back(record_int);
@@ -585,7 +585,7 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_int = new OptionRecordInt(
         "simplex_crash_strategy",
-        "Strategy for simplex crash: off / LTSSF / Bixby (0/1/2)", advanced,
+        "Strategy for simplex crash: off / LTSSF / Bixby (0/1/2)", now_advanced,
         &simplex_crash_strategy, kSimplexCrashStrategyMin,
         kSimplexCrashStrategyOff, kSimplexCrashStrategyMax);
     records.push_back(record_int);
@@ -681,41 +681,41 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_bool =
-        new OptionRecordBool("icrash", "Run iCrash", advanced, &icrash, false);
+        new OptionRecordBool("icrash", "Run iCrash", now_advanced, &icrash, false);
     records.push_back(record_bool);
 
     record_bool =
         new OptionRecordBool("icrash_dualize", "Dualise strategy for iCrash",
-                             advanced, &icrash_dualize, false);
+                             now_advanced, &icrash_dualize, false);
     records.push_back(record_bool);
 
     record_string =
         new OptionRecordString("icrash_strategy", "Strategy for iCrash",
-                               advanced, &icrash_strategy, "ICA");
+                               now_advanced, &icrash_strategy, "ICA");
     records.push_back(record_string);
 
     record_double = new OptionRecordDouble(
-        "icrash_starting_weight", "iCrash starting weight", advanced,
+        "icrash_starting_weight", "iCrash starting weight", now_advanced,
         &icrash_starting_weight, 1e-10, 1e-3, 1e50);
     records.push_back(record_double);
 
     record_int = new OptionRecordInt("icrash_iterations", "iCrash iterations",
-                                     advanced, &icrash_iterations, 0, 30, 200);
+                                     now_advanced, &icrash_iterations, 0, 30, 200);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
         "icrash_approx_iter", "iCrash approximate minimization iterations",
-        advanced, &icrash_approx_iter, 0, 50, 100);
+        now_advanced, &icrash_approx_iter, 0, 50, 100);
     records.push_back(record_int);
 
     record_bool = new OptionRecordBool("icrash_exact",
                                        "Exact subproblem solution for iCrash",
-                                       advanced, &icrash_exact, false);
+                                       now_advanced, &icrash_exact, false);
     records.push_back(record_bool);
 
     record_bool = new OptionRecordBool("icrash_breakpoints",
                                        "Exact subproblem solution for iCrash",
-                                       advanced, &icrash_breakpoints, false);
+                                       now_advanced, &icrash_breakpoints, false);
     records.push_back(record_bool);
 
     record_string = new OptionRecordString(
@@ -758,13 +758,13 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_int = new OptionRecordInt(
         "mip_max_improving_sols",
-        "limit on the number of improving solutions found to stop the MIP "
+        "Limit on the number of improving solutions found to stop the MIP "
         "solver prematurely",
         advanced, &mip_max_improving_sols, 1, kHighsIInf, kHighsIInf);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("mip_lp_age_limit",
-                                     "maximal age of dynamic LP rows before "
+                                     "Maximal age of dynamic LP rows before "
                                      "they are removed from the LP relaxation",
                                      advanced, &mip_lp_age_limit, 0, 10,
                                      std::numeric_limits<int16_t>::max());
@@ -772,19 +772,19 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_int = new OptionRecordInt(
         "mip_pool_age_limit",
-        "maximal age of rows in the cutpool before they are deleted", advanced,
+        "Maximal age of rows in the cutpool before they are deleted", advanced,
         &mip_pool_age_limit, 0, 30, 1000);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("mip_pool_soft_limit",
-                                     "soft limit on the number of rows in the "
+                                     "Soft limit on the number of rows in the "
                                      "cutpool for dynamic age adjustment",
                                      advanced, &mip_pool_soft_limit, 1, 10000,
                                      kHighsIInf);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("mip_pscost_minreliable",
-                                     "minimal number of observations before "
+                                     "Minimal number of observations before "
                                      "pseudo costs are considered reliable",
                                      advanced, &mip_pscost_minreliable, 0, 8,
                                      kHighsIInf);
@@ -792,7 +792,7 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_int = new OptionRecordInt(
         "mip_min_cliquetable_entries_for_parallelism",
-        "minimal number of entries in the cliquetable before neighborhood "
+        "Minimal number of entries in the cliquetable before neighborhood "
         "queries of the conflict graph use parallel processing",
         advanced, &mip_min_cliquetable_entries_for_parallelism, 0, 100000,
         kHighsIInf);
@@ -809,20 +809,20 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_double);
 
     record_double = new OptionRecordDouble(
-        "mip_heuristic_effort", "effort spent for MIP heuristics", advanced,
+        "mip_heuristic_effort", "Effort spent for MIP heuristics", advanced,
         &mip_heuristic_effort, 0.0, 0.05, 1.0);
     records.push_back(record_double);
 
     record_double = new OptionRecordDouble(
         "mip_rel_gap",
-        "tolerance on relative gap, |ub-lb|/|ub|, to determine whether "
+        "Tolerance on relative gap, |ub-lb|/|ub|, to determine whether "
         "optimality has been reached for a MIP instance",
         advanced, &mip_rel_gap, 0.0, 1e-4, kHighsInf);
     records.push_back(record_double);
 
     record_double = new OptionRecordDouble(
         "mip_abs_gap",
-        "tolerance on absolute gap of MIP, |ub-lb|, to determine whether "
+        "Tolerance on absolute gap of MIP, |ub-lb|, to determine whether "
         "optimality has been reached for a MIP instance",
         advanced, &mip_abs_gap, 0.0, 1e-6, kHighsInf);
     records.push_back(record_double);

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -1056,6 +1056,7 @@ class HighsOptions : public HighsOptionsStruct {
     log_options.output_flag = &output_flag;
     log_options.log_to_console = &log_to_console;
     log_options.log_dev_level = &log_dev_level;
+    log_options.log_highs_callback = nullptr;
     log_options.log_user_callback = nullptr;
     log_options.log_deprecated = nullptr;
   }

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -555,10 +555,10 @@ class HighsOptions : public HighsOptionsStruct {
         &threads, 0, 0, kHighsIInf);
     records.push_back(record_int);
 
-    record_int =
-        new OptionRecordInt("highs_debug_level", "Debugging level in HiGHS",
-                            now_advanced, &highs_debug_level, kHighsDebugLevelMin,
-                            kHighsDebugLevelMin, kHighsDebugLevelMax);
+    record_int = new OptionRecordInt("highs_debug_level",
+                                     "Debugging level in HiGHS", now_advanced,
+                                     &highs_debug_level, kHighsDebugLevelMin,
+                                     kHighsDebugLevelMin, kHighsDebugLevelMax);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
@@ -680,8 +680,8 @@ class HighsOptions : public HighsOptionsStruct {
         kHighsIInf);
     records.push_back(record_int);
 
-    record_bool =
-        new OptionRecordBool("icrash", "Run iCrash", now_advanced, &icrash, false);
+    record_bool = new OptionRecordBool("icrash", "Run iCrash", now_advanced,
+                                       &icrash, false);
     records.push_back(record_bool);
 
     record_bool =
@@ -699,8 +699,9 @@ class HighsOptions : public HighsOptionsStruct {
         &icrash_starting_weight, 1e-10, 1e-3, 1e50);
     records.push_back(record_double);
 
-    record_int = new OptionRecordInt("icrash_iterations", "iCrash iterations",
-                                     now_advanced, &icrash_iterations, 0, 30, 200);
+    record_int =
+        new OptionRecordInt("icrash_iterations", "iCrash iterations",
+                            now_advanced, &icrash_iterations, 0, 30, 200);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
@@ -713,9 +714,9 @@ class HighsOptions : public HighsOptionsStruct {
                                        now_advanced, &icrash_exact, false);
     records.push_back(record_bool);
 
-    record_bool = new OptionRecordBool("icrash_breakpoints",
-                                       "Exact subproblem solution for iCrash",
-                                       now_advanced, &icrash_breakpoints, false);
+    record_bool = new OptionRecordBool(
+        "icrash_breakpoints", "Exact subproblem solution for iCrash",
+        now_advanced, &icrash_breakpoints, false);
     records.push_back(record_bool);
 
     record_string = new OptionRecordString(

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -27,6 +27,8 @@ using std::string;
 
 enum class OptionStatus { kOk = 0, kUnknownOption, kIllegalValue };
 
+const bool kAdvancedInDocumentation = false;
+
 class OptionRecord {
  public:
   HighsOptionType type;

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -145,6 +145,8 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
       case HighsLoadOptionsStatus::kError:
 	return false;
       case HighsLoadOptionsStatus::kEmpty:
+	printf("loadOptions: HighsLoadOptionsStatus::kEmpty\n");
+	writeOptionsToFile(stdout, options.records);
 	return false;
       default:
 	break;

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -145,7 +145,6 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
         case HighsLoadOptionsStatus::kError:
           return false;
         case HighsLoadOptionsStatus::kEmpty:
-          printf("loadOptions: HighsLoadOptionsStatus::kEmpty\n");
           writeOptionsToFile(stdout, options.records);
           return false;
         default:

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -141,7 +141,14 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
         std::cout << "Multiple options files not implemented.\n";
         return false;
       }
-      if (!loadOptionsFromFile(report_log_options, options, v[0])) return false;
+      switch (loadOptionsFromFile(report_log_options, options, v[0])) {
+      case HighsLoadOptionsStatus::kError:
+	return false;
+      case HighsLoadOptionsStatus::kEmpty:
+	return false;
+      default:
+	break;
+      }
     }
 
     // Handle command line option specifications

--- a/src/lp_data/HighsRuntimeOptions.h
+++ b/src/lp_data/HighsRuntimeOptions.h
@@ -142,14 +142,14 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
         return false;
       }
       switch (loadOptionsFromFile(report_log_options, options, v[0])) {
-      case HighsLoadOptionsStatus::kError:
-	return false;
-      case HighsLoadOptionsStatus::kEmpty:
-	printf("loadOptions: HighsLoadOptionsStatus::kEmpty\n");
-	writeOptionsToFile(stdout, options.records);
-	return false;
-      default:
-	break;
+        case HighsLoadOptionsStatus::kError:
+          return false;
+        case HighsLoadOptionsStatus::kEmpty:
+          printf("loadOptions: HighsLoadOptionsStatus::kEmpty\n");
+          writeOptionsToFile(stdout, options.records);
+          return false;
+        default:
+          break;
       }
     }
 


### PR DESCRIPTION
Running `bin/highs` with `options_file=""` (or `options_file=`!) now becomes a means of writing the full options documentation as a text file

Generalise Highs::openWriteFile last parameter to be member of `enum class WriteFileFormat` rather than `bool html`

WIP