### PR TITLE
Fix signature of Highs_versionXXX in highs_c_api.h

### DIFF
--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -168,14 +168,14 @@ HighsInt Highs_qpCall(
   return (HighsInt)status;
 }
 
-void* Highs_create() { return new Highs(); }
+void* Highs_create(void) { return new Highs(); }
 
 void Highs_destroy(void* highs) { delete (Highs*)highs; }
 
 const char* Highs_version(void) { return highsVersion(); }
-HighsInt Highs_versionMajor() { return highsVersionMajor(); }
-HighsInt Highs_versionMinor() { return highsVersionMinor(); }
-HighsInt Highs_versionPatch() { return highsVersionPatch(); }
+HighsInt Highs_versionMajor(void) { return highsVersionMajor(); }
+HighsInt Highs_versionMinor(void) { return highsVersionMinor(); }
+HighsInt Highs_versionPatch(void) { return highsVersionPatch(); }
 const char* Highs_githash(void) { return highsGithash(); }
 const char* Highs_compilationDate(void) { return highsCompilationDate(); }
 

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -227,21 +227,21 @@ const char* Highs_version(void);
  *
  * @returns the HiGHS major version number
  */
-HighsInt Highs_versionMajor();
+HighsInt Highs_versionMajor(void);
 
 /**
  * Return the HiGHS minor version number
  *
  * @returns the HiGHS minor version number
  */
-HighsInt Highs_versionMinor();
+HighsInt Highs_versionMinor(void);
 
 /**
  * Return the HiGHS patch version number
  *
  * @returns the HiGHS patch version number
  */
-HighsInt Highs_versionPatch();
+HighsInt Highs_versionPatch(void);
 
 /**
  * Return the HiGHS githash


### PR DESCRIPTION
Stackoverflow tells me that this is the correct way to say that a function has zero arguments in C: https://stackoverflow.com/questions/693788/is-it-better-to-use-c-void-arguments-void-foovoid-or-not-void-foo

I got a warning when I tried to parse the header in Julia. x-ref: https://github.com/ERGO-Code/HiGHS/pull/1200