### PR TITLE
[docs] fix building on Julia 1.8

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,5 @@ Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Clang = "0.14"
+Clang = "0.14, 0.17"
+Documenter = "0.27"


### PR DESCRIPTION
Clang.jl v0.14 supports only Julia 1.6 because it requires a specific version of LLVM that is tied to the Julia version.

Julia 1.7 and later uses a different version of LLVM, so we need a different version of Clang.jl.

Closes #1216 

I build the docs locally with Julia 1.8.3:
```Julia
(docs) pkg> st
Status `~/Documents/Code/HiGHS/docs/Project.toml`
  [40e3b903] Clang v0.17.3
  [e30172f5] Documenter v0.27.24

julia> include("docs/make.jl")
  Activating project at `~/Documents/Code/HiGHS/docs`
[ Info: Parsing headers...
/Users/oscar/Documents/Code/HiGHS/src/util/HighsInt.h:27:10: fatal error: 'HConfig.h' file not found
/Users/oscar/Documents/Code/HiGHS/src/util/HighsInt.h:27:10: fatal error: 'HConfig.h' file not found
[ Info: Processing header: /Users/oscar/Documents/Code/HiGHS/src/interfaces/highs_c_api.h
[ Info: Processing header: /Users/oscar/Documents/Code/HiGHS/src/util/HighsInt.h
[ Info: Building the DAG...
[ Info: Emit Julia expressions...
[ Info: [ProloguePrinter]: print to docs/c_api_gen/libhighs.jl
[ Info: [GeneralPrinter]: print to docs/c_api_gen/libhighs.jl
[ Info: [EpiloguePrinter]: print to docs/c_api_gen/libhighs.jl
[ Info: Done!
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: Doctest: running doctests.
[ Info: ExpandTemplates: expanding markdown templates.
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
┌ Warning: Documenter could not auto-detect the building environment Skipping deployment.
└ @ Documenter ~/.julia/packages/Documenter/H5y27/src/deployconfig.jl:75

julia> versioninfo()
Julia Version 1.8.3
Commit 0434deb161e (2022-11-14 20:14 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin21.4.0)
  CPU: 8 × Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, skylake)
  Threads: 1 on 8 virtual cores
```