### PR TITLE
BUG: Gracefully fail for OOM (Out of Memory) in Presolve

### DIFF
--- a/check/TestOOMKill.cpp
+++ b/check/TestOOMKill.cpp
@@ -62,7 +62,7 @@ TEST_CASE("linprog_oom", "[highs_solver]") {
     // highs.setOptionValue("threads", 1);
     REQUIRE(highs.setOptionValue("presolve", "on") == HighsStatus::kOk);
     REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
-    REQUIRE(highs.run() == HighsStatus::kOk);
+    REQUIRE(highs.run() == HighsStatus::kError);
 }
 
 

--- a/check/TestOOMKill.cpp
+++ b/check/TestOOMKill.cpp
@@ -1,0 +1,124 @@
+#include "HCheckConfig.h"
+#include "Highs.h"
+#include <iostream>
+#include <vector>
+#include <cstdlib>
+#include <ctime>
+
+#include "catch.hpp"
+#include "lp_data/HConst.h"
+
+TEST_CASE("linprog_oom", "[highs_solver]") {
+    const HighsInt n_ctr = 500000;
+    const HighsInt n_var = 500;
+
+    // Seed random number generator
+    std::srand(0);
+
+    // Create c_ vector of ones
+    std::vector<double> c_(n_var, 1.0);
+
+    // Create A_ub matrix with random values between 0 and 1
+    std::vector<double> Avalue(n_ctr * n_var);
+    for (int i = 0; i < n_ctr * n_var; ++i) {
+        Avalue[i] = (double)rand() / RAND_MAX;
+    }
+
+    // Create b_ub vector of zeros and set bounds
+    std::vector<double> rowUpper(n_ctr, 0.0);
+    std::vector<double> rowLower(n_ctr, -kHighsInf);
+
+    // Assuming A_ub is in column-wise format, similar to the provided example
+    std::vector<HighsInt> Astart(n_var + 1);
+    std::vector<HighsInt> Aindex(n_ctr * n_var);
+    for (int col = 0; col < n_var; ++col) {
+        Astart[col] = col * n_ctr;
+    }
+    for (int idx = 0; idx < n_ctr * n_var; ++idx) {
+        Aindex[idx] = idx % n_ctr;
+    }
+    Astart[n_var] = n_ctr * n_var;
+
+    // Column bounds are (0, infinity)
+    std::vector<double> colUpper(n_var, kHighsInf);
+    std::vector<double> colLower(n_var, 0);
+
+    Highs highs;
+
+    // Set up the LP externally
+    HighsLp lp;
+    lp.num_col_ = n_var;
+    lp.num_row_ = n_ctr;
+    lp.col_cost_ = c_;
+    lp.col_lower_ = colLower;
+    lp.col_upper_ = colUpper;
+    lp.row_lower_ = rowLower;
+    lp.row_upper_ = rowUpper;
+    lp.a_matrix_.start_ = Astart;
+    lp.a_matrix_.index_ = Aindex;
+    lp.a_matrix_.value_ = Avalue;
+    lp.a_matrix_.format_ = MatrixFormat::kColwise;
+    highs.setOptionValue("log_dev_level", kHighsLogDevLevelVerbose);
+    // highs.setOptionValue("threads", 1);
+    REQUIRE(highs.setOptionValue("presolve", "on") == HighsStatus::kOk);
+    REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+    REQUIRE(highs.run() == HighsStatus::kOk);
+}
+
+
+TEST_CASE("linprog_oom_no_presolve", "[highs_solver]") {
+    const HighsInt n_ctr = 500000;
+    const HighsInt n_var = 500;
+
+    // Seed random number generator
+    std::srand(0);
+
+    // Create c_ vector of ones
+    std::vector<double> c_(n_var, 1.0);
+
+    // Create A_ub matrix with random values between 0 and 1
+    std::vector<double> Avalue(n_ctr * n_var);
+    for (int i = 0; i < n_ctr * n_var; ++i) {
+        Avalue[i] = (double)rand() / RAND_MAX;
+    }
+
+    // Create b_ub vector of zeros and set bounds
+    std::vector<double> rowUpper(n_ctr, 0.0);
+    std::vector<double> rowLower(n_ctr, -kHighsInf);
+
+    // Assuming A_ub is in column-wise format, similar to the provided example
+    std::vector<HighsInt> Astart(n_var + 1);
+    std::vector<HighsInt> Aindex(n_ctr * n_var);
+    for (int col = 0; col < n_var; ++col) {
+        Astart[col] = col * n_ctr;
+    }
+    for (int idx = 0; idx < n_ctr * n_var; ++idx) {
+        Aindex[idx] = idx % n_ctr;
+    }
+    Astart[n_var] = n_ctr * n_var;
+
+    // Column bounds are (0, infinity)
+    std::vector<double> colUpper(n_var, kHighsInf);
+    std::vector<double> colLower(n_var, 0);
+
+    Highs highs;
+
+    // Set up the LP externally
+    HighsLp lp;
+    lp.num_col_ = n_var;
+    lp.num_row_ = n_ctr;
+    lp.col_cost_ = c_;
+    lp.col_lower_ = colLower;
+    lp.col_upper_ = colUpper;
+    lp.row_lower_ = rowLower;
+    lp.row_upper_ = rowUpper;
+    lp.a_matrix_.start_ = Astart;
+    lp.a_matrix_.index_ = Aindex;
+    lp.a_matrix_.value_ = Avalue;
+    lp.a_matrix_.format_ = MatrixFormat::kColwise;
+    highs.setOptionValue("log_dev_level", kHighsLogDevLevelVerbose);
+    // highs.setOptionValue("threads", 1);
+    REQUIRE(highs.setOptionValue("presolve", "off") == HighsStatus::kOk);
+    REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+    REQUIRE(highs.run() == HighsStatus::kOk);
+}

--- a/check/meson.build
+++ b/check/meson.build
@@ -54,6 +54,7 @@ test_array = [
   ['test_lpvalidation', 'TestLpValidation.cpp'],
   ['test_lpmodification', 'TestLpModification.cpp'],
   ['test_lporientation', 'TestLpOrientation.cpp'],
+  ['test_oomkill', 'TestOOMKill.cpp'],
 ]
 foreach test : test_array
   test(test.get(0),

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -21,9 +21,9 @@
 #include "lp_data/HighsRanging.h"
 #include "lp_data/HighsSolutionDebug.h"
 #include "model/HighsModel.h"
-#include "util/HighsExceptions.h"
 #include "presolve/ICrash.h"
 #include "presolve/PresolveComponent.h"
+#include "util/HighsExceptions.h"
 
 /**
  * @brief Return the version

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -21,6 +21,7 @@
 #include "lp_data/HighsRanging.h"
 #include "lp_data/HighsSolutionDebug.h"
 #include "model/HighsModel.h"
+#include "util/HighsExceptions.h"
 #include "presolve/ICrash.h"
 #include "presolve/PresolveComponent.h"
 

--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -168,6 +168,7 @@ enum class HighsPresolveStatus {
   kNullError,     // V2.0: Delete since it's not used!
   kOptionsError,  // V2.0: Delete since it's not used!
   kNotSet,
+  kError,
 };
 
 enum class HighsPostsolveStatus {  // V2.0: Delete if not used!

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2903,6 +2903,8 @@ std::string Highs::presolveStatusToString(
       return "Null error";
     case HighsPresolveStatus::kOptionsError:
       return "Options error";
+    case HighsPresolveStatus::kError:
+      return "Presolve error";
     default:
       assert(1 == 0);
       return "Unrecognised presolve status";

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -16,6 +16,7 @@
 #include <limits>
 
 #include "Highs.h"
+#include "HighsExceptions.h"
 #include "io/HighsIO.h"
 #include "lp_data/HConst.h"
 #include "lp_data/HStruct.h"
@@ -4053,7 +4054,14 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
       }
     };
 
-    HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
+    try {
+      HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
+    } catch (const DataStackOverflow& e) {
+      highsLogUser(options->log_options, HighsLogType::kInfo,
+                   "Problem is too large to be presolved\n");
+      // Here we re-throw the error
+      throw;
+    }
 
     HighsInt numParallelRowColCalls = 0;
 #if ENABLE_SPARSIFY_FOR_LP

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -16,7 +16,6 @@
 #include <limits>
 
 #include "Highs.h"
-#include "HighsExceptions.h"
 #include "io/HighsIO.h"
 #include "lp_data/HConst.h"
 #include "lp_data/HStruct.h"
@@ -35,6 +34,7 @@
 #include "util/HighsLinearSumBounds.h"
 #include "util/HighsSplay.h"
 #include "util/HighsUtils.h"
+#include "util/HighsExceptions.h"
 
 #define ENABLE_SPARSIFY_FOR_LP 0
 

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -34,7 +34,6 @@
 #include "util/HighsLinearSumBounds.h"
 #include "util/HighsSplay.h"
 #include "util/HighsUtils.h"
-#include "util/HighsExceptions.h"
 
 #define ENABLE_SPARSIFY_FOR_LP 0
 
@@ -4054,12 +4053,7 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
       }
     };
 
-    try {
-      HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
-    } catch (const DataStackOverflow& e) {
-      // Here we re-throw the error
-      throw PresolveTooLarge(e.what());
-    }
+    HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
 
     HighsInt numParallelRowColCalls = 0;
 #if ENABLE_SPARSIFY_FOR_LP

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4057,10 +4057,8 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
     try {
       HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
     } catch (const DataStackOverflow& e) {
-      highsLogUser(options->log_options, HighsLogType::kInfo,
-                   "Problem is too large to be presolved\n");
       // Here we re-throw the error
-      throw;
+      throw PresolveTooLarge(e.what());
     }
 
     HighsInt numParallelRowColCalls = 0;

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -3695,7 +3695,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
                            "Problem too large for Presolve, try without\n");
               highsLogUser(options->log_options, HighsLogType::kInfo,
                            "Specific error raised:\n%s\n", e.what());
-              return Result::kPrimalInfeasible;
+              return Result::kError;
             }
             if (model->col_upper_[nonzero.index()] >
                 model->col_lower_[nonzero.index()])
@@ -4297,9 +4297,14 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
     case Result::kPrimalInfeasible:
       presolve_status_ = HighsPresolveStatus::kInfeasible;
       return HighsModelStatus::kInfeasible;
-    case Result::kDualInfeasible:
+    case Result::kDualInfeasible: {
       presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
       return HighsModelStatus::kUnboundedOrInfeasible;
+    }
+    case Result::kError: {
+      presolve_status_ = HighsPresolveStatus::kError;
+      return HighsModelStatus::kPresolveError;
+    }
   }
 
   if (options->presolve != kHighsOffString &&

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -31,7 +31,6 @@
 #include "util/HighsHash.h"
 #include "util/HighsLinearSumBounds.h"
 #include "util/HighsMatrixSlice.h"
-#include "util/HighsExceptions.h"
 
 namespace presolve {
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -31,6 +31,7 @@
 #include "util/HighsHash.h"
 #include "util/HighsLinearSumBounds.h"
 #include "util/HighsMatrixSlice.h"
+#include "util/HighsExceptions.h"
 
 namespace presolve {
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -134,6 +134,7 @@ class HPresolve {
     kPrimalInfeasible,
     kDualInfeasible,
     kStopped,
+    kError,
   };
   HighsPresolveStatus presolve_status_;
   HPresolveAnalysis analysis_;

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -22,13 +22,13 @@
 #include <tuple>
 #include <vector>
 
-#include "HighsExceptions.h"
 #include "lp_data/HConst.h"
 #include "lp_data/HStruct.h"
 #include "lp_data/HighsOptions.h"
 #include "util/HighsCDouble.h"
 #include "util/HighsDataStack.h"
 #include "util/HighsMatrixSlice.h"
+#include "util/HighsExceptions.h"
 
 // class HighsOptions;
 namespace presolve {

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -27,7 +27,6 @@
 #include "lp_data/HighsOptions.h"
 #include "util/HighsCDouble.h"
 #include "util/HighsDataStack.h"
-#include "util/HighsExceptions.h"
 #include "util/HighsMatrixSlice.h"
 
 // class HighsOptions;
@@ -375,22 +374,15 @@ class HighsPostsolveStack {
                        const HighsMatrixSlice<ColStorageFormat>& colVec) {
     assert(std::isfinite(fixValue));
     colValues.clear();
-    for (const HighsSliceNonzero& colVal : colVec) {
-      try {
-        colValues.emplace_back(origRowIndex[colVal.index()], colVal.value());
-      } catch (const DataStackOverflow& e) {
-        std::cerr
-            << "Memory allocation failed while processing fixedColAtLower: "
-            << std::endl;
-        // Rethrow.
-        throw;
-      }
-    }
+    for (const HighsSliceNonzero& colVal : colVec)
+      colValues.emplace_back(origRowIndex[colVal.index()], colVal.value());
+
     reductionValues.push(FixedCol{fixValue, colCost, origColIndex[col],
                                   HighsBasisStatus::kLower});
     reductionValues.push(colValues);
     reductionAdded(ReductionType::kFixedCol);
   }
+
   template <typename ColStorageFormat>
   void fixedColAtUpper(HighsInt col, double fixValue, double colCost,
                        const HighsMatrixSlice<ColStorageFormat>& colVec) {

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -27,8 +27,8 @@
 #include "lp_data/HighsOptions.h"
 #include "util/HighsCDouble.h"
 #include "util/HighsDataStack.h"
-#include "util/HighsMatrixSlice.h"
 #include "util/HighsExceptions.h"
+#include "util/HighsMatrixSlice.h"
 
 // class HighsOptions;
 namespace presolve {
@@ -373,22 +373,23 @@ class HighsPostsolveStack {
   template <typename ColStorageFormat>
   void fixedColAtLower(HighsInt col, double fixValue, double colCost,
                        const HighsMatrixSlice<ColStorageFormat>& colVec) {
-    try {
-      assert(std::isfinite(fixValue));
-      colValues.clear();
-      for (const HighsSliceNonzero& colVal : colVec)
+    assert(std::isfinite(fixValue));
+    colValues.clear();
+    for (const HighsSliceNonzero& colVal : colVec) {
+      try {
         colValues.emplace_back(origRowIndex[colVal.index()], colVal.value());
-
-      reductionValues.push(FixedCol{fixValue, colCost, origColIndex[col],
-                                    HighsBasisStatus::kLower});
-      reductionValues.push(colValues);
-      reductionAdded(ReductionType::kFixedCol);
-    } catch (const DataStackOverflow& e) {
-      std::cerr << "Memory allocation failed while processing fixedColAtLower: "
-                << std::endl;
-      // Rethrow.
-      throw;
+      } catch (const DataStackOverflow& e) {
+        std::cerr
+            << "Memory allocation failed while processing fixedColAtLower: "
+            << std::endl;
+        // Rethrow.
+        throw;
+      }
     }
+    reductionValues.push(FixedCol{fixValue, colCost, origColIndex[col],
+                                  HighsBasisStatus::kLower});
+    reductionValues.push(colValues);
+    reductionAdded(ReductionType::kFixedCol);
   }
   template <typename ColStorageFormat>
   void fixedColAtUpper(HighsInt col, double fixValue, double colCost,

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -385,7 +385,7 @@ class HighsPostsolveStack {
       reductionAdded(ReductionType::kFixedCol);
     } catch (const DataStackOverflow& e) {
       std::cerr << "Memory allocation failed while processing fixedColAtLower: "
-                << e.what() << std::endl;
+                << std::endl;
       // Rethrow.
       throw;
     }

--- a/src/util/HighsDataStack.h
+++ b/src/util/HighsDataStack.h
@@ -47,7 +47,7 @@ class HighsDataStack {
       throw DataStackOverflow(
           "Failed to resize the vector. Requested new size: " +
           std::to_string(newSize) + ". Size to add is " +
-          std::to_string(sizeof(T)) + "for "+
+          std::to_string(sizeof(T)) +
           ". Current size: " + std::to_string(data.size()) + ".");
     }
     std::memcpy(data.data() + dataSize, &r, sizeof(T));

--- a/src/util/HighsDataStack.h
+++ b/src/util/HighsDataStack.h
@@ -52,6 +52,7 @@ class HighsDataStack {
     }
     std::memcpy(data.data() + dataSize, &r, sizeof(T));
   }
+
   template <typename T,
             typename std::enable_if<IS_TRIVIALLY_COPYABLE(T), int>::type = 0>
   void pop(T& r) {

--- a/src/util/HighsExceptions.h
+++ b/src/util/HighsExceptions.h
@@ -2,7 +2,7 @@
 #include <stdexcept>
 
 class DataStackOverflow : public std::runtime_error {
-public:
-    explicit DataStackOverflow(const std::string& msg)
-        : std::runtime_error(msg) {}
+ public:
+  explicit DataStackOverflow(const std::string& msg)
+      : std::runtime_error(msg) {}
 };

--- a/src/util/HighsExceptions.h
+++ b/src/util/HighsExceptions.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <stdexcept>
+
+class DataStackOverflow : public std::runtime_error {
+public:
+    explicit DataStackOverflow(const std::string& msg)
+        : std::runtime_error(msg) {}
+};
+
+class ProblemTooLargeException : public std::runtime_error {
+public:
+    explicit ProblemTooLargeException(const std::string& msg)
+        : std::runtime_error(msg) {}
+};
+
+
+class PresolveTooLarge : public std::runtime_error {
+public:
+    explicit PresolveTooLarge(const std::string& msg)
+        : std::runtime_error(msg) {}
+};

--- a/src/util/HighsExceptions.h
+++ b/src/util/HighsExceptions.h
@@ -6,16 +6,3 @@ public:
     explicit DataStackOverflow(const std::string& msg)
         : std::runtime_error(msg) {}
 };
-
-class ProblemTooLargeException : public std::runtime_error {
-public:
-    explicit ProblemTooLargeException(const std::string& msg)
-        : std::runtime_error(msg) {}
-};
-
-
-class PresolveTooLarge : public std::runtime_error {
-public:
-    explicit PresolveTooLarge(const std::string& msg)
-        : std::runtime_error(msg) {}
-};


### PR DESCRIPTION
As noted in the title. Essentially this is a fix for https://github.com/scipy/scipy/issues/15888.


Although this does introduce `HighsExceptions` it requires no changes to the `C` API or any other part of the code, this is just to propagate the error internally, and it maps (within the C++ part itself) to existing error codes, raising `Infeasible`.

Some more context. For an unreasonably large problem (which none the less has a trivial solution which can be found without Presolve):

```python
from scipy.optimize import linprog
import numpy as np
np.random.seed(0)
n_ctr = 500000
n_var = 500
c_ = np.ones(n_var)
A_ub = np.random.random((n_ctr, n_var))
b_ub = np.zeros((n_ctr, ))

res = linprog(c_, A_ub=A_ub, b_ub=b_ub, method='highs-ds', bounds=(0, None), options={'disp': True})

print('End')
```

This previously triggered the out of memory killer and crashes. Now it will instead report:

```python
Running HiGHS 1.6.0: Copyright (c) 2023 HiGHS under MIT licence terms
Presolving model
ERROR:   Problem too large for Presolve, try without
Specific error raised:
Failed to resize the vector. Requested new size: -2142950640. Size to add is 24. Current size: 2152016632.
Problem status detected on presolve: Infeasible
Model   status      : Infeasible
Objective value     :  0.0000000000e+00
HiGHS run time      :         29.61
```

This will also save similar crashes across the rest of highs, I used the `python` example because that was where it was reported first.

FWIW (maybe something for the Highs team) this problem has a trivial solution:

```python
from scipy.optimize import linprog
import numpy as np
np.random.seed(0)
n_ctr = 500000
n_var = 500
c_ = np.ones(n_var)
A_ub = np.random.random((n_ctr, n_var))
b_ub = np.zeros((n_ctr, ))

res = linprog(c_, A_ub=A_ub, b_ub=b_ub, method='highs-ds', bounds=(0, None), options={'disp': True, 'presolve': False})
Solving LP without presolve or with basis
Model   status      : Optimal
Objective value     :  0.0000000000e+00
HiGHS run time      :         25.84
```


So my understanding is that this should somehow trigger `HighsPresolveStatus::kReducedToEmpty` and then bailout (special cased) instead of entering the PostSolve phase (the length error comes from the `PostSolveStack`). Currently the code treats `kReducedToEmpty` and `kReduced` the same way:

```cpp
// Highs.cpp ~ line 1398
      if (model_presolve_status_ == HighsPresolveStatus::kReduced ||
          model_presolve_status_ == HighsPresolveStatus::kReducedToEmpty) {
```

However, I think that can be dealt with later (if at all), as that would be an improvement (faster runtime than the current approach), while this PR fixes a bug (the crashing of Highs).