### PR TITLE
Fix 1187

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -292,6 +292,9 @@ HighsStatus Highs::passModel(HighsModel model) {
   // This is the "master" Highs::passModel, in that all the others
   // eventually call it
   this->logHeader();
+  // Possibly analyse the LP data
+  if (kHighsAnalysisLevelModelData & options_.highs_analysis_level)
+    analyseLp(options_.log_options, model.lp_);
   HighsStatus return_status = HighsStatus::kOk;
   // Clear the incumbent model and any associated data
   clearModel();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1141,25 +1141,26 @@ HighsStatus Highs::run() {
       case HighsPresolveStatus::kReduced: {
         HighsLp& reduced_lp = presolve_.getReducedProblem();
         reduced_lp.setMatrixDimensions();
-	if (kAllowDeveloperAssert) {
-	  // Validate the reduced LP
-	  //
-	  // Although preseolve can yield small values in the matrix,
-	  // they are only stripped out (by assessLp) in debug. This
-	  // suggests that they are no real danger to the simplex
-	  // solver. The only danger is pivoting on them, but that
-	  // implies that values of roughly that size have been chosen
-	  // in the ratio test. Even with the filter, values of 1e-9
-	  // could be in the matrix, and these would be bad
-	  // pivots. Hence, since the small values may play a
-	  // meaningful role in postsolve, then it's better to keep
-	  // them.
-	  //
-	  // ToDo. Analyse the extent of small value creation. See #1187
-	  assert(assessLp(reduced_lp, options_) == HighsStatus::kOk);
-	} else {
-	  reduced_lp.a_matrix_.assessSmallValues(options_.log_options, options_.small_matrix_value);
-	}
+        if (kAllowDeveloperAssert) {
+          // Validate the reduced LP
+          //
+          // Although preseolve can yield small values in the matrix,
+          // they are only stripped out (by assessLp) in debug. This
+          // suggests that they are no real danger to the simplex
+          // solver. The only danger is pivoting on them, but that
+          // implies that values of roughly that size have been chosen
+          // in the ratio test. Even with the filter, values of 1e-9
+          // could be in the matrix, and these would be bad
+          // pivots. Hence, since the small values may play a
+          // meaningful role in postsolve, then it's better to keep
+          // them.
+          //
+          // ToDo. Analyse the extent of small value creation. See #1187
+          assert(assessLp(reduced_lp, options_) == HighsStatus::kOk);
+        } else {
+          reduced_lp.a_matrix_.assessSmallValues(options_.log_options,
+                                                 options_.small_matrix_value);
+        }
         call_status = cleanBounds(options_, reduced_lp);
         // Ignore any warning from clean bounds since the original LP
         // is still solved after presolve

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1138,10 +1138,25 @@ HighsStatus Highs::run() {
       case HighsPresolveStatus::kReduced: {
         HighsLp& reduced_lp = presolve_.getReducedProblem();
         reduced_lp.setMatrixDimensions();
-        // Validate the reduced LP
-        //
-        // ToDo. Assess #1187
-        assert(assessLp(reduced_lp, options_) == HighsStatus::kOk);
+	if (kAllowDeveloperAssert) {
+	  // Validate the reduced LP
+	  //
+	  // Although preseolve can yield small values in the matrix,
+	  // they are only stripped out (by assessLp) in debug. This
+	  // suggests that they are no real danger to the simplex
+	  // solver. The only danger is pivoting on them, but that
+	  // implies that values of roughly that size have been chosen
+	  // in the ratio test. Even with the filter, values of 1e-9
+	  // could be in the matrix, and these would be bad
+	  // pivots. Hence, since the small values may play a
+	  // meaningful role in postsolve, then it's better to keep
+	  // them.
+	  //
+	  // ToDo. Analyse the extent of small value creation. See #1187
+	  assert(assessLp(reduced_lp, options_) == HighsStatus::kOk);
+	} else {
+	  reduced_lp.a_matrix_.assessSmallValues(options_.log_options, options_.small_matrix_value);
+	}
         call_status = cleanBounds(options_, reduced_lp);
         // Ignore any warning from clean bounds since the original LP
         // is still solved after presolve

--- a/src/util/HighsSparseMatrix.cpp
+++ b/src/util/HighsSparseMatrix.cpp
@@ -692,6 +692,17 @@ HighsStatus HighsSparseMatrix::assess(const HighsLogOptions& log_options,
                       small_matrix_value, large_matrix_value);
 }
 
+void HighsSparseMatrix::assessSmallValues(const HighsLogOptions& log_options,
+					  const double small_matrix_value) {
+  double min_value = kHighsInf;
+  const HighsInt num_values = this->value_.size();
+  for (HighsInt iX = 0; iX < num_values; iX++) 
+    min_value = std::min(std::abs(this->value_[iX]), min_value);
+  if (min_value > small_matrix_value) return;
+  analyseVectorValues(&log_options, "Small values in matrix", num_values, this->value_, false, "");
+}
+
+
 bool HighsSparseMatrix::hasLargeValue(const double large_matrix_value) {
   for (HighsInt iEl = 0; iEl < this->numNz(); iEl++)
     if (std::abs(this->value_[iEl]) > large_matrix_value) return true;

--- a/src/util/HighsSparseMatrix.cpp
+++ b/src/util/HighsSparseMatrix.cpp
@@ -693,15 +693,15 @@ HighsStatus HighsSparseMatrix::assess(const HighsLogOptions& log_options,
 }
 
 void HighsSparseMatrix::assessSmallValues(const HighsLogOptions& log_options,
-					  const double small_matrix_value) {
+                                          const double small_matrix_value) {
   double min_value = kHighsInf;
   const HighsInt num_values = this->value_.size();
-  for (HighsInt iX = 0; iX < num_values; iX++) 
+  for (HighsInt iX = 0; iX < num_values; iX++)
     min_value = std::min(std::abs(this->value_[iX]), min_value);
   if (min_value > small_matrix_value) return;
-  analyseVectorValues(&log_options, "Small values in matrix", num_values, this->value_, false, "");
+  analyseVectorValues(&log_options, "Small values in matrix", num_values,
+                      this->value_, false, "");
 }
-
 
 bool HighsSparseMatrix::hasLargeValue(const double large_matrix_value) {
   for (HighsInt iEl = 0; iEl < this->numNz(); iEl++)

--- a/src/util/HighsSparseMatrix.h
+++ b/src/util/HighsSparseMatrix.h
@@ -68,7 +68,7 @@ class HighsSparseMatrix {
                      const double small_matrix_value,
                      const double large_matrix_value);
   void assessSmallValues(const HighsLogOptions& log_options,
-			 const double small_matrix_value);
+                         const double small_matrix_value);
   bool hasLargeValue(const double large_matrix_value);
   void considerColScaling(const HighsInt max_scale_factor_exponent,
                           double* col_scale);

--- a/src/util/HighsSparseMatrix.h
+++ b/src/util/HighsSparseMatrix.h
@@ -67,6 +67,8 @@ class HighsSparseMatrix {
                      const std::string matrix_name,
                      const double small_matrix_value,
                      const double large_matrix_value);
+  void assessSmallValues(const HighsLogOptions& log_options,
+			 const double small_matrix_value);
   bool hasLargeValue(const double large_matrix_value);
   void considerColScaling(const HighsInt max_scale_factor_exponent,
                           double* col_scale);


### PR DESCRIPTION
Although presolve can yield small values in the matrix, they were only stripped out (by assessLp) in debug. This suggests that they are no real danger to the simplex solver. The only danger is pivoting on them, but that implies that values of roughly that size have been chosen in the ratio test. Even with the filter, values of 1e-9 could be in the matrix, and these would be bad pivots. Hence, since the small values may play a meaningful role in postsolve, then it's better to keep them.

The fix only executes the assert if `kAllowDeveloperAssert` is true, otherwise it calls `assessSmallValues` to report on matrix values (when `log_dev_level` is positive) 