### PR TITLE
Fix 1340

### DIFF
--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -882,7 +882,7 @@ PYBIND11_MODULE(highspy, m) {
       .def("deleteCols", &highs_deleteCols)
       .def("deleteVars", &highs_deleteVars)
       .def("deleteRows", &highs_deleteRows)
-      .def("writeInfo", &Highs::writeInfo)
+      .def("setSolution", &Highs::setSolution)
       .def("modelStatusToString", &Highs::modelStatusToString)
       .def("solutionStatusToString", &Highs::solutionStatusToString)
       .def("basisStatusToString", &Highs::basisStatusToString)


### PR DESCRIPTION
Added 
`.def("setSolution", &Highs::setSolution)`
to `highs_bindings.cpp` and removed duplicate definition for
` .def("writeInfo", &Highs::writeInfo)`

This will close #1340 

