### PR TITLE
JH mod

### DIFF
--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -21,11 +21,9 @@
 #include "lp_data/HighsOptions.h"
 
 void highsLogHeader(const HighsLogOptions& log_options) {
-  highsLogUser(log_options, HighsLogType::kInfo,
-               "Running HiGHS %d.%d.%d: %s\n",
+  highsLogUser(log_options, HighsLogType::kInfo, "Running HiGHS %d.%d.%d: %s\n",
                (int)HIGHS_VERSION_MAJOR, (int)HIGHS_VERSION_MINOR,
-               (int)HIGHS_VERSION_PATCH,
-               kHighsCopyrightStatement.c_str());
+               (int)HIGHS_VERSION_PATCH, kHighsCopyrightStatement.c_str());
 }
 
 std::array<char, 32> highsDoubleToString(const double val,

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -22,10 +22,9 @@
 
 void highsLogHeader(const HighsLogOptions& log_options) {
   highsLogUser(log_options, HighsLogType::kInfo,
-               "Running HiGHS %d.%d.%d [date: %s, git hash: %s]\n",
+               "Running HiGHS %d.%d.%d: %s\n",
                (int)HIGHS_VERSION_MAJOR, (int)HIGHS_VERSION_MINOR,
-               (int)HIGHS_VERSION_PATCH, HIGHS_COMPILATION_DATE, HIGHS_GITHASH);
-  highsLogUser(log_options, HighsLogType::kInfo, "%s\n",
+               (int)HIGHS_VERSION_PATCH,
                kHighsCopyrightStatement.c_str());
 }
 

--- a/src/io/HighsIO.h
+++ b/src/io/HighsIO.h
@@ -52,8 +52,7 @@ struct HighsLogOptions {
 };
 
 /**
- * @brief Write the HiGHS version, compilation date, git hash and
- * copyright statement
+ * @brief Write the HiGHS version and copyright statement
  */
 void highsLogHeader(const HighsLogOptions& log_options);
 

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -62,7 +62,8 @@ bool activeModifiedUpperBounds(const HighsOptions& options, const HighsLp& lp,
                                const std::vector<double> col_value);
 
 bool considerScaling(const HighsOptions& options, HighsLp& lp);
-void scaleLp(const HighsOptions& options, HighsLp& lp);
+void scaleLp(const HighsOptions& options, HighsLp& lp,
+             const bool force_scaling = false);
 bool equilibrationScaleMatrix(const HighsOptions& options, HighsLp& lp,
                               const HighsInt use_scale_strategy);
 bool maxValueScaleMatrix(const HighsOptions& options, HighsLp& lp,

--- a/src/util/HighsUtils.cpp
+++ b/src/util/HighsUtils.cpp
@@ -302,6 +302,7 @@ void analyseVectorValues(const HighsLogOptions* log_options,
                          const std::string message, HighsInt vecDim,
                          const std::vector<double>& vec, bool analyseValueList,
                          std::string model_name) {
+  assert(vecDim == int(vec.size()));
   if (vecDim == 0) return;
   double log10 = log(10.0);
   const HighsInt nVK = 20;
@@ -1132,7 +1133,13 @@ double nearestPowerOfTwoScale(const double value) {
   // (if arg is not zero), if no errors occur, returns the value x in
   // the range (-1;-0.5], [0.5; 1) and stores an integer value in *exp
   // such that x×2(*exp)=arg
-  std::frexp(value, &exp_scale);
+  double check_x = std::frexp(value, &exp_scale);
+  if (std::fabs(check_x) == 0.5) {
+    check_x *= 2;
+    exp_scale--;
+  }
+  const double check_value = check_x * std::pow(2, exp_scale);
+  assert(check_value == value);
   exp_scale = -exp_scale;
   // Multiply a floating point value x(=1) by the number 2 raised to
   // the exp power

--- a/src/util/HighsUtils.cpp
+++ b/src/util/HighsUtils.cpp
@@ -404,8 +404,8 @@ void analyseVectorValues(const HighsLogOptions* log_options,
       highsFormatToString(
           "%s of dimension %" HIGHSINT_FORMAT " with %" HIGHSINT_FORMAT
           " nonzeros (%3d%%) in [%11.4g, %11.4g]\n",
-          message.c_str(), vecDim, nNz, int(1e2 * double(nNz) / double(vecDim)), min_abs_value,
-          max_abs_value));
+          message.c_str(), vecDim, nNz, int(1e2 * double(nNz) / double(vecDim)),
+          min_abs_value, max_abs_value));
   if (nNegInfV > 0)
     highsReportDevInfo(
         log_options, highsFormatToString(

--- a/src/util/HighsUtils.cpp
+++ b/src/util/HighsUtils.cpp
@@ -403,8 +403,8 @@ void analyseVectorValues(const HighsLogOptions* log_options,
       log_options,
       highsFormatToString(
           "%s of dimension %" HIGHSINT_FORMAT " with %" HIGHSINT_FORMAT
-          " nonzeros (%3" HIGHSINT_FORMAT "%%) in [%11.4g, %11.4g]\n",
-          message.c_str(), vecDim, nNz, 100 * nNz / vecDim, min_abs_value,
+          " nonzeros (%3d%%) in [%11.4g, %11.4g]\n",
+          message.c_str(), vecDim, nNz, int(1e2 * double(nNz) / double(vecDim)), min_abs_value,
           max_abs_value));
   if (nNegInfV > 0)
     highsReportDevInfo(


### PR DESCRIPTION
No longer writes compilation date and Git hash in first line of logging.

`force_scaling` is an optional argument to `scaleLp`, with default value `false`

Poor improvement in scaling now defined to be `improvement_factor <= improvement_factor_required; ` rather than `<`
      