### PR TITLE
pass log callback data to log callback again

### DIFF
--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1010,8 +1010,7 @@ class Highs {
    */
   HighsStatus setLogCallback(void (*log_user_callback)(HighsLogType,
                                                        const char*, void*),
-                             void* deprecated = nullptr  // V2.0 remove
-  );
+                             void* log_user_callback_data = nullptr);
 
   /**
    * @brief Use the HighsBasis passed to set the internal HighsBasis

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -135,7 +135,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_user_callback(type, msgbuffer, nullptr);
+    log_options_.log_user_callback(type, msgbuffer, log_options_.log_user_callback_data);
   }
   va_end(argptr);
 }
@@ -184,7 +184,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
       // Output was truncated: for now just ensure string is null-terminated
       msgbuffer[sizeof(msgbuffer) - 1] = '\0';
     }
-    log_options_.log_user_callback(type, msgbuffer, nullptr);
+    log_options_.log_user_callback(type, msgbuffer, log_options_.log_user_callback_data);
   }
   va_end(argptr);
 }

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -48,6 +48,7 @@ struct HighsLogOptions {
   HighsInt* log_dev_level;
   void (*log_highs_callback)(HighsLogType, const char*, void*) = nullptr;
   void (*log_user_callback)(HighsLogType, const char*, void*) = nullptr;
+  void* log_user_callback_data = nullptr;
 };
 
 /**

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1846,9 +1846,9 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
 
 HighsStatus Highs::setLogCallback(void (*log_user_callback)(HighsLogType,
                                                             const char*, void*),
-                                  void* deprecated  // V2.0 remove
-) {
+                                  void* log_user_callback_data) {
   options_.log_options.log_user_callback = log_user_callback;
+  options_.log_options.log_user_callback_data = log_user_callback_data;
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -1106,6 +1106,7 @@ class HighsOptions : public HighsOptionsStruct {
     log_options.log_dev_level = &log_dev_level;
     log_options.log_highs_callback = nullptr;
     log_options.log_user_callback = nullptr;
+    log_options.log_user_callback_data = nullptr;
   }
 
   void deleteRecords() {


### PR DESCRIPTION
Undoes e002eca1b and previous renamings. "Undeprecates" log callback data argument.

Closes #1309.