### PR TITLE
Automatically build and document the C API

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+c_api_gen/libhighs.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,6 @@
 [deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Clang = "0.14"

--- a/docs/c_api_gen/build.jl
+++ b/docs/c_api_gen/build.jl
@@ -1,0 +1,33 @@
+#=* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+*                                                                       *
+*    This file is part of the HiGHS linear optimization suite           *
+*                                                                       *
+*    Written and engineered 2008-2023 by Julian Hall, Ivet Galabova,    *
+*    Leona Gottwald and Michael Feldmeier                               *
+*    Available as open-source under the MIT License                     *
+*                                                                       *
+* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *=#
+
+using Clang.Generators
+
+root_dir = dirname(dirname(@__DIR__))
+highs = joinpath(root_dir, "src")
+c_api = joinpath(highs, "interfaces", "highs_c_api.h")
+
+build!(
+    create_context(
+        [c_api, joinpath(highs, "util", "HighsInt.h")],
+        vcat(get_default_args(), "-I$highs"),
+        load_options(joinpath(@__DIR__, "generate.toml")),
+    ),
+)
+
+open(joinpath(@__DIR__, "libhighs.jl"), "a") do io
+    for line in readlines(c_api)
+        m = match(r"const HighsInt kHighs([a-zA-Z]+) = (-?[0-9]+);", line)
+        if m === nothing
+            continue
+        end
+        println(io, "const kHighs$(m[1]) = HighsInt($(m[2]))")
+    end
+end

--- a/docs/c_api_gen/generate.toml
+++ b/docs/c_api_gen/generate.toml
@@ -1,0 +1,5 @@
+[general]
+library_name = "libhighs"
+output_file_path = "docs/c_api_gen/libhighs.jl"
+print_using_CEnum = false
+extract_c_comment_style = "doxygen"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,24 @@ Pkg.instantiate()
 
 import Documenter
 
+# ==============================================================================
+#  Parse and build docstrings from the C API
+# ==============================================================================
+
+include(joinpath(@__DIR__, "c_api_gen", "build.jl"))
+
+"""
+This module exists solely to collate the docstrings of libhighs.jl
+"""
+module HiGHS
+    const libhighs = ""
+    include(joinpath(@__DIR__, "c_api_gen", "libhighs.jl"))
+end
+
+# ==============================================================================
+#  Make the documentation
+# ==============================================================================
+
 Documenter.makedocs(
     sitename = "HiGHS Documentation",
     authors = "Julian Hall and Ivet Galabova",
@@ -49,6 +67,7 @@ Documenter.makedocs(
             "Linking" => "cpp/link.md",
             "Examples" => "cpp/examples.md",
         ],
+        "HiGHS in C" => Any["API" => "c/api.md"],
         "HiGHS in Julia" => "julia/index.md",
         "Binaries" => "binaries.md",
         "Executable" => "executable.md",

--- a/docs/src/c/api.md
+++ b/docs/src/c/api.md
@@ -1,0 +1,3 @@
+```@autodocs
+Modules = [HiGHS]
+```

--- a/docs/src/c/api.md
+++ b/docs/src/c/api.md
@@ -1,3 +1,4 @@
 ```@autodocs
 Modules = [HiGHS]
+Filter = t -> startswith("$t", "Highs")
 ```


### PR DESCRIPTION
A follow up to #1203

Preview link: https://ergo-code.github.io/HiGHS/previews/PR1204/c/api/

We'd need to finesse things slightly. I'd want to remove the `Main.HiGHS.` prefix, and the link to the source doesn't work. But those are both things that can probably be fixed.