### PR TITLE
build highs with identical name with and without FAST_BUILD

### DIFF
--- a/highs-config.cmake.in
+++ b/highs-config.cmake.in
@@ -13,7 +13,7 @@ else()
     include("${CMAKE_CURRENT_LIST_DIR}/highs-targets.cmake")
   endif()
 
-  set(HIGHS_LIBRARIES libhighs)
+  set(HIGHS_LIBRARIES highs)
 endif() 
 
 set(HIGHS_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")


### PR DESCRIPTION
This causes an issue at the moment when building SCIP with HiGHS, it seems highs is expected as a name for the library?