### PR TITLE
Fixed #1345 as suggested; formatted

### DIFF
--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -1,9 +1,10 @@
-#include "catch.hpp"
 #include <sstream>
-#include "util/HFactor.h"
-#include "util/HighsRandom.h"
+
 #include "HCheckConfig.h"
 #include "Highs.h"
+#include "catch.hpp"
+#include "util/HFactor.h"
+#include "util/HighsRandom.h"
 
 const double inf = kHighsInf;
 const bool dev_run = false;

--- a/check/TestBasis.cpp
+++ b/check/TestBasis.cpp
@@ -1,7 +1,7 @@
 #include <fstream>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const bool dev_run = false;

--- a/check/TestBasisSolves.cpp
+++ b/check/TestBasisSolves.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "util/HighsRandom.h"
 

--- a/check/TestCheckSolution.cpp
+++ b/check/TestCheckSolution.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "SpecialLps.h"
 #include "catch.hpp"
 

--- a/check/TestCrossover.cpp
+++ b/check/TestCrossover.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "lp_data/HighsModelUtils.h"
 

--- a/check/TestDualize.cpp
+++ b/check/TestDualize.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const double inf = kHighsInf;

--- a/check/TestEkk.cpp
+++ b/check/TestEkk.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "SpecialLps.h"
 #include "catch.hpp"
 #include "lp_data/HConst.h"

--- a/check/TestFactor.cpp
+++ b/check/TestFactor.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "util/HFactor.h"
 

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "io/FilereaderEms.h"
 #include "io/HMPSIO.h"

--- a/check/TestFreezeBasis.cpp
+++ b/check/TestFreezeBasis.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const double inf = kHighsInf;

--- a/check/TestHighsGFkSolve.cpp
+++ b/check/TestHighsGFkSolve.cpp
@@ -1,9 +1,9 @@
 #include <numeric>
 
+#include "HCheckConfig.h"
 #include "catch.hpp"
 #include "mip/HighsGFkSolve.h"
 #include "util/HighsRandom.h"
-#include "HCheckConfig.h"
 
 const bool dev_run = false;
 

--- a/check/TestHighsHash.cpp
+++ b/check/TestHighsHash.cpp
@@ -1,6 +1,6 @@
-#include "HCheckConfig.h"
 #include <numeric>
 
+#include "HCheckConfig.h"
 #include "catch.hpp"
 #include "util/HighsHash.h"
 #include "util/HighsHashTree.h"

--- a/check/TestHighsModel.cpp
+++ b/check/TestHighsModel.cpp
@@ -1,8 +1,8 @@
 #include <algorithm>
 #include <cassert>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "SpecialLps.h"
 #include "catch.hpp"
 

--- a/check/TestHighsRbTree.cpp
+++ b/check/TestHighsRbTree.cpp
@@ -1,7 +1,6 @@
-#include "HCheckConfig.h"
-
 #include <numeric>
 
+#include "HCheckConfig.h"
 #include "catch.hpp"
 #include "util/HighsRandom.h"
 #include "util/HighsRbTree.h"

--- a/check/TestHighsVersion.cpp
+++ b/check/TestHighsVersion.cpp
@@ -1,8 +1,8 @@
 #include <cassert>
 #include <sstream>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const bool dev_run = false;

--- a/check/TestHotStart.cpp
+++ b/check/TestHotStart.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const double inf = kHighsInf;

--- a/check/TestICrash.cpp
+++ b/check/TestICrash.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "lp_data/HighsLpUtils.h"
 #include "util/HighsUtils.h"

--- a/check/TestIO.cpp
+++ b/check/TestIO.cpp
@@ -1,8 +1,8 @@
 #include <cstdio>
 #include <cstring>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const bool dev_run = false;

--- a/check/TestInfo.cpp
+++ b/check/TestInfo.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "io/FilereaderEms.h"
 #include "io/HMPSIO.h"

--- a/check/TestLPFileFormat.cpp
+++ b/check/TestLPFileFormat.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "filereaderlp/reader.hpp"
 

--- a/check/TestLogging.cpp
+++ b/check/TestLogging.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const bool dev_run = false;

--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -1,5 +1,5 @@
-#include "HCheckConfig.h"
 #include "Avgas.h"
+#include "HCheckConfig.h"
 #include "Highs.h"
 #include "catch.hpp"
 #include "lp_data/HighsLpUtils.h"

--- a/check/TestLpOrientation.cpp
+++ b/check/TestLpOrientation.cpp
@@ -1,6 +1,6 @@
 #include "Avgas.h"
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "lp_data/HighsLpUtils.h"
 #include "util/HighsUtils.h"

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -1,5 +1,5 @@
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 
 const bool dev_run = false;

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -1,6 +1,6 @@
 #include "Avgas.h"
-#include "Highs.h"
 #include "HCheckConfig.h"
+#include "Highs.h"
 #include "catch.hpp"
 #include "lp_data/HighsLpUtils.h"
 

--- a/check/TestSort.cpp
+++ b/check/TestSort.cpp
@@ -1,8 +1,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "catch.hpp"
 #include "HCheckConfig.h"
+#include "catch.hpp"
 #include "lp_data/HConst.h"
 #include "util/HighsRandom.h"
 #include "util/HighsSort.h"

--- a/check/TestThrow.cpp
+++ b/check/TestThrow.cpp
@@ -1,8 +1,8 @@
 // #include "Highs.h"
-#include "HCheckConfig.h"
 #include <iostream>
 #include <stdexcept>  //Used in HiGHS
 
+#include "HCheckConfig.h"
 #include "catch.hpp"
 // #include <exception>
 const bool dev_run = false;

--- a/extern/filereaderlp/reader.cpp
+++ b/extern/filereaderlp/reader.cpp
@@ -1272,7 +1272,7 @@ bool Reader::readnexttoken(RawToken& t) {
       return false;
 
     case '\0':  // empty line
-      assert(this->linebufferpos == this->linebuffer.size());
+      lpassert(this->linebufferpos == this->linebuffer.size());
       return false;
   }
 


### PR DESCRIPTION
Change to `reader.cpp` as suggested so that `case '\0':  // empty line` is `lpassert`, not plain `assert`