### PR TITLE
BUG: Fix `highspy` `__getitem__` speed

### DIFF
--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -543,26 +543,7 @@ std::tuple<HighsStatus, int> highs_getRowByName(Highs* h,
 }
 
 PYBIND11_MODULE(highspy, m) {
-  py::class_<std::vector<double>>(m, "VectorDouble")
-      .def(py::init<>())
-      .def("clear", &std::vector<double>::clear)
-      .def("pop_back", &std::vector<double>::pop_back)
-      .def("__len__", [](const std::vector<double>& v) { return v.size(); })
-      .def(
-          "__iter__",
-          [](std::vector<double>& v) {
-            return py::make_iterator(v.begin(), v.end());
-          },
-          py::keep_alive<0, 1>())
-      .def("__getitem__",
-           [](const std::vector<double>& v, size_t i) {
-             if (i >= v.size()) throw py::index_error();
-             return v.at(i);
-           })
-      .def("__setitem__", [](std::vector<double>& v, size_t i, double value) {
-        if (i >= v.size()) throw py::index_error();
-        v.at(i) = value;
-      });
+  py::bind_vector<std::vector<double>>(m, "VectorDouble");
   // enum classes
   py::enum_<ObjSense>(m, "ObjSense")
       .value("kMinimize", ObjSense::kMinimize)

--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -10,6 +10,8 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+PYBIND11_MAKE_OPAQUE(std::vector<double>);
+
 HighsStatus highs_passModel(Highs* h, HighsModel& model) {
   return h->passModel(model);
 }
@@ -541,6 +543,7 @@ std::tuple<HighsStatus, int> highs_getRowByName(Highs* h,
 }
 
 PYBIND11_MODULE(highspy, m) {
+  py::bind_vector<std::vector<double>>(m, "VectorDouble");
   // enum classes
   py::enum_<ObjSense>(m, "ObjSense")
       .value("kMinimize", ObjSense::kMinimize)
@@ -906,34 +909,10 @@ PYBIND11_MODULE(highspy, m) {
       .def(py::init<>())
       .def_readwrite("value_valid", &HighsSolution::value_valid)
       .def_readwrite("dual_valid", &HighsSolution::dual_valid)
-      .def_property(
-          "col_value",
-          [](HighsSolution& self) {
-            return py::array_t<double>(self.col_value.size(),
-                                       self.col_value.data());
-          },
-          nullptr)
-      .def_property(
-          "col_dual",
-          [](HighsSolution& self) {
-            return py::array_t<double>(self.col_dual.size(),
-                                       self.col_dual.data());
-          },
-          nullptr)
-      .def_property(
-          "row_value",
-          [](HighsSolution& self) {
-            return py::array_t<double>(self.row_value.size(),
-                                       self.row_value.data());
-          },
-          nullptr)
-      .def_property(
-          "row_dual",
-          [](HighsSolution& self) {
-            return py::array_t<double>(self.row_dual.size(),
-                                       self.row_dual.data());
-          },
-          nullptr);
+      .def_readwrite("col_value", &HighsSolution::col_value)
+      .def_readwrite("col_dual", &HighsSolution::col_dual)
+      .def_readwrite("row_value", &HighsSolution::row_value)
+      .def_readwrite("row_dual", &HighsSolution::row_dual);
   py::class_<HighsObjectiveSolution>(m, "HighsObjectiveSolution")
       .def(py::init<>())
       .def_readwrite("objective", &HighsObjectiveSolution::objective)

--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -543,7 +543,26 @@ std::tuple<HighsStatus, int> highs_getRowByName(Highs* h,
 }
 
 PYBIND11_MODULE(highspy, m) {
-  py::bind_vector<std::vector<double>>(m, "VectorDouble");
+  py::class_<std::vector<double>>(m, "VectorDouble")
+      .def(py::init<>())
+      .def("clear", &std::vector<double>::clear)
+      .def("pop_back", &std::vector<double>::pop_back)
+      .def("__len__", [](const std::vector<double>& v) { return v.size(); })
+      .def(
+          "__iter__",
+          [](std::vector<double>& v) {
+            return py::make_iterator(v.begin(), v.end());
+          },
+          py::keep_alive<0, 1>())
+      .def("__getitem__",
+           [](const std::vector<double>& v, size_t i) {
+             if (i >= v.size()) throw py::index_error();
+             return v.at(i);
+           })
+      .def("__setitem__", [](std::vector<double>& v, size_t i, double value) {
+        if (i >= v.size()) throw py::index_error();
+        v.at(i) = value;
+      });
   // enum classes
   py::enum_<ObjSense>(m, "ObjSense")
       .value("kMinimize", ObjSense::kMinimize)

--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 
 #include <cassert>
 
@@ -905,10 +906,34 @@ PYBIND11_MODULE(highspy, m) {
       .def(py::init<>())
       .def_readwrite("value_valid", &HighsSolution::value_valid)
       .def_readwrite("dual_valid", &HighsSolution::dual_valid)
-      .def_readwrite("col_value", &HighsSolution::col_value)
-      .def_readwrite("col_dual", &HighsSolution::col_dual)
-      .def_readwrite("row_value", &HighsSolution::row_value)
-      .def_readwrite("row_dual", &HighsSolution::row_dual);
+      .def_property(
+          "col_value",
+          [](HighsSolution& self) {
+            return py::array_t<double>(self.col_value.size(),
+                                       self.col_value.data());
+          },
+          nullptr)
+      .def_property(
+          "col_dual",
+          [](HighsSolution& self) {
+            return py::array_t<double>(self.col_dual.size(),
+                                       self.col_dual.data());
+          },
+          nullptr)
+      .def_property(
+          "row_value",
+          [](HighsSolution& self) {
+            return py::array_t<double>(self.row_value.size(),
+                                       self.row_value.data());
+          },
+          nullptr)
+      .def_property(
+          "row_dual",
+          [](HighsSolution& self) {
+            return py::array_t<double>(self.row_dual.size(),
+                                       self.row_dual.data());
+          },
+          nullptr);
   py::class_<HighsObjectiveSolution>(m, "HighsObjectiveSolution")
       .def(py::init<>())
       .def_readwrite("objective", &HighsObjectiveSolution::objective)


### PR DESCRIPTION
Closes https://github.com/ERGO-Code/HiGHS/issues/1277. For this test case (adapted from [here](https://gist.github.com/aphi/4b2f7cfc7ccc52465bead3c24ee9c3f4)):

```python
import highspy
import timeit

h = highspy.Highs()

h.readModel("80bau3b.mps")
h.setOptionValue("time_limit", 10)

# Solve
start_time = timeit.default_timer()
h.run()
elapsed = timeit.default_timer() - start_time

print(f"Time taken to solve: {elapsed:.4f}")

solution = h.getSolution()
num_vars = h.getNumCol()

# Extract values using __getitem__ N times
start_time = timeit.default_timer()
values = [solution.col_value[icol] for icol in range(num_vars)]
elapsed = timeit.default_timer() - start_time
print(f"__getitem__ method for {num_vars} vars: {elapsed:.4f}")


# Extract values by copying first to list
start_time = timeit.default_timer()
col_values = list(solution.col_value)
values = [col_values[icol] for icol in range(num_vars)]
elapsed = timeit.default_timer() - start_time
print(f"Copy-first method for {num_vars} vars: {elapsed:.4f}")
```

Where the `80bau3b.mps` is part of this repo, we have:

```bash
# Original
Time taken to solve: 0.1016
__getitem__ method for 9799 vars: 0.7423
Copy-first method for 9799 vars: 0.0003
```

As a first approximation, we can use the buff protocol and `numpy`:

```bash

# Numpy readonly (33b6634823b41252f28fdd9daa5b553c6b9b43cd)
Time taken to solve: 0.0974
__getitem__ method for 9799 vars: 0.0956
Copy-first method for 9799 vars: 0.0010
```

However, this isn't equivalent to `readwrite` and isn't very nice conceptually, so we can try to use an opaque type:

```bash
# Opaque type (standard) for std::vector<double> (2aa08d9c8471a86aafa544d7976de1e520c7357f)
Time taken to solve: 0.1007
__getitem__ method for 9799 vars: 0.0064
Copy-first method for 9799 vars: 0.0015
```

This can be optimized a bit more:
```bash
# Custom opaque type and class
Time taken to solve: 0.0919
__getitem__ method for 9799 vars: 0.0046
Copy-first method for 9799 vars: 0.0015
```

Note that this method has the caveats listed in [the documentation](https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#making-opaque-types). I think the standard opaque type is probably about as far as can be optimized safely, though there seem to be some micro-optimizations [discussed on Gitter](https://matrix.to/#/!vYqYcTzqekPEfQIxEf:gitter.im/$DaLVlGr0PT27yS8vp0LGt5ap7QfqYqCM5YjKW-0seLc?via=gitter.im&via=matrix.org&via=chaos.jetzt) (which I admit are beyond me).