### PR TITLE
Fix #1372

### DIFF
--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -268,7 +268,7 @@ class HighsHashTree {
         // make space at that position, otherwise nothing needs to be done but
         // incrementing i increasing the sorted range by 1.
         if (pos < i) {
-          uint16_t hash = hashes[i];
+          uint64_t hash = hashes[i];
           auto entry = std::move(entries[i]);
           std::move_backward(&entries[pos], &entries[i], &entries[i + 1]);
           memmove(&hashes[pos + 1], &hashes[pos],
@@ -509,13 +509,15 @@ class HighsHashTree {
       int pos = HighsHashHelpers::log2i(matchMask);
       matchMask ^= (uint64_t{1} << pos);
 
-      int i = leaf1->occupation.num_set_until(pos) + offset1;
+      int i =
+          leaf1->occupation.num_set_until(static_cast<uint8_t>(pos)) + offset1;
       while (get_first_chunk16(leaf1->hashes[i]) != pos) {
         ++i;
         ++offset1;
       }
 
-      int j = leaf2->occupation.num_set_until(pos) + offset2;
+      int j =
+          leaf2->occupation.num_set_until(static_cast<uint8_t>(pos)) + offset2;
       while (get_first_chunk16(leaf2->hashes[j]) != pos) {
         ++j;
         ++offset2;
@@ -568,13 +570,15 @@ class HighsHashTree {
           int pos = HighsHashHelpers::log2i(matchMask);
           matchMask ^= (uint64_t{1} << pos);
 
-          int i = leaf->occupation.num_set_until(pos) + offset;
+          int i = leaf->occupation.num_set_until(static_cast<uint8_t>(pos)) +
+                  offset;
           while (get_first_chunk16(leaf->hashes[i]) != pos) {
             ++i;
             ++offset;
           }
 
-          int j = branch->occupation.num_set_until(pos) - 1;
+          int j =
+              branch->occupation.num_set_until(static_cast<uint8_t>(pos)) - 1;
 
           do {
             if (find_recurse(branch->child[j],
@@ -1144,8 +1148,10 @@ class HighsHashTree {
 
           assert(((matchMask >> pos) & 1) == 0);
 
-          int location1 = branch1->occupation.num_set_until(pos) - 1;
-          int location2 = branch2->occupation.num_set_until(pos) - 1;
+          int location1 =
+              branch1->occupation.num_set_until(static_cast<uint8_t>(pos)) - 1;
+          int location2 =
+              branch2->occupation.num_set_until(static_cast<uint8_t>(pos)) - 1;
 
           const HighsHashTableEntry<K, V>* match =
               find_common_recurse(branch1->child[location1],

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -272,7 +272,7 @@ class HighsHashTree {
           auto entry = std::move(entries[i]);
           std::move_backward(&entries[pos], &entries[i], &entries[i + 1]);
           memmove(&hashes[pos + 1], &hashes[pos],
-                  sizeof(hashes[0]) * (size - pos));
+                  sizeof(hashes[0]) * (i - pos));
           hashes[pos] = hash;
           entries[pos] = std::move(entry);
         }

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -655,6 +655,9 @@ class HighsHashTree {
               for (int i = 0; i <= newNumChild; ++i)
                 mergeIntoLeaf(newLeafSize4, hashPos, branch->child[i]);
             }
+            default:
+              throw std::logic_error(
+                  "Unexpected result from entries_to_size_class");
           }
 
           destroyBranchingNode(branch);
@@ -841,7 +844,7 @@ class HighsHashTree {
           } else {
             // there are many collisions, determine the exact sizes first
             uint8_t sizes[InnerLeaf<4>::capacity() + 1];
-            memset(sizes, 0, branchSize);
+            memset(sizes, 0, branchSize * sizeof(uint8_t));
             sizes[occupation.num_set_until(hashChunk) - 1] += 1;
             for (int i = 0; i < leaf->size; ++i) {
               int pos =
@@ -864,6 +867,9 @@ class HighsHashTree {
                 case 4:
                   branch->child[i] = new InnerLeaf<4>;
                   break;
+                default:
+                  throw std::logic_error(
+                      "Unexpected result from entries_to_size_class");
               }
             }
 

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -843,8 +843,7 @@ class HighsHashTree {
                 hash, hashPos + 1, entry);
           } else {
             // there are many collisions, determine the exact sizes first
-            uint8_t sizes[InnerLeaf<4>::capacity() + 1];
-            memset(sizes, 0, branchSize * sizeof(uint8_t));
+            uint8_t sizes[InnerLeaf<4>::capacity() + 1] = {};
             sizes[occupation.num_set_until(hashChunk) - 1] += 1;
             for (int i = 0; i < leaf->size; ++i) {
               int pos =

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -660,8 +660,8 @@ class HighsHashTree {
                 mergeIntoLeaf(newLeafSize4, hashPos, branch->child[i]);
             }
             default:
-              throw std::logic_error(
-                  "Unexpected result from entries_to_size_class");
+              // Unexpected result from 'entries_to_size_class'
+              assert(false);
           }
 
           destroyBranchingNode(branch);
@@ -871,8 +871,8 @@ class HighsHashTree {
                   branch->child[i] = new InnerLeaf<4>;
                   break;
                 default:
-                  throw std::logic_error(
-                      "Unexpected result from entries_to_size_class");
+                  // Unexpected result from 'entries_to_size_class'
+                  assert(false);
               }
             }
 


### PR DESCRIPTION
Fix #1372:
- Initialize array.
- Fix `memmove` statement.

Notes:
- These changes did not introduce any regressions in my testing on publicly available benchmarking libraries. 
- I think that the `memmove` statements are error-prone and could be replaced by `move_backward` or `move` respectively. However, I decided to keep the bug fix as simple as possible in this case.