### PR TITLE
Restrict meson-python to 0.13.2 temporarily

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('highs', 'cpp',
   version : '1.6.0',
+  meson_version: '>= 1.2.0',
   default_options : ['warning_level=1',
                      'cpp_std=c++17',
                      'wrap_mode=forcefallback'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = {text = "MIT"}
 "Bug Tracker" = "https://github.com/ERGO-Code/HiGHS/issues"
 
 [build-system]
-requires = ["meson-python<0.14.0"]
+requires = ["meson-python<0.14.0", "meson>=1.2.0"]
 build-backend = "mesonpy"
 
 [tool.meson-python.args]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = {text = "MIT"}
 "Bug Tracker" = "https://github.com/ERGO-Code/HiGHS/issues"
 
 [build-system]
-requires = ["meson-python"]
+requires = ["meson-python<0.14.0"]
 build-backend = "mesonpy"
 
 [tool.meson-python.args]


### PR DESCRIPTION
meson-python 0.14.0 has a bug that handles rpath of python binding incorrectly. Use 0.13.2 temporarily as a fix.
The upstream fix has landed in https://github.com/mesonbuild/meson-python/pull/510