### PR TITLE
Minor changes to HighsHashTree.h motivated by #1372

### DIFF
--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -655,6 +655,9 @@ class HighsHashTree {
               for (int i = 0; i <= newNumChild; ++i)
                 mergeIntoLeaf(newLeafSize4, hashPos, branch->child[i]);
             }
+            default:
+              throw std::logic_error(
+                  "Unexpected result from entries_to_size_class");
           }
 
           destroyBranchingNode(branch);
@@ -841,7 +844,7 @@ class HighsHashTree {
           } else {
             // there are many collisions, determine the exact sizes first
             uint8_t sizes[InnerLeaf<4>::capacity() + 1];
-            memset(sizes, 0, branchSize);
+            memset(sizes, 0, branchSize * sizeof(uint8_t));
             sizes[occupation.num_set_until(hashChunk) - 1] += 1;
             for (int i = 0; i < leaf->size; ++i) {
               int pos =
@@ -864,6 +867,9 @@ class HighsHashTree {
                 case 4:
                   branch->child[i] = new InnerLeaf<4>;
                   break;
+                default:
+                  throw std::logic_error(
+                      "Unexpected result from entries_to_size_class");
               }
             }
 

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -843,8 +843,7 @@ class HighsHashTree {
                 hash, hashPos + 1, entry);
           } else {
             // there are many collisions, determine the exact sizes first
-            uint8_t sizes[InnerLeaf<4>::capacity() + 1];
-            memset(sizes, 0, branchSize * sizeof(uint8_t));
+            uint8_t sizes[InnerLeaf<4>::capacity() + 1] = {};
             sizes[occupation.num_set_until(hashChunk) - 1] += 1;
             for (int i = 0; i < leaf->size; ++i) {
               int pos =


### PR DESCRIPTION
1. Properly initialize an array.
2. Handle unexpected result from "entries_to_size_class".