### PR TITLE
Allow small matrix values introduced by presolve, also in debug mode

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1130,8 +1130,10 @@ HighsStatus Highs::run() {
       case HighsPresolveStatus::kReduced: {
         HighsLp& reduced_lp = presolve_.getReducedProblem();
         reduced_lp.setMatrixDimensions();
-        // Validate the reduced LP
-        assert(assessLp(reduced_lp, options_) == HighsStatus::kOk);
+        // Validate the reduced LP; note that assessLp() may return a warning
+        // if matrix values dropped below the small_matrix_value threshold
+        // during presolving
+        assert(assessLp(reduced_lp, options_) != HighsStatus::kError);
         call_status = cleanBounds(options_, reduced_lp);
         // Ignore any warning from clean bounds since the original LP
         // is still solved after presolve


### PR DESCRIPTION
During presolve it can happen that matrix coefficients smaller than the threshold `small_matrix_value` in absolute value are introduced, even if in the original problem all coefficients have absolute value larger or equal. This leads to a warning in `assessLp()` and as a result the assert in `Highs::run()` fails in debug mode.

This PR relaxes this assert to accept this case, as would happen in optimized mode.

An example where the assert is triggered quickly is ` bin/scip -c "read /nfs/optimi/kombadon/IP/miplib/momentum1.mps.gz o"`, but it happens also for numerically nicer instances. I checked, and in this case the small values were introduced by the aggregator.

```
opt111:~/opti/devel/scip/optbuild/Debug-highs% gdb --args bin/scip -c "read /nfs/optimi/kombadon/IP/miplib/momentum1.mps.gz o"
GNU gdb (Ubuntu 8.1.1-0ubuntu1) 8.1.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from bin/scip...done.
(gdb) r
Starting program: /scratch/opt/bzfgleix/devel/scip/optbuild/Debug-highs/bin/scip -c read\ /nfs/optimi/kombadon/IP/miplib/momentum1.mps.gz\ o
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
SCIP version 8.0.4 [precision: 8 byte] [memory: block] [mode: debug] [LP solver: HiGHS 1.5.1] [GitHash: 72e9bb731e]
Copyright (c) 2002-2023 Zuse Institute Berlin (ZIB)

External libraries:
  Readline 7.0         GNU library for command line editing (gnu.org/s/readline)
  HiGHS 1.5.1          Linear optimization suite written and engineered at the University of Edinburgh [2023-02-24] [GitHash: b7d434514]
  CppAD 20180000.0     Algorithmic Differentiation of C++ algorithms developed by B. Bell (github.com/coin-or/CppAD)
  ZLIB 1.2.11          General purpose compression library by J. Gailly and M. Adler (zlib.net)
  GMP 6.1.2            GNU Multiple Precision Arithmetic Library developed by T. Granlund (gmplib.org)
  ZIMPL 3.5.2          Zuse Institute Mathematical Programming Language developed by T. Koch (zimpl.zib.de)
  AMPL/MP 4e2d45c4     AMPL .nl file reader library (github.com/ampl/mp)
  PaPILO 2.2.0.2       parallel presolve for integer and linear optimization (github.com/scipopt/papilo) [GitHash: ab089f1]
  bliss 0.77           Computing Graph Automorphism Groups by T. Junttila and P. Kaski (www.tcs.hut.fi/Software/bliss/)
  Ipopt 3.12.11        Interior Point Optimizer developed by A. Waechter et.al. (github.com/coin-or/Ipopt)
  TinyCThread          Small, portable implementation of the C11 threads API (tinycthread.github.io)

user parameter file <scip.set> not found - using default parameters


read problem </nfs/optimi/kombadon/IP/miplib/momentum1.mps.gz>
============

WARNING: SCIP is compiled with 'DEBUGSOL=true' but no debug solution is given:
WARNING:  *** Please set the parameter 'misc/debugsol' and reload the problem again to use the debugging-mechanism ***

original problem has 5174 variables (2349 bin, 0 int, 0 impl, 2825 cont) and 42680 constraints

presolving:
(round 1, fast)       858 del vars, 1131 del conss, 0 add conss, 1001 chg bounds, 2119 chg sides, 2119 chg coeffs, 0 upgd conss, 0 impls, 13792 clqs
(round 2, fast)       1907 del vars, 14476 del conss, 0 add conss, 1687 chg bounds, 2384 chg sides, 2394 chg coeffs, 0 upgd conss, 7 impls, 13790 clqs
(round 3, fast)       1915 del vars, 16098 del conss, 0 add conss, 1761 chg bounds, 5419 chg sides, 5427 chg coeffs, 0 upgd conss, 9 impls, 13790 clqs
(round 4, fast)       1915 del vars, 16117 del conss, 0 add conss, 1823 chg bounds, 5457 chg sides, 5472 chg coeffs, 0 upgd conss, 9 impls, 13790 clqs
(round 5, fast)       1923 del vars, 16214 del conss, 0 add conss, 1871 chg bounds, 5505 chg sides, 5524 chg coeffs, 0 upgd conss, 9 impls, 13723 clqs
   (0.6s) running MILP presolver
   (3.7s) MILP presolver (24 rounds): 282 aggregations, 756 fixings, 298 bound changes
(round 6, medium)     2961 del vars, 42680 del conss, 14760 add conss, 2169 chg bounds, 5505 chg sides, 5524 chg coeffs, 0 upgd conss, 10 impls, 7027 clqs
(round 7, fast)       2961 del vars, 42680 del conss, 14760 add conss, 2174 chg bounds, 5543 chg sides, 5524 chg coeffs, 0 upgd conss, 18 impls, 7027 clqs
(round 8, exhaustive) 2961 del vars, 42712 del conss, 14760 add conss, 2174 chg bounds, 5543 chg sides, 5524 chg coeffs, 0 upgd conss, 18 impls, 7027 clqs
(round 9, exhaustive) 2961 del vars, 42712 del conss, 14760 add conss, 2174 chg bounds, 5543 chg sides, 5524 chg coeffs, 11290 upgd conss, 18 impls, 7027 clqs
(round 10, medium)     2961 del vars, 43737 del conss, 14760 add conss, 2182 chg bounds, 5553 chg sides, 6020 chg coeffs, 11290 upgd conss, 3251 impls, 7027 clqs
   (10.5s) probing: 1000/1181 (84.7%) - 8 fixings, 1 aggregations, 119140 implications, 119 bound changes
   (12.5s) probing cycle finished: starting next cycle
(round 11, exhaustive) 2984 del vars, 43737 del conss, 14760 add conss, 2310 chg bounds, 5563 chg sides, 6040 chg coeffs, 11290 upgd conss, 125959 impls, 51667 clqs
(round 12, fast)       2984 del vars, 43941 del conss, 14760 add conss, 2310 chg bounds, 6055 chg sides, 6541 chg coeffs, 11290 upgd conss, 125959 impls, 51667 clqs
   (12.7s) probing: 51/1169 (4.4%) - 22 fixings, 1 aggregations, 161579 implications, 121 bound changes
   (12.7s) probing aborted: 50/50 successive totally useless probings
   (12.8s) symmetry computation started: requiring (bin +, int -, cont +), (fixed: bin -, int +, cont -)
   (12.8s) no symmetry present
presolving (13 rounds: 13 fast, 6 medium, 4 exhaustive):
 2984 deleted vars, 43941 deleted constraints, 14760 added constraints, 2310 tightened bounds, 0 added holes, 6055 changed sides, 6541 changed coefficients
 125959 implications, 51667 cliques
presolved problem has 2712 variables (1169 bin, 0 int, 0 impl, 1543 cont) and 13499 constraints
   3205 constraints of type <varbound>
   6889 constraints of type <setppc>
   3405 constraints of type <linear>
Presolving Time: 12.75

scip: /home/optimi/bzfgleix/opti/devel/HiGHS/src/lp_data/Highs.cpp:1134: HighsStatus Highs::run(): Assertion `assessLp(reduced_lp, options_) == HighsStatus::kOk' failed.
```