### PR TITLE
[docs] allow docs to be build from any directory and tidy README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,27 @@
-Documentation for [HiGHS](https://github.com/ERGO-Code/HiGHS)
+# Documentation
 
-## Editing the Docs
+This directory contains the source files for the [documentation](https://ergo-code.github.io/HiGHS).
 
-To edit the documentation, checkout a branch and edit the Markdown files in
-[docs/src].
+## Editing the documentation
 
-To build locally, call
+To edit the documentation, checkout a branch and edit the Markdown files in the
+`src` directory.
+
+## Building the documentation
+
+To build locally, [install Julia](https://julialang.org/downloads/), then run:
+
 ```
-julia --project=. make.jl
+$ julia docs/make.jl
 ```
 
-and the website is generated in the `build/` folder. To check it out, load `build/index.html` in your browser.
+The first time you run this command, Julia will download and install the
+necessary packages. This may take a couple of minutes.
 
-When you are happy with the changes, rename the `build/` folder to `docs/` and push to the highs-docs branch. Alternatively, if you have pending changes you wish to discuss with the team, please checkout a new branch and open a PR to branch highs-docs.
+The website is generated in the `build/` folder. To check it out, load
+`build/index.html` in your browser.
 
-The GH Page is generated from the `docs/` folder of the highs-docs branch.
+## Deploying the documentation
+
+The documentation is automatically built and deployed by a GitHub action. You
+should not check the `build/` directory into git.

--- a/docs/c_api_gen/build.jl
+++ b/docs/c_api_gen/build.jl
@@ -8,17 +8,23 @@
 *                                                                       *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *=#
 
-using Clang.Generators
+import Clang: Generators
 
-root_dir = dirname(dirname(@__DIR__))
-highs = joinpath(root_dir, "src")
-c_api = joinpath(highs, "interfaces", "highs_c_api.h")
+highs_src = joinpath(dirname(dirname(@__DIR__)), "src")
+c_api = joinpath(highs_src, "interfaces", "highs_c_api.h")
 
-build!(
-    create_context(
-        [c_api, joinpath(highs, "util", "HighsInt.h")],
-        vcat(get_default_args(), "-I$highs"),
-        load_options(joinpath(@__DIR__, "generate.toml")),
+Generators.build!(
+    Generators.create_context(
+        [c_api, joinpath(highs_src, "util", "HighsInt.h")],
+        vcat(Generators.get_default_args(), "-I$highs_src"),
+        Dict{String,Any}(
+            "general" => Dict{String,Any}(
+                "output_file_path" => joinpath(@__DIR__, "libhighs.jl"),
+                "library_name" => "libhighs",
+                "print_using_CEnum" => false,
+                "extract_c_comment_style" => "doxygen",
+            )
+        ),
     ),
 )
 

--- a/docs/c_api_gen/generate.toml
+++ b/docs/c_api_gen/generate.toml
@@ -1,5 +1,0 @@
-[general]
-library_name = "libhighs"
-output_file_path = "docs/c_api_gen/libhighs.jl"
-print_using_CEnum = false
-extract_c_comment_style = "doxygen"


### PR DESCRIPTION
I tend the build the docs locally very infrequently. I find it easier to just start a PR and then look at the preview links.

Once CI finishes, the preview link will be: https://ergo-code.github.io/HiGHS/previews/PR1219


Closes #1216 