### PR TITLE
autoformat other cmakelists files

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,53 +1,49 @@
-if (FAST_BUILD)
+if(FAST_BUILD)
+  # create highs binary using library without pic
+  add_executable(highs-bin)
 
-# create highs binary using library without pic
-add_executable(highs-bin)
+  target_sources(highs-bin PRIVATE RunHighs.cpp)
 
-target_sources(highs-bin PRIVATE RunHighs.cpp)
+  target_include_directories(highs-bin PRIVATE
+    $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/app>
+  )
 
-target_include_directories(highs-bin PRIVATE
-        $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/app>  
-        )
+  if(UNIX)
+    target_compile_options(highs-bin PUBLIC "-Wno-unused-variable")
+    target_compile_options(highs-bin PUBLIC "-Wno-unused-const-variable")
+  endif()
 
-if (UNIX)
-        target_compile_options(highs-bin PUBLIC "-Wno-unused-variable")
-        target_compile_options(highs-bin PUBLIC "-Wno-unused-const-variable")
-endif()
+  set_target_properties(highs-bin
+    PROPERTIES OUTPUT_NAME highs)
 
-set_target_properties(highs-bin
-        PROPERTIES OUTPUT_NAME highs)
+  target_link_libraries(highs-bin highs)
 
-target_link_libraries(highs-bin highs)
-
-
-# install the binary
-install(TARGETS highs-bin EXPORT highs-targets
-        RUNTIME)
+  # install the binary
+  install(TARGETS highs-bin EXPORT highs-targets
+    RUNTIME)
 else()
+  # create highs binary using library without pic
+  add_executable(highs)
 
-# create highs binary using library without pic
-add_executable(highs)
+  target_sources(highs PRIVATE RunHighs.cpp)
 
-target_sources(highs PRIVATE RunHighs.cpp)
+  if(UNIX)
+    target_compile_options(highs PUBLIC "-Wno-unused-variable")
+    target_compile_options(highs PUBLIC "-Wno-unused-const-variable")
+  endif()
 
-if (UNIX)
-        target_compile_options(highs PUBLIC "-Wno-unused-variable")
-        target_compile_options(highs PUBLIC "-Wno-unused-const-variable")
-endif()
+  target_link_libraries(highs libhighs)
 
-target_link_libraries(highs libhighs)
+  if(EMSCRIPTEN AND EMSCRIPTEN_HTML)
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+    set_target_properties(highs PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/highs_webdemo_shell.html)
+  endif()
 
-if(EMSCRIPTEN AND EMSCRIPTEN_HTML)
-        set(CMAKE_EXECUTABLE_SUFFIX ".html")
-        set_target_properties(highs PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/highs_webdemo_shell.html)
-endif()
+  target_include_directories(highs PRIVATE
+    $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/app>
+  )
 
-target_include_directories(highs PRIVATE
-        $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/app>  
-        )
-
-# install the binary
-install(TARGETS highs EXPORT highs-targets
-        RUNTIME)
-
+  # install the binary
+  install(TARGETS highs EXPORT highs-targets
+    RUNTIME)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT BUILD_EXAMPLES)
-	return()
+  return()
 endif()
 
 if(BUILD_CXX_EXAMPLE)
@@ -22,4 +22,3 @@ if(BUILD_CXX_EXAMPLE)
     add_c_example(${FILE_NAME})
   endforeach()
 endif()
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,74 +2,74 @@
 # Outdated CMake approach: update in progress
 
 set(basiclu_sources
-    ipm/basiclu/basiclu_factorize.c
-    ipm/basiclu/basiclu_solve_dense.c
-    ipm/basiclu/lu_build_factors.c
-    ipm/basiclu/lu_factorize_bump.c
-    ipm/basiclu/lu_initialize.c
-    ipm/basiclu/lu_markowitz.c
-    ipm/basiclu/lu_setup_bump.c
-    ipm/basiclu/lu_solve_sparse.c
-    ipm/basiclu/basiclu_get_factors.c
-    ipm/basiclu/basiclu_solve_for_update.c
-    ipm/basiclu/lu_condest.c
-    ipm/basiclu/lu_file.c
-    ipm/basiclu/lu_internal.c
-    ipm/basiclu/lu_matrix_norm.c
-    ipm/basiclu/lu_singletons.c
-    ipm/basiclu/lu_solve_symbolic.c
-    ipm/basiclu/lu_update.c
-    ipm/basiclu/basiclu_initialize.c
-    ipm/basiclu/basiclu_solve_sparse.c
-    ipm/basiclu/lu_pivot.c
-    ipm/basiclu/lu_solve_dense.c
-    ipm/basiclu/lu_solve_triangular.c
-    ipm/basiclu/basiclu_object.c
-    ipm/basiclu/basiclu_update.c
-    ipm/basiclu/lu_dfs.c
-    ipm/basiclu/lu_garbage_perm.c
-    ipm/basiclu/lu_residual_test.c
-    ipm/basiclu/lu_solve_for_update.c)
+  ipm/basiclu/basiclu_factorize.c
+  ipm/basiclu/basiclu_solve_dense.c
+  ipm/basiclu/lu_build_factors.c
+  ipm/basiclu/lu_factorize_bump.c
+  ipm/basiclu/lu_initialize.c
+  ipm/basiclu/lu_markowitz.c
+  ipm/basiclu/lu_setup_bump.c
+  ipm/basiclu/lu_solve_sparse.c
+  ipm/basiclu/basiclu_get_factors.c
+  ipm/basiclu/basiclu_solve_for_update.c
+  ipm/basiclu/lu_condest.c
+  ipm/basiclu/lu_file.c
+  ipm/basiclu/lu_internal.c
+  ipm/basiclu/lu_matrix_norm.c
+  ipm/basiclu/lu_singletons.c
+  ipm/basiclu/lu_solve_symbolic.c
+  ipm/basiclu/lu_update.c
+  ipm/basiclu/basiclu_initialize.c
+  ipm/basiclu/basiclu_solve_sparse.c
+  ipm/basiclu/lu_pivot.c
+  ipm/basiclu/lu_solve_dense.c
+  ipm/basiclu/lu_solve_triangular.c
+  ipm/basiclu/basiclu_object.c
+  ipm/basiclu/basiclu_update.c
+  ipm/basiclu/lu_dfs.c
+  ipm/basiclu/lu_garbage_perm.c
+  ipm/basiclu/lu_residual_test.c
+  ipm/basiclu/lu_solve_for_update.c)
 
 set(ipx_sources
-    ipm/ipx/basiclu_kernel.cc
-    ipm/ipx/basiclu_wrapper.cc
-    ipm/ipx/basis.cc
-    ipm/ipx/conjugate_residuals.cc
-    ipm/ipx/control.cc
-    ipm/ipx/crossover.cc
-    ipm/ipx/diagonal_precond.cc
-    ipm/ipx/forrest_tomlin.cc
-    ipm/ipx/guess_basis.cc
-    ipm/ipx/indexed_vector.cc
-    ipm/ipx/info.cc
-    ipm/ipx/ipm.cc
-    ipm/ipx/ipx_c.cc
-    ipm/ipx/iterate.cc
-    ipm/ipx/kkt_solver.cc
-    ipm/ipx/kkt_solver_basis.cc
-    ipm/ipx/kkt_solver_diag.cc
-    ipm/ipx/linear_operator.cc
-    ipm/ipx/lp_solver.cc
-    ipm/ipx/lu_factorization.cc
-    ipm/ipx/lu_update.cc
-    ipm/ipx/maxvolume.cc
-    ipm/ipx/model.cc
-    ipm/ipx/normal_matrix.cc
-    ipm/ipx/sparse_matrix.cc
-    ipm/ipx/sparse_utils.cc
-    ipm/ipx/splitted_normal_matrix.cc
-    ipm/ipx/starting_basis.cc
-    ipm/ipx/symbolic_invert.cc
-    ipm/ipx/timer.cc
-    ipm/ipx/utils.cc)
+  ipm/ipx/basiclu_kernel.cc
+  ipm/ipx/basiclu_wrapper.cc
+  ipm/ipx/basis.cc
+  ipm/ipx/conjugate_residuals.cc
+  ipm/ipx/control.cc
+  ipm/ipx/crossover.cc
+  ipm/ipx/diagonal_precond.cc
+  ipm/ipx/forrest_tomlin.cc
+  ipm/ipx/guess_basis.cc
+  ipm/ipx/indexed_vector.cc
+  ipm/ipx/info.cc
+  ipm/ipx/ipm.cc
+  ipm/ipx/ipx_c.cc
+  ipm/ipx/iterate.cc
+  ipm/ipx/kkt_solver.cc
+  ipm/ipx/kkt_solver_basis.cc
+  ipm/ipx/kkt_solver_diag.cc
+  ipm/ipx/linear_operator.cc
+  ipm/ipx/lp_solver.cc
+  ipm/ipx/lu_factorization.cc
+  ipm/ipx/lu_update.cc
+  ipm/ipx/maxvolume.cc
+  ipm/ipx/model.cc
+  ipm/ipx/normal_matrix.cc
+  ipm/ipx/sparse_matrix.cc
+  ipm/ipx/sparse_utils.cc
+  ipm/ipx/splitted_normal_matrix.cc
+  ipm/ipx/starting_basis.cc
+  ipm/ipx/symbolic_invert.cc
+  ipm/ipx/timer.cc
+  ipm/ipx/utils.cc)
 
 # Outdated CMake approach: update in progress
-if (NOT FAST_BUILD)
-include_directories(ipm/ipx)
-include_directories(ipm/basiclu)
+if(NOT FAST_BUILD)
+  include_directories(ipm/ipx)
+  include_directories(ipm/basiclu)
 
-set(sources
+  set(sources
     ../extern/filereaderlp/reader.cpp
     io/Filereader.cpp
     io/FilereaderLp.cpp
@@ -174,7 +174,7 @@ set(sources
     util/stringutil.cpp
     interfaces/highs_c_api.cpp)
 
-set(headers
+  set(headers
     ../extern/filereaderlp/builder.hpp
     ../extern/filereaderlp/model.hpp
     ../extern/filereaderlp/reader.hpp
@@ -303,132 +303,133 @@ set(headers
     util/stringutil.h
     Highs.h
     interfaces/highs_c_api.h
-)
+  )
 
-set(headers ${headers} ipm/IpxWrapper.h ${basiclu_headers}
+  set(headers ${headers} ipm/IpxWrapper.h ${basiclu_headers}
     ${ipx_headers})
-set(sources ${sources} ipm/IpxWrapper.cpp ${basiclu_sources} ${ipx_sources})
+  set(sources ${sources} ipm/IpxWrapper.cpp ${basiclu_sources} ${ipx_sources})
 
-add_library(libhighs ${sources})
+  add_library(libhighs ${sources})
 
-if(${BUILD_SHARED_LIBS})
+  if(${BUILD_SHARED_LIBS})
     # put version information into shared library file
     set_target_properties(libhighs PROPERTIES
-        VERSION
-        ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR}.${HIGHS_VERSION_PATCH}
-        SOVERSION ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR})
+      VERSION
+      ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR}.${HIGHS_VERSION_PATCH}
+      SOVERSION ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR})
     if(MINGW)
-        target_compile_definitions(libhighs PUBLIC LIBHIGHS_STATIC_DEFINE)
+      target_compile_definitions(libhighs PUBLIC LIBHIGHS_STATIC_DEFINE)
     endif()
-else()
+  else()
     # create static highs library with pic
     set_target_properties(libhighs PROPERTIES
-        POSITION_INDEPENDENT_CODE on)
+      POSITION_INDEPENDENT_CODE on)
     target_compile_definitions(libhighs PUBLIC LIBHIGHS_STATIC_DEFINE)
-endif()
+  endif()
 
-# on UNIX system the 'lib' prefix is automatically added
-set_target_properties(libhighs PROPERTIES
+  # on UNIX system the 'lib' prefix is automatically added
+  set_target_properties(libhighs PROPERTIES
     OUTPUT_NAME "highs"
     MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
-if (ZLIB AND ZLIB_FOUND)
-  target_link_libraries(libhighs ZLIB::ZLIB)
-  set(CONF_DEPENDENCIES "include(CMakeFindDependencyMacro)\nfind_dependency(ZLIB)")
-endif()
+  if(ZLIB AND ZLIB_FOUND)
+    target_link_libraries(libhighs ZLIB::ZLIB)
+    set(CONF_DEPENDENCIES "include(CMakeFindDependencyMacro)\nfind_dependency(ZLIB)")
+  endif()
 
-# set the install rpath to the installed destination
-set_target_properties(libhighs PROPERTIES INSTALL_RPATH
+  # set the install rpath to the installed destination
+  set_target_properties(libhighs PROPERTIES INSTALL_RPATH
     "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
-# install the header files of highs
-foreach ( file ${headers} )
-    get_filename_component( dir ${file} DIRECTORY )
-    if ( NOT dir STREQUAL "" )
-        string( REPLACE ../extern/ "" dir ${dir} )
-    endif ()
-    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/${dir} )
-endforeach()
-install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
+  # install the header files of highs
+  foreach(file ${headers})
+    get_filename_component(dir ${file} DIRECTORY)
 
-if (UNIX)
-    #target_compile_options(libhighs PRIVATE "-Wno-defaulted-function-deleted")
-    #target_compile_options(libhighs PRIVATE "-Wno-return-type-c-linkage")
+    if(NOT dir STREQUAL "")
+      string(REPLACE ../extern/ "" dir ${dir})
+    endif()
+
+    install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/${dir})
+  endforeach()
+  install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
+
+  if(UNIX)
+    # target_compile_options(libhighs PRIVATE "-Wno-defaulted-function-deleted")
+    # target_compile_options(libhighs PRIVATE "-Wno-return-type-c-linkage")
     target_compile_options(libhighs PRIVATE "-Wno-return-type" "-Wno-switch")
 
     target_compile_options(libhighs PRIVATE "-Wno-unused-variable")
     target_compile_options(libhighs PRIVATE "-Wno-unused-const-variable")
-    #target_compile_options(libhighs PRIVATE "-Wno-sign-compare")
-    #target_compile_options(libhighs PRIVATE "-Wno-logical-op-parentheses")
 
-    #target_compile_options(libipx PRIVATE "-Wno-defaulted-function-deleted")
-    #target_compile_options(libipx PRIVATE "-Wno-return-type-c-linkage")
-    #target_compile_options(libipx PRIVATE "-Wno-return-type" "-Wno-switch")
+    # target_compile_options(libhighs PRIVATE "-Wno-sign-compare")
+    # target_compile_options(libhighs PRIVATE "-Wno-logical-op-parentheses")
 
-    #target_compile_options(libipx PRIVATE "-Wno-unused-variable")
-    #target_compile_options(libipx PRIVATE "-Wno-sign-compare")
-    #target_compile_options(libipx PRIVATE "-Wno-logical-op-parentheses")
-endif()
+    # target_compile_options(libipx PRIVATE "-Wno-defaulted-function-deleted")
+    # target_compile_options(libipx PRIVATE "-Wno-return-type-c-linkage")
+    # target_compile_options(libipx PRIVATE "-Wno-return-type" "-Wno-switch")
 
-install(TARGETS libhighs EXPORT highs-targets
+    # target_compile_options(libipx PRIVATE "-Wno-unused-variable")
+    # target_compile_options(libipx PRIVATE "-Wno-sign-compare")
+    # target_compile_options(libipx PRIVATE "-Wno-logical-op-parentheses")
+  endif()
+
+  install(TARGETS libhighs EXPORT highs-targets
     LIBRARY
     ARCHIVE
     RUNTIME
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
-# Add library targets to the build-tree export set
-export(TARGETS libhighs
+  # Add library targets to the build-tree export set
+  export(TARGETS libhighs
     FILE "${HIGHS_BINARY_DIR}/highs-targets.cmake")
 
-# Configure the config file for the build tree:
-# Either list all the src/* directories here, or put explicit paths in all the
-# include statements.
-# M reckons that the latter is more transparent, and I'm inclined to agree.
-set(CONF_INCLUDE_DIRS "${HIGHS_SOURCE_DIR}/src" "${HIGHS_BINARY_DIR}")
-configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
+  # Configure the config file for the build tree:
+  # Either list all the src/* directories here, or put explicit paths in all the
+  # include statements.
+  # M reckons that the latter is more transparent, and I'm inclined to agree.
+  set(CONF_INCLUDE_DIRS "${HIGHS_SOURCE_DIR}/src" "${HIGHS_BINARY_DIR}")
+  configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
     "${HIGHS_BINARY_DIR}/highs-config.cmake" @ONLY)
 
-# Configure the config file for the install
-set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR}/highs")
-configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
+  # Configure the config file for the install
+  set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR}/highs")
+  configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
     "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake" @ONLY)
 
-# Configure the pkg-config file for the install
-configure_file(${HIGHS_SOURCE_DIR}/highs.pc.in
+  # Configure the pkg-config file for the install
+  configure_file(${HIGHS_SOURCE_DIR}/highs.pc.in
     "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc" @ONLY)
 
-# Install the targets of the highs export group, the config file so that other
-# cmake-projects can link easily against highs, and the pkg-config flie so that
-# other projects can easily build against highs
-install(EXPORT highs-targets FILE highs-targets.cmake DESTINATION
+  # Install the targets of the highs export group, the config file so that other
+  # cmake-projects can link easily against highs, and the pkg-config flie so that
+  # other projects can easily build against highs
+  install(EXPORT highs-targets FILE highs-targets.cmake DESTINATION
     ${CMAKE_INSTALL_LIBDIR}/cmake/highs)
-install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake"
+  install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/highs)
-install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc"
+  install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 else()
+  # FAST_BUILD is set to on.
+  # At the moment used only for gradually updating the CMake targets build and
+  # install / export.
+  # Define library in modern CMake using target_*()
+  # No interfaces (apart from c); No ipx; New (short) ctest instances.
+  add_library(highs)
 
-# FAST_BUILD is set to on.
-# At the moment used only for gradually updating the CMake targets build and
-# install / export.
-# Define library in modern CMake using target_*()
-# No interfaces (apart from c); No ipx; New (short) ctest instances.
-add_library(highs)
+  set_target_properties(highs PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  target_compile_definitions(highs PUBLIC LIBHIGHS_STATIC_DEFINE)
 
-set_target_properties(highs PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_compile_definitions(highs PUBLIC LIBHIGHS_STATIC_DEFINE)
-
-
-if(${BUILD_SHARED_LIBS})
+  if(${BUILD_SHARED_LIBS})
     # put version information into shared library file
     set_target_properties(highs PROPERTIES
-        VERSION
-        ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR}.${HIGHS_VERSION_PATCH}
-        SOVERSION ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR})
-endif()
+      VERSION
+      ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR}.${HIGHS_VERSION_PATCH}
+      SOVERSION ${HIGHS_VERSION_MAJOR}.${HIGHS_VERSION_MINOR})
+  endif()
 
-target_sources(highs PRIVATE
+  target_sources(highs PRIVATE
     ../extern/filereaderlp/reader.cpp
     io/Filereader.cpp
     io/FilereaderLp.cpp
@@ -533,55 +534,54 @@ target_sources(highs PRIVATE
     util/HVectorBase.cpp
     util/stringutil.cpp
     interfaces/highs_c_api.cpp)
-  
-target_include_directories(highs PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>  
+
+  target_include_directories(highs PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${HIGHS_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/highs>
-    )
+  )
 
-target_include_directories(highs PRIVATE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interfaces>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/io>  
+  target_include_directories(highs PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/interfaces>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/io>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ipm>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ipm/ipx>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ipm/basiclu>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lp_data>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mip>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/model>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/parallel>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/presolve>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/qpsolver>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/simplex>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/util>  
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>  
-    )
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/lp_data>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mip>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/model>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/parallel>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/presolve>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/qpsolver>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/simplex>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/util>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+  )
 
-target_include_directories(highs PRIVATE
+  target_include_directories(highs PRIVATE
     $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/extern/>
     $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/extern/filereader>
     $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/extern/pdqsort>
-    )
+  )
 
-if (ZLIB AND ZLIB_FOUND)
+  if(ZLIB AND ZLIB_FOUND)
     target_include_directories(highs PRIVATE
-    $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/extern/zstr>
+      $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/extern/zstr>
     )
     target_link_libraries(highs ZLIB::ZLIB)
     set(CONF_DEPENDENCIES "include(CMakeFindDependencyMacro)\nfind_dependency(ZLIB)")
-endif()
+  endif()
 
-# # on UNIX system the 'lib' prefix is automatically added
-# set_target_properties(highs PROPERTIES
-#     OUTPUT_NAME "highs"
-#     MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  # # on UNIX system the 'lib' prefix is automatically added
+  # set_target_properties(highs PROPERTIES
+  # OUTPUT_NAME "highs"
+  # MACOSX_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
-# if (UNIX)
-#     set_target_properties(highs PROPERTIES
-#         LIBRARY_OUTPUT_DIRECTORY "${HIGHS_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
-# endif()
-
-set(headers_fast_build_
+  # if (UNIX)
+  # set_target_properties(highs PROPERTIES
+  # LIBRARY_OUTPUT_DIRECTORY "${HIGHS_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+  # endif()
+  set(headers_fast_build_
     ../extern/filereaderlp/builder.hpp
     ../extern/filereaderlp/model.hpp
     ../extern/filereaderlp/reader.hpp
@@ -710,102 +710,103 @@ set(headers_fast_build_
     util/stringutil.h
     Highs.h
     interfaces/highs_c_api.h
-)
+  )
 
-set(headers_fast_build_ ${headers_fast_build_} ipm/IpxWrapper.h ${basiclu_headers}
+  set(headers_fast_build_ ${headers_fast_build_} ipm/IpxWrapper.h ${basiclu_headers}
     ${ipx_headers})
 
-#set_target_properties(highs PROPERTIES PUBLIC_HEADER "src/Highs.h;src/lp_data/HighsLp.h;src/lp_data/HighsLpSolverObject.h")
+  # set_target_properties(highs PROPERTIES PUBLIC_HEADER "src/Highs.h;src/lp_data/HighsLp.h;src/lp_data/HighsLpSolverObject.h")
 
-# set the install rpath to the installed destination
-# set_target_properties(highs PROPERTIES INSTALL_RPATH
-#     "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  # set the install rpath to the installed destination
+  # set_target_properties(highs PROPERTIES INSTALL_RPATH
+  # "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
-# install the header files of highs
-foreach ( file ${headers_fast_build_} )
-    get_filename_component( dir ${file} DIRECTORY )
-    if ( NOT dir STREQUAL "" )
-        string( REPLACE ../extern/ "" dir ${dir} )
-    endif ()
-    install( FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/${dir} )
-endforeach()
-install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
+  # install the header files of highs
+  foreach(file ${headers_fast_build_})
+    get_filename_component(dir ${file} DIRECTORY)
 
+    if(NOT dir STREQUAL "")
+      string(REPLACE ../extern/ "" dir ${dir})
+    endif()
 
-# target_compile_options(highs PRIVATE "-Wall")
-# target_compile_options(highs PRIVATE "-Wunused")
+    install(FILES ${file} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/${dir})
+  endforeach()
+  install(FILES ${HIGHS_BINARY_DIR}/HConfig.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs)
 
-target_sources(highs PRIVATE ${basiclu_sources} ${ipx_sources} ipm/IpxWrapper.cpp)
+  # target_compile_options(highs PRIVATE "-Wall")
+  # target_compile_options(highs PRIVATE "-Wunused")
+  target_sources(highs PRIVATE ${basiclu_sources} ${ipx_sources} ipm/IpxWrapper.cpp)
 
-if (UNIX)
+  if(UNIX)
     target_compile_options(highs PRIVATE "-Wno-unused-variable")
     target_compile_options(highs PRIVATE "-Wno-unused-const-variable")
-endif()
+  endif()
 
-    # Configure the config file for the build tree:
-    # Either list all the src/* directories here, or put explicit paths in all the
-    # include statements.
-    # M reckons that the latter is more transparent, and I'm inclined to agree.
-    set(CONF_INCLUDE_DIRS "${HIGHS_SOURCE_DIR}/src" "${HIGHS_BINARY_DIR}")
-    configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
-        "${HIGHS_BINARY_DIR}/highs-config.cmake" @ONLY)
+  # Configure the config file for the build tree:
+  # Either list all the src/* directories here, or put explicit paths in all the
+  # include statements.
+  # M reckons that the latter is more transparent, and I'm inclined to agree.
+  set(CONF_INCLUDE_DIRS "${HIGHS_SOURCE_DIR}/src" "${HIGHS_BINARY_DIR}")
+  configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
+    "${HIGHS_BINARY_DIR}/highs-config.cmake" @ONLY)
 
-    # Configure the config file for the install
-    set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR}")
-    configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
-        "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake" @ONLY)
+  # Configure the config file for the install
+  set(CONF_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${CMAKE_INSTALL_INCLUDEDIR}")
+  configure_file(${HIGHS_SOURCE_DIR}/highs-config.cmake.in
+    "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake" @ONLY)
 
-    # Configure the pkg-config file for the install
-    configure_file(${HIGHS_SOURCE_DIR}/highs.pc.in
-        "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc" @ONLY)
+  # Configure the pkg-config file for the install
+  configure_file(${HIGHS_SOURCE_DIR}/highs.pc.in
+    "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc" @ONLY)
 
-    # Install the targets of the highs export group, the config file so that other
-    # cmake-projects can link easily against highs, and the pkg-config flie so that
-    # other projects can easily build against highs
-    install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake"
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/highs)
-    install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc"
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-
+  # Install the targets of the highs export group, the config file so that other
+  # cmake-projects can link easily against highs, and the pkg-config flie so that
+  # other projects can easily build against highs
+  install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs-config.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/highs)
+  install(FILES "${HIGHS_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/highs.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 
 if(FORTRAN_FOUND)
-    set(fortransources interfaces/highs_fortran_api.f90)
-    set(CMAKE_Fortran_MODULE_DIRECTORY ${HIGHS_BINARY_DIR}/modules)
-    add_library(FortranHighs interfaces/highs_fortran_api.f90)
-    if (NOT FAST_BUILD)
-        target_link_libraries(FortranHighs PUBLIC libhighs)
-    else()
-        target_link_libraries(FortranHighs PUBLIC highs)
-    endif()
+  set(fortransources interfaces/highs_fortran_api.f90)
+  set(CMAKE_Fortran_MODULE_DIRECTORY ${HIGHS_BINARY_DIR}/modules)
+  add_library(FortranHighs interfaces/highs_fortran_api.f90)
 
-    install(TARGETS FortranHighs
-        LIBRARY
-        ARCHIVE
-        RUNTIME
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs
-        MODULES DESTINATION modules)
-    install(FILES ${HIGHS_BINARY_DIR}/modules/highs_fortran_api.mod DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/fortran)
-    set_target_properties(FortranHighs PROPERTIES INSTALL_RPATH
-        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+  if(NOT FAST_BUILD)
+    target_link_libraries(FortranHighs PUBLIC libhighs)
+  else()
+    target_link_libraries(FortranHighs PUBLIC highs)
+  endif()
+
+  install(TARGETS FortranHighs
+    LIBRARY
+    ARCHIVE
+    RUNTIME
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs
+    MODULES DESTINATION modules)
+  install(FILES ${HIGHS_BINARY_DIR}/modules/highs_fortran_api.mod DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/highs/fortran)
+  set_target_properties(FortranHighs PROPERTIES INSTALL_RPATH
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 endif(FORTRAN_FOUND)
 
 if(CSHARP_FOUND)
-    message(STATUS "CSharp supported")
-    set(csharpsources
+  message(STATUS "CSharp supported")
+  set(csharpsources
     interfaces/highs_csharp_api.cs)
-    add_library(HighsCsharp interfaces/highs_csharp_api.cs)
-    target_compile_options(HighsCsharp PUBLIC "/unsafe")
-    add_executable(csharpexample ../examples/call_highs_from_csharp.cs)
-    target_compile_options(csharpexample PUBLIC "/unsafe")
-    target_link_libraries(csharpexample PUBLIC HighsCsharp)
+  add_library(HighsCsharp interfaces/highs_csharp_api.cs)
+  target_compile_options(HighsCsharp PUBLIC "/unsafe")
+  add_executable(csharpexample ../examples/call_highs_from_csharp.cs)
+  target_compile_options(csharpexample PUBLIC "/unsafe")
+  target_link_libraries(csharpexample PUBLIC HighsCsharp)
 else()
-    message(STATUS "No CSharp support")
+  message(STATUS "No CSharp support")
 endif()
 
 find_package(Threads REQUIRED)
-if (FAST_BUILD)
-target_link_libraries(highs Threads::Threads)
+
+if(FAST_BUILD)
+  target_link_libraries(highs Threads::Threads)
 else()
-target_link_libraries(libhighs Threads::Threads)
+  target_link_libraries(libhighs Threads::Threads)
 endif()


### PR DESCRIPTION
Auto-formatted other CMakelists. I understand if you need to close this because it is annoying to merge with other cmake changes you have.

FYI my VSCode was detecting weird tab sizes by default (8 spaces?) in app/CMakeLists.txt so I had to change some editor settings to get the auto-format to work ("editor.detectIndentation": false).
