### PR TITLE
Fixed 1386: error in lp_data/HighsLpUtils.cpp

### DIFF
--- a/check/TestLpModification.cpp
+++ b/check/TestLpModification.cpp
@@ -1457,6 +1457,41 @@ TEST_CASE("LP-free-row", "[highs_data]") {
   REQUIRE(highs.getInfo().objective_function_value == -3);
 }
 
+TEST_CASE("LP-delete-ip-var", "[highs_data]") {
+  Highs highs;
+  HighsInt num_var = 5;
+  std::vector<double> lower = {1, 2, 3, 4, 5};
+  std::vector<double> upper = {1, 2, 3, 4, 5};
+  highs.addVars(num_var, lower.data(), upper.data());
+  const HighsInt og_ip_var = 3;
+  const std::vector<HighsInt> og_ip_var_set = {og_ip_var};
+  const std::vector<HighsVarType> og_ip_var_integrality = {
+      HighsVarType::kInteger};
+  const HighsInt delete_var = 2;
+  const std::vector<HighsInt> delete_var_set = {delete_var};
+  const HighsInt later_ip_var = 2;
+  highs.changeColsIntegrality(1, og_ip_var_set.data(),
+                              og_ip_var_integrality.data());
+
+  for (HighsInt iCol = 0; iCol < num_var; iCol++) {
+    if (iCol == og_ip_var) {
+      REQUIRE(highs.getLp().integrality_[iCol] == HighsVarType::kInteger);
+    } else {
+      REQUIRE(highs.getLp().integrality_[iCol] == HighsVarType::kContinuous);
+    }
+  }
+  highs.deleteVars(1, delete_var_set.data());
+  // Now that #1386 is fixed, the integrality should be correct
+  num_var--;
+  for (HighsInt iCol = 0; iCol < num_var; iCol++) {
+    if (iCol == later_ip_var) {
+      REQUIRE(highs.getLp().integrality_[iCol] == HighsVarType::kInteger);
+    } else {
+      REQUIRE(highs.getLp().integrality_[iCol] == HighsVarType::kContinuous);
+    }
+  }
+}
+
 void HighsStatusReport(const HighsLogOptions& log_options, std::string message,
                        HighsStatus status) {
   if (!dev_run) return;

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -1451,6 +1451,7 @@ void deleteColsFromLpVectors(HighsLp& lp, HighsInt& new_num_col,
   HighsInt col_dim = lp.num_col_;
   new_num_col = 0;
   bool have_names = lp.col_names_.size();
+  bool have_integrality = lp.integrality_.size();
   for (HighsInt k = from_k; k <= to_k; k++) {
     updateOutInIndex(index_collection, delete_from_col, delete_to_col,
                      keep_from_col, keep_to_col, current_set_entry);
@@ -1463,6 +1464,7 @@ void deleteColsFromLpVectors(HighsLp& lp, HighsInt& new_num_col,
       lp.col_lower_[new_num_col] = lp.col_lower_[col];
       lp.col_upper_[new_num_col] = lp.col_upper_[col];
       if (have_names) lp.col_names_[new_num_col] = lp.col_names_[col];
+      if (have_integrality) lp.integrality_[new_num_col] = lp.integrality_[col];
       new_num_col++;
     }
     if (keep_to_col >= col_dim - 1) break;


### PR DESCRIPTION
`lp.integrality_` now handled correctly when a variable/column is deleted

This will close #1386 