### PR TITLE
CI: Disable agressive wheel builds

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,6 +1,12 @@
 name: Build wheels
+on:
+  release:
+    types:
+      - published
 
-on: [push, pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Stops building wheels except on published versions.

No more:
![image](https://github.com/ERGO-Code/HiGHS/assets/4336207/244ef83f-fdaa-4c3b-914c-960da1e9d2ce)
