### PR TITLE
macos-version-update

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macOS-10.15] #  windows-2019 ubuntu-20.04,
+        os: [macOS-12] #  windows-2019 ubuntu-20.04,
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Update of version of macOS in wheel workflow, 10.15 deprecated in GitHub runners