### PR TITLE
Fix 1350

### DIFF
--- a/check/TestQpSolver.cpp
+++ b/check/TestQpSolver.cpp
@@ -5,7 +5,7 @@
 #include "catch.hpp"
 #include "io/FilereaderLp.h"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double inf = kHighsInf;
 const double double_equal_tolerance = 1e-5;
 

--- a/check/TestRays.cpp
+++ b/check/TestRays.cpp
@@ -208,8 +208,8 @@ void checkPrimalRayValue(Highs& highs, const vector<double>& primal_ray_value) {
   REQUIRE(ray_error_norm < 1e-6);
 }
 
-void testInfeasibleMps(const std::string model,
-                       const bool has_dual_ray_ = true) {
+void testInfeasibleMpsLp(const std::string model,
+                         const bool has_dual_ray_ = true) {
   std::string model_file;
   HighsLp lp;
   HighsModelStatus require_model_status;
@@ -247,8 +247,44 @@ void testInfeasibleMps(const std::string model,
   REQUIRE(has_primal_ray == false);
 }
 
-void testUnboundedMps(const std::string model,
-                      const ObjSense sense = ObjSense::kMinimize) {
+void testInfeasibleMpsMip(const std::string model) {
+  std::string model_file;
+  HighsLp lp;
+  HighsModelStatus require_model_status;
+  bool has_dual_ray;
+  bool has_primal_ray;
+
+  Highs highs;
+  if (!dev_run) {
+    highs.setOptionValue("output_flag", false);
+  } else {
+    highs.setOptionValue("log_dev_level", 2);
+  }
+
+  REQUIRE(highs.setOptionValue("presolve", "off") == HighsStatus::kOk);
+
+  // Test dual ray for MIP of infeasible LP
+  model_file = std::string(HIGHS_DIR) + "/check/instances/" + model + ".mps";
+  require_model_status = HighsModelStatus::kInfeasible;
+  REQUIRE(highs.readModel(model_file) == HighsStatus::kOk);
+  lp = highs.getLp();
+  lp.integrality_.clear();
+  for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++)
+    lp.integrality_.push_back(HighsVarType::kInteger);
+  highs.passModel(lp);
+  REQUIRE(highs.setBasis() == HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(highs.getModelStatus() == require_model_status);
+  // Check that there is no dual ray
+  REQUIRE(highs.getDualRay(has_dual_ray) == HighsStatus::kOk);
+  REQUIRE(!has_dual_ray);
+  // Check that there is no primal ray
+  REQUIRE(highs.getPrimalRay(has_primal_ray) == HighsStatus::kOk);
+  REQUIRE(has_primal_ray == false);
+}
+
+void testUnboundedMpsLp(const std::string model,
+                        const ObjSense sense = ObjSense::kMinimize) {
   Highs highs;
   if (!dev_run) highs.setOptionValue("output_flag", false);
 
@@ -401,33 +437,38 @@ TEST_CASE("Rays", "[highs_test_rays]") {
   REQUIRE(has_primal_ray == false);
 }
 
-TEST_CASE("Rays-gas11", "[highs_test_rays]") { testUnboundedMps("gas11"); }
+TEST_CASE("Rays-gas11", "[highs_test_rays]") { testUnboundedMpsLp("gas11"); }
 TEST_CASE("Rays-adlittlemax", "[highs_test_rays]") {
-  testUnboundedMps("adlittle", ObjSense::kMaximize);
+  testUnboundedMpsLp("adlittle", ObjSense::kMaximize);
 }
 
-TEST_CASE("Rays-galenet", "[highs_test_rays]") { testInfeasibleMps("galenet"); }
+TEST_CASE("Rays-galenet", "[highs_test_rays]") {
+  testInfeasibleMpsLp("galenet");
+}
 
 TEST_CASE("Rays-woodinfe", "[highs_test_rays]") {
-  testInfeasibleMps("woodinfe");
+  testInfeasibleMpsLp("woodinfe");
 }
 
 // klein1 is infeasible, but currently has no dual ray
 TEST_CASE("Rays-klein1", "[highs_test_rays]") {
-  testInfeasibleMps("klein1", true);
+  testInfeasibleMpsLp("klein1", true);
 }
 
 TEST_CASE("Rays-gams10am", "[highs_test_rays]") {
-  testInfeasibleMps("gams10am");
+  testInfeasibleMpsLp("gams10am");
+  testInfeasibleMpsMip("gams10am");
 }
 
-TEST_CASE("Rays-ex72a", "[highs_test_rays]") { testInfeasibleMps("ex72a"); }
+TEST_CASE("Rays-ex72a", "[highs_test_rays]") { testInfeasibleMpsLp("ex72a"); }
 
-TEST_CASE("Rays-forest6", "[highs_test_rays]") { testInfeasibleMps("forest6"); }
+TEST_CASE("Rays-forest6", "[highs_test_rays]") {
+  testInfeasibleMpsLp("forest6");
+}
 
-TEST_CASE("Rays-box1", "[highs_test_rays]") { testInfeasibleMps("box1"); }
+TEST_CASE("Rays-box1", "[highs_test_rays]") { testInfeasibleMpsLp("box1"); }
 
-TEST_CASE("Rays-bgetam", "[highs_test_rays]") { testInfeasibleMps("bgetam"); }
+TEST_CASE("Rays-bgetam", "[highs_test_rays]") { testInfeasibleMpsLp("bgetam"); }
 
 TEST_CASE("Rays-464a", "[highs_test_rays]") {
   // The model is:

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1427,6 +1427,7 @@ class Highs {
   HighsStatus checkOptimality(const std::string& solver_type,
                               HighsStatus return_status);
   HighsStatus invertRequirementError(std::string method_name);
+  HighsStatus lpInvertRequirementError(std::string method_name);
 };
 
 #endif

--- a/src/io/Filereader.cpp
+++ b/src/io/Filereader.cpp
@@ -11,12 +11,12 @@
 
 #include "io/Filereader.h"
 
+#include <cctype>
+
 #include "io/FilereaderEms.h"
 #include "io/FilereaderLp.h"
 #include "io/FilereaderMps.h"
 #include "io/HighsIO.h"
-
-#include <cctype>
 
 // convert string to lower-case, modifies string
 static inline void tolower(std::string& s) {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1533,8 +1533,11 @@ HighsStatus Highs::run() {
 }
 
 HighsStatus Highs::getDualRay(bool& has_dual_ray, double* dual_ray_value) {
+  // Can't get a ray without an INVERT, but absence is only an error
+  // when solving an LP #1350
+  has_dual_ray = false;
   if (!ekk_instance_.status_.has_invert)
-    return invertRequirementError("getDualRay");
+    return lpInvertRequirementError("getDualRay");
   return getDualRayInterface(has_dual_ray, dual_ray_value);
 }
 
@@ -1558,8 +1561,11 @@ HighsStatus Highs::getDualRaySparse(bool& has_dual_ray,
 
 HighsStatus Highs::getPrimalRay(bool& has_primal_ray,
                                 double* primal_ray_value) {
+  // Can't get a ray without an INVERT, but absence is only an error
+  // when solving an LP #1350
+  has_primal_ray = false;
   if (!ekk_instance_.status_.has_invert)
-    return invertRequirementError("getPrimalRay");
+    return lpInvertRequirementError("getPrimalRay");
   return getPrimalRayInterface(has_primal_ray, primal_ray_value);
 }
 

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -1538,3 +1538,11 @@ HighsStatus Highs::invertRequirementError(std::string method_name) {
                "No invertible representation for %s\n", method_name.c_str());
   return HighsStatus::kError;
 }
+
+HighsStatus Highs::lpInvertRequirementError(std::string method_name) {
+  assert(!ekk_instance_.status_.has_invert);
+  if (model_.isMip() || model_.isQp()) return HighsStatus::kOk;
+  highsLogUser(options_.log_options, HighsLogType::kError,
+               "No LP invertible representation for %s\n", method_name.c_str());
+  return HighsStatus::kError;
+}


### PR DESCRIPTION
Absence of an INVERT when calling `get(Primal)DualRay` is now only an error when solving an LP

This will close #1350 