### PR TITLE
Improve pkg-config template

### DIFF
--- a/highs.pc.in
+++ b/highs.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/highs
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/highs
 
 Name: HiGHS
 Description: Linear Optimization Software


### PR DESCRIPTION
Hi,

thank you for your work on HiGHS! While packaging it for the [Nix package manager](https://nixos.org), I ran into a minor issue with your current pkg-config setup. Nix stores every package in the *Nix store* with a unique hash for each build. A path for HiGHS would look something like `/nix/store/<hash>-highs-1.5.4`. To this end, the install path is set to this absolute path. However, your pkg-config template always includes a prefix. Beside the `CMAKE_INSTALL_*` variables, there are also the [`CMAKE_INSTALL_FULL_*` variables](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html), which automatically include the prefix if applicable, but leave it out if the install path is already absolute. I have verified that this patch allows HiGHS to be built and packaged for Nix and probably other package managers with similar philosophies such as Guix, without any impact on more standard installations.

Thank you for your consideration!