### PR TITLE
MAINT: Add numpy dep [highspy]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.pdm]
-
 [project]
 name = "highspy"
 version = "1.5.3"
@@ -7,7 +5,11 @@ description = "A thin set of pybind11 wrappers to HiGHS"
 authors = [
     {name = "HiGHS developers", email = "highsopt@gmail.com"},
 ]
-dependencies = []
+dependencies = [
+    # pybind11/numpy runtime dep
+    # https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html
+    "numpy>=1.7.0",
+]
 requires-python = ">=3.8"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Closes https://github.com/ERGO-Code/HiGHS/issues/1378.

`numpy` is not a build dependency (because `pybind11` [doesn't need the package](https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html), just the header), it is a runtime dependency, and it makes sense to add it.


Note that generally anyone using `highspy` probably has it at runtime anyway (and at a much higher version), but this makes it clearer.