### PR TITLE
Fix 1484

### DIFF
--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -1085,7 +1085,7 @@ bool equilibrationScaleMatrix(const HighsOptions& options, HighsLp& lp,
       exp(sum_log_col_equilibration / numCol);
   const double geomean_row_equilibration =
       exp(sum_log_row_equilibration / numRow);
-  if (options.highs_analysis_level) {
+  if (options.log_dev_level) {
     highsLogDev(
         options.log_options, HighsLogType::kInfo,
         "Scaling: Original equilibration: min/mean/max %11.4g/%11.4g/%11.4g "
@@ -1131,7 +1131,7 @@ bool equilibrationScaleMatrix(const HighsOptions& options, HighsLp& lp,
       original_matrix_max_value / original_matrix_min_value;
   const double matrix_value_ratio_improvement =
       original_matrix_value_ratio / matrix_value_ratio;
-  if (options.highs_analysis_level) {
+  if (options.log_dev_level) {
     highsLogDev(
         options.log_options, HighsLogType::kInfo,
         "Scaling: Extreme equilibration improvement =      ( %11.4g + "
@@ -1182,14 +1182,18 @@ bool equilibrationScaleMatrix(const HighsOptions& options, HighsLp& lp,
         Avalue[k] /= (colScale[iCol] * rowScale[iRow]);
       }
     }
-    if (options.highs_analysis_level)
+    if (options.log_dev_level)
       highsLogDev(options.log_options, HighsLogType::kInfo,
                   "Scaling: Improvement factor %0.4g < %0.4g required, so no "
                   "scaling applied\n",
                   improvement_factor, improvement_factor_required);
     return false;
   } else {
-    if (options.highs_analysis_level) {
+    if (options.log_dev_level) {
+      highsLogDev(options.log_options, HighsLogType::kInfo,
+                  "Scaling: Factors are in [%0.4g, %0.4g] for columns and in "
+                  "[%0.4g, %0.4g] for rows\n",
+                  min_col_scale, max_col_scale, min_row_scale, max_row_scale);
       highsLogDev(options.log_options, HighsLogType::kInfo,
                   "Scaling: Improvement factor is %0.4g >= %0.4g so scale LP\n",
                   improvement_factor, improvement_factor_required);
@@ -1344,14 +1348,14 @@ bool maxValueScaleMatrix(const HighsOptions& options, HighsLp& lp,
         Avalue[k] /= (colScale[iCol] * rowScale[iRow]);
       }
     }
-    if (options.highs_analysis_level)
+    if (options.log_dev_level)
       highsLogDev(options.log_options, HighsLogType::kInfo,
                   "Scaling: Improvement factor %0.4g < %0.4g required, so no "
                   "scaling applied\n",
                   improvement_factor, improvement_factor_required);
     return false;
   } else {
-    if (options.highs_analysis_level) {
+    if (options.log_dev_level) {
       highsLogDev(options.log_options, HighsLogType::kInfo,
                   "Scaling: Factors are in [%0.4g, %0.4g] for columns and in "
                   "[%0.4g, %0.4g] for rows\n",

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -722,6 +722,17 @@ void HEkkDual::solvePhase1() {
     // chooseColumn has failed or excessive primal values have been
     // created Behave as "Report strange issues" below
     solve_phase = kSolvePhaseError;
+    // Solve error is opaque to users, so put in some logging
+    if (rebuild_reason == kRebuildReasonChooseColumnFail) {
+      highsLogUser(
+          ekk_instance_.options_->log_options, HighsLogType::kError,
+          "Dual simplex ratio test failed due to excessive dual values: "
+          "consider scaling down the LP objective coefficients\n");
+    } else {
+      highsLogUser(ekk_instance_.options_->log_options, HighsLogType::kError,
+                   "Dual simplex detected excessive primal values: consider "
+                   "scaling down the LP bounds\n");
+    }
     highsLogDev(ekk_instance_.options_->log_options, HighsLogType::kInfo,
                 "dual-phase-1-not-solved\n");
     model_status = HighsModelStatus::kSolveError;
@@ -971,6 +982,17 @@ void HEkkDual::solvePhase2() {
     // chooseColumn has failed or excessive primal values have been
     // created Behave as "Report strange issues" below
     solve_phase = kSolvePhaseError;
+    // Solve error is opaque to users, so put in some logging
+    if (rebuild_reason == kRebuildReasonChooseColumnFail) {
+      highsLogUser(
+          ekk_instance_.options_->log_options, HighsLogType::kError,
+          "Dual simplex ratio test failed due to excessive dual values: "
+          "consider scaling down the LP objective coefficients\n");
+    } else {
+      highsLogUser(ekk_instance_.options_->log_options, HighsLogType::kError,
+                   "Dual simplex detected excessive primal values: consider "
+                   "scaling down the LP bounds\n");
+    }
     highsLogDev(ekk_instance_.options_->log_options, HighsLogType::kInfo,
                 "dual-phase-2-not-solved\n");
     model_status = HighsModelStatus::kSolveError;


### PR DESCRIPTION
 Scaling dev logging now driven by `log_dev_level>0` rather than `highs_analysis_level>0`

Added logging when dual simplex fails due to excessive primal values or ratio test failure

