### PR TITLE
reject quadratic constraints in FilereaderLp

### DIFF
--- a/check/TestLPFileFormat.cpp
+++ b/check/TestLPFileFormat.cpp
@@ -8,9 +8,16 @@ const bool dev_run = false;
 TEST_CASE("lp-file-format-quad-no-space", "[LpFileFormat]") {
   std::string filename =
       std::string(HIGHS_DIR) + "/check/instances/quadratic.lp";
-  Highs highs;
-  highs.setOptionValue("output_flag", dev_run);
-  REQUIRE(highs.readModel(filename) == HighsStatus::kOk);
+
+  //HiGHS cannot handle quadratic constraints as there are in quadratic.lp
+  //so only test that filereaderlp succeeds for now
+  //Highs highs;
+  //highs.setOptionValue("output_flag", dev_run);
+  //REQUIRE(highs.readModel(filename) == HighsStatus::kOk);
+
+  // lpassert in extern/filereaderlp/def.hpp throws
+  // std::invalid_argument whatever the error
+  REQUIRE_NOTHROW(readinstance(filename));
 
   // todo: read the coefficients/variables off the highs model
 }

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -141,6 +141,12 @@ FilereaderRetcode FilereaderLp::readModelFromFile(const HighsOptions& options,
 
       lp.row_lower_.push_back(con->lowerbound);
       lp.row_upper_.push_back(con->upperbound);
+
+      if (!con->expr->quadterms.empty()) {
+        highsLogUser(options.log_options, HighsLogType::kError,
+                     "Quadratic constraints not supported by HiGHS\n");
+        return FilereaderRetcode::kParserError;
+      }
     }
 
     // Check for empty row names, giving them a special name if possible


### PR DESCRIPTION
Instead of ignoring the quadratic coefficients.

Triggered by http://listserv.zib.de/pipermail/scip/2023-July/004699.html