### PR TITLE
Improve formatting of docstrings in the C API

### DIFF
--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -229,21 +229,21 @@ const char* Highs_version(void);
  *
  * @returns The HiGHS major version number.
  */
-HighsInt Highs_versionMajor(void);
+HighsInt Highs_versionMajor();
 
 /**
  * Return the HiGHS minor version number.
  *
  * @returns The HiGHS minor version number.
  */
-HighsInt Highs_versionMinor(void);
+HighsInt Highs_versionMinor();
 
 /**
  * Return the HiGHS patch version number.
  *
  * @returns The HiGHS patch version number.
  */
-HighsInt Highs_versionPatch(void);
+HighsInt Highs_versionPatch();
 
 /**
  * Return the HiGHS githash.
@@ -648,8 +648,8 @@ HighsInt Highs_getNumOptions(const void* highs);
  * Get the name of an option identified by index
  *
  * @param highs     A pointer to the Highs instance.
- * @param index     the index of the option
- * @param name      the name of the option
+ * @param index     The index of the option.
+ * @param name      The name of the option.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -660,8 +660,8 @@ HighsInt Highs_getOptionName(const void* highs, const HighsInt index,
  * Get the current and default values of a bool option
  *
  * @param highs         A pointer to the Highs instance.
- * @param current_value a pointer to the current value of the option
- * @param default_value a pointer to the default value of the option
+ * @param current_value A pointer to the current value of the option.
+ * @param default_value A pointer to the default value of the option.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -672,10 +672,10 @@ HighsInt Highs_getBoolOptionValues(const void* highs, const char* option,
  * Get the current and default values of an int option
  *
  * @param highs         A pointer to the Highs instance.
- * @param current_value a pointer to the current value of the option
- * @param min_value     a pointer to the minimum value of the option
- * @param max_value     a pointer to the maximum value of the option
- * @param default_value a pointer to the default value of the option
+ * @param current_value A pointer to the current value of the option.
+ * @param min_value     A pointer to the minimum value of the option.
+ * @param max_value     A pointer to the maximum value of the option.
+ * @param default_value A pointer to the default value of the option.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -687,10 +687,10 @@ HighsInt Highs_getIntOptionValues(const void* highs, const char* option,
  * Get the current and default values of a double option
  *
  * @param highs         A pointer to the Highs instance.
- * @param current_value a pointer to the current value of the option
- * @param min_value     a pointer to the minimum value of the option
- * @param max_value     a pointer to the maximum value of the option
- * @param default_value a pointer to the default value of the option
+ * @param current_value A pointer to the current value of the option.
+ * @param min_value     A pointer to the minimum value of the option.
+ * @param max_value     A pointer to the maximum value of the option.
+ * @param default_value A pointer to the default value of the option.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -702,8 +702,8 @@ HighsInt Highs_getDoubleOptionValues(const void* highs, const char* option,
  * Get the current and default values of a string option
  *
  * @param highs         A pointer to the Highs instance.
- * @param current_value a pointer to the current value of the option
- * @param default_value a pointer to the default value of the option
+ * @param current_value A pointer to the current value of the option.
+ * @param default_value A pointer to the default value of the option.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -714,8 +714,8 @@ HighsInt Highs_getStringOptionValues(const void* highs, const char* option,
  * Get an int-valued info value.
  *
  * @param highs     A pointer to the Highs instance.
- * @param info      the name of the info item
- * @param value     a reference to an integer that the result will be stored in
+ * @param info      The name of the info item.
+ * @param value     A reference to an integer that the result will be stored in.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -726,8 +726,8 @@ HighsInt Highs_getIntInfoValue(const void* highs, const char* info,
  * Get a double-valued info value.
  *
  * @param highs     A pointer to the Highs instance.
- * @param info      the name of the info item
- * @param value     a reference to an double that the result will be stored in
+ * @param info      The name of the info item.
+ * @param value     A reference to a double that the result will be stored in.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -738,8 +738,8 @@ HighsInt Highs_getDoubleInfoValue(const void* highs, const char* info,
  * Get an int64-valued info value.
  *
  * @param highs     A pointer to the Highs instance.
- * @param info      the name of the info item
- * @param value     a reference to a int64 that the result will be stored in
+ * @param info      The name of the info item.
+ * @param value     A reference to an int64 that the result will be stored in.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -750,9 +750,9 @@ HighsInt Highs_getInt64InfoValue(const void* highs, const char* info,
  * Get the type expected by an info item.
  *
  * @param highs     A pointer to the Highs instance.
- * @param info      the name of the info item
- * @param type      int in which the corresponding `kHighsOptionType` constant
- *                  is stored
+ * @param info      The name of the info item.
+ * @param type      An int in which the corresponding `kHighsOptionType`
+ *                  constant is stored.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -762,10 +762,14 @@ HighsInt Highs_getInfoType(const void* highs, const char* info, HighsInt* type);
  * Get the primal and dual solution from an optimized model.
  *
  * @param highs      A pointer to the Highs instance.
- * @param col_value  array of length [num_col], filled with primal column values
- * @param col_dual   array of length [num_col], filled with dual column values
- * @param row_value  array of length [num_row], filled with primal row values
- * @param row_dual   array of length [num_row], filled with dual row values
+ * @param col_value  An array of length [num_col], to be filled with primal
+ *                   column values.
+ * @param col_dual   An array of length [num_col], to be filled with dual column
+ *                   values.
+ * @param row_value  An array of length [num_row], to be filled with primal row
+ *                   values.
+ * @param row_dual   An array of length [num_row], to be filled with dual row
+ *                   values.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -778,12 +782,12 @@ HighsInt Highs_getSolution(const void* highs, double* col_value,
  * basis statuses.
  *
  * @param highs       A pointer to the Highs instance.
- * @param col_status  array of length [num_col], to be filled with the column
+ * @param col_status  An array of length [num_col], to be filled with the column
  *                    basis statuses in the form of a `kHighsBasisStatus`
- *                    constant
- * @param row_status  array of length [num_row], to be filled with the row
+ *                    constant.
+ * @param row_status  An array of length [num_row], to be filled with the row
  *                    basis statuses in the form of a `kHighsBasisStatus`
- *                    constant
+ *                    constant.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -804,10 +808,10 @@ HighsInt Highs_getModelStatus(const void* highs);
  * Get an unbounded dual ray that is a certificate of primal infeasibility.
  *
  * @param highs             A pointer to the Highs instance.
- * @param has_dual_ray      a pointer to an int to store 1 if the dual ray
- *                          exists
- * @param dual_ray_value    an array of length [num_row] filled with the
- *                          unbounded ray
+ * @param has_dual_ray      A pointer to an int to store 1 if the dual ray
+ *                          exists.
+ * @param dual_ray_value    An array of length [num_row] filled with the
+ *                          unbounded ray.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -818,10 +822,10 @@ HighsInt Highs_getDualRay(const void* highs, HighsInt* has_dual_ray,
  * Get an unbounded primal ray that is a certificate of dual infeasibility.
  *
  * @param highs             A pointer to the Highs instance.
- * @param has_primal_ray    a pointer to an int to store 1 if the primal ray
- *                          exists
- * @param primal_ray_value  an array of length [num_col] filled with the
- *                          unbounded ray
+ * @param has_primal_ray    A pointer to an int to store 1 if the primal ray
+ *                          exists.
+ * @param primal_ray_value  An array of length [num_col] filled with the
+ *                          unbounded ray.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -846,6 +850,7 @@ double Highs_getObjectiveValue(const void* highs);
  * row.
  *
  * The order of these rows and columns is important for calls to the functions:
+ *
  *  - `Highs_getBasisInverseRow`
  *  - `Highs_getBasisInverseCol`
  *  - `Highs_getBasisSolve`
@@ -854,8 +859,8 @@ double Highs_getObjectiveValue(const void* highs);
  *  - `Highs_getReducedColumn`
  *
  * @param highs             A pointer to the Highs instance.
- * @param basic_variables   array of size [num_rows], filled with the indices of
- *                          the basic variables
+ * @param basic_variables   An array of size [num_rows], filled with the indices
+ *                          of the basic variables.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -871,10 +876,12 @@ HighsInt Highs_getBasicVariables(const void* highs, HighsInt* basic_variables);
  * actually stored.
  *
  * @param highs         A pointer to the Highs instance.
- * @param row           index of the row to compute
- * @param row_vector    values of the non-zero elements
- * @param row_num_nz    the number of non-zeros in the row
- * @param row_index     indices of the non-zero elements
+ * @param row           The index of the row to compute.
+ * @param row_vector    An array of length [num_row] in which to store the
+ *                      values of the non-zero elements.
+ * @param row_num_nz    The number of non-zeros in the row.
+ * @param row_index     An array of length [num_row] in which to store the
+ *                      indices of the non-zero elements.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -892,10 +899,12 @@ HighsInt Highs_getBasisInverseRow(const void* highs, const HighsInt row,
  * actually stored.
  *
  * @param highs         A pointer to the Highs instance.
- * @param col           index of the column to compute
- * @param col_vector    values of the non-zero elements
- * @param col_num_nz    the number of non-zeros in the column
- * @param col_index     indices of the non-zero elements
+ * @param col           The index of the column to compute.
+ * @param col_vector    An array of length [num_row] in which to store the
+ *                      values of the non-zero elements.
+ * @param col_num_nz    The number of non-zeros in the column.
+ * @param col_index     An array of length [num_row] in which to store the
+ *                      indices of the non-zero elements.
 
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -914,10 +923,12 @@ HighsInt Highs_getBasisInverseCol(const void* highs, const HighsInt col,
  * non-zero elements are actually stored.
  *
  * @param highs             A pointer to the Highs instance.
- * @param rhs               the right-hand side vector `b`
- * @param solution_vector   values of the non-zero elements
- * @param solution_num_nz   the number of non-zeros in the solution
- * @param solution_index    indices of the non-zero elements
+ * @param rhs               The right-hand side vector `b`.
+ * @param solution_vector   An array of length [num_row] in which to store the
+ *                          values of the non-zero elements.
+ * @param solution_num_nz   The number of non-zeros in the solution.
+ * @param solution_index    An array of length [num_row] in which to store the
+ *                          indices of the non-zero elements.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -936,10 +947,12 @@ HighsInt Highs_getBasisSolve(const void* highs, const double* rhs,
  * non-zero elements are actually stored.
  *
  * @param highs             A pointer to the Highs instance.
- * @param rhs               the right-hand side vector `b`
- * @param solution_vector   values of the non-zero elements
- * @param solution_num_nz   the number of non-zeros in the solution
- * @param solution_index    indices of the non-zero elements
+ * @param rhs               The right-hand side vector `b`
+ * @param solution_vector   An array of length [num_row] in whcih to store the
+ *                          values of the non-zero elements.
+ * @param solution_num_nz   The number of non-zeros in the solution.
+ * @param solution_index    An array of length [num_row] in whcih to store the
+ *                          indices of the non-zero elements.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -958,10 +971,12 @@ HighsInt Highs_getBasisTransposeSolve(const void* highs, const double* rhs,
  * actually stored.
  *
  * @param highs         A pointer to the Highs instance.
- * @param row           index of the row to compute
- * @param row_vector    values of the non-zero elements
- * @param row_num_nz    the number of non-zeros in the row
- * @param row_index     indices of the non-zero elements
+ * @param row           The index of the row to compute.
+ * @param row_vector    An array of length [num_row] in which to store the
+ *                      values of the non-zero elements.
+ * @param row_num_nz    The number of non-zeros in the row.
+ * @param row_index     An array of length [num_row] in which to store the
+ *                      indices of the non-zero elements.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -979,10 +994,12 @@ HighsInt Highs_getReducedRow(const void* highs, const HighsInt row,
  * actually stored.
  *
  * @param highs         A pointer to the Highs instance.
- * @param col           index of the column to compute
- * @param col_vector    values of the non-zero elements
- * @param col_num_nz    the number of non-zeros in the column
- * @param col_index     indices of the non-zero elements
+ * @param col           The index of the column to compute.
+ * @param col_vector    An array of length [num_row] in which to store the
+*                       values of the non-zero elements.
+ * @param col_num_nz    The number of non-zeros in the column.
+ * @param col_index     An array of length [num_row] in which to store the
+*                       indices of the non-zero elements.
 
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1015,16 +1032,17 @@ HighsInt Highs_setBasis(void* highs, const HighsInt* col_status,
 HighsInt Highs_setLogicalBasis(void* highs);
 
 /**
- * Set a solution by passing the column and row primal and dual
- * solution values. For any values that are unavailable pass NULL.
+ * Set a solution by passing the column and row primal and dual solution values.
+ *
+ * For any values that are unavailable, pass NULL.
  *
  * @param highs       A pointer to the Highs instance.
- * @param col_value   an array of length [num_col] with the column solution
- *                    values
- * @param row_value   an array of length [num_row] with the row solution
- *                    values
- * @param col_dual    an array of length [num_col] with the column dual values
- * @param row_dual    an array of length [num_row] with the row dual values
+ * @param col_value   An array of length [num_col] with the column solution
+ *                    values.
+ * @param row_value   An array of length [num_row] with the row solution
+ *                    values.
+ * @param col_dual    An array of length [num_col] with the column dual values.
+ * @param row_dual    An array of length [num_row] with the row dual values.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1045,12 +1063,12 @@ double Highs_getRunTime(const void* highs);
  * Add a new column (variable) to the model.
  *
  * @param highs         A pointer to the Highs instance.
- * @param cost          objective coefficient of the column
- * @param lower         lower bound of the column
- * @param upper         upper bound of the column
- * @param num_new_nz    number of non-zeros in the column
- * @param index         array of size [num_new_nz] with the row indices
- * @param value         array of size [num_new_nz] with row values
+ * @param cost          The objective coefficient of the column.
+ * @param lower         The lower bound of the column.
+ * @param upper         The upper bound of the column.
+ * @param num_new_nz    The number of non-zeros in the column.
+ * @param index         An array of size [num_new_nz] with the row indices.
+ * @param value         An array of size [num_new_nz] with row values.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1062,18 +1080,19 @@ HighsInt Highs_addCol(void* highs, const double cost, const double lower,
  * Add multiple columns (variables) to the model.
  *
  * @param highs         A pointer to the Highs instance.
- * @param num_new_col   number of new columns to add
- * @param costs         array of size [num_new_col] with objective coefficients
- * @param lower         array of size [num_new_col] with lower bounds
- * @param upper         array of size [num_new_col] with upper bounds
- * @param num_new_nz    number of new nonzeros in the constraint matrix
- * @param starts        the constraint coefficients are given as a matrix in
+ * @param num_new_col   The number of new columns to add.
+ * @param costs         An array of size [num_new_col] with objective
+ *                      coefficients.
+ * @param lower         An array of size [num_new_col] with lower bounds.
+ * @param upper         An array of size [num_new_col] with upper bounds.
+ * @param num_new_nz    The number of new nonzeros in the constraint matrix.
+ * @param starts        The constraint coefficients are given as a matrix in
  *                      compressed sparse column form by the arrays `starts`,
  *                      `index`, and `value`. `starts` is an array of size
  *                      [num_new_cols] with the start index of each row in
  *                      indices and values.
- * @param index         array of size [num_new_nz] with row indices
- * @param value         array of size [num_new_nz] with row values
+ * @param index         An array of size [num_new_nz] with row indices.
+ * @param value         An array of size [num_new_nz] with row values.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1087,8 +1106,8 @@ HighsInt Highs_addCols(void* highs, const HighsInt num_new_col,
  * Add a new variable to the model.
  *
  * @param highs         A pointer to the Highs instance.
- * @param lower         lower bound of the column
- * @param upper         upper bound of the column
+ * @param lower         The lower bound of the column.
+ * @param upper         The upper bound of the column.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1098,9 +1117,9 @@ HighsInt Highs_addVar(void* highs, const double lower, const double upper);
  * Add multiple variables to the model.
  *
  * @param highs         A pointer to the Highs instance.
- * @param num_new_var   number of new variables to add
- * @param lower         array of size [num_new_var] with lower bounds
- * @param upper         array of size [num_new_var] with upper bounds
+ * @param num_new_var   The number of new variables to add.
+ * @param lower         An array of size [num_new_var] with lower bounds.
+ * @param upper         An array of size [num_new_var] with upper bounds.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1111,11 +1130,11 @@ HighsInt Highs_addVars(void* highs, const HighsInt num_new_var,
  * Add a new row (a linear constraint) to the model.
  *
  * @param highs         A pointer to the Highs instance.
- * @param lower         lower bound of the row
- * @param upper         upper bound of the row
- * @param num_new_nz    number of non-zeros in the row
- * @param index         array of size [num_new_nz] with column indices
- * @param value         array of size [num_new_nz] with column values
+ * @param lower         The lower bound of the row.
+ * @param upper         The upper bound of the row.
+ * @param num_new_nz    The number of non-zeros in the row
+ * @param index         An array of size [num_new_nz] with column indices.
+ * @param value         An array of size [num_new_nz] with column values.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1127,19 +1146,19 @@ HighsInt Highs_addRow(void* highs, const double lower, const double upper,
  * Add multiple rows (linear constraints) to the model.
  *
  * @param highs         A pointer to the Highs instance.
- * @param num_new_row   the number of new rows to add
- * @param lower         array of size [num_new_row] with the lower bounds of the
- *                      rows
- * @param upper         array of size [num_new_row] with the upper bounds of the
- *                      rows
- * @param num_new_nz    number of non-zeros in the rows
- * @param starts        the constraint coefficients are given as a matrix in
+ * @param num_new_row   The number of new rows to add
+ * @param lower         An array of size [num_new_row] with the lower bounds of
+ *                      the rows.
+ * @param upper         An array of size [num_new_row] with the upper bounds of
+ *                      the rows.
+ * @param num_new_nz    The number of non-zeros in the rows.
+ * @param starts        The constraint coefficients are given as a matrix in
  *                      compressed sparse row form by the arrays `starts`,
  *                      `index`, and `value`. `starts` is an array of size
  *                      [num_new_rows] with the start index of each row in
  *                      indices and values.
- * @param index         array of size [num_new_nz] with column indices
- * @param value         array of size [num_new_nz] with column values
+ * @param index         An array of size [num_new_nz] with column indices.
+ * @param value         An array of size [num_new_nz] with column values.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1152,8 +1171,8 @@ HighsInt Highs_addRows(void* highs, const HighsInt num_new_row,
  * Change the objective sense of the model.
  *
  * @param highs     A pointer to the Highs instance.
- * @param sense     the new optimization sense in the form of a `kHighsObjSense`
- *                  constant
+ * @param sense     The new optimization sense in the form of a `kHighsObjSense`
+ *                  constant.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1163,7 +1182,7 @@ HighsInt Highs_changeObjectiveSense(void* highs, const HighsInt sense);
  * Change the objective offset of the model.
  *
  * @param highs     A pointer to the Highs instance.
- * @param offset    the new objective offset
+ * @param offset    The new objective offset.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1173,9 +1192,9 @@ HighsInt Highs_changeObjectiveOffset(void* highs, const double offset);
  * Change the integrality of a column.
  *
  * @param highs         A pointer to the Highs instance.
- * @param col           the column index to change
- * @param integrality   the new integrality of the column in the form of a
- *                      `kHighsVarType` constant
+ * @param col           The column index to change.
+ * @param integrality   The new integrality of the column in the form of a
+ *                      `kHighsVarType` constant.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1186,12 +1205,12 @@ HighsInt Highs_changeColIntegrality(void* highs, const HighsInt col,
  * Change the integrality of multiple adjacent columns.
  *
  * @param highs         A pointer to the Highs instance.
- * @param from_col      the index of the first column whose integrality changes
- * @param to_col        the index of the last column whose integrality
- *                      changes
- * @param integrality   an array of length [to_col - from_col + 1] with the new
+ * @param from_col      The index of the first column whose integrality changes.
+ * @param to_col        The index of the last column whose integrality
+ *                      changes.
+ * @param integrality   An array of length [to_col - from_col + 1] with the new
  *                      integralities of the columns in the form of
- *                      `kHighsVarType` constants
+ *                      `kHighsVarType` constants.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1204,12 +1223,12 @@ HighsInt Highs_changeColsIntegralityByRange(void* highs,
  * Change the integrality of multiple columns given by an array of indices.
  *
  * @param highs             A pointer to the Highs instance.
- * @param num_set_entries   the number of columns to change
- * @param set               an array of size [num_set_entries] with the indices
- *                          of the columns to change
- * @param integrality       an array of length [num_set_entries] with the new
+ * @param num_set_entries   The number of columns to change.
+ * @param set               An array of size [num_set_entries] with the indices
+ *                          of the columns to change.
+ * @param integrality       An array of length [num_set_entries] with the new
  *                          integralities of the columns in the form of
- *                          `kHighsVarType` constants
+ *                          `kHighsVarType` constants.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1222,11 +1241,11 @@ HighsInt Highs_changeColsIntegralityBySet(void* highs,
  * Change the integrality of multiple columns given by a mask.
  *
  * @param highs         A pointer to the Highs instance.
- * @param mask          an array of length [num_col] with 1 if the column
- *                      integrality should be changed and 0 otherwise
- * @param integrality   an array of length [num_col] with the new
+ * @param mask          An array of length [num_col] with 1 if the column
+ *                      integrality should be changed and 0 otherwise.
+ * @param integrality   An array of length [num_col] with the new
  *                      integralities of the columns in the form of
- *                      `kHighsVarType` constants
+ *                      `kHighsVarType` constants.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1237,8 +1256,8 @@ HighsInt Highs_changeColsIntegralityByMask(void* highs, const HighsInt* mask,
  * Change the objective coefficient of a column.
  *
  * @param highs     A pointer to the Highs instance.
- * @param col       the index of the column fo change
- * @param cost      the new objective coefficient
+ * @param col       The index of the column fo change.
+ * @param cost      The new objective coefficient.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1249,10 +1268,10 @@ HighsInt Highs_changeColCost(void* highs, const HighsInt col,
  * Change the cost coefficients of multiple adjacent columns.
  *
  * @param highs     A pointer to the Highs instance.
- * @param from_col  the index of the first column whose cost changes
- * @param to_col    the index of the last column whose cost changes
- * @param cost      an array of length [to_col - from_col + 1] with the new
- *                  objective coefficients
+ * @param from_col  The index of the first column whose cost changes.
+ * @param to_col    The index of the last column whose cost changes.
+ * @param cost      An array of length [to_col - from_col + 1] with the new
+ *                  objective coefficients.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1263,10 +1282,10 @@ HighsInt Highs_changeColsCostByRange(void* highs, const HighsInt from_col,
  * Change the cost of multiple columns given by an array of indices.
  *
  * @param highs             A pointer to the Highs instance.
- * @param num_set_entries   the number of columns to change
- * @param set               an array of size [num_set_entries] with the indices
- *                          of the columns to change
- * @param cost              an array of length [num_set_entries] with the new
+ * @param num_set_entries   The number of columns to change.
+ * @param set               An array of size [num_set_entries] with the indices
+ *                          of the columns to change.
+ * @param cost              An array of length [num_set_entries] with the new
  *                          costs of the columns.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
@@ -1278,9 +1297,9 @@ HighsInt Highs_changeColsCostBySet(void* highs, const HighsInt num_set_entries,
  * Change the cost of multiple columns given by a mask.
  *
  * @param highs     A pointer to the Highs instance.
- * @param mask      an array of length [num_col] with 1 if the column
- *                  cost should be changed and 0 otherwise
- * @param cost      an array of length [num_col] with the new costs
+ * @param mask      An array of length [num_col] with 1 if the column
+ *                  cost should be changed and 0 otherwise.
+ * @param cost      An array of length [num_col] with the new costs.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1291,9 +1310,9 @@ HighsInt Highs_changeColsCostByMask(void* highs, const HighsInt* mask,
  * Change the variable bounds of a column.
  *
  * @param highs     A pointer to the Highs instance.
- * @param col       the index of the column whose bounds are to change
- * @param lower     the new lower bound
- * @param upper     the new upper bound
+ * @param col       The index of the column whose bounds are to change.
+ * @param lower     The new lower bound.
+ * @param upper     The new upper bound.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1304,12 +1323,12 @@ HighsInt Highs_changeColBounds(void* highs, const HighsInt col,
  * Change the variable bounds of multiple adjacent columns.
  *
  * @param highs     A pointer to the Highs instance.
- * @param from_col  the index of the first column whose bound changes
- * @param to_col    the index of the last column whose bound changes
- * @param lower     an array of length [to_col - from_col + 1] with the new
- *                  lower bounds
- * @param upper     an array of length [to_col - from_col + 1] with the new
- *                  upper bounds
+ * @param from_col  The index of the first column whose bound changes.
+ * @param to_col    The index of the last column whose bound changes.
+ * @param lower     An array of length [to_col - from_col + 1] with the new
+ *                  lower bounds.
+ * @param upper     An array of length [to_col - from_col + 1] with the new
+ *                  upper bounds.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1322,13 +1341,13 @@ HighsInt Highs_changeColsBoundsByRange(void* highs, const HighsInt from_col,
  * Change the bounds of multiple columns given by an array of indices.
  *
  * @param highs             A pointer to the Highs instance.
- * @param num_set_entries   the number of columns to change
- * @param set               an array of size [num_set_entries] with the indices
- *                          of the columns to change
- * @param lower             an array of length [num_set_entries] with the new
- *                          lower bounds
- * @param upper             an array of length [num_set_entries] with the new
- *                          upper bounds
+ * @param num_set_entries   The number of columns to change.
+ * @param set               An array of size [num_set_entries] with the indices
+ *                          of the columns to change.
+ * @param lower             An array of length [num_set_entries] with the new
+ *                          lower bounds.
+ * @param upper             An array of length [num_set_entries] with the new
+ *                          upper bounds.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1341,10 +1360,10 @@ HighsInt Highs_changeColsBoundsBySet(void* highs,
  * Change the variable bounds of multiple columns given by a mask.
  *
  * @param highs     A pointer to the Highs instance.
- * @param mask      an array of length [num_col] with 1 if the column
- *                  bounds should be changed and 0 otherwise
- * @param lower     an array of length [num_col] with the new lower bounds
- * @param upper     an array of length [num_col] with the new upper bounds
+ * @param mask      An array of length [num_col] with 1 if the column
+ *                  bounds should be changed and 0 otherwise.
+ * @param lower     An array of length [num_col] with the new lower bounds.
+ * @param upper     An array of length [num_col] with the new upper bounds.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1355,9 +1374,9 @@ HighsInt Highs_changeColsBoundsByMask(void* highs, const HighsInt* mask,
  * Change the bounds of a row.
  *
  * @param highs     A pointer to the Highs instance.
- * @param row       the index of the row whose bounds are to change
- * @param lower     the new lower bound
- * @param upper     the new upper bound
+ * @param row       The index of the row whose bounds are to change.
+ * @param lower     The new lower bound.
+ * @param upper     The new upper bound.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
@@ -1368,13 +1387,13 @@ HighsInt Highs_changeRowBounds(void* highs, const HighsInt row,
  * Change the bounds of multiple rows given by an array of indices.
  *
  * @param highs             A pointer to the Highs instance.
- * @param num_set_entries   the number of rows to change
- * @param set               an array of size [num_set_entries] with the indices
- *                          of the rows to change
- * @param lower             an array of length [num_set_entries] with the new
- *                          lower bounds
- * @param upper             an array of length [num_set_entries] with the new
- *                          upper bounds
+ * @param num_set_entries   The number of rows to change.
+ * @param set               An array of size [num_set_entries] with the indices
+ *                          of the rows to change.
+ * @param lower             An array of length [num_set_entries] with the new
+ *                          lower bounds.
+ * @param upper             An array of length [num_set_entries] with the new
+ *                          upper bounds.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -91,19 +91,19 @@ extern "C" {
 /**
  * Formulate and solve a linear program using HiGHS.
  *
- * @param num_col   the number of columns
- * @param num_row   the number of rows
- * @param num_nz    the number of nonzeros in the constraint matrix
- * @param a_format  the format of the constraint matrix as a
- *                  `kHighsMatrixFormat` constant
- * @param sense     the optimization sense as a `kHighsObjSense` constant
- * @param offset    the objective constant
- * @param col_cost  array of length [num_col] with the column costs
- * @param col_lower array of length [num_col] with the column lower bounds
- * @param col_upper array of length [num_col] with the column upper bounds
- * @param row_lower array of length [num_row] with the row lower bounds
- * @param row_upper array of length [num_row] with the row upper bounds
- * @param a_start   the constraint matrix is provided to HiGHS in compressed
+ * @param num_col   The number of columns.
+ * @param num_row   The number of rows.
+ * @param num_nz    The number of nonzeros in the constraint matrix.
+ * @param a_format  The format of the constraint matrix as a
+ *                  `kHighsMatrixFormat` constant.
+ * @param sense     The optimization sense as a `kHighsObjSense` constant.
+ * @param offset    The objective constant.
+ * @param col_cost  An array of length [num_col] with the column costs.
+ * @param col_lower An array of length [num_col] with the column lower bounds.
+ * @param col_upper An array of length [num_col] with the column upper bounds.
+ * @param row_lower An array of length [num_row] with the row lower bounds.
+ * @param row_upper An array of length [num_row] with the row upper bounds.
+ * @param a_start   The constraint matrix is provided to HiGHS in compressed
  *                  sparse column form (if `a_format` is
  *                  `kHighsMatrixFormatColwise`, otherwise compressed sparse row
  *                  form). The sparse matrix consists of three arrays,
@@ -112,27 +112,28 @@ extern "C" {
  *                  column in `a_index`. If `a_format` is
  *                  `kHighsMatrixFormatRowwise` the array is of length [num_row]
  *                  corresponding to each row.
- * @param a_index   array of length [num_nz] with indices of matrix entries
- * @param a_value   array of length [num_nz] with values of matrix entries
+ * @param a_index   An array of length [num_nz] with indices of matrix entries.
+ * @param a_value   An array of length [num_nz] with values of matrix entries.
  *
- * @param col_value      array of length [num_col], filled with the primal
- *                       column solution
- * @param col_dual       array of length [num_col], filled with the dual column
- *                       solution
- * @param row_value      array of length [num_row], filled with the primal row
- *                       solution
- * @param row_dual       array of length [num_row], filled with the dual row
- *                       solution
- * @param col_basis_status  array of length [num_col], filled with the basis
- *                          status of the columns in the form of a
- *                          `kHighsBasisStatus` constant
- * @param row_basis_status  array of length [num_row], filled with the basis
- *                          status of the rows in the form of a
- *                          `kHighsBasisStatus` constant
- * @param model_status      termination status of the model after the solve in
- *                          the form of a `kHighsModelStatus` constant
+ * @param col_value      An array of length [num_col], to be filled with the
+ *                       primal column solution.
+ * @param col_dual       An array of length [num_col], to be filled with the
+ *                       dual column solution.
+ * @param row_value      An array of length [num_row], to be filled with the
+ *                       primal row solution.
+ * @param row_dual       An array of length [num_row], to be filled with the
+ *                       dual row solution.
+ * @param col_basis_status  An array of length [num_col], to be filled with the
+ *                          basis status of the columns in the form of a
+ *                          `kHighsBasisStatus` constant.
+ * @param row_basis_status  An array of length [num_row], to be filled with the
+ *                          basis status of the rows in the form of a
+ *                          `kHighsBasisStatus` constant.
+ * @param model_status      The location in which to place the termination
+ *                          status of the model after the solve in the form of a
+ *                          `kHighsModelStatus` constant.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_lpCall(const HighsInt num_col, const HighsInt num_row,
                       const HighsInt num_nz, const HighsInt a_format,
@@ -152,10 +153,10 @@ HighsInt Highs_lpCall(const HighsInt num_col, const HighsInt num_row,
  * has an additional `integrality` argument, and that it is missing the
  * `col_dual`, `row_dual`, `col_basis_status` and `row_basis_status` arguments.
  *
- * @param integrality   array of length [num_col] containing a `kHighsVarType`
- *                      constant for each column
+ * @param integrality   An array of length [num_col], containing a
+ *                      `kHighsVarType` constant for each column.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_mipCall(const HighsInt num_col, const HighsInt num_row,
                        const HighsInt num_nz, const HighsInt a_format,
@@ -172,18 +173,19 @@ HighsInt Highs_mipCall(const HighsInt num_col, const HighsInt num_row,
  *
  * The signature of this method is identical to `Highs_lpCall`, except that it
  * has additional arguments for specifying the Hessian matrix.
-
- * @param q_num_nz  the number of nonzeros in the Hessian matrix
- * @param q_format  the format of the Hessian matrix in the form of a
+ *
+ * @param q_num_nz  The number of nonzeros in the Hessian matrix.
+ * @param q_format  The format of the Hessian matrix in the form of a
  *                  `kHighsHessianStatus` constant. If q_num_nz > 0, this must
-                    be `kHighsHessianFormatTriangular`
- * @param q_start   the Hessian matrix is provided in the same format as the
+ *                  be `kHighsHessianFormatTriangular`.
+ * @param q_start   The Hessian matrix is provided in the same format as the
  *                  constraint matrix, using `q_start`, `q_index`, and `q_value`
- *                  in the place of `a_start`, `a_index`, and `a_value`
- * @param q_index   array of length [q_num_nz] with indices of matrix entries
- * @param q_value   array of length [q_num_nz] with values of matrix entries
-  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ *                  in the place of `a_start`, `a_index`, and `a_value`.
+ * @param q_index   An array of length [q_num_nz] with indices of matrix
+ *                  sentries.
+ * @param q_value   An array of length [q_num_nz] with values of matrix entries.
+ *
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_qpCall(
     const HighsInt num_col, const HighsInt num_row, const HighsInt num_nz,
@@ -201,7 +203,7 @@ HighsInt Highs_qpCall(
  *
  * Call `Highs_destroy` on the returned reference to clean up allocated memory.
  *
- * @returns A pointer to the Highs instance
+ * @returns A pointer to the Highs instance.
  */
 void* Highs_create(void);
 
@@ -211,80 +213,80 @@ void* Highs_create(void);
  *
  * To empty a model without invalidating `highs`, see `Highs_clearModel`.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  */
 void Highs_destroy(void* highs);
 
 /**
- * Return the HiGHS version number vX.Y.Z
+ * Return the HiGHS version number as a string of the form "vX.Y.Z".
  *
- * @returns the HiGHS version as a char*
+ * @returns The HiGHS version as a `char*`.
  */
 const char* Highs_version(void);
 
 /**
- * Return the HiGHS major version number
+ * Return the HiGHS major version number.
  *
- * @returns the HiGHS major version number
+ * @returns The HiGHS major version number.
  */
-HighsInt Highs_versionMajor();
+HighsInt Highs_versionMajor(void);
 
 /**
- * Return the HiGHS minor version number
+ * Return the HiGHS minor version number.
  *
- * @returns the HiGHS minor version number
+ * @returns The HiGHS minor version number.
  */
-HighsInt Highs_versionMinor();
+HighsInt Highs_versionMinor(void);
 
 /**
- * Return the HiGHS patch version number
+ * Return the HiGHS patch version number.
  *
- * @returns the HiGHS patch version number
+ * @returns The HiGHS patch version number.
  */
-HighsInt Highs_versionPatch();
+HighsInt Highs_versionPatch(void);
 
 /**
- * Return the HiGHS githash
+ * Return the HiGHS githash.
  *
- * @returns the HiGHS githash
+ * @returns The HiGHS githash.
  */
 const char* Highs_githash(void);
 
 /**
- * Return the HiGHS compilation date
+ * Return the HiGHS compilation date.
  *
- * @returns the HiGHS compilation date
+ * @returns Thse HiGHS compilation date.
  */
 const char* Highs_compilationDate(void);
 
 /**
  * Read a model from `filename` into `highs`.
  *
- * @param highs     a pointer to the Highs instance
- * @param filename  the filename to read
+ * @param highs     A pointer to the Highs instance.
+ * @param filename  The filename to read.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_readModel(void* highs, const char* filename);
 
 /**
  * Write the model in `highs` to `filename`.
  *
- * @param highs     a pointer to the Highs instance
- * @param filename  the filename to write.
+ * @param highs     A pointer to the Highs instance.
+ * @param filename  The filename to write.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_writeModel(void* highs, const char* filename);
 
 /**
- * Reset the options and then calls clearModel()
+ * Reset the options and then call `clearModel`.
  *
  * See `Highs_destroy` to free all associated memory.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_clear(void* highs);
 
@@ -293,20 +295,20 @@ HighsInt Highs_clear(void* highs);
  * invalidate the pointer `highs`. Future calls (for example, adding new
  * variables and constraints) are allowed.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_clearModel(void* highs);
 
 /**
- * Clear all solution data associated with the model
+ * Clear all solution data associated with the model.
  *
  * See `Highs_destroy` to clear the model and free all associated memory.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_clearSolver(void* highs);
 
@@ -314,9 +316,9 @@ HighsInt Highs_clearSolver(void* highs);
  * Optimize a model. The algorithm used by HiGHS depends on the options that
  * have been set.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_run(void* highs);
 
@@ -326,10 +328,10 @@ HighsInt Highs_run(void* highs);
  *
  * See also: `Highs_writeSolutionPretty`.
  *
- * @param highs     a pointer to the Highs instance
- * @param filename  the name of the file to write the results to
+ * @param highs     A pointer to the Highs instance.
+ * @param filename  The name of the file to write the results to.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_writeSolution(const void* highs, const char* filename);
 
@@ -340,10 +342,10 @@ HighsInt Highs_writeSolution(const void* highs, const char* filename);
  * The method identical to `Highs_writeSolution`, except that the
  * printout is in a human-readiable format.
  *
- * @param highs     a pointer to the Highs instance
- * @param filename  the name of the file to write the results to
+ * @param highs     A pointer to the Highs instance.
+ * @param filename  The name of the file to write the results to.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_writeSolutionPretty(const void* highs, const char* filename);
 
@@ -354,7 +356,7 @@ HighsInt Highs_writeSolutionPretty(const void* highs, const char* filename);
  * arguments for passing the Hessian matrix of a quadratic program and the
  * integrality vector.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_passLp(void* highs, const HighsInt num_col,
                       const HighsInt num_row, const HighsInt num_nz,
@@ -372,7 +374,7 @@ HighsInt Highs_passLp(void* highs, const HighsInt num_col,
  * The signature of function is identical to `Highs_passModel`, without the
  * arguments for passing the Hessian matrix of a quadratic program.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_passMip(void* highs, const HighsInt num_col,
                        const HighsInt num_row, const HighsInt num_nz,
@@ -387,24 +389,25 @@ HighsInt Highs_passMip(void* highs, const HighsInt num_col,
  * Pass a model to HiGHS in a single function call. This is faster than
  * constructing the model using `Highs_addRow` and `Highs_addCol`.
  *
- * @param highs       a pointer to the Highs instance
- * @param num_col     the number of columns
- * @param num_row     the number of rows
- * @param num_nz      the number of elements in the constraint matrix
- * @param q_num_nz    the number of elements in the Hessian matrix
- * @param a_format    the format of the constraint matrix to use in th form of a
- *                    `kHighsMatrixFormat` constant
- * @param q_format    the format of the Hessian matrix to use in the form of a
- *                    `kHighsHessianFormat` constant
- * @param sense       the optimization sense in the form of a `kHighsObjSense`
- *                    constant
- * @param offset      the constant term in the objective function
- * @param col_cost    array of length [num_col] with the objective coefficients
- * @param col_lower   array of length [num_col] with the lower column bounds
- * @param col_upper   array of length [num_col] with the upper column bounds
- * @param row_lower   array of length [num_row] with the upper row bounds
- * @param row_upper   array of length [num_row] with the upper row bounds
- * @param a_start     the constraint matrix is provided to HiGHS in compressed
+ * @param highs       A pointer to the Highs instance.
+ * @param num_col     The number of columns.
+ * @param num_row     The number of rows.
+ * @param num_nz      The number of elements in the constraint matrix.
+ * @param q_num_nz    The number of elements in the Hessian matrix.
+ * @param a_format    The format of the constraint matrix to use in the form of
+ *                    a `kHighsMatrixFormat` constant.
+ * @param q_format    The format of the Hessian matrix to use in the form of a
+ *                    `kHighsHessianFormat` constant.
+ * @param sense       The optimization sense in the form of a `kHighsObjSense`
+ *                    constant.
+ * @param offset      The constant term in the objective function.
+ * @param col_cost    An array of length [num_col] with the objective
+ *                    coefficients.
+ * @param col_lower   An array of length [num_col] with the lower column bounds.
+ * @param col_upper   An array of length [num_col] with the upper column bounds.
+ * @param row_lower   An array of length [num_row] with the upper row bounds.
+ * @param row_upper   An array of length [num_row] with the upper row bounds.
+ * @param a_start     The constraint matrix is provided to HiGHS in compressed
  *                    sparse column form (if `a_format` is
  *                    `kHighsMatrixFormatColwise`, otherwise compressed sparse
  *                    row form). The sparse matrix consists of three arrays,
@@ -413,20 +416,21 @@ HighsInt Highs_passMip(void* highs, const HighsInt num_col,
  *                    column in `a_index`. If `a_format` is
  *                    `kHighsMatrixFormatRowwise` the array is of length
  *                    [num_row] corresponding to each row.
- * @param a_index     array of length [num_nz] with indices of matrix entries
- * @param a_value     array of length [num_nz] with values of matrix entries
- * @param q_start     the Hessian matrix is provided in the same format as the
+ * @param a_index     An array of length [num_nz] with indices of matrix
+ *                    entries.
+ * @param a_value     An array of length [num_nz] with values of matrix entries.
+ * @param q_start     The Hessian matrix is provided in the same format as the
  *                    constraint matrix, using `q_start`, `q_index`, and
  *                    `q_value` in the place of `a_start`, `a_index`, and
  *                    `a_value`. If the model is linear, pass NULL.
- * @param q_index     array of length [q_num_nz] with indices of matrix entries.
- *                    If the model is linear, pass NULL.
- * @param q_value     array of length [q_num_nz] with values of matrix entries.
- *                    If the model is linear, pass NULL.
- * @param integrality an array of length [num_col] containing a `kHighsVarType`
- *                    consatnt for each column
+ * @param q_index     An array of length [q_num_nz] with indices of matrix
+ *                    entries. If the model is linear, pass NULL.
+ * @param q_value     An array of length [q_num_nz] with values of matrix
+ *                     entries. If the model is linear, pass NULL.
+ * @param integrality An array of length [num_col] containing a `kHighsVarType`
+ *                    consatnt for each column.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_passModel(void* highs, const HighsInt num_col,
                          const HighsInt num_row, const HighsInt num_nz,
@@ -443,20 +447,20 @@ HighsInt Highs_passModel(void* highs, const HighsInt num_col,
 /**
  * Set the Hessian matrix for a quadratic objective.
  *
- * @param highs     a pointer to the Highs instance
- * @param dim       the dimension of the Hessian matrix. Should be [num_col].
- * @param num_nz    the number of non-zero elements in the Hessian matrix
- * @param format    the format of the Hessian matrix as a `kHighsHessianFormat`
+ * @param highs     A pointer to the Highs instance.
+ * @param dim       The dimension of the Hessian matrix. Should be [num_col].
+ * @param num_nz    The number of non-zero elements in the Hessian matrix.
+ * @param format    The format of the Hessian matrix as a `kHighsHessianFormat`
  *                  constant. This must be `kHighsHessianFormatTriangular`.
- * @param start     the Hessian matrix is provided to HiGHS as the upper
+ * @param start     The Hessian matrix is provided to HiGHS as the upper
  *                  triangular component in compressed sparse column form. The
  *                  sparse matrix consists of three arrays, `start`, `index`,
  *                  and `value`. `start` is an array of length [num_col]
  *                  containing the starting index of each column in `index`.
- * @param index     array of length [num_nz] with indices of matrix entries
- * @param value     array of length [num_nz] with values of matrix entries
+ * @param index     An array of length [num_nz] with indices of matrix entries.
+ * @param value     An array of length [num_nz] with values of matrix entries.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_passHessian(void* highs, const HighsInt dim,
                            const HighsInt num_nz, const HighsInt format,
@@ -464,23 +468,25 @@ HighsInt Highs_passHessian(void* highs, const HighsInt dim,
                            const double* value);
 
 /**
- * Pass the name of a row
+ * Pass the name of a row.
  *
- * @param row   the row for which the name is supplied
- * @param name  the name of the row
+ * @param highs A pointer to the Highs instance.
+ * @param row   The row for which the name is supplied.
+ * @param name  The name of the row.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_passRowName(const void* highs, const HighsInt row,
                            const char* name);
 
 /**
- * Pass the name of a column
+ * Pass the name of a column.
  *
- * @param col   the column for which the name is supplied
- * @param name  the name of the column
+ * @param highs A pointer to the Highs instance.
+ * @param col   The column for which the name is supplied.
+ * @param name  The name of the column.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_passColName(const void* highs, const HighsInt col,
                            const char* name);
@@ -488,11 +494,11 @@ HighsInt Highs_passColName(const void* highs, const HighsInt col,
 /**
  * Set a boolean-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The new value of the option.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setBoolOptionValue(void* highs, const char* option,
                                   const HighsInt value);
@@ -500,11 +506,11 @@ HighsInt Highs_setBoolOptionValue(void* highs, const char* option,
 /**
  * Set an int-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The new value of the option.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setIntOptionValue(void* highs, const char* option,
                                  const HighsInt value);
@@ -512,11 +518,11 @@ HighsInt Highs_setIntOptionValue(void* highs, const char* option,
 /**
  * Set a double-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The new value of the option.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setDoubleOptionValue(void* highs, const char* option,
                                     const double value);
@@ -524,11 +530,11 @@ HighsInt Highs_setDoubleOptionValue(void* highs, const char* option,
 /**
  * Set a string-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The new value of the option.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setStringOptionValue(void* highs, const char* option,
                                     const char* value);
@@ -536,11 +542,12 @@ HighsInt Highs_setStringOptionValue(void* highs, const char* option,
 /**
  * Get a boolean-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     storage for the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The location in which the current value of the option should
+ *                  be placed.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBoolOptionValue(const void* highs, const char* option,
                                   HighsInt* value);
@@ -548,11 +555,12 @@ HighsInt Highs_getBoolOptionValue(const void* highs, const char* option,
 /**
  * Get an int-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     storage for the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The location in which the current value of the option should
+ *                  be placed.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getIntOptionValue(const void* highs, const char* option,
                                  HighsInt* value);
@@ -560,11 +568,12 @@ HighsInt Highs_getIntOptionValue(const void* highs, const char* option,
 /**
  * Get a double-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     storage for the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     The location in which the current value of the option should
+ *                  be placed.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getDoubleOptionValue(const void* highs, const char* option,
                                     double* value);
@@ -572,11 +581,13 @@ HighsInt Highs_getDoubleOptionValue(const void* highs, const char* option,
 /**
  * Get a string-valued option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param value     pointer to allocated memory to store the value of the option
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param value     A pointer to allocated memory (of at least
+ *                  `kMaximumStringLength`) to store the current value of the
+ *                  option.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getStringOptionValue(const void* highs, const char* option,
                                     char* value);
@@ -584,12 +595,12 @@ HighsInt Highs_getStringOptionValue(const void* highs, const char* option,
 /**
  * Get the type expected by an option.
  *
- * @param highs     a pointer to the Highs instance
- * @param option    the name of the option
- * @param type      int in which the corresponding `kHighsOptionType` constant
- *                  is stored
+ * @param highs     A pointer to the Highs instance.
+ * @param option    The name of the option.
+ * @param type      An int in which the corresponding `kHighsOptionType`
+ *                  constant should be placed.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getOptionType(const void* highs, const char* option,
                              HighsInt* type);
@@ -597,19 +608,19 @@ HighsInt Highs_getOptionType(const void* highs, const char* option,
 /**
  * Reset all options to their default value.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_resetOptions(void* highs);
 
 /**
  * Write the current options to file.
  *
- * @param highs     a pointer to the Highs instance
- * @param filename  the filename to write the options to
+ * @param highs     A pointer to the Highs instance.
+ * @param filename  The filename to write the options to.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_writeOptions(const void* highs, const char* filename);
 
@@ -619,28 +630,28 @@ HighsInt Highs_writeOptions(const void* highs, const char* filename);
  * This is similar to `Highs_writeOptions`, except only options with
  * non-default value are written to `filename`.
  *
- * @param highs     a pointer to the Highs instance
- * @param filename  the filename to write the options to
+ * @param highs     A pointer to the Highs instance.
+ * @param filename  The filename to write the options to.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_writeOptionsDeviations(const void* highs, const char* filename);
 
 /**
  * Return the number of options
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  */
 HighsInt Highs_getNumOptions(const void* highs);
 
 /**
  * Get the name of an option identified by index
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param index     the index of the option
  * @param name      the name of the option
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getOptionName(const void* highs, const HighsInt index,
                              char** name);
@@ -648,11 +659,11 @@ HighsInt Highs_getOptionName(const void* highs, const HighsInt index,
 /**
  * Get the current and default values of a bool option
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param current_value a pointer to the current value of the option
  * @param default_value a pointer to the default value of the option
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBoolOptionValues(const void* highs, const char* option,
                                    HighsInt* current_value,
@@ -660,13 +671,13 @@ HighsInt Highs_getBoolOptionValues(const void* highs, const char* option,
 /**
  * Get the current and default values of an int option
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param current_value a pointer to the current value of the option
  * @param min_value     a pointer to the minimum value of the option
  * @param max_value     a pointer to the maximum value of the option
  * @param default_value a pointer to the default value of the option
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getIntOptionValues(const void* highs, const char* option,
                                   HighsInt* current_value, HighsInt* min_value,
@@ -675,13 +686,13 @@ HighsInt Highs_getIntOptionValues(const void* highs, const char* option,
 /**
  * Get the current and default values of a double option
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param current_value a pointer to the current value of the option
  * @param min_value     a pointer to the minimum value of the option
  * @param max_value     a pointer to the maximum value of the option
  * @param default_value a pointer to the default value of the option
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getDoubleOptionValues(const void* highs, const char* option,
                                      double* current_value, double* min_value,
@@ -690,11 +701,11 @@ HighsInt Highs_getDoubleOptionValues(const void* highs, const char* option,
 /**
  * Get the current and default values of a string option
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param current_value a pointer to the current value of the option
  * @param default_value a pointer to the default value of the option
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getStringOptionValues(const void* highs, const char* option,
                                      char* current_value, char* default_value);
@@ -702,11 +713,11 @@ HighsInt Highs_getStringOptionValues(const void* highs, const char* option,
 /**
  * Get an int-valued info value.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param info      the name of the info item
  * @param value     a reference to an integer that the result will be stored in
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getIntInfoValue(const void* highs, const char* info,
                                HighsInt* value);
@@ -714,11 +725,11 @@ HighsInt Highs_getIntInfoValue(const void* highs, const char* info,
 /**
  * Get a double-valued info value.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param info      the name of the info item
  * @param value     a reference to an double that the result will be stored in
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getDoubleInfoValue(const void* highs, const char* info,
                                   double* value);
@@ -726,11 +737,11 @@ HighsInt Highs_getDoubleInfoValue(const void* highs, const char* info,
 /**
  * Get an int64-valued info value.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param info      the name of the info item
  * @param value     a reference to a int64 that the result will be stored in
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getInt64InfoValue(const void* highs, const char* info,
                                  int64_t* value);
@@ -738,25 +749,25 @@ HighsInt Highs_getInt64InfoValue(const void* highs, const char* info,
 /**
  * Get the type expected by an info item.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param info      the name of the info item
  * @param type      int in which the corresponding `kHighsOptionType` constant
  *                  is stored
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getInfoType(const void* highs, const char* info, HighsInt* type);
 
 /**
  * Get the primal and dual solution from an optimized model.
  *
- * @param highs      a pointer to the Highs instance
+ * @param highs      A pointer to the Highs instance.
  * @param col_value  array of length [num_col], filled with primal column values
  * @param col_dual   array of length [num_col], filled with dual column values
  * @param row_value  array of length [num_row], filled with primal row values
  * @param row_dual   array of length [num_row], filled with dual row values
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getSolution(const void* highs, double* col_value,
                            double* col_dual, double* row_value,
@@ -766,7 +777,7 @@ HighsInt Highs_getSolution(const void* highs, double* col_value,
  * Given a linear program with a basic feasible solution, get the column and row
  * basis statuses.
  *
- * @param highs       a pointer to the Highs instance
+ * @param highs       A pointer to the Highs instance.
  * @param col_status  array of length [num_col], to be filled with the column
  *                    basis statuses in the form of a `kHighsBasisStatus`
  *                    constant
@@ -774,7 +785,7 @@ HighsInt Highs_getSolution(const void* highs, double* col_value,
  *                    basis statuses in the form of a `kHighsBasisStatus`
  *                    constant
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBasis(const void* highs, HighsInt* col_status,
                         HighsInt* row_status);
@@ -783,22 +794,22 @@ HighsInt Highs_getBasis(const void* highs, HighsInt* col_status,
  * Return the optimization status of the model in the form of a
  * `kHighsModelStatus` constant.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns an integer corresponding to the `kHighsModelStatus` constant
+ * @returns An integer corresponding to the `kHighsModelStatus` constant
  */
 HighsInt Highs_getModelStatus(const void* highs);
 
 /**
  * Get an unbounded dual ray that is a certificate of primal infeasibility.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param has_dual_ray      a pointer to an int to store 1 if the dual ray
  *                          exists
  * @param dual_ray_value    an array of length [num_row] filled with the
  *                          unbounded ray
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getDualRay(const void* highs, HighsInt* has_dual_ray,
                           double* dual_ray_value);
@@ -806,13 +817,13 @@ HighsInt Highs_getDualRay(const void* highs, HighsInt* has_dual_ray,
 /**
  * Get an unbounded primal ray that is a certificate of dual infeasibility.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param has_primal_ray    a pointer to an int to store 1 if the primal ray
  *                          exists
  * @param primal_ray_value  an array of length [num_col] filled with the
  *                          unbounded ray
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getPrimalRay(const void* highs, HighsInt* has_primal_ray,
                             double* primal_ray_value);
@@ -820,9 +831,9 @@ HighsInt Highs_getPrimalRay(const void* highs, HighsInt* has_primal_ray,
 /**
  * Get the primal objective function value.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the primal objective function value
+ * @returns The primal objective function value
  */
 double Highs_getObjectiveValue(const void* highs);
 
@@ -842,11 +853,11 @@ double Highs_getObjectiveValue(const void* highs);
  *  - `Highs_getReducedRow`
  *  - `Highs_getReducedColumn`
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param basic_variables   array of size [num_rows], filled with the indices of
  *                          the basic variables
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBasicVariables(const void* highs, HighsInt* basic_variables);
 
@@ -859,13 +870,13 @@ HighsInt Highs_getBasicVariables(const void* highs, HighsInt* basic_variables);
  * [num_row]. However, check `row_num_nz` to see how many non-zero elements are
  * actually stored.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param row           index of the row to compute
  * @param row_vector    values of the non-zero elements
  * @param row_num_nz    the number of non-zeros in the row
  * @param row_index     indices of the non-zero elements
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBasisInverseRow(const void* highs, const HighsInt row,
                                   double* row_vector, HighsInt* row_num_nz,
@@ -880,13 +891,13 @@ HighsInt Highs_getBasisInverseRow(const void* highs, const HighsInt row,
  * [num_row]. However, check `col_num_nz` to see how many non-zero elements are
  * actually stored.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param col           index of the column to compute
  * @param col_vector    values of the non-zero elements
  * @param col_num_nz    the number of non-zeros in the column
  * @param col_index     indices of the non-zero elements
 
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBasisInverseCol(const void* highs, const HighsInt col,
                                   double* col_vector, HighsInt* col_num_nz,
@@ -902,13 +913,13 @@ HighsInt Highs_getBasisInverseCol(const void* highs, const HighsInt col,
  * length of [num_row]. However, check `solution_num_nz` to see how many
  * non-zero elements are actually stored.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param rhs               the right-hand side vector `b`
  * @param solution_vector   values of the non-zero elements
  * @param solution_num_nz   the number of non-zeros in the solution
  * @param solution_index    indices of the non-zero elements
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBasisSolve(const void* highs, const double* rhs,
                              double* solution_vector, HighsInt* solution_num_nz,
@@ -924,13 +935,13 @@ HighsInt Highs_getBasisSolve(const void* highs, const double* rhs,
  * length of [num_row]. However, check `solution_num_nz` to see how many
  * non-zero elements are actually stored.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param rhs               the right-hand side vector `b`
  * @param solution_vector   values of the non-zero elements
  * @param solution_num_nz   the number of non-zeros in the solution
  * @param solution_index    indices of the non-zero elements
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getBasisTransposeSolve(const void* highs, const double* rhs,
                                       double* solution_vector,
@@ -946,13 +957,13 @@ HighsInt Highs_getBasisTransposeSolve(const void* highs, const double* rhs,
  * [num_row]. However, check `row_num_nz` to see how many non-zero elements are
  * actually stored.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param row           index of the row to compute
  * @param row_vector    values of the non-zero elements
  * @param row_num_nz    the number of non-zeros in the row
  * @param row_index     indices of the non-zero elements
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getReducedRow(const void* highs, const HighsInt row,
                              double* row_vector, HighsInt* row_num_nz,
@@ -967,13 +978,13 @@ HighsInt Highs_getReducedRow(const void* highs, const HighsInt row,
  * [num_row]. However, check `col_num_nz` to see how many non-zero elements are
  * actually stored.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param col           index of the column to compute
  * @param col_vector    values of the non-zero elements
  * @param col_num_nz    the number of non-zeros in the column
  * @param col_index     indices of the non-zero elements
 
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getReducedColumn(const void* highs, const HighsInt col,
                                 double* col_vector, HighsInt* col_num_nz,
@@ -983,13 +994,13 @@ HighsInt Highs_getReducedColumn(const void* highs, const HighsInt col,
  * Set a basic feasible solution by passing the column and row basis statuses to
  * the model.
  *
- * @param highs       a pointer to the Highs instance
+ * @param highs       A pointer to the Highs instance.
  * @param col_status  an array of length [num_col] with the column basis status
  *                    in the form of `kHighsBasisStatus` constants
  * @param row_status  an array of length [num_row] with the row basis status
  *                    in the form of `kHighsBasisStatus` constants
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setBasis(void* highs, const HighsInt* col_status,
                         const HighsInt* row_status);
@@ -997,9 +1008,9 @@ HighsInt Highs_setBasis(void* highs, const HighsInt* col_status,
 /**
  * Set a logical basis in the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setLogicalBasis(void* highs);
 
@@ -1007,7 +1018,7 @@ HighsInt Highs_setLogicalBasis(void* highs);
  * Set a solution by passing the column and row primal and dual
  * solution values. For any values that are unavailable pass NULL.
  *
- * @param highs       a pointer to the Highs instance
+ * @param highs       A pointer to the Highs instance.
  * @param col_value   an array of length [num_col] with the column solution
  *                    values
  * @param row_value   an array of length [num_row] with the row solution
@@ -1015,7 +1026,7 @@ HighsInt Highs_setLogicalBasis(void* highs);
  * @param col_dual    an array of length [num_col] with the column dual values
  * @param row_dual    an array of length [num_row] with the row dual values
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_setSolution(void* highs, const double* col_value,
                            const double* row_value, const double* col_dual,
@@ -1024,16 +1035,16 @@ HighsInt Highs_setSolution(void* highs, const double* col_value,
 /**
  * Return the cumulative wall-clock time spent in `Highs_run`.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the cumulative wall-clock time spent in `Highs_run`
+ * @returns The cumulative wall-clock time spent in `Highs_run`
  */
 double Highs_getRunTime(const void* highs);
 
 /**
  * Add a new column (variable) to the model.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param cost          objective coefficient of the column
  * @param lower         lower bound of the column
  * @param upper         upper bound of the column
@@ -1041,7 +1052,7 @@ double Highs_getRunTime(const void* highs);
  * @param index         array of size [num_new_nz] with the row indices
  * @param value         array of size [num_new_nz] with row values
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_addCol(void* highs, const double cost, const double lower,
                       const double upper, const HighsInt num_new_nz,
@@ -1050,7 +1061,7 @@ HighsInt Highs_addCol(void* highs, const double cost, const double lower,
 /**
  * Add multiple columns (variables) to the model.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param num_new_col   number of new columns to add
  * @param costs         array of size [num_new_col] with objective coefficients
  * @param lower         array of size [num_new_col] with lower bounds
@@ -1064,7 +1075,7 @@ HighsInt Highs_addCol(void* highs, const double cost, const double lower,
  * @param index         array of size [num_new_nz] with row indices
  * @param value         array of size [num_new_nz] with row values
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_addCols(void* highs, const HighsInt num_new_col,
                        const double* costs, const double* lower,
@@ -1075,23 +1086,23 @@ HighsInt Highs_addCols(void* highs, const HighsInt num_new_col,
 /**
  * Add a new variable to the model.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param lower         lower bound of the column
  * @param upper         upper bound of the column
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_addVar(void* highs, const double lower, const double upper);
 
 /**
  * Add multiple variables to the model.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param num_new_var   number of new variables to add
  * @param lower         array of size [num_new_var] with lower bounds
  * @param upper         array of size [num_new_var] with upper bounds
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_addVars(void* highs, const HighsInt num_new_var,
                        const double* lower, const double* upper);
@@ -1099,14 +1110,14 @@ HighsInt Highs_addVars(void* highs, const HighsInt num_new_var,
 /**
  * Add a new row (a linear constraint) to the model.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param lower         lower bound of the row
  * @param upper         upper bound of the row
  * @param num_new_nz    number of non-zeros in the row
  * @param index         array of size [num_new_nz] with column indices
  * @param value         array of size [num_new_nz] with column values
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_addRow(void* highs, const double lower, const double upper,
                       const HighsInt num_new_nz, const HighsInt* index,
@@ -1115,7 +1126,7 @@ HighsInt Highs_addRow(void* highs, const double lower, const double upper,
 /**
  * Add multiple rows (linear constraints) to the model.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param num_new_row   the number of new rows to add
  * @param lower         array of size [num_new_row] with the lower bounds of the
  *                      rows
@@ -1130,7 +1141,7 @@ HighsInt Highs_addRow(void* highs, const double lower, const double upper,
  * @param index         array of size [num_new_nz] with column indices
  * @param value         array of size [num_new_nz] with column values
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_addRows(void* highs, const HighsInt num_new_row,
                        const double* lower, const double* upper,
@@ -1140,33 +1151,33 @@ HighsInt Highs_addRows(void* highs, const HighsInt num_new_row,
 /**
  * Change the objective sense of the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param sense     the new optimization sense in the form of a `kHighsObjSense`
  *                  constant
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeObjectiveSense(void* highs, const HighsInt sense);
 
 /**
  * Change the objective offset of the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param offset    the new objective offset
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeObjectiveOffset(void* highs, const double offset);
 
 /**
  * Change the integrality of a column.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param col           the column index to change
  * @param integrality   the new integrality of the column in the form of a
  *                      `kHighsVarType` constant
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColIntegrality(void* highs, const HighsInt col,
                                     const HighsInt integrality);
@@ -1174,7 +1185,7 @@ HighsInt Highs_changeColIntegrality(void* highs, const HighsInt col,
 /**
  * Change the integrality of multiple adjacent columns.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param from_col      the index of the first column whose integrality changes
  * @param to_col        the index of the last column whose integrality
  *                      changes
@@ -1182,7 +1193,7 @@ HighsInt Highs_changeColIntegrality(void* highs, const HighsInt col,
  *                      integralities of the columns in the form of
  *                      `kHighsVarType` constants
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsIntegralityByRange(void* highs,
                                             const HighsInt from_col,
@@ -1192,7 +1203,7 @@ HighsInt Highs_changeColsIntegralityByRange(void* highs,
 /**
  * Change the integrality of multiple columns given by an array of indices.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param num_set_entries   the number of columns to change
  * @param set               an array of size [num_set_entries] with the indices
  *                          of the columns to change
@@ -1200,7 +1211,7 @@ HighsInt Highs_changeColsIntegralityByRange(void* highs,
  *                          integralities of the columns in the form of
  *                          `kHighsVarType` constants
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsIntegralityBySet(void* highs,
                                           const HighsInt num_set_entries,
@@ -1210,14 +1221,14 @@ HighsInt Highs_changeColsIntegralityBySet(void* highs,
 /**
  * Change the integrality of multiple columns given by a mask.
  *
- * @param highs         a pointer to the Highs instance
+ * @param highs         A pointer to the Highs instance.
  * @param mask          an array of length [num_col] with 1 if the column
  *                      integrality should be changed and 0 otherwise
  * @param integrality   an array of length [num_col] with the new
  *                      integralities of the columns in the form of
  *                      `kHighsVarType` constants
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsIntegralityByMask(void* highs, const HighsInt* mask,
                                            const HighsInt* integrality);
@@ -1225,11 +1236,11 @@ HighsInt Highs_changeColsIntegralityByMask(void* highs, const HighsInt* mask,
 /**
  * Change the objective coefficient of a column.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param col       the index of the column fo change
  * @param cost      the new objective coefficient
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColCost(void* highs, const HighsInt col,
                              const double cost);
@@ -1237,13 +1248,13 @@ HighsInt Highs_changeColCost(void* highs, const HighsInt col,
 /**
  * Change the cost coefficients of multiple adjacent columns.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param from_col  the index of the first column whose cost changes
  * @param to_col    the index of the last column whose cost changes
  * @param cost      an array of length [to_col - from_col + 1] with the new
  *                  objective coefficients
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsCostByRange(void* highs, const HighsInt from_col,
                                      const HighsInt to_col, const double* cost);
@@ -1251,14 +1262,14 @@ HighsInt Highs_changeColsCostByRange(void* highs, const HighsInt from_col,
 /**
  * Change the cost of multiple columns given by an array of indices.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param num_set_entries   the number of columns to change
  * @param set               an array of size [num_set_entries] with the indices
  *                          of the columns to change
  * @param cost              an array of length [num_set_entries] with the new
  *                          costs of the columns.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsCostBySet(void* highs, const HighsInt num_set_entries,
                                    const HighsInt* set, const double* cost);
@@ -1266,12 +1277,12 @@ HighsInt Highs_changeColsCostBySet(void* highs, const HighsInt num_set_entries,
 /**
  * Change the cost of multiple columns given by a mask.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param mask      an array of length [num_col] with 1 if the column
  *                  cost should be changed and 0 otherwise
  * @param cost      an array of length [num_col] with the new costs
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsCostByMask(void* highs, const HighsInt* mask,
                                     const double* cost);
@@ -1279,12 +1290,12 @@ HighsInt Highs_changeColsCostByMask(void* highs, const HighsInt* mask,
 /**
  * Change the variable bounds of a column.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param col       the index of the column whose bounds are to change
  * @param lower     the new lower bound
  * @param upper     the new upper bound
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColBounds(void* highs, const HighsInt col,
                                const double lower, const double upper);
@@ -1292,7 +1303,7 @@ HighsInt Highs_changeColBounds(void* highs, const HighsInt col,
 /**
  * Change the variable bounds of multiple adjacent columns.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param from_col  the index of the first column whose bound changes
  * @param to_col    the index of the last column whose bound changes
  * @param lower     an array of length [to_col - from_col + 1] with the new
@@ -1300,7 +1311,7 @@ HighsInt Highs_changeColBounds(void* highs, const HighsInt col,
  * @param upper     an array of length [to_col - from_col + 1] with the new
  *                  upper bounds
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsBoundsByRange(void* highs, const HighsInt from_col,
                                        const HighsInt to_col,
@@ -1310,7 +1321,7 @@ HighsInt Highs_changeColsBoundsByRange(void* highs, const HighsInt from_col,
 /**
  * Change the bounds of multiple columns given by an array of indices.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param num_set_entries   the number of columns to change
  * @param set               an array of size [num_set_entries] with the indices
  *                          of the columns to change
@@ -1319,7 +1330,7 @@ HighsInt Highs_changeColsBoundsByRange(void* highs, const HighsInt from_col,
  * @param upper             an array of length [num_set_entries] with the new
  *                          upper bounds
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsBoundsBySet(void* highs,
                                      const HighsInt num_set_entries,
@@ -1329,13 +1340,13 @@ HighsInt Highs_changeColsBoundsBySet(void* highs,
 /**
  * Change the variable bounds of multiple columns given by a mask.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param mask      an array of length [num_col] with 1 if the column
  *                  bounds should be changed and 0 otherwise
  * @param lower     an array of length [num_col] with the new lower bounds
  * @param upper     an array of length [num_col] with the new upper bounds
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeColsBoundsByMask(void* highs, const HighsInt* mask,
                                       const double* lower, const double* upper);
@@ -1343,12 +1354,12 @@ HighsInt Highs_changeColsBoundsByMask(void* highs, const HighsInt* mask,
 /**
  * Change the bounds of a row.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  * @param row       the index of the row whose bounds are to change
  * @param lower     the new lower bound
  * @param upper     the new upper bound
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeRowBounds(void* highs, const HighsInt row,
                                const double lower, const double upper);
@@ -1356,7 +1367,7 @@ HighsInt Highs_changeRowBounds(void* highs, const HighsInt row,
 /**
  * Change the bounds of multiple rows given by an array of indices.
  *
- * @param highs             a pointer to the Highs instance
+ * @param highs             A pointer to the Highs instance.
  * @param num_set_entries   the number of rows to change
  * @param set               an array of size [num_set_entries] with the indices
  *                          of the rows to change
@@ -1365,7 +1376,7 @@ HighsInt Highs_changeRowBounds(void* highs, const HighsInt row,
  * @param upper             an array of length [num_set_entries] with the new
  *                          upper bounds
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeRowsBoundsBySet(void* highs,
                                      const HighsInt num_set_entries,
@@ -1375,13 +1386,13 @@ HighsInt Highs_changeRowsBoundsBySet(void* highs,
 /**
  * Change the bounds of multiple rows given by a mask.
  *
- * @param highs     a pointer to the Highs instance
- * @param mask      an array of length [num_row] with 1 if the row
- *                  bounds should be changed and 0 otherwise
- * @param lower     an array of length [num_row] with the new lower bounds
- * @param upper     an array of length [num_row] with the new upper bounds
+ * @param highs     A pointer to the Highs instance.
+ * @param mask      An array of length [num_row] with 1 if the row
+ *                  bounds should be changed and 0 otherwise.
+ * @param lower     An array of length [num_row] with the new lower bounds.
+ * @param upper     An array of length [num_row] with the new upper bounds.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeRowsBoundsByMask(void* highs, const HighsInt* mask,
                                       const double* lower, const double* upper);
@@ -1389,12 +1400,12 @@ HighsInt Highs_changeRowsBoundsByMask(void* highs, const HighsInt* mask,
 /**
  * Change a coefficient in the constraint matrix.
  *
- * @param highs     a pointer to the Highs instance
- * @param row       the index of the row to change
- * @param col       the index of the col to change
- * @param value     the new constraint coefficient
+ * @param highs     A pointer to the Highs instance.
+ * @param row       The index of the row to change.
+ * @param col       The index of the column to change.
+ * @param value     The new constraint coefficient.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_changeCoeff(void* highs, const HighsInt row, const HighsInt col,
                            const double value);
@@ -1402,58 +1413,60 @@ HighsInt Highs_changeCoeff(void* highs, const HighsInt row, const HighsInt col,
 /**
  * Get the objective sense.
  *
- * @param highs     a pointer to the Highs instance
- * @param sense     stores the current objective sense as a `kHighsObjSense`
- *                  constant
+ * @param highs     A pointer to the Highs instance.
+ * @param sense     The location in which the current objective sense should be
+ *                  placed. The sense is a `kHighsObjSense` constant.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getObjectiveSense(const void* highs, HighsInt* sense);
 
 /**
  * Get the objective offset.
  *
- * @param highs     a pointer to the Highs instance
- * @param offset    stores the current objective offset
+ * @param highs     A pointer to the Highs instance.
+ * @param offset    The location in which the current objective offset should be
+ *                  placed.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getObjectiveOffset(const void* highs, double* offset);
 
 /**
  * Get data associated with multiple adjacent columns from the model.
  *
- * To query the constraint coefficients, this function should be called twice:
- *  - First, call this function with `matrix_start`, `matrix_index`, and
- *    `matrix_value` as `NULL`. This call will populate `num_nz` with the
- *    number of nonzero elements in the corresponding section of the constraint
- *    matrix.
- *  - Second, allocate new `matrix_index` and `matrix_value` arrays of length
- *    `num_nz` and call this function again to populate the new arrays with
- *    their contents.
+ * To query the constraint coefficients, this function should be called twice.
  *
- * @param highs         a pointer to the Highs instance
- * @param from_col      the first column for which to query data for
- * @param to_col        the last column (inclusive) for which to query data for
- * @param num_col       an integer populated with the number of columns got from
- *                      the model (this should equal `to_col - from_col + 1`)
- * @param costs         array of size [to_col - from_col + 1] for the column
- *                      cost coefficients
- * @param lower         array of size [to_col - from_col + 1] for the column
- *                      lower bounds
- * @param upper         array of size [to_col - from_col + 1] for the column
- *                      upper bounds
- * @param num_nz        an integer populated with the number of non-zero
- *                      elements in the constraint matrix
- * @param matrix_start  array of size [to_col - from_col + 1] with the start
- *                      indices of each
- *                      column in `matrix_index` and `matrix_value`
- * @param matrix_index  array of size [num_nz] with the row indices of each
- *                      element in the constraint matrix
- * @param matrix_value  array of size [num_nz] with the non-zero elements of the
- *                      constraint matrix.
+ * First, call this function with `matrix_start`, `matrix_index`, and
+ * `matrix_value` as `NULL`. This call will populate `num_nz` with the number of
+ * nonzero elements in the corresponding section of the constraint matrix.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * Second, allocate new `matrix_index` and `matrix_value` arrays of length
+ * `num_nz` and call this function again to populate the new arrays with their
+ * contents.
+ *
+ * @param highs         A pointer to the Highs instance.
+ * @param from_col      The first column for which to query data for.
+ * @param to_col        The last column (inclusive) for which to query data for.
+ * @param num_col       An integer populated with the number of columns got from
+ *                      the model (this should equal `to_col - from_col + 1`).
+ * @param costs         An array of size [to_col - from_col + 1] for the column
+ *                      cost coefficients.
+ * @param lower         An array of size [to_col - from_col + 1] for the column
+ *                      lower bounds.
+ * @param upper         An array of size [to_col - from_col + 1] for the column
+ *                      upper bounds.
+ * @param num_nz        An integer to be populated with the number of non-zero
+ *                      elements in the constraint matrix.
+ * @param matrix_start  An array of size [to_col - from_col + 1] with the start
+ *                      indices of each column in `matrix_index` and
+ *                      `matrix_value`.
+ * @param matrix_index  An array of size [num_nz] with the row indices of each
+ *                      element in the constraint matrix.
+ * @param matrix_value  An array of size [num_nz] with the non-zero elements of
+ *                      the constraint matrix.
+ *
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getColsByRange(const void* highs, const HighsInt from_col,
                               const HighsInt to_col, HighsInt* num_col,
@@ -1467,11 +1480,11 @@ HighsInt Highs_getColsByRange(const void* highs, const HighsInt from_col,
  * This function is identical to `Highs_getColsByRange`, except for how the
  * columns are specified.
  *
- * @param num_set_indices   the number of indices in the set
- * @param set               array of size [num_set_entries] with the column
- *                          indices to get
+ * @param num_set_indices   The number of indices in `set`.
+ * @param set               An array of size [num_set_entries] with the column
+ *                          indices to get.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getColsBySet(const void* highs, const HighsInt num_set_entries,
                             const HighsInt* set, HighsInt* num_col,
@@ -1485,10 +1498,10 @@ HighsInt Highs_getColsBySet(const void* highs, const HighsInt num_set_entries,
  * This function is identical to `Highs_getColsByRange`, except for how the
  * columns are specified.
  *
- * @param mask  array of length [num_col] containing a 1 to get the column and 0
- *              otherwise
+ * @param mask  An array of length [num_col] containing a `1` to get the column
+ *              and `0` otherwise.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getColsByMask(const void* highs, const HighsInt* mask,
                              HighsInt* num_col, double* costs, double* lower,
@@ -1499,34 +1512,36 @@ HighsInt Highs_getColsByMask(const void* highs, const HighsInt* mask,
 /**
  * Get data associated with multiple adjacent rows from the model.
  *
- * To query the constraint coefficients, this function should be called twice:
- *  - First, call this function with `matrix_start`, `matrix_index`, and
- *    `matrix_value` as `NULL`. This call will populate `num_nz` with the
- *    number of nonzero elements in the corresponding section of the constraint
- *    matrix.
- *  - Second, allocate new `matrix_index` and `matrix_value` arrays of length
- *    `num_nz` and call this function again to populate the new arrays with
- *    their contents.
+ * To query the constraint coefficients, this function should be called twice.
  *
- * @param highs         a pointer to the Highs instance
- * @param from_row      the first row for which to query data for
- * @param to_row        the last row (inclusive) for which to query data for
- * @param num_row       an integer populated with the number of row got from the
- *                      model
- * @param lower         array of size [to_row - from_row + 1] for the row lower
- *                      bounds
- * @param upper         array of size [to_row - from_row + 1] for the row upper
- *                      bounds
- * @param num_nz        an integer populated with the number of non-zero
- *                      elements in the constraint matrix
- * @param matrix_start  array of size [to_row - from_row + 1] with the start
- *                      indices of each row in `matrix_index` and `matrix_value`
- * @param matrix_index  array of size [num_nz] with the column indices of each
- *                      element in the constraint matrix
- * @param matrix_value  array of size [num_nz] with the non-zero elements of the
- *                      constraint matrix.
+ * First, call this function with `matrix_start`, `matrix_index`, and
+ * `matrix_value` as `NULL`. This call will populate `num_nz` with the number of
+ * nonzero elements in the corresponding section of the constraint matrix.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * Second, allocate new `matrix_index` and `matrix_value` arrays of length
+ * `num_nz` and call this function again to populate the new arrays with their
+ * contents.
+ *
+ * @param highs         A pointer to the Highs instance.
+ * @param from_row      The first row for which to query data for.
+ * @param to_row        The last row (inclusive) for which to query data for.
+ * @param num_row       An integer to be populated with the number of rows got
+ *                      from the smodel.
+ * @param lower         An array of size [to_row - from_row + 1] for the row
+ *                      lower bounds.
+ * @param upper         An array of size [to_row - from_row + 1] for the row
+ *                      upper bounds.
+ * @param num_nz        An integer to be populated with the number of non-zero
+ *                      elements in the constraint matrix.
+ * @param matrix_start  An array of size [to_row - from_row + 1] with the start
+ *                      indices of each row in `matrix_index` and
+ *                      `matrix_value`.
+ * @param matrix_index  An array of size [num_nz] with the column indices of
+ *                      each element in the constraint matrix.
+ * @param matrix_value  An array of size [num_nz] with the non-zero elements of
+ *                      the constraint matrix.
+ *
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getRowsByRange(const void* highs, const HighsInt from_row,
                               const HighsInt to_row, HighsInt* num_row,
@@ -1540,11 +1555,11 @@ HighsInt Highs_getRowsByRange(const void* highs, const HighsInt from_row,
  * This function is identical to `Highs_getRowsByRange`, except for how the
  * rows are specified.
  *
- * @param num_set_indices   the number of indices in the set
- * @param set               array of size [num_set_entries] with the row indices
- *                          to get
+ * @param num_set_indices   The number of indices in `set`.
+ * @param set               An array of size [num_set_entries] containing the
+ *                          row indices to get.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getRowsBySet(const void* highs, const HighsInt num_set_entries,
                             const HighsInt* set, HighsInt* num_row,
@@ -1558,42 +1573,46 @@ HighsInt Highs_getRowsBySet(const void* highs, const HighsInt num_set_entries,
  * This function is identical to `Highs_getRowsByRange`, except for how the
  * rows are specified.
  *
- * @param mask  array of length [num_row] containing a 1 to get the row and 0
- *              otherwise
+ * @param mask  An array of length [num_row] containing a `1` to get the row and
+ *              `0` otherwise.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getRowsByMask(const void* highs, const HighsInt* mask,
                              HighsInt* num_row, double* lower, double* upper,
                              HighsInt* num_nz, HighsInt* matrix_start,
                              HighsInt* matrix_index, double* matrix_value);
 /**
- * Get the name of a row
+ * Get the name of a row.
  *
- * @param row   the row for which the name is required
- * @param name  the name of the row
+ * @param row   The index of the row to query.
+ * @param name  A pointer in which to store the name of the row. This must have
+ *              length `kHighsMaximumStringLength`.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getRowName(const void* highs, const HighsInt row, char* name);
 
 /**
- * Get the name of a column
+ * Get the name of a column.
  *
- * @param col   the column for which the name is required
- * @param name  the name of the column
+ * @param col   The index of the column to query.
+ * @param name  A pointer in which to store the name of the column. This must
+ *              have length `kHighsMaximumStringLength`.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getColName(const void* highs, const HighsInt col, char* name);
 
 /**
- * Get the integrality of a column
+ * Get the integrality of a column.
  *
- * @param col          the column for which the name is required
- * @param integrality  the integrality of the column
+ * @param col          The index of the column to query.
+ * @param integrality  An integer in which the integrality of the column should
+ *                     be placed. The integer is one of the `kHighsVarTypeXXX`
+ *                     constants.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getColIntegrality(const void* highs, const HighsInt col,
                                  HighsInt* integrality);
@@ -1601,11 +1620,11 @@ HighsInt Highs_getColIntegrality(const void* highs, const HighsInt col,
 /**
  * Delete multiple adjacent columns.
  *
- * @param highs     a pointer to the Highs instance
- * @param from_col  the index of the first column to delete
- * @param to_col    the index of the last column to delete
+ * @param highs     A pointer to the Highs instance.
+ * @param from_col  The index of the first column to delete.
+ * @param to_col    The index of the last column to delete.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_deleteColsByRange(void* highs, const HighsInt from_col,
                                  const HighsInt to_col);
@@ -1613,12 +1632,12 @@ HighsInt Highs_deleteColsByRange(void* highs, const HighsInt from_col,
 /**
  * Delete multiple columns given by an array of indices.
  *
- * @param highs             a pointer to the Highs instance
- * @param num_set_entries   the number of columns to delete
- * @param set               an array of size [num_set_entries] with the indices
- *                          of the columns to delete
+ * @param highs             A pointer to the Highs instance.
+ * @param num_set_entries   The number of columns to delete.
+ * @param set               An array of size [num_set_entries] with the indices
+ *                          of the columns to delete.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_deleteColsBySet(void* highs, const HighsInt num_set_entries,
                                const HighsInt* set);
@@ -1626,22 +1645,22 @@ HighsInt Highs_deleteColsBySet(void* highs, const HighsInt num_set_entries,
 /**
  * Delete multiple columns given by a mask.
  *
- * @param highs     a pointer to the Highs instance
- * @param mask      an array of length [num_col] with 1 if the column
- *                  should be deleted and 0 otherwise
+ * @param highs     A pointer to the Highs instance.
+ * @param mask      An array of length [num_col] with 1 if the column
+ *                  should be deleted and 0 otherwise.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_deleteColsByMask(void* highs, HighsInt* mask);
 
 /**
  * Delete multiple adjacent rows.
  *
- * @param highs     a pointer to the Highs instance
- * @param from_row  the index of the first row to delete
- * @param to_row    the index of the last row to delete
+ * @param highs     A pointer to the Highs instance.
+ * @param from_row  The index of the first row to delete.
+ * @param to_row    The index of the last row to delete.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_deleteRowsByRange(void* highs, const int from_row,
                                  const HighsInt to_row);
@@ -1649,12 +1668,12 @@ HighsInt Highs_deleteRowsByRange(void* highs, const int from_row,
 /**
  * Delete multiple rows given by an array of indices.
  *
- * @param highs             a pointer to the Highs instance
- * @param num_set_entries   the number of rows to delete
- * @param set               an array of size [num_set_entries] with the indices
- *                          of the rows to delete
+ * @param highs             A pointer to the Highs instance.
+ * @param num_set_entries   The number of rows to delete.
+ * @param set               An array of size [num_set_entries] with the indices
+ *                          of the rows to delete.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_deleteRowsBySet(void* highs, const HighsInt num_set_entries,
                                const HighsInt* set);
@@ -1662,12 +1681,12 @@ HighsInt Highs_deleteRowsBySet(void* highs, const HighsInt num_set_entries,
 /**
  * Delete multiple rows given by a mask.
  *
- * @param highs     a pointer to the Highs instance
- * @param mask      an array of length [num_row] with 1 if the row should be
- *                  deleted and 0 otherwise. New index of any column not
- *                  deleted is returned in place of the value 0.
+ * @param highs     A pointer to the Highs instance.
+ * @param mask      An array of length [num_row] with `1` if the row should be
+ *                  deleted and `0` otherwise. The new index of any column not
+ *                  deleted is stored in place of the value `0`.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_deleteRowsByMask(void* highs, HighsInt* mask);
 
@@ -1677,71 +1696,69 @@ HighsInt Highs_deleteRowsByMask(void* highs, HighsInt* mask);
  * Scaling a column modifies the elements in the constraint matrix, the variable
  * bounds, and the objective coefficient.
  *
- * If scaleval < 0, the variable bounds flipped.
+ * @param highs     A pointer to the Highs instance.
+ * @param col       The index of the column to scale.
+ * @param scaleval  The value by which to scale the column. If `scaleval < 0`,
+ *                  the variable bounds flipped.
  *
- * @param highs     a pointer to the Highs instance
- * @param col       the index of the column to scale
- * @param scaleval  the value by which to scale the column
- *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_scaleCol(void* highs, const HighsInt col, const double scaleval);
 
 /**
  * Scale a row by a constant.
  *
- * If scaleval < 0, the row bounds are flipped.
+ * @param highs     A pointer to the Highs instance.
+ * @param row       The index of the row to scale.
+ * @param scaleval  The value by which to scale the row. If `scaleval < 0`, the
+ *                  row bounds are flipped.
  *
- * @param highs     a pointer to the Highs instance
- * @param row       the index of the row to scale
- * @param scaleval  the value by which to scale the row
- *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_scaleRow(void* highs, const HighsInt row, const double scaleval);
 
 /**
  * Return the value of infinity used by HiGHS.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the value of infinity used by HiGHS
+ * @returns The value of infinity used by HiGHS.
  */
 double Highs_getInfinity(const void* highs);
 
 /**
  * Return the number of columns in the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the number of columns in the model
+ * @returns The number of columns in the model.
  */
 HighsInt Highs_getNumCol(const void* highs);
 
 /**
  * Return the number of rows in the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the number of rows in the model.
+ * @returns The number of rows in the model.
  */
 HighsInt Highs_getNumRow(const void* highs);
 
 /**
  * Return the number of nonzeros in the constraint matrix of the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the number of nonzeros in the constraint matrix of the model.
+ * @returns The number of nonzeros in the constraint matrix of the model.
  */
 HighsInt Highs_getNumNz(const void* highs);
 
 /**
  * Return the number of nonzeroes in the Hessian matrix of the model.
  *
- * @param highs     a pointer to the Highs instance
+ * @param highs     A pointer to the Highs instance.
  *
- * @returns the number of nonzeroes in the Hessian matrix of the model.
+ * @returns The number of nonzeroes in the Hessian matrix of the model.
  */
 HighsInt Highs_getHessianNumNz(const void* highs);
 
@@ -1759,7 +1776,7 @@ HighsInt Highs_getHessianNumNz(const void* highs);
  *  - `Highs_getNumNz`
  *  - `Highs_getHessianNumNz`
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_getModel(const void* highs, const HighsInt a_format,
                         const HighsInt q_format, HighsInt* num_col,
@@ -1773,37 +1790,45 @@ HighsInt Highs_getModel(const void* highs, const HighsInt a_format,
 
 /**
  * Set a primal (and possibly dual) solution as a starting point, then run
- * crossover to compute a basic feasible solution. If there is no dual solution,
- * pass col_dual and row_dual as nullptr.
+ * crossover to compute a basic feasible solution.
  *
- * @param highs      a pointer to the Highs instance
- * @param num_col    the number of variables
- * @param num_row    the number of rows
- * @param col_value  array of length [num_col] with optimal primal solution for
- *                   each column
- * @param col_dual   array of length [num_col] with optimal dual solution for
- *                   each column
- * @param row_dual   array of length [num_row] with optimal dual solution for
- *                   each row
+ * @param highs      A pointer to the Highs instance.
+ * @param num_col    The number of variables.
+ * @param num_row    The number of rows.
+ * @param col_value  An array of length [num_col] with optimal primal solution
+ *                   for each column.
+ * @param col_dual   An array of length [num_col] with optimal dual solution for
+ *                   each column. May be `NULL`, in which case no dual solution
+ *                   is passed.
+ * @param row_dual   An array of length [num_row] with optimal dual solution for
+ *                   each row. . May be `NULL`, in which case no dual solution
+ *                   is passed.
  *
- * @returns a `kHighsStatus` constant indicating whether the call succeeded
+ * @returns A `kHighsStatus` constant indicating whether the call succeeded.
  */
 HighsInt Highs_crossover(void* highs, const int num_col, const int num_row,
                          const double* col_value, const double* col_dual,
                          const double* row_dual);
 
 /**
- * Releases all resources held by the global scheduler instance. It is
- * not thread-safe to call this function while calling Highs_run()/Highs_*call()
- * on any other Highs instance in any thread. After this function has terminated
- * it is guaranteed that eventually all previously created scheduler threads
- * will terminate and allocated memory will be released. After this function
- * has returned the option value for the number of threads may be altered to a
- * new value before the next call to Highs_run()/Highs_*call(). If the given
- * parameter has a nonzero value, then the function will not return until all
- * memory is freed, which might be desirable when debugging heap memory but
- * requires the calling thread to wait for all scheduler threads to wake-up
- * which is usually not necessary.
+ * Releases all resources held by the global scheduler instance.
+ *
+ * It is not thread-safe to call this function while calling `Highs_run` or one
+ * of the `Highs_XXXcall` methods on any other Highs instance in any thread.
+ *
+ * After this function has terminated, it is guaranteed that eventually all
+ * previously created scheduler threads will terminate and allocated memory will
+ * be released.
+ *
+ * After this function has returned, the option value for the number of threads
+ * may be altered to a new value before the next call to `Highs_run` or one of
+ * the `Highs_XXXcall` methods.
+ *
+ * @param blocking   If the `blocking` parameter has a nonzero value, then this
+ *                   function will not return until all memory is freed, which
+ *                   might be desirable when debugging heap memory, but it
+ *                   requires the calling thread to wait for all scheduler
+ *                   threads to wake-up which is usually not necessary.
  *
  * @returns No status is returned since the function call cannot fail. Calling
  * this function while any Highs instance is in use on any thread is


### PR DESCRIPTION
This is a very minor thing and I haven't finished yet, but I though I'd open this to start with.

I was working on https://github.com/jump-dev/HiGHS.jl/pull/152 and got annoyed at the inconsistency in capitalization and punctuation in the docstrings that were coming through.

Ideally, I think we should aim for the Gurobi API documentation: https://www.gurobi.com/documentation/10.0/refman/c_setdblattr.html.