### PR TITLE
Fix 1487

### DIFF
--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TEST_SOURCES
     TestRanging.cpp
     TestSemiVariables.cpp
     TestThrow.cpp
+    TestUserScale.cpp
     Avgas.cpp)
 
 if (NOT APPLE)

--- a/check/TestLpSolvers.cpp
+++ b/check/TestLpSolvers.cpp
@@ -279,7 +279,7 @@ TEST_CASE("LP-solver", "[highs_lp_solver]") {
   const HighsInfo& info = highs.getInfo();
   REQUIRE(info.num_dual_infeasibilities == 0);
 
-  REQUIRE(info.simplex_iteration_count == 472); //476);  // 444);
+  REQUIRE(info.simplex_iteration_count == 472);  // 476);  // 444);
 
   HighsModelStatus model_status = highs.getModelStatus();
   REQUIRE(model_status == HighsModelStatus::kOptimal);
@@ -292,7 +292,7 @@ TEST_CASE("LP-solver", "[highs_lp_solver]") {
   return_status = highs.run();
   REQUIRE(return_status == HighsStatus::kOk);
 
-  REQUIRE(info.simplex_iteration_count == 592); //621);  // 584);  //
+  REQUIRE(info.simplex_iteration_count == 592);  // 621);  // 584);  //
 }
 
 TEST_CASE("mip-with-lp-solver", "[highs_lp_solver]") {

--- a/check/TestUserScale.cpp
+++ b/check/TestUserScale.cpp
@@ -7,19 +7,18 @@ const bool dev_run = true;
 const double inf = kHighsInf;
 
 void checkModelScaling(const HighsInt user_bound_scale,
-			 const HighsInt user_cost_scale,
-			 const HighsModel& unscaled_model,
-			 const HighsModel& scaled_model);
+                       const HighsInt user_cost_scale,
+                       const HighsModel& unscaled_model,
+                       const HighsModel& scaled_model);
 
 void checkLpScaling(const HighsInt user_bound_scale,
-			 const HighsInt user_cost_scale,
-			 const HighsLp& unscaled_lp,
-			 const HighsLp& scaled_lp);
+                    const HighsInt user_cost_scale, const HighsLp& unscaled_lp,
+                    const HighsLp& scaled_lp);
 
 void checkSolutionScaling(const HighsInt user_bound_scale,
-			 const HighsInt user_cost_scale,
-			 const HighsSolution& unscaled_solution,
-			 const HighsSolution& scaled_solution);
+                          const HighsInt user_cost_scale,
+                          const HighsSolution& unscaled_solution,
+                          const HighsSolution& scaled_solution);
 
 TEST_CASE("user-cost-scale-after-run", "[highs_user_scale]") {
   std::string filename =
@@ -51,12 +50,14 @@ TEST_CASE("user-cost-scale-after-run", "[highs_user_scale]") {
   HighsLp scaled_lp = highs.getLp();
   HighsSolution scaled_solution = highs.getSolution();
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
-  checkSolutionScaling(user_bound_scale, user_cost_scale, unscaled_solution, scaled_solution);
+  checkSolutionScaling(user_bound_scale, user_cost_scale, unscaled_solution,
+                       scaled_solution);
 
   REQUIRE(highs.getModelStatus() == HighsModelStatus::kNotset);
   REQUIRE(info.dual_solution_status == kSolutionStatusInfeasible);
-  REQUIRE(info.objective_function_value ==
-          user_cost_scale_value * user_bound_scale_value * objective_function_value);
+  REQUIRE(info.objective_function_value == user_cost_scale_value *
+                                               user_bound_scale_value *
+                                               objective_function_value);
   REQUIRE(info.num_dual_infeasibilities == kHighsIllegalInfeasibilityCount);
   REQUIRE(info.max_dual_infeasibility ==
           user_cost_scale_value * max_dual_infeasibility);
@@ -86,7 +87,8 @@ TEST_CASE("user-cost-scale-after-load", "[highs_user_scale]") {
   HighsLp scaled_lp = highs.getLp();
 
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
-  //  checkSolutionScaling(user_bound_scale, user_cost_scale, unscaled_solution, scaled_solution);
+  //  checkSolutionScaling(user_bound_scale, user_cost_scale, unscaled_solution,
+  //  scaled_solution);
   highs.run();
 }
 
@@ -135,71 +137,80 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
   std::vector<HighsInt> matrix_start = {0, 2};
   std::vector<HighsInt> matrix_index = {0, 1, 0, 1};
   std::vector<double> matrix_value = {1, 1, 2, 4};
-  unscaled_highs.addCols(2, cost.data(), lower.data(), upper.data(),
-			 4, matrix_start.data(), matrix_index.data(), matrix_value.data());
-  scaled_highs.addCols(2, cost.data(), lower.data(), upper.data(),
-		       4, matrix_start.data(), matrix_index.data(), matrix_value.data());
+  unscaled_highs.addCols(2, cost.data(), lower.data(), upper.data(), 4,
+                         matrix_start.data(), matrix_index.data(),
+                         matrix_value.data());
+  scaled_highs.addCols(2, cost.data(), lower.data(), upper.data(), 4,
+                       matrix_start.data(), matrix_index.data(),
+                       matrix_value.data());
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
-  
+
   lower = {-kHighsInf, -kHighsInf};
   upper = {120, 150};
   matrix_start = {0, 2};
   matrix_index = {0, 2, 1, 3};
   matrix_value = {1, 1, 2, 4};
-  unscaled_highs.addRows(2, lower.data(), upper.data(),
-			 4, matrix_start.data(), matrix_index.data(), matrix_value.data());
-  scaled_highs.addRows(2, lower.data(), upper.data(),
-		       4, matrix_start.data(), matrix_index.data(), matrix_value.data());
-  
-  checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
+  unscaled_highs.addRows(2, lower.data(), upper.data(), 4, matrix_start.data(),
+                         matrix_index.data(), matrix_value.data());
+  scaled_highs.addRows(2, lower.data(), upper.data(), 4, matrix_start.data(),
+                       matrix_index.data(), matrix_value.data());
 
-  
+  checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
 }
 
 void checkModelScaling(const HighsInt user_bound_scale,
-		       const HighsInt user_cost_scale,
-		       const HighsModel& unscaled_model,
-		       const HighsModel& scaled_model) {
-  checkLpScaling(user_bound_scale, user_cost_scale, unscaled_model.lp_, scaled_model.lp_);
+                       const HighsInt user_cost_scale,
+                       const HighsModel& unscaled_model,
+                       const HighsModel& scaled_model) {
+  checkLpScaling(user_bound_scale, user_cost_scale, unscaled_model.lp_,
+                 scaled_model.lp_);
 }
 
 void checkLpScaling(const HighsInt user_bound_scale,
-		    const HighsInt user_cost_scale,
-		    const HighsLp& unscaled_lp,
-		    const HighsLp& scaled_lp) {
+                    const HighsInt user_cost_scale, const HighsLp& unscaled_lp,
+                    const HighsLp& scaled_lp) {
   const double user_bound_scale_value = std::pow(2, user_bound_scale);
   const double user_cost_scale_value = std::pow(2, user_cost_scale);
   REQUIRE(unscaled_lp.num_col_ == scaled_lp.num_col_);
   REQUIRE(unscaled_lp.num_row_ == scaled_lp.num_row_);
   for (HighsInt iCol = 0; iCol < unscaled_lp.num_col_; iCol++) {
-    REQUIRE(scaled_lp.col_cost_[iCol] == unscaled_lp.col_cost_[iCol] * user_cost_scale_value);
-    if (unscaled_lp.col_lower_[iCol] > -inf) 
-      REQUIRE(scaled_lp.col_lower_[iCol] == unscaled_lp.col_lower_[iCol] * user_bound_scale_value);
-    if (unscaled_lp.col_upper_[iCol] < inf) 
-      REQUIRE(scaled_lp.col_upper_[iCol] == unscaled_lp.col_upper_[iCol] * user_bound_scale_value);
+    REQUIRE(scaled_lp.col_cost_[iCol] ==
+            unscaled_lp.col_cost_[iCol] * user_cost_scale_value);
+    if (unscaled_lp.col_lower_[iCol] > -inf)
+      REQUIRE(scaled_lp.col_lower_[iCol] ==
+              unscaled_lp.col_lower_[iCol] * user_bound_scale_value);
+    if (unscaled_lp.col_upper_[iCol] < inf)
+      REQUIRE(scaled_lp.col_upper_[iCol] ==
+              unscaled_lp.col_upper_[iCol] * user_bound_scale_value);
   }
   for (HighsInt iRow = 0; iRow < unscaled_lp.num_row_; iRow++) {
-    if (unscaled_lp.row_lower_[iRow] > -inf) 
-      REQUIRE(scaled_lp.row_lower_[iRow] == unscaled_lp.row_lower_[iRow] * user_bound_scale_value);
-    if (unscaled_lp.row_upper_[iRow] < inf) 
-      REQUIRE(scaled_lp.row_upper_[iRow] == unscaled_lp.row_upper_[iRow] * user_bound_scale_value);
+    if (unscaled_lp.row_lower_[iRow] > -inf)
+      REQUIRE(scaled_lp.row_lower_[iRow] ==
+              unscaled_lp.row_lower_[iRow] * user_bound_scale_value);
+    if (unscaled_lp.row_upper_[iRow] < inf)
+      REQUIRE(scaled_lp.row_upper_[iRow] ==
+              unscaled_lp.row_upper_[iRow] * user_bound_scale_value);
   }
-  
 }
 
 void checkSolutionScaling(const HighsInt user_bound_scale,
-			  const HighsInt user_cost_scale,
-			  const HighsSolution& unscaled_solution,
-			  const HighsSolution& scaled_solution) {
+                          const HighsInt user_cost_scale,
+                          const HighsSolution& unscaled_solution,
+                          const HighsSolution& scaled_solution) {
   const double user_bound_scale_value = std::pow(2, user_bound_scale);
   const double user_cost_scale_value = std::pow(2, user_cost_scale);
-  for (HighsInt iCol = 0; iCol < HighsInt(unscaled_solution.col_value.size()); iCol++) {
-    REQUIRE(scaled_solution.col_value[iCol] == unscaled_solution.col_value[iCol] * user_bound_scale_value);
-    REQUIRE(scaled_solution.col_dual[iCol] == unscaled_solution.col_dual[iCol] * user_cost_scale_value);
+  for (HighsInt iCol = 0; iCol < HighsInt(unscaled_solution.col_value.size());
+       iCol++) {
+    REQUIRE(scaled_solution.col_value[iCol] ==
+            unscaled_solution.col_value[iCol] * user_bound_scale_value);
+    REQUIRE(scaled_solution.col_dual[iCol] ==
+            unscaled_solution.col_dual[iCol] * user_cost_scale_value);
   }
-  for (HighsInt iRow = 0; iRow < HighsInt(unscaled_solution.row_value.size()); iRow++) {
-    REQUIRE(scaled_solution.row_value[iRow] == unscaled_solution.row_value[iRow] * user_bound_scale_value);
-    REQUIRE(scaled_solution.row_dual[iRow] == unscaled_solution.row_dual[iRow] * user_cost_scale_value);
+  for (HighsInt iRow = 0; iRow < HighsInt(unscaled_solution.row_value.size());
+       iRow++) {
+    REQUIRE(scaled_solution.row_value[iRow] ==
+            unscaled_solution.row_value[iRow] * user_bound_scale_value);
+    REQUIRE(scaled_solution.row_dual[iRow] ==
+            unscaled_solution.row_dual[iRow] * user_cost_scale_value);
   }
 }
-

--- a/check/TestUserScale.cpp
+++ b/check/TestUserScale.cpp
@@ -3,7 +3,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double inf = kHighsInf;
 
 void checkModelScaling(const HighsInt user_bound_scale,
@@ -156,12 +156,6 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
                        matrix_index.data(), matrix_value.data());
 
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
-
-  scaled_highs.changeObjectiveSense(ObjSense::kMaximize);
-
-  scaled_highs.writeModel("");
-  scaled_highs.writeModel("test.lp");
-  scaled_highs.run();
 }
 
 void checkModelScaling(const HighsInt user_bound_scale,

--- a/check/TestUserScale.cpp
+++ b/check/TestUserScale.cpp
@@ -1,0 +1,84 @@
+#include <cmath>
+
+#include "Highs.h"
+#include "catch.hpp"
+
+const bool dev_run = true;
+const double inf = kHighsInf;
+
+TEST_CASE("user-cost-scale-after-run", "[highs_user_scale]") {
+  std::string filename =
+      std::string(HIGHS_DIR) + "/check/instances/adlittle.mps";
+  Highs highs;
+  const HighsLp& lp = highs.getLp();
+  const HighsInfo& info = highs.getInfo();
+  const HighsSolution& solution = highs.getSolution();
+  highs.setOptionValue("output_flag", dev_run);
+  highs.readModel(filename);
+  highs.run();
+  HighsSolution unscaled_solution = solution;
+  HighsInfo unscaled_info = info;
+  HighsLp unscaled_lp = lp;
+  double max_primal_infeasibility = info.max_primal_infeasibility;
+  double max_dual_infeasibility = info.max_dual_infeasibility;
+  double sum_dual_infeasibilities = info.sum_dual_infeasibilities;
+  printf("Max primal infeasibility = %g\n", max_primal_infeasibility);
+  printf("Max dual infeasibility = %g\n", max_dual_infeasibility);
+  printf("Sum dual infeasibility = %g\n", sum_dual_infeasibilities);
+  double objective_function_value = info.objective_function_value;
+
+  HighsInt user_bound_scale = 10;
+  double user_bound_scale_value = std::pow(2, user_bound_scale);
+  highs.setOptionValue("user_bound_scale", user_bound_scale);
+
+  HighsInt user_cost_scale = 30;
+  double user_cost_scale_value = std::pow(2, user_cost_scale);
+  highs.setOptionValue("user_cost_scale", user_cost_scale);
+
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kNotset);
+  REQUIRE(info.dual_solution_status == kSolutionStatusInfeasible);
+  REQUIRE(info.objective_function_value ==
+          user_cost_scale_value * user_bound_scale_value * objective_function_value);
+  REQUIRE(info.num_dual_infeasibilities == kHighsIllegalInfeasibilityCount);
+  REQUIRE(info.max_dual_infeasibility ==
+          user_cost_scale_value * max_dual_infeasibility);
+  REQUIRE(info.sum_dual_infeasibilities ==
+          user_cost_scale_value * sum_dual_infeasibilities);
+  for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
+    REQUIRE(solution.col_value[iCol] == unscaled_solution.col_value[iCol] * user_bound_scale_value);
+    REQUIRE(solution.col_dual[iCol] == unscaled_solution.col_dual[iCol] * user_cost_scale_value);
+    REQUIRE(lp.col_cost_[iCol] == unscaled_lp.col_cost_[iCol] * user_cost_scale_value);
+    if (lp.col_lower_[iCol] > -inf) 
+      REQUIRE(lp.col_lower_[iCol] == unscaled_lp.col_lower_[iCol] * user_bound_scale_value);
+    if (lp.col_upper_[iCol] < inf) 
+      REQUIRE(lp.col_upper_[iCol] == unscaled_lp.col_upper_[iCol] * user_bound_scale_value);
+  }
+  for (HighsInt iRow = 0; iRow < lp.num_row_; iRow++) {
+    REQUIRE(solution.row_value[iRow] == unscaled_solution.row_value[iRow] * user_bound_scale_value);
+    REQUIRE(solution.row_dual[iRow] == unscaled_solution.row_dual[iRow] * user_cost_scale_value);
+    if (lp.row_lower_[iRow] > -inf) 
+      REQUIRE(lp.row_lower_[iRow] == unscaled_lp.row_lower_[iRow] * user_bound_scale_value);
+    if (lp.row_upper_[iRow] < inf) 
+      REQUIRE(lp.row_upper_[iRow] == unscaled_lp.row_upper_[iRow] * user_bound_scale_value);
+  }
+}
+
+TEST_CASE("user-cost-scale-before-run", "[highs_user_scale]") {
+    Highs highs;
+  const HighsLp& lp = highs.getLp();
+  const HighsInfo& info = highs.getInfo();
+  const HighsSolution& solution = highs.getSolution();
+  const HighsInt user_cost_scale = -30;
+  const double user_cost_scale_value = std::pow(2, user_cost_scale);
+  const double unscaled_col0_cost = 1e14;
+  highs.addVar(0, 1);
+  highs.changeColCost(0, unscaled_col0_cost);
+
+  highs.setOptionValue("user_cost_scale", user_cost_scale);
+  REQUIRE(lp.col_cost_[0] == unscaled_col0_cost *  user_cost_scale_value);
+
+  const double unscaled_col1_cost = 1e12;
+  highs.addVar(0, 1);
+  highs.changeColCost(1, unscaled_col1_cost);
+  REQUIRE(lp.col_cost_[1] == unscaled_col1_cost *  user_cost_scale_value);
+}

--- a/check/TestUserScale.cpp
+++ b/check/TestUserScale.cpp
@@ -104,8 +104,8 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
   const HighsInt user_cost_scale = -30;
   const HighsInt user_bound_scale = 10;
   const double unscaled_col0_cost = 1e14;
-  unscaled_highs.addVar(0, 1);
-  scaled_highs.addVar(0, 1);
+  unscaled_highs.addVar(0, kHighsInf);
+  scaled_highs.addVar(0, kHighsInf);
   unscaled_highs.changeColCost(0, unscaled_col0_cost);
   scaled_highs.changeColCost(0, unscaled_col0_cost);
 
@@ -114,8 +114,8 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
 
   const double unscaled_col1_cost = 1e12;
-  unscaled_highs.addVar(0, 1);
-  scaled_highs.addVar(0, 1);
+  unscaled_highs.addVar(1, kHighsInf);
+  scaled_highs.addVar(1, kHighsInf);
   unscaled_highs.changeColCost(1, unscaled_col1_cost);
   scaled_highs.changeColCost(1, unscaled_col1_cost);
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
@@ -131,9 +131,9 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
   scaled_highs.addRow(-kHighsInf, 150, 2, index.data(), value1.data());
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
 
-  std::vector<double> cost = {8, 10};
-  std::vector<double> lower = {-kHighsInf, -kHighsInf};
-  std::vector<double> upper = {120, 150};
+  std::vector<double> cost = {0, 10};
+  std::vector<double> lower = {2, 4};
+  std::vector<double> upper = {kHighsInf, kHighsInf};
   std::vector<HighsInt> matrix_start = {0, 2};
   std::vector<HighsInt> matrix_index = {0, 1, 0, 1};
   std::vector<double> matrix_value = {1, 1, 2, 4};
@@ -145,7 +145,7 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
                        matrix_value.data());
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
 
-  lower = {-kHighsInf, -kHighsInf};
+  lower = {-kHighsInf, 0};
   upper = {120, 150};
   matrix_start = {0, 2};
   matrix_index = {0, 2, 1, 3};
@@ -156,6 +156,12 @@ TEST_CASE("user-cost-scale-in-build", "[highs_user_scale]") {
                        matrix_index.data(), matrix_value.data());
 
   checkLpScaling(user_bound_scale, user_cost_scale, unscaled_lp, scaled_lp);
+
+  scaled_highs.changeObjectiveSense(ObjSense::kMaximize);
+
+  scaled_highs.writeModel("");
+  scaled_highs.writeModel("test.lp");
+  scaled_highs.run();
 }
 
 void checkModelScaling(const HighsInt user_bound_scale,

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1457,5 +1457,6 @@ class Highs {
 
   HighsStatus handleInfCost();
   void restoreInfCost(HighsStatus& return_status);
+  HighsStatus userScaleAction();
 };
 #endif

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1457,6 +1457,6 @@ class Highs {
 
   HighsStatus handleInfCost();
   void restoreInfCost(HighsStatus& return_status);
-  HighsStatus userScaleAction();
+  HighsStatus optionChangeAction();
 };
 #endif

--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -35,6 +35,11 @@ const std::string kHighsOnString = "on";
 const HighsInt kHighsMaxStringLength = 512;
 const HighsInt kSimplexConcurrencyLimit = 8;
 const double kRunningAverageMultiplier = 0.05;
+const double kExcessivelyLargeBoundValue = 1e10;
+const double kExcessivelyLargeCostValue = 1e10;
+const double kExcessivelySmallBoundValue = 1e-4;
+const double kExcessivelySmallCostValue = 1e-4;
+
 
 const bool kAllowDeveloperAssert = false;
 const bool kExtendInvertWhenAddingRows = false;

--- a/src/lp_data/HConst.h
+++ b/src/lp_data/HConst.h
@@ -40,7 +40,6 @@ const double kExcessivelyLargeCostValue = 1e10;
 const double kExcessivelySmallBoundValue = 1e-4;
 const double kExcessivelySmallCostValue = 1e-4;
 
-
 const bool kAllowDeveloperAssert = false;
 const bool kExtendInvertWhenAddingRows = false;
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -76,30 +76,24 @@ HighsStatus Highs::clearSolver() {
 
 HighsStatus Highs::setOptionValue(const std::string& option, const bool value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk) {
-    printf("Highs::setOptionValue - bool\n");
+                          value) == OptionStatus::kOk)
     return optionChangeAction();
-  }
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::setOptionValue(const std::string& option,
                                   const HighsInt value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk) {
-    printf("Highs::setOptionValue - HighsInt\n");
+                          value) == OptionStatus::kOk)
     return optionChangeAction();
-  }
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::setOptionValue(const std::string& option,
                                   const double value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk) {
-    printf("Highs::setOptionValue - double\n");
+                          value) == OptionStatus::kOk)
     return optionChangeAction();
-  }
   return HighsStatus::kError;
 }
 
@@ -107,10 +101,8 @@ HighsStatus Highs::setOptionValue(const std::string& option,
                                   const std::string& value) {
   HighsLogOptions report_log_options = options_.log_options;
   if (setLocalOptionValue(report_log_options, option, options_.log_options,
-                          options_.records, value) == OptionStatus::kOk) {
-    printf("Highs::setOptionValue - string\n");
+                          options_.records, value) == OptionStatus::kOk)
     return optionChangeAction();
-  }
   return HighsStatus::kError;
 }
 
@@ -118,10 +110,8 @@ HighsStatus Highs::setOptionValue(const std::string& option,
                                   const char* value) {
   HighsLogOptions report_log_options = options_.log_options;
   if (setLocalOptionValue(report_log_options, option, options_.log_options,
-                          options_.records, value) == OptionStatus::kOk) {
-    printf("Highs::setOptionValue - char*\n");
+                          options_.records, value) == OptionStatus::kOk)
     return optionChangeAction();
-  }
   return HighsStatus::kError;
 }
 
@@ -510,19 +500,6 @@ HighsStatus Highs::passModel(const HighsInt num_col, const HighsInt num_row,
 HighsStatus Highs::passHessian(HighsHessian hessian_) {
   this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
-  if (this->model_.lp_.user_cost_scale_) {
-    // Assess and apply any user cost scaling
-    if (!hessian_.scaleOk(this->model_.lp_.user_cost_scale_,
-			  this->options_.small_matrix_value,
-			  this->options_.large_matrix_value)) {
-      highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User cost scaling yields zeroed or excessive Hessian values\n");
-      return HighsStatus::kError;
-    }
-    double cost_scale_value = std::pow(2, this->model_.lp_.user_cost_scale_);
-    for (HighsInt iEl = 0; iEl < hessian_.numNz(); iEl++)
-      hessian_.value_[iEl] *= cost_scale_value;
-  }
   HighsHessian& hessian = model_.hessian_;
   hessian = std::move(hessian_);
   // Check validity of any Hessian, normalising its entries
@@ -540,7 +517,21 @@ HighsStatus Highs::passHessian(HighsHessian hessian_) {
       hessian.clear();
     }
   }
-  
+
+  if (this->model_.lp_.user_cost_scale_) {
+    // Assess and apply any user cost scaling
+    if (!hessian.scaleOk(this->model_.lp_.user_cost_scale_,
+                         this->options_.small_matrix_value,
+                         this->options_.large_matrix_value)) {
+      highsLogUser(
+          options_.log_options, HighsLogType::kError,
+          "User cost scaling yields zeroed or excessive Hessian values\n");
+      return HighsStatus::kError;
+    }
+    double cost_scale_value = std::pow(2, this->model_.lp_.user_cost_scale_);
+    for (HighsInt iEl = 0; iEl < hessian.numNz(); iEl++)
+      hessian.value_[iEl] *= cost_scale_value;
+  }
   return_status = interpretCallStatus(options_.log_options, clearSolver(),
                                       return_status, "clearSolver");
   return returnFromHighs(return_status);
@@ -912,8 +903,10 @@ HighsStatus Highs::run() {
   HighsStatus return_status = HighsStatus::kOk;
   HighsStatus call_status;
   // Assess whether to warn the user about excessive bounds and costs
-  return_status = interpretCallStatus(options_.log_options, excessiveBoundCost(options_.log_options, this->model_),
-				      return_status, "excessiveBoundCost");
+  return_status = interpretCallStatus(
+      options_.log_options,
+      excessiveBoundCost(options_.log_options, this->model_), return_status,
+      "excessiveBoundCost");
 
   // HiGHS solvers require models with no infinite costs, and no semi-variables
   //

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -635,7 +635,7 @@ HighsStatus Highs::readModel(const std::string& filename) {
       interpretCallStatus(options_.log_options, passModel(std::move(model)),
                           return_status, "passModel");
   return_status =
-      interpretCallStatus(options_.log_options, optionChangeAction()),
+      interpretCallStatus(options_.log_options, optionChangeAction(),
                           return_status, "optionChangeAction");
   return returnFromHighs(return_status);
 }

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -893,20 +893,8 @@ HighsStatus Highs::run() {
   // Check whether model is consistent with any user bound/cost scaling
   assert(this->model_.lp_.user_bound_scale_ == this->options_.user_bound_scale);
   assert(this->model_.lp_.user_cost_scale_ == this->options_.user_cost_scale);
-  /*
-  if (optionChangeAction() != HighsStatus::kOk) {
-    highsLogDev(options_.log_options, HighsLogType::kError,
-                "Highs::run() called for model inconsistent with user bound/cost
-  scaling\n"); return HighsStatus::kError;
-  }
-  */
-  HighsStatus return_status = HighsStatus::kOk;
-  HighsStatus call_status;
   // Assess whether to warn the user about excessive bounds and costs
-  return_status = interpretCallStatus(
-      options_.log_options,
-      excessiveBoundCost(options_.log_options, this->model_), return_status,
-      "excessiveBoundCost");
+  assessExcessiveBoundCost(options_.log_options, this->model_);
 
   // HiGHS solvers require models with no infinite costs, and no semi-variables
   //
@@ -957,6 +945,8 @@ HighsStatus Highs::run() {
   // Set this so that calls to returnFromRun() can be checked: from
   // here all return statements execute returnFromRun()
   called_return_from_run = false;
+  HighsStatus return_status = HighsStatus::kOk;
+  HighsStatus call_status;
   // Initialise the HiGHS model status
   model_status_ = HighsModelStatus::kNotset;
   // Clear the run info
@@ -3820,6 +3810,13 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status,
                                  const bool undo_mods) {
   assert(!called_return_from_run);
   HighsStatus return_status = highsStatusFromHighsModelStatus(model_status_);
+  if (return_status != run_return_status) {
+    printf(
+        "Highs::returnFromRun: return_status = %d != %d = run_return_status "
+        "For model_status_ = %s\n",
+        int(return_status), int(run_return_status),
+        modelStatusToString(model_status_).c_str());
+  }
   assert(return_status == run_return_status);
   //  return_status = run_return_status;
   switch (model_status_) {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -634,6 +634,9 @@ HighsStatus Highs::readModel(const std::string& filename) {
   return_status =
       interpretCallStatus(options_.log_options, passModel(std::move(model)),
                           return_status, "passModel");
+  return_status =
+      interpretCallStatus(options_.log_options, optionChangeAction()),
+                          return_status, "optionChangeAction");
   return returnFromHighs(return_status);
 }
 
@@ -881,6 +884,12 @@ HighsStatus Highs::run() {
     return HighsStatus::kError;
   }
 
+  // Check whether model is consistent with any user bound/cost scaling
+  if (optionChangeAction() != HighsStatus::kOk) {
+    highsLogDev(options_.log_options, HighsLogType::kError,
+                "Highs::run() called for model inconsistent with user bound/cost scaling\n");
+    return HighsStatus::kError;
+  }
   // HiGHS solvers require models with no infinite costs, and no semi-variables
   //
   // Since completeSolutionFromDiscreteAssignment() may require a call

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -77,7 +77,8 @@ HighsStatus Highs::clearSolver() {
 HighsStatus Highs::setOptionValue(const std::string& option, const bool value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
                           value) == OptionStatus::kOk) {
-    return HighsStatus::kOk;
+    printf("Highs::setOptionValue - bool\n");
+    return optionChangeAction();
   }
   return HighsStatus::kError;
 }
@@ -87,8 +88,7 @@ HighsStatus Highs::setOptionValue(const std::string& option,
   if (setLocalOptionValue(options_.log_options, option, options_.records,
                           value) == OptionStatus::kOk) {
     printf("Highs::setOptionValue - HighsInt\n");
-    userScaleAction();
-    return HighsStatus::kOk;
+    return optionChangeAction();
   }
   return HighsStatus::kError;
 }
@@ -97,7 +97,8 @@ HighsStatus Highs::setOptionValue(const std::string& option,
                                   const double value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
                           value) == OptionStatus::kOk) {
-    return HighsStatus::kOk;
+    printf("Highs::setOptionValue - double\n");
+    return optionChangeAction();
   }
   return HighsStatus::kError;
 }
@@ -108,8 +109,7 @@ HighsStatus Highs::setOptionValue(const std::string& option,
   if (setLocalOptionValue(report_log_options, option, options_.log_options,
                           options_.records, value) == OptionStatus::kOk) {
     printf("Highs::setOptionValue - string\n");
-    userScaleAction();
-    return HighsStatus::kOk;
+    return optionChangeAction();
   }
   return HighsStatus::kError;
 }
@@ -120,8 +120,7 @@ HighsStatus Highs::setOptionValue(const std::string& option,
   if (setLocalOptionValue(report_log_options, option, options_.log_options,
                           options_.records, value) == OptionStatus::kOk) {
     printf("Highs::setOptionValue - char*\n");
-    userScaleAction();
-    return HighsStatus::kOk;
+    return optionChangeAction();
   }
   return HighsStatus::kError;
 }
@@ -145,17 +144,14 @@ HighsStatus Highs::readOptions(const std::string& filename) {
 
 HighsStatus Highs::passOptions(const HighsOptions& options) {
   if (passLocalOptions(options_.log_options, options, options_) ==
-      OptionStatus::kOk) {
-    userScaleAction();
-    return HighsStatus::kOk;
-  }
+      OptionStatus::kOk)
+    return optionChangeAction();
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::resetOptions() {
   resetLocalOptions(options_.records);
-  userScaleAction();
-  return HighsStatus::kOk;
+  return optionChangeAction();
 }
 
 HighsStatus Highs::writeOptions(const std::string& filename,

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -76,24 +76,29 @@ HighsStatus Highs::clearSolver() {
 
 HighsStatus Highs::setOptionValue(const std::string& option, const bool value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk)
+                          value) == OptionStatus::kOk) {
     return HighsStatus::kOk;
+  }
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::setOptionValue(const std::string& option,
                                   const HighsInt value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk)
+                          value) == OptionStatus::kOk) {
+    printf("Highs::setOptionValue - HighsInt\n");
+    userScaleAction();
     return HighsStatus::kOk;
+  }
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::setOptionValue(const std::string& option,
                                   const double value) {
   if (setLocalOptionValue(options_.log_options, option, options_.records,
-                          value) == OptionStatus::kOk)
+                          value) == OptionStatus::kOk) {
     return HighsStatus::kOk;
+  }
   return HighsStatus::kError;
 }
 
@@ -101,8 +106,11 @@ HighsStatus Highs::setOptionValue(const std::string& option,
                                   const std::string& value) {
   HighsLogOptions report_log_options = options_.log_options;
   if (setLocalOptionValue(report_log_options, option, options_.log_options,
-                          options_.records, value) == OptionStatus::kOk)
+                          options_.records, value) == OptionStatus::kOk) {
+    printf("Highs::setOptionValue - string\n");
+    userScaleAction();
     return HighsStatus::kOk;
+  }
   return HighsStatus::kError;
 }
 
@@ -110,8 +118,11 @@ HighsStatus Highs::setOptionValue(const std::string& option,
                                   const char* value) {
   HighsLogOptions report_log_options = options_.log_options;
   if (setLocalOptionValue(report_log_options, option, options_.log_options,
-                          options_.records, value) == OptionStatus::kOk)
+                          options_.records, value) == OptionStatus::kOk) {
+    printf("Highs::setOptionValue - char*\n");
+    userScaleAction();
     return HighsStatus::kOk;
+  }
   return HighsStatus::kError;
 }
 
@@ -134,13 +145,16 @@ HighsStatus Highs::readOptions(const std::string& filename) {
 
 HighsStatus Highs::passOptions(const HighsOptions& options) {
   if (passLocalOptions(options_.log_options, options, options_) ==
-      OptionStatus::kOk)
+      OptionStatus::kOk) {
+    userScaleAction();
     return HighsStatus::kOk;
+  }
   return HighsStatus::kError;
 }
 
 HighsStatus Highs::resetOptions() {
   resetLocalOptions(options_.records);
+  userScaleAction();
   return HighsStatus::kOk;
 }
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -891,8 +891,8 @@ HighsStatus Highs::run() {
   /*
   if (optionChangeAction() != HighsStatus::kOk) {
     highsLogDev(options_.log_options, HighsLogType::kError,
-                "Highs::run() called for model inconsistent with user bound/cost scaling\n");
-    return HighsStatus::kError;
+                "Highs::run() called for model inconsistent with user bound/cost
+  scaling\n"); return HighsStatus::kError;
   }
   */
   // HiGHS solvers require models with no infinite costs, and no semi-variables

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -123,9 +123,10 @@ HighsStatus Highs::addColsInterface(
   if (return_status == HighsStatus::kError) return return_status;
   if (lp.user_bound_scale_) {
     // Assess and apply any user bound scaling
-    if (!boundScaleOk(local_colLower, local_colUpper, lp.user_bound_scale_, options.infinite_bound)) {
+    if (!boundScaleOk(local_colLower, local_colUpper, lp.user_bound_scale_,
+                      options.infinite_bound)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User bound scaling yields infinite bound\n");
+                   "User bound scaling yields infinite bound\n");
       return HighsStatus::kError;
     }
     double bound_scale_value = std::pow(2, lp.user_bound_scale_);
@@ -136,16 +137,17 @@ HighsStatus Highs::addColsInterface(
   }
   if (lp.user_cost_scale_) {
     // Assess and apply any user cost scaling
-    if (!costScaleOk(local_colCost, lp.user_cost_scale_, options.infinite_cost)) {
+    if (!costScaleOk(local_colCost, lp.user_cost_scale_,
+                     options.infinite_cost)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User bound scaling yields infinite cost\n");
+                   "User bound scaling yields infinite cost\n");
       return HighsStatus::kError;
     }
     double cost_scale_value = std::pow(2, lp.user_cost_scale_);
     for (HighsInt iCol = 0; iCol < ext_num_new_col; iCol++)
       local_colCost[iCol] *= cost_scale_value;
   }
-    // Append the columns to the LP vectors and matrix
+  // Append the columns to the LP vectors and matrix
   appendColsToLpVectors(lp, ext_num_new_col, local_colCost, local_colLower,
                         local_colUpper);
   // Form a column-wise HighsSparseMatrix of the new matrix columns so
@@ -272,9 +274,10 @@ HighsStatus Highs::addRowsInterface(HighsInt ext_num_new_row,
   if (return_status == HighsStatus::kError) return return_status;
   if (lp.user_bound_scale_) {
     // Assess and apply any user bound scaling
-    if (!boundScaleOk(local_rowLower, local_rowUpper, lp.user_bound_scale_, options_.infinite_bound)) {
+    if (!boundScaleOk(local_rowLower, local_rowUpper, lp.user_bound_scale_,
+                      options_.infinite_bound)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User bound scaling yields infinite bound\n");
+                   "User bound scaling yields infinite bound\n");
       return HighsStatus::kError;
     }
     double bound_scale_value = std::pow(2, lp.user_bound_scale_);
@@ -675,9 +678,10 @@ HighsStatus Highs::changeCostsInterface(HighsIndexCollection& index_collection,
   HighsLp& lp = model_.lp_;
   if (lp.user_cost_scale_) {
     // Assess and apply any user cost scaling
-    if (!costScaleOk(local_colCost, lp.user_cost_scale_, options_.infinite_cost)) {
+    if (!costScaleOk(local_colCost, lp.user_cost_scale_,
+                     options_.infinite_cost)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User bound scaling yields infinite cost\n");
+                   "User bound scaling yields infinite cost\n");
       return HighsStatus::kError;
     }
     double cost_scale_value = std::pow(2, lp.user_cost_scale_);
@@ -685,7 +689,7 @@ HighsStatus Highs::changeCostsInterface(HighsIndexCollection& index_collection,
       local_colCost[iCol] *= cost_scale_value;
   }
   changeLpCosts(lp, index_collection, local_colCost, options_.infinite_cost);
-  
+
   // Interpret possible introduction of infinite costs
   lp.has_infinite_cost_ = lp.has_infinite_cost_ || local_has_infinite_cost;
   assert(lp.has_infinite_cost_ == lp.hasInfiniteCost(options_.infinite_cost));
@@ -731,9 +735,10 @@ HighsStatus Highs::changeColBoundsInterface(
   HighsLp& lp = model_.lp_;
   if (lp.user_bound_scale_) {
     // Assess and apply any user bound scaling
-    if (!boundScaleOk(local_colLower, local_colUpper, lp.user_bound_scale_, options_.infinite_bound)) {
+    if (!boundScaleOk(local_colLower, local_colUpper, lp.user_bound_scale_,
+                      options_.infinite_bound)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User bound scaling yields infinite bound\n");
+                   "User bound scaling yields infinite bound\n");
       return HighsStatus::kError;
     }
     double bound_scale_value = std::pow(2, lp.user_bound_scale_);
@@ -788,9 +793,10 @@ HighsStatus Highs::changeRowBoundsInterface(
   HighsLp& lp = model_.lp_;
   if (lp.user_bound_scale_) {
     // Assess and apply any user bound scaling
-    if (!boundScaleOk(local_rowLower, local_rowUpper, lp.user_bound_scale_, options_.infinite_bound)) {
+    if (!boundScaleOk(local_rowLower, local_rowUpper, lp.user_bound_scale_,
+                      options_.infinite_bound)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-		   "User bound scaling yields infinite bound\n");
+                   "User bound scaling yields infinite bound\n");
       return HighsStatus::kError;
     }
     double bound_scale_value = std::pow(2, lp.user_bound_scale_);
@@ -1764,13 +1770,14 @@ HighsStatus Highs::optionChangeAction() {
   HighsInt dl_user_bound_scale = 0;
   double dl_user_bound_scale_value = 1;
   // Ensure that user bound scaling does not yield infinite bounds
-  bool user_bound_scale_ok = lp.userBoundScaleOk(options.user_bound_scale,
-						 options.infinite_bound);
+  bool user_bound_scale_ok =
+      lp.userBoundScaleOk(options.user_bound_scale, options.infinite_bound);
   if (!user_bound_scale_ok) {
     options.user_bound_scale = lp.user_bound_scale_;
     highsLogUser(options_.log_options, HighsLogType::kError,
-		 "New user bound scaling yields infinite bound: reverting user bound scaling to %d\n",
-		 int(options.user_bound_scale));
+                 "New user bound scaling yields infinite bound: reverting user "
+                 "bound scaling to %d\n",
+                 int(options.user_bound_scale));
   } else {
     dl_user_bound_scale = options.user_bound_scale - lp.user_bound_scale_;
     dl_user_bound_scale_value = std::pow(2, dl_user_bound_scale);
@@ -1788,9 +1795,9 @@ HighsStatus Highs::optionChangeAction() {
     info.primal_solution_status = kSolutionStatusInfeasible;
     info.num_primal_infeasibilities = kHighsIllegalInfeasibilityCount;
   } else if (!lp.isMip() &&
-	     info.primal_solution_status == kSolutionStatusInfeasible) {
+             info.primal_solution_status == kSolutionStatusInfeasible) {
     highsLogUser(options_.log_options, HighsLogType::kInfo,
-		 "Option change leads to gain of primal feasibility\n");
+                 "Option change leads to gain of primal feasibility\n");
     info.primal_solution_status = kSolutionStatusFeasible;
     info.num_primal_infeasibilities = 0;
   }
@@ -1800,8 +1807,9 @@ HighsStatus Highs::optionChangeAction() {
     if (dl_user_bound_scale < 0) {
       // MIP with negative bound scaling exponent loses feasibility
       if (info.primal_solution_status == kSolutionStatusFeasible) {
-	highsLogUser(options_.log_options, HighsLogType::kInfo,
-		     "Option change leads to loss of primal feasibility for MIP\n");
+        highsLogUser(
+            options_.log_options, HighsLogType::kInfo,
+            "Option change leads to loss of primal feasibility for MIP\n");
       }
       info.primal_solution_status = kSolutionStatusInfeasible;
     }
@@ -1811,9 +1819,9 @@ HighsStatus Highs::optionChangeAction() {
     info.objective_function_value *= dl_user_bound_scale_value;
     info.max_primal_infeasibility *= dl_user_bound_scale_value;
     info.sum_primal_infeasibilities *= dl_user_bound_scale_value;
-    for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) 
+    for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++)
       this->solution_.col_value[iCol] *= dl_user_bound_scale_value;
-    for (HighsInt iRow = 0; iRow < lp.num_row_; iRow++) 
+    for (HighsInt iRow = 0; iRow < lp.num_row_; iRow++)
       this->solution_.row_value[iRow] *= dl_user_bound_scale_value;
     // Update LP with respect to non-trivial user bound scaling
     lp.userBoundScale(options_.user_bound_scale);
@@ -1821,15 +1829,15 @@ HighsStatus Highs::optionChangeAction() {
   // Now consider whether options.user_cost_scale has changed
   HighsInt dl_user_cost_scale = 0;
   double dl_user_cost_scale_value = 1;
-  bool user_cost_scale_ok = model.userCostScaleOk(options.user_cost_scale,
-						  options.small_matrix_value,
-						  options.large_matrix_value,
-						  options.infinite_cost);
+  bool user_cost_scale_ok =
+      model.userCostScaleOk(options.user_cost_scale, options.small_matrix_value,
+                            options.large_matrix_value, options.infinite_cost);
   if (!user_cost_scale_ok) {
     options.user_cost_scale = lp.user_cost_scale_;
     highsLogUser(options_.log_options, HighsLogType::kError,
-		 "New user cost scaling yields excessive cost coefficient: reverting user cost scaling to %d\n",
-		 int(options.user_cost_scale));
+                 "New user cost scaling yields excessive cost coefficient: "
+                 "reverting user cost scaling to %d\n",
+                 int(options.user_cost_scale));
   } else {
     dl_user_cost_scale = options.user_cost_scale - lp.user_cost_scale_;
     dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
@@ -1849,9 +1857,9 @@ HighsStatus Highs::optionChangeAction() {
     info.num_dual_infeasibilities = kHighsIllegalInfeasibilityCount;
   } else if (info.dual_solution_status == kSolutionStatusInfeasible) {
     // No MIP should have even an infeasible dual solution
-    assert(!lp.isMip());	     
+    assert(!lp.isMip());
     highsLogUser(options_.log_options, HighsLogType::kInfo,
-		 "Option change leads to gain of dual feasibility\n");
+                 "Option change leads to gain of dual feasibility\n");
     info.dual_solution_status = kSolutionStatusFeasible;
     info.num_dual_infeasibilities = 0;
   }
@@ -1873,7 +1881,7 @@ HighsStatus Highs::optionChangeAction() {
   }
   if (this->model_status_ != HighsModelStatus::kOptimal) {
     if (info.primal_solution_status == kSolutionStatusFeasible &&
-	info.dual_solution_status == kSolutionStatusFeasible) {
+        info.dual_solution_status == kSolutionStatusFeasible) {
       highsLogUser(options_.log_options, HighsLogType::kInfo,
                    "Option change leads to gain of optimality\n");
       this->model_status_ = HighsModelStatus::kOptimal;

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -140,7 +140,7 @@ HighsStatus Highs::addColsInterface(
     if (!costScaleOk(local_colCost, lp.user_cost_scale_,
                      options.infinite_cost)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-                   "User bound scaling yields infinite cost\n");
+                   "User cost scaling yields infinite cost\n");
       return HighsStatus::kError;
     }
     double cost_scale_value = std::pow(2, lp.user_cost_scale_);
@@ -681,7 +681,7 @@ HighsStatus Highs::changeCostsInterface(HighsIndexCollection& index_collection,
     if (!costScaleOk(local_colCost, lp.user_cost_scale_,
                      options_.infinite_cost)) {
       highsLogUser(options_.log_options, HighsLogType::kError,
-                   "User bound scaling yields infinite cost\n");
+                   "User cost scaling yields infinite cost\n");
       return HighsStatus::kError;
     }
     double cost_scale_value = std::pow(2, lp.user_cost_scale_);

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -1748,6 +1748,7 @@ HighsStatus Highs::optionChangeAction() {
   HighsInt dl_user_cost_scale = 0;
   double dl_user_cost_scale_value = 1;
   bool user_cost_scale_ok = model.userCostScaleOk(options.user_cost_scale,
+						  options.small_matrix_value,
 						  options.large_matrix_value,
 						  options.infinite_cost);
   if (!user_cost_scale_ok) {

--- a/src/lp_data/HighsLp.cpp
+++ b/src/lp_data/HighsLp.cpp
@@ -12,10 +12,10 @@
  * @brief
  */
 #include "lp_data/HighsLp.h"
-#include "lp_data/HighsLpUtils.h"
 
 #include <cassert>
 
+#include "lp_data/HighsLpUtils.h"
 #include "util/HighsMatrixUtils.h"
 
 bool HighsLp::isMip() const {
@@ -261,12 +261,15 @@ void HighsLp::moveBackLpAndUnapplyScaling(HighsLp& lp) {
 }
 
 bool HighsLp::userBoundScaleOk(const HighsInt user_bound_scale,
-			     const double infinite_bound) const {
+                               const double infinite_bound) const {
   const HighsInt dl_user_bound_scale =
       user_bound_scale - this->user_bound_scale_;
   if (!dl_user_bound_scale) return true;
-  if (!boundScaleOk(this->col_lower_, this->col_upper_, dl_user_bound_scale, infinite_bound)) return false;
-  return boundScaleOk(this->row_lower_, this->row_upper_, dl_user_bound_scale, infinite_bound);
+  if (!boundScaleOk(this->col_lower_, this->col_upper_, dl_user_bound_scale,
+                    infinite_bound))
+    return false;
+  return boundScaleOk(this->row_lower_, this->row_upper_, dl_user_bound_scale,
+                      infinite_bound);
 }
 
 void HighsLp::userBoundScale(const HighsInt user_bound_scale) {
@@ -287,16 +290,14 @@ void HighsLp::userBoundScale(const HighsInt user_bound_scale) {
 }
 
 bool HighsLp::userCostScaleOk(const HighsInt user_cost_scale,
-			      const double infinite_cost) const {
-  const HighsInt dl_user_cost_scale =
-      user_cost_scale - this->user_cost_scale_;
+                              const double infinite_cost) const {
+  const HighsInt dl_user_cost_scale = user_cost_scale - this->user_cost_scale_;
   if (!dl_user_cost_scale) return true;
   return costScaleOk(this->col_cost_, dl_user_cost_scale, infinite_cost);
 }
 
 void HighsLp::userCostScale(const HighsInt user_cost_scale) {
-  const HighsInt dl_user_cost_scale =
-      user_cost_scale - this->user_cost_scale_;
+  const HighsInt dl_user_cost_scale = user_cost_scale - this->user_cost_scale_;
   if (!dl_user_cost_scale) return;
   double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
   for (HighsInt iCol = 0; iCol < this->num_col_; iCol++)

--- a/src/lp_data/HighsLp.cpp
+++ b/src/lp_data/HighsLp.cpp
@@ -175,6 +175,9 @@ void HighsLp::clear() {
   this->col_hash_.clear();
   this->row_hash_.clear();
 
+  this->user_cost_scale_ = 0;
+  this->user_bound_scale_ = 0;
+
   this->clearScale();
   this->is_scaled_ = false;
   this->is_moved_ = false;

--- a/src/lp_data/HighsLp.cpp
+++ b/src/lp_data/HighsLp.cpp
@@ -259,6 +259,72 @@ void HighsLp::moveBackLpAndUnapplyScaling(HighsLp& lp) {
   assert(this->is_moved_ == false);
 }
 
+bool HighsLp::userBoundScaleOk(const HighsInt user_bound_scale,
+			     const double infinite_bound) {
+  const HighsInt dl_user_bound_scale =
+      user_bound_scale - this->user_bound_scale_;
+  if (!dl_user_bound_scale) return true;
+  double dl_user_bound_scale_value = std::pow(2, dl_user_bound_scale);
+  for (HighsInt iCol = 0; iCol < this->num_col_; iCol++) {
+    double new_value = this->col_lower_[iCol] * dl_user_bound_scale_value;
+    if (this->col_lower_[iCol] > -kHighsInf &&
+	std::abs(new_value) > infinite_bound) return false;
+    new_value = this->col_upper_[iCol] * dl_user_bound_scale_value;
+    if (this->col_upper_[iCol] < kHighsInf &&
+	std::abs(new_value) > infinite_bound) return false;
+  }
+  for (HighsInt iRow = 0; iRow < this->num_row_; iRow++) {
+    double new_value = this->row_lower_[iRow] * dl_user_bound_scale_value;
+    if (this->row_lower_[iRow] > -kHighsInf &&
+	std::abs(new_value) > infinite_bound) return false;
+    new_value = this->row_upper_[iRow] * dl_user_bound_scale_value;
+    if (this->row_upper_[iRow] < kHighsInf &&
+	std::abs(new_value) > infinite_bound) return false;
+  }
+  return true;
+}
+
+void HighsLp::userBoundScale(const HighsInt user_bound_scale) {
+  const HighsInt dl_user_bound_scale =
+      user_bound_scale - this->user_bound_scale_;
+  if (!dl_user_bound_scale) return;
+  double dl_user_bound_scale_value = std::pow(2, dl_user_bound_scale);
+  for (HighsInt iCol = 0; iCol < this->num_col_; iCol++) {
+    this->col_lower_[iCol] *= dl_user_bound_scale_value;
+    this->col_upper_[iCol] *= dl_user_bound_scale_value;
+  }
+  for (HighsInt iRow = 0; iRow < this->num_row_; iRow++) {
+    this->row_lower_[iRow] *= dl_user_bound_scale_value;
+    this->row_upper_[iRow] *= dl_user_bound_scale_value;
+  }
+  // Record the current user bound scaling applied to the LP
+  this->user_bound_scale_ = user_bound_scale;
+}
+
+bool HighsLp::userCostScaleOk(const HighsInt user_cost_scale,
+			      const double infinite_cost) {
+  const HighsInt dl_user_cost_scale =
+      user_cost_scale - this->user_cost_scale_;
+  if (!dl_user_cost_scale) return true;
+  double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
+  // Ensure that user cost scaling does not yield infinite costs
+  for (HighsInt iCol = 0; iCol < this->num_col_; iCol++) {
+    double new_value = this->col_cost_[iCol] * dl_user_cost_scale_value;
+    if (std::abs(new_value) > infinite_cost) return false;
+  }
+  return true;
+}
+
+void HighsLp::userCostScale(const HighsInt user_cost_scale) {
+  const HighsInt dl_user_cost_scale =
+      user_cost_scale - this->user_cost_scale_;
+  if (!dl_user_cost_scale) return;
+  double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
+  for (HighsInt iCol = 0; iCol < this->num_col_; iCol++)
+    this->col_cost_[iCol] *= dl_user_cost_scale_value;
+  this->user_cost_scale_ = user_cost_scale;
+}
+
 void HighsLp::addColNames(const std::string name, const HighsInt num_new_col) {
   // Don't add names if there are no columns, or if the names are
   // already incomplete

--- a/src/lp_data/HighsLp.h
+++ b/src/lp_data/HighsLp.h
@@ -50,8 +50,8 @@ class HighsLp {
   HighsNameHash col_hash_;
   HighsNameHash row_hash_;
 
-  HighsInt user_cost_scale_;
   HighsInt user_bound_scale_;
+  HighsInt user_cost_scale_;
   HighsScale scale_;
   bool is_scaled_;
   bool is_moved_;

--- a/src/lp_data/HighsLp.h
+++ b/src/lp_data/HighsLp.h
@@ -80,10 +80,10 @@ class HighsLp {
   void unapplyScale();
   void moveBackLpAndUnapplyScaling(HighsLp& lp);
   bool userBoundScaleOk(const HighsInt user_bound_scale,
-			     const double infinite_bound);
+			const double infinite_bound) const;
   void userBoundScale(const HighsInt user_bound_scale);
   bool userCostScaleOk(const HighsInt user_cost_scale,
-			      const double infinite_cost);
+		       const double infinite_cost) const;
   void userCostScale(const HighsInt user_cost_scale);
   void exactResize();
   void addColNames(const std::string name, const HighsInt num_new_col = 1);

--- a/src/lp_data/HighsLp.h
+++ b/src/lp_data/HighsLp.h
@@ -79,6 +79,12 @@ class HighsLp {
   void applyScale();
   void unapplyScale();
   void moveBackLpAndUnapplyScaling(HighsLp& lp);
+  bool userBoundScaleOk(const HighsInt user_bound_scale,
+			     const double infinite_bound);
+  void userBoundScale(const HighsInt user_bound_scale);
+  bool userCostScaleOk(const HighsInt user_cost_scale,
+			      const double infinite_cost);
+  void userCostScale(const HighsInt user_cost_scale);
   void exactResize();
   void addColNames(const std::string name, const HighsInt num_new_col = 1);
   void addRowNames(const std::string name, const HighsInt num_new_row = 1);

--- a/src/lp_data/HighsLp.h
+++ b/src/lp_data/HighsLp.h
@@ -50,6 +50,8 @@ class HighsLp {
   HighsNameHash col_hash_;
   HighsNameHash row_hash_;
 
+  HighsInt user_cost_scale_;
+  HighsInt user_bound_scale_;
   HighsScale scale_;
   bool is_scaled_;
   bool is_moved_;

--- a/src/lp_data/HighsLp.h
+++ b/src/lp_data/HighsLp.h
@@ -80,10 +80,10 @@ class HighsLp {
   void unapplyScale();
   void moveBackLpAndUnapplyScaling(HighsLp& lp);
   bool userBoundScaleOk(const HighsInt user_bound_scale,
-			const double infinite_bound) const;
+                        const double infinite_bound) const;
   void userBoundScale(const HighsInt user_bound_scale);
   bool userCostScaleOk(const HighsInt user_cost_scale,
-		       const double infinite_cost) const;
+                       const double infinite_cost) const;
   void userCostScale(const HighsInt user_cost_scale);
   void exactResize();
   void addColNames(const std::string name, const HighsInt num_new_col = 1);

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -765,6 +765,32 @@ HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp) {
   return HighsStatus::kOk;
 }
 
+bool boundScaleOk(const vector<double>& lower,
+		  const vector<double>& upper,
+		  const HighsInt bound_scale,
+		  const double infinite_bound) {
+  if (!bound_scale) return true;
+  double bound_scale_value = std::pow(2, bound_scale);
+  for (HighsInt iCol = 0; iCol < HighsInt(lower.size()); iCol++) {
+    if (lower[iCol] > -kHighsInf &&
+	std::abs(lower[iCol] * bound_scale_value) > infinite_bound) return false;
+    if (upper[iCol] < kHighsInf &&
+	std::abs(upper[iCol] * bound_scale_value) > infinite_bound) return false;
+  }
+  return true;
+}
+                        
+bool costScaleOk(const vector<double>& cost,
+		 const HighsInt cost_scale,
+		 const double infinite_cost) {
+  if (!cost_scale) return true;
+  double cost_scale_value = std::pow(2, cost_scale);
+  for (HighsInt iCol = 0; iCol < HighsInt(cost.size()); iCol++)
+    if (std::abs(cost[iCol]) < kHighsInf &&
+	std::abs(cost[iCol] * cost_scale_value) > infinite_cost) return false;
+  return true;
+}
+
 bool considerScaling(const HighsOptions& options, HighsLp& lp) {
   // Indicate whether new scaling has been determined in the return value.
   bool new_scaling = false;

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -765,29 +765,29 @@ HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp) {
   return HighsStatus::kOk;
 }
 
-bool boundScaleOk(const vector<double>& lower,
-		  const vector<double>& upper,
-		  const HighsInt bound_scale,
-		  const double infinite_bound) {
+bool boundScaleOk(const vector<double>& lower, const vector<double>& upper,
+                  const HighsInt bound_scale, const double infinite_bound) {
   if (!bound_scale) return true;
   double bound_scale_value = std::pow(2, bound_scale);
   for (HighsInt iCol = 0; iCol < HighsInt(lower.size()); iCol++) {
     if (lower[iCol] > -kHighsInf &&
-	std::abs(lower[iCol] * bound_scale_value) > infinite_bound) return false;
+        std::abs(lower[iCol] * bound_scale_value) > infinite_bound)
+      return false;
     if (upper[iCol] < kHighsInf &&
-	std::abs(upper[iCol] * bound_scale_value) > infinite_bound) return false;
+        std::abs(upper[iCol] * bound_scale_value) > infinite_bound)
+      return false;
   }
   return true;
 }
-                        
-bool costScaleOk(const vector<double>& cost,
-		 const HighsInt cost_scale,
-		 const double infinite_cost) {
+
+bool costScaleOk(const vector<double>& cost, const HighsInt cost_scale,
+                 const double infinite_cost) {
   if (!cost_scale) return true;
   double cost_scale_value = std::pow(2, cost_scale);
   for (HighsInt iCol = 0; iCol < HighsInt(cost.size()); iCol++)
     if (std::abs(cost[iCol]) < kHighsInf &&
-	std::abs(cost[iCol] * cost_scale_value) > infinite_cost) return false;
+        std::abs(cost[iCol] * cost_scale_value) > infinite_cost)
+      return false;
   return true;
 }
 

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -57,6 +57,15 @@ HighsStatus assessBounds(const HighsOptions& options, const char* type,
 
 HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp);
 
+bool boundScaleOk(const std::vector<double>& lower,
+		  const std::vector<double>& upper,
+		  const HighsInt bound_scale,
+		  const double infinite_bound);
+                        
+bool costScaleOk(const std::vector<double>& cost,
+		 const HighsInt cost_scale,
+		 const double infinite_cost);
+
 HighsStatus assessSemiVariables(HighsLp& lp, const HighsOptions& options,
                                 bool& made_semi_variable_mods);
 void relaxSemiVariables(HighsLp& lp, bool& made_semi_variable_mods);

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -58,13 +58,11 @@ HighsStatus assessBounds(const HighsOptions& options, const char* type,
 HighsStatus cleanBounds(const HighsOptions& options, HighsLp& lp);
 
 bool boundScaleOk(const std::vector<double>& lower,
-		  const std::vector<double>& upper,
-		  const HighsInt bound_scale,
-		  const double infinite_bound);
-                        
-bool costScaleOk(const std::vector<double>& cost,
-		 const HighsInt cost_scale,
-		 const double infinite_cost);
+                  const std::vector<double>& upper, const HighsInt bound_scale,
+                  const double infinite_bound);
+
+bool costScaleOk(const std::vector<double>& cost, const HighsInt cost_scale,
+                 const double infinite_cost);
 
 HighsStatus assessSemiVariables(HighsLp& lp, const HighsOptions& options,
                                 bool& made_semi_variable_mods);

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -570,13 +570,13 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "user_cost_scale", "Exponent of power-of-two cost scaling for model", advanced,
-        &user_cost_scale, -30, 0, 30);
+        "user_cost_scale", "Exponent of power-of-two cost scaling for model",
+        advanced, &user_cost_scale, -30, 0, 30);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "user_bound_scale", "Exponent of power-of-two bound scaling for model", advanced,
-        &user_bound_scale, -30, 0, 30);
+        "user_bound_scale", "Exponent of power-of-two bound scaling for model",
+        advanced, &user_bound_scale, -30, 0, 30);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("highs_debug_level",

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -303,6 +303,8 @@ struct HighsOptionsStruct {
   double objective_bound;
   double objective_target;
   HighsInt threads;
+  HighsInt user_cost_scale;
+  HighsInt user_bound_scale;
   HighsInt highs_debug_level;
   HighsInt highs_analysis_level;
   HighsInt simplex_strategy;
@@ -565,6 +567,16 @@ class HighsOptions : public HighsOptionsStruct {
     record_int = new OptionRecordInt(
         "threads", "Number of threads used by HiGHS (0: automatic)", advanced,
         &threads, 0, 0, kHighsIInf);
+    records.push_back(record_int);
+
+    record_int = new OptionRecordInt(
+        "user_cost_scale", "Exponent of power-of-two cost scaling for model", advanced,
+        &user_cost_scale, -30, 0, 30);
+    records.push_back(record_int);
+
+    record_int = new OptionRecordInt(
+        "user_bound_scale", "Exponent of power-of-two bound scaling for model", advanced,
+        &user_bound_scale, -30, 0, 30);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("highs_debug_level",

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -303,8 +303,8 @@ struct HighsOptionsStruct {
   double objective_bound;
   double objective_target;
   HighsInt threads;
-  HighsInt user_cost_scale;
   HighsInt user_bound_scale;
+  HighsInt user_cost_scale;
   HighsInt highs_debug_level;
   HighsInt highs_analysis_level;
   HighsInt simplex_strategy;
@@ -570,13 +570,13 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "user_cost_scale", "Exponent of power-of-two cost scaling for model",
-        advanced, &user_cost_scale, -30, 0, 30);
+        "user_bound_scale", "Exponent of power-of-two bound scaling for model",
+        advanced, &user_bound_scale, -30, 0, 30);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "user_bound_scale", "Exponent of power-of-two bound scaling for model",
-        advanced, &user_bound_scale, -30, 0, 30);
+        "user_cost_scale", "Exponent of power-of-two cost scaling for model",
+        advanced, &user_cost_scale, -30, 0, 30);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("highs_debug_level",

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -571,12 +571,12 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_int = new OptionRecordInt(
         "user_bound_scale", "Exponent of power-of-two bound scaling for model",
-        advanced, &user_bound_scale, -30, 0, 30);
+        advanced, &user_bound_scale, -kHighsIInf, 0, kHighsIInf);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
         "user_cost_scale", "Exponent of power-of-two cost scaling for model",
-        advanced, &user_cost_scale, -30, 0, 30);
+        advanced, &user_cost_scale, -kHighsIInf, 0, kHighsIInf);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt("highs_debug_level",

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -290,8 +290,9 @@ HighsStatus solveUnconstrainedLp(const HighsOptions& options, const HighsLp& lp,
 }
 
 HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
-			       const HighsModel& model) {
-  auto assessFiniteNonzero = [&](const double value, double& min_value, double& max_value) {
+                               const HighsModel& model) {
+  auto assessFiniteNonzero = [&](const double value, double& min_value,
+                                 double& max_value) {
     double abs_value = std::abs(value);
     if (abs_value > 0 && abs_value < kHighsInf) {
       min_value = std::min(abs_value, min_value);
@@ -308,37 +309,47 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
   double min_matrix_value = kHighsInf;
   double max_matrix_value = -kHighsInf;
   for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
-    assessFiniteNonzero(lp.col_cost_[iCol], min_finite_col_cost, max_finite_col_cost);
-    assessFiniteNonzero(lp.col_lower_[iCol], min_finite_col_bound, max_finite_col_bound);
-    assessFiniteNonzero(lp.col_upper_[iCol], min_finite_col_bound, max_finite_col_bound);
+    assessFiniteNonzero(lp.col_cost_[iCol], min_finite_col_cost,
+                        max_finite_col_cost);
+    assessFiniteNonzero(lp.col_lower_[iCol], min_finite_col_bound,
+                        max_finite_col_bound);
+    assessFiniteNonzero(lp.col_upper_[iCol], min_finite_col_bound,
+                        max_finite_col_bound);
   }
   if (min_finite_col_cost == kHighsInf) min_finite_col_cost = 0;
   if (max_finite_col_cost == -kHighsInf) max_finite_col_cost = 0;
   if (min_finite_col_bound == kHighsInf) min_finite_col_bound = 0;
   if (max_finite_col_bound == -kHighsInf) max_finite_col_bound = 0;
   for (HighsInt iRow = 0; iRow < lp.num_row_; iRow++) {
-    assessFiniteNonzero(lp.row_lower_[iRow], min_finite_row_bound, max_finite_row_bound);
-    assessFiniteNonzero(lp.row_upper_[iRow], min_finite_row_bound, max_finite_row_bound);
+    assessFiniteNonzero(lp.row_lower_[iRow], min_finite_row_bound,
+                        max_finite_row_bound);
+    assessFiniteNonzero(lp.row_upper_[iRow], min_finite_row_bound,
+                        max_finite_row_bound);
   }
   if (min_finite_row_bound == kHighsInf) min_finite_row_bound = 0;
   if (max_finite_row_bound == -kHighsInf) max_finite_row_bound = 0;
   HighsInt num_nz = lp.a_matrix_.numNz();
   for (HighsInt iEl = 0; iEl < num_nz; iEl++)
-    assessFiniteNonzero(lp.a_matrix_.value_[iEl], min_matrix_value, max_matrix_value);
-    
+    assessFiniteNonzero(lp.a_matrix_.value_[iEl], min_matrix_value,
+                        max_matrix_value);
+
   highsLogUser(log_options, HighsLogType::kInfo, "Coefficient statistics:\n");
   if (num_nz)
-    highsLogUser(log_options, HighsLogType::kInfo, "  Matrix range [%5.0e, %5.0e]\n",
-		 min_matrix_value, max_matrix_value);
+    highsLogUser(log_options, HighsLogType::kInfo,
+                 "  Matrix range [%5.0e, %5.0e]\n", min_matrix_value,
+                 max_matrix_value);
   if (lp.num_col_) {
-    highsLogUser(log_options, HighsLogType::kInfo, "  Cost range   [%5.0e, %5.0e]\n",
-		 min_finite_col_cost, max_finite_col_cost);
-    highsLogUser(log_options, HighsLogType::kInfo, "  Bound range  [%5.0e, %5.0e]\n",
-		 min_finite_col_bound, max_finite_col_bound);
+    highsLogUser(log_options, HighsLogType::kInfo,
+                 "  Cost range   [%5.0e, %5.0e]\n", min_finite_col_cost,
+                 max_finite_col_cost);
+    highsLogUser(log_options, HighsLogType::kInfo,
+                 "  Bound range  [%5.0e, %5.0e]\n", min_finite_col_bound,
+                 max_finite_col_bound);
   }
-  if (lp.num_row_) 
-    highsLogUser(log_options, HighsLogType::kInfo, "  RHS range    [%5.0e, %5.0e]\n",
-		 min_finite_row_bound, max_finite_row_bound);
+  if (lp.num_row_)
+    highsLogUser(log_options, HighsLogType::kInfo,
+                 "  RHS range    [%5.0e, %5.0e]\n", min_finite_row_bound,
+                 max_finite_row_bound);
 
   HighsStatus return_status = HighsStatus::kOk;
   // LPs with no columns or no finite nonzero costs will have
@@ -350,9 +361,10 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
     HighsInt suggested_user_cost_scale = std::floor(std::log2(ratio));
     assert(suggested_user_cost_scale < 0);
     highsLogUser(log_options, HighsLogType::kWarning,
-		 "Problem has excessive costs: consider scaling the costs down by at least %g, "
-		 "or setting option user_cost_scale to %d or less\n",
-		 1.0 / ratio, int(suggested_user_cost_scale));
+                 "Problem has excessive costs: consider scaling the costs down "
+                 "by at least %g, "
+                 "or setting option user_cost_scale to %d or less\n",
+                 1.0 / ratio, int(suggested_user_cost_scale));
     return_status = HighsStatus::kWarning;
   }
   // LPs with no columns or no finite nonzero bounds will have
@@ -365,13 +377,15 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
     assert(suggested_user_bound_scale < 0);
     if (lp.isMip()) {
       highsLogUser(log_options, HighsLogType::kWarning,
-		   "Problem has excessive bounds: consider scaling the bounds down by at least %g\n",
-		   1.0 / ratio);
+                   "Problem has excessive bounds: consider scaling the bounds "
+                   "down by at least %g\n",
+                   1.0 / ratio);
     } else {
       highsLogUser(log_options, HighsLogType::kWarning,
-		   "Problem has excessive bounds: consider scaling the bounds down by at least %g, "
-		   "or setting option user_bound_scale to %d or less\n",
-		   1.0 / ratio, int(suggested_user_bound_scale));
+                   "Problem has excessive bounds: consider scaling the bounds "
+                   "down by at least %g, "
+                   "or setting option user_bound_scale to %d or less\n",
+                   1.0 / ratio, int(suggested_user_bound_scale));
     }
     return_status = HighsStatus::kWarning;
   }
@@ -385,13 +399,15 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
     assert(suggested_user_bound_scale < 0);
     if (lp.isMip()) {
       highsLogUser(log_options, HighsLogType::kWarning,
-		   "Problem has excessive bounds: consider scaling the bounds down by at least %g\n",
-		   1.0 / ratio);
+                   "Problem has excessive bounds: consider scaling the bounds "
+                   "down by at least %g\n",
+                   1.0 / ratio);
     } else {
       highsLogUser(log_options, HighsLogType::kWarning,
-		   "Problem has excessive bounds: consider scaling the bounds down by at least %g, "
-		   "or setting option user_bound_scale to %d or less\n",
-		   1.0 / ratio, int(suggested_user_bound_scale));
+                   "Problem has excessive bounds: consider scaling the bounds "
+                   "down by at least %g, "
+                   "or setting option user_bound_scale to %d or less\n",
+                   1.0 / ratio, int(suggested_user_bound_scale));
     }
     return_status = HighsStatus::kWarning;
   }

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -356,12 +356,12 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
   // max_finite_col_cost = 0
   assert(max_finite_col_cost >= 0);
   if (max_finite_col_cost > kExcessivelyLargeCostValue) {
-    // Warn that costs are excessive, and suggest scaling
+    // Warn that costs are excessively large, and suggest scaling
     double ratio = kExcessivelyLargeCostValue / max_finite_col_cost;
     HighsInt suggested_user_cost_scale = std::floor(std::log2(ratio));
     assert(suggested_user_cost_scale < 0);
     highsLogUser(log_options, HighsLogType::kWarning,
-                 "Problem has excessive costs: consider scaling the costs down "
+                 "Problem has excessively large costs: consider scaling the costs down "
                  "by at least %g, "
                  "or setting option user_cost_scale to %d or less\n",
                  1.0 / ratio, int(suggested_user_cost_scale));
@@ -371,18 +371,18 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
   // max_finite_col_bound = 0
   assert(max_finite_col_bound >= 0);
   if (max_finite_col_bound > kExcessivelyLargeBoundValue) {
-    // Warn that bounds are excessive, and suggest scaling
+    // Warn that bounds are excessively large, and suggest scaling
     double ratio = kExcessivelyLargeBoundValue / max_finite_col_bound;
     HighsInt suggested_user_bound_scale = std::floor(std::log2(ratio));
     assert(suggested_user_bound_scale < 0);
     if (lp.isMip()) {
       highsLogUser(log_options, HighsLogType::kWarning,
-                   "Problem has excessive bounds: consider scaling the bounds "
+                   "Problem has excessively large bounds: consider scaling the bounds "
                    "down by at least %g\n",
                    1.0 / ratio);
     } else {
       highsLogUser(log_options, HighsLogType::kWarning,
-                   "Problem has excessive bounds: consider scaling the bounds "
+                   "Problem has excessively large bounds: consider scaling the bounds "
                    "down by at least %g, "
                    "or setting option user_bound_scale to %d or less\n",
                    1.0 / ratio, int(suggested_user_bound_scale));
@@ -393,23 +393,75 @@ HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
   // max_finite_row_bound = 0
   assert(max_finite_row_bound >= 0);
   if (max_finite_row_bound > kExcessivelyLargeBoundValue) {
-    // Warn that bounds are excessive, and suggest scaling
+    // Warn that bounds are excessively large, and suggest scaling
     double ratio = kExcessivelyLargeBoundValue / max_finite_row_bound;
     HighsInt suggested_user_bound_scale = std::floor(std::log2(ratio));
     assert(suggested_user_bound_scale < 0);
     if (lp.isMip()) {
       highsLogUser(log_options, HighsLogType::kWarning,
-                   "Problem has excessive bounds: consider scaling the bounds "
+                   "Problem has excessively large bounds: consider scaling the bounds "
                    "down by at least %g\n",
                    1.0 / ratio);
     } else {
       highsLogUser(log_options, HighsLogType::kWarning,
-                   "Problem has excessive bounds: consider scaling the bounds "
+                   "Problem has excessively large bounds: consider scaling the bounds "
                    "down by at least %g, "
                    "or setting option user_bound_scale to %d or less\n",
                    1.0 / ratio, int(suggested_user_bound_scale));
     }
     return_status = HighsStatus::kWarning;
   }
+  // Now consider warning relating to small maximum costs and bounds
+  if (max_finite_col_cost > 0 && max_finite_col_cost < kExcessivelySmallCostValue) {
+    // Warn that costs are excessively small, and suggest scaling
+    double ratio = kExcessivelySmallCostValue / max_finite_col_cost;
+    HighsInt suggested_user_cost_scale = std::ceil(std::log2(ratio));
+    assert(suggested_user_cost_scale > 0);
+    highsLogUser(log_options, HighsLogType::kWarning,
+                 "Problem has excessively small costs: consider scaling the costs up "
+                 "by at least %g, "
+                 "or setting option user_cost_scale to %d or more\n",
+                 ratio, int(suggested_user_cost_scale));
+    return_status = HighsStatus::kWarning;
+  }
+  if (max_finite_col_bound > 0 && max_finite_col_bound < kExcessivelySmallBoundValue) {
+    // Warn that bounds are excessively small, and suggest scaling
+    double ratio = kExcessivelySmallBoundValue / max_finite_col_bound;
+    HighsInt suggested_user_bound_scale = std::ceil(std::log2(ratio));
+    assert(suggested_user_bound_scale > 0);
+    if (lp.isMip()) {
+      highsLogUser(log_options, HighsLogType::kWarning,
+                   "Problem has excessively small bounds: consider scaling the bounds "
+                   "up by at least %g\n",
+                   ratio);
+    } else {
+      highsLogUser(log_options, HighsLogType::kWarning,
+                   "Problem has excessively small bounds: consider scaling the bounds "
+                   "up by at least %g, "
+                   "or setting option user_bound_scale to %d or more\n",
+                   ratio, int(suggested_user_bound_scale));
+    }
+    return_status = HighsStatus::kWarning;
+  }
+  if (max_finite_row_bound > 0 && max_finite_row_bound < kExcessivelySmallBoundValue) {
+    // Warn that bounds are excessively small, and suggest scaling
+    double ratio = kExcessivelySmallBoundValue / max_finite_row_bound;
+    HighsInt suggested_user_bound_scale = std::ceil(std::log2(ratio));
+    assert(suggested_user_bound_scale > 0);
+    if (lp.isMip()) {
+      highsLogUser(log_options, HighsLogType::kWarning,
+                   "Problem has excessively small bounds: consider scaling the bounds "
+                   "up by at least %g\n",
+                   ratio);
+    } else {
+      highsLogUser(log_options, HighsLogType::kWarning,
+                   "Problem has excessively small bounds: consider scaling the bounds "
+                   "up by at least %g, "
+                   "or setting option user_bound_scale to %d or more\n",
+                   ratio, int(suggested_user_bound_scale));
+    }
+    return_status = HighsStatus::kWarning;
+  }
+  
   return return_status;
 }

--- a/src/lp_data/HighsSolve.h
+++ b/src/lp_data/HighsSolve.h
@@ -22,5 +22,5 @@ HighsStatus solveUnconstrainedLp(const HighsOptions& options, const HighsLp& lp,
                                  HighsInfo& highs_info, HighsSolution& solution,
                                  HighsBasis& basis);
 HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
-			       const HighsModel& model);
+                               const HighsModel& model);
 #endif  // LP_DATA_HIGHSSOLVE_H_

--- a/src/lp_data/HighsSolve.h
+++ b/src/lp_data/HighsSolve.h
@@ -21,6 +21,6 @@ HighsStatus solveUnconstrainedLp(const HighsOptions& options, const HighsLp& lp,
                                  HighsModelStatus& model_status,
                                  HighsInfo& highs_info, HighsSolution& solution,
                                  HighsBasis& basis);
-HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
-                               const HighsModel& model);
+void assessExcessiveBoundCost(const HighsLogOptions log_options,
+                              const HighsModel& model);
 #endif  // LP_DATA_HIGHSSOLVE_H_

--- a/src/lp_data/HighsSolve.h
+++ b/src/lp_data/HighsSolve.h
@@ -21,4 +21,6 @@ HighsStatus solveUnconstrainedLp(const HighsOptions& options, const HighsLp& lp,
                                  HighsModelStatus& model_status,
                                  HighsInfo& highs_info, HighsSolution& solution,
                                  HighsBasis& basis);
+HighsStatus excessiveBoundCost(const HighsLogOptions log_options,
+			       const HighsModel& model);
 #endif  // LP_DATA_HIGHSSOLVE_H_

--- a/src/model/HighsHessian.cpp
+++ b/src/model/HighsHessian.cpp
@@ -40,6 +40,19 @@ void HighsHessian::exactResize() {
   }
 }
 
+bool HighsHessian::scaleOk(const HighsInt hessian_scale,
+			   const double small_matrix_value,
+			   const double large_matrix_value) const {
+  if (!this->dim_) return true;
+  double hessian_scale_value = std::pow(2, hessian_scale);
+  for (HighsInt iEl = 0; iEl < this->start_[this->dim_]; iEl++) {
+    double abs_new_value = std::abs(this->value_[iEl] * hessian_scale_value);
+    if (abs_new_value >= large_matrix_value) return false;
+    if (abs_new_value <= small_matrix_value) return false;
+  }
+  return true;
+}
+
 HighsInt HighsHessian::numNz() const {
   assert(this->formatOk());
   assert((HighsInt)this->start_.size() >= this->dim_ + 1);

--- a/src/model/HighsHessian.cpp
+++ b/src/model/HighsHessian.cpp
@@ -41,8 +41,8 @@ void HighsHessian::exactResize() {
 }
 
 bool HighsHessian::scaleOk(const HighsInt hessian_scale,
-			   const double small_matrix_value,
-			   const double large_matrix_value) const {
+                           const double small_matrix_value,
+                           const double large_matrix_value) const {
   if (!this->dim_) return true;
   double hessian_scale_value = std::pow(2, hessian_scale);
   for (HighsInt iEl = 0; iEl < this->start_[this->dim_]; iEl++) {

--- a/src/model/HighsHessian.h
+++ b/src/model/HighsHessian.h
@@ -42,6 +42,9 @@ class HighsHessian {
     return (this->format_ == HessianFormat::kTriangular ||
             this->format_ == HessianFormat::kSquare);
   };
+  bool scaleOk(const HighsInt cost_scale,
+	       const double small_matrix_value,
+	       const double large_matrix_value) const;
   HighsInt numNz() const;
   void print() const;
 };

--- a/src/model/HighsHessian.h
+++ b/src/model/HighsHessian.h
@@ -42,9 +42,8 @@ class HighsHessian {
     return (this->format_ == HessianFormat::kTriangular ||
             this->format_ == HessianFormat::kSquare);
   };
-  bool scaleOk(const HighsInt cost_scale,
-	       const double small_matrix_value,
-	       const double large_matrix_value) const;
+  bool scaleOk(const HighsInt cost_scale, const double small_matrix_value,
+               const double large_matrix_value) const;
   HighsInt numNz() const;
   void print() const;
 };

--- a/src/model/HighsModel.cpp
+++ b/src/model/HighsModel.cpp
@@ -29,6 +29,35 @@ bool HighsModel::equalButForNames(const HighsModel& model) const {
   return equal;
 }
 
+bool HighsModel::userCostScaleOk(const HighsInt user_cost_scale,
+			      const double large_matrix_value,
+			      const double infinite_cost) {
+  const HighsInt dl_user_cost_scale =
+      user_cost_scale - this->lp_.user_cost_scale_;
+  if (!dl_user_cost_scale) return true;
+  double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
+  if (this->hessian_.dim_) {
+    for (HighsInt iEl = 0; iEl < this->hessian_.start_[this->hessian_.dim_]; iEl++) {
+      double new_value =
+	this->hessian_.value_[iEl] * dl_user_cost_scale_value;
+      if (std::abs(new_value) > large_matrix_value) return false;
+    }
+  }
+  return this->lp_.userCostScaleOk(user_cost_scale, infinite_cost);
+}
+
+void HighsModel::userCostScale(const HighsInt user_cost_scale) {
+  const HighsInt dl_user_cost_scale =
+    user_cost_scale - this->lp_.user_cost_scale_;
+  if (!dl_user_cost_scale) return;
+  double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
+  if (this->hessian_.dim_) {
+    for (HighsInt iEl = 0; iEl < this->hessian_.start_[this->hessian_.dim_]; iEl++) 
+      this->hessian_.value_[iEl] *= dl_user_cost_scale_value;
+  }
+  this->lp_.userCostScale(user_cost_scale);
+}
+
 void HighsModel::clear() {
   this->lp_.clear();
   this->hessian_.clear();

--- a/src/model/HighsModel.cpp
+++ b/src/model/HighsModel.cpp
@@ -30,26 +30,27 @@ bool HighsModel::equalButForNames(const HighsModel& model) const {
 }
 
 bool HighsModel::userCostScaleOk(const HighsInt user_cost_scale,
-				 const double small_matrix_value,
-				 const double large_matrix_value,
-				 const double infinite_cost) const {
+                                 const double small_matrix_value,
+                                 const double large_matrix_value,
+                                 const double infinite_cost) const {
   const HighsInt dl_user_cost_scale =
       user_cost_scale - this->lp_.user_cost_scale_;
   if (!dl_user_cost_scale) return true;
   if (this->hessian_.dim_ &&
-      !this->hessian_.scaleOk(dl_user_cost_scale,
-			      small_matrix_value,
-			      large_matrix_value)) return false;
+      !this->hessian_.scaleOk(dl_user_cost_scale, small_matrix_value,
+                              large_matrix_value))
+    return false;
   return this->lp_.userCostScaleOk(user_cost_scale, infinite_cost);
 }
 
 void HighsModel::userCostScale(const HighsInt user_cost_scale) {
   const HighsInt dl_user_cost_scale =
-    user_cost_scale - this->lp_.user_cost_scale_;
+      user_cost_scale - this->lp_.user_cost_scale_;
   if (!dl_user_cost_scale) return;
   double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
   if (this->hessian_.dim_) {
-    for (HighsInt iEl = 0; iEl < this->hessian_.start_[this->hessian_.dim_]; iEl++) 
+    for (HighsInt iEl = 0; iEl < this->hessian_.start_[this->hessian_.dim_];
+         iEl++)
       this->hessian_.value_[iEl] *= dl_user_cost_scale_value;
   }
   this->lp_.userCostScale(user_cost_scale);

--- a/src/model/HighsModel.cpp
+++ b/src/model/HighsModel.cpp
@@ -30,19 +30,16 @@ bool HighsModel::equalButForNames(const HighsModel& model) const {
 }
 
 bool HighsModel::userCostScaleOk(const HighsInt user_cost_scale,
-			      const double large_matrix_value,
-			      const double infinite_cost) {
+				 const double small_matrix_value,
+				 const double large_matrix_value,
+				 const double infinite_cost) const {
   const HighsInt dl_user_cost_scale =
       user_cost_scale - this->lp_.user_cost_scale_;
   if (!dl_user_cost_scale) return true;
-  double dl_user_cost_scale_value = std::pow(2, dl_user_cost_scale);
-  if (this->hessian_.dim_) {
-    for (HighsInt iEl = 0; iEl < this->hessian_.start_[this->hessian_.dim_]; iEl++) {
-      double new_value =
-	this->hessian_.value_[iEl] * dl_user_cost_scale_value;
-      if (std::abs(new_value) > large_matrix_value) return false;
-    }
-  }
+  if (this->hessian_.dim_ &&
+      !this->hessian_.scaleOk(dl_user_cost_scale,
+			      small_matrix_value,
+			      large_matrix_value)) return false;
   return this->lp_.userCostScaleOk(user_cost_scale, infinite_cost);
 }
 

--- a/src/model/HighsModel.h
+++ b/src/model/HighsModel.h
@@ -39,9 +39,9 @@ class HighsModel {
   }
   bool hasMods() const { return this->lp_.hasMods(); }
   bool userCostScaleOk(const HighsInt user_cost_scale,
-		       const double small_matrix_value,
-		       const double large_matrix_value,
-		       const double infinite_cost) const;
+                       const double small_matrix_value,
+                       const double large_matrix_value,
+                       const double infinite_cost) const;
   void userCostScale(const HighsInt user_cost_scale);
   void clear();
   double objectiveValue(const std::vector<double>& solution) const;

--- a/src/model/HighsModel.h
+++ b/src/model/HighsModel.h
@@ -39,8 +39,9 @@ class HighsModel {
   }
   bool hasMods() const { return this->lp_.hasMods(); }
   bool userCostScaleOk(const HighsInt user_cost_scale,
+		       const double small_matrix_value,
 		       const double large_matrix_value,
-		       const double infinite_cost);
+		       const double infinite_cost) const;
   void userCostScale(const HighsInt user_cost_scale);
   void clear();
   double objectiveValue(const std::vector<double>& solution) const;

--- a/src/model/HighsModel.h
+++ b/src/model/HighsModel.h
@@ -38,6 +38,10 @@ class HighsModel {
     return this->lp_.needsMods(infinite_cost);
   }
   bool hasMods() const { return this->lp_.hasMods(); }
+  bool userCostScaleOk(const HighsInt user_cost_scale,
+		       const double large_matrix_value,
+		       const double infinite_cost);
+  void userCostScale(const HighsInt user_cost_scale);
   void clear();
   double objectiveValue(const std::vector<double>& solution) const;
   void objectiveGradient(const std::vector<double>& solution,


### PR DESCRIPTION
HiGHS can now be run with user scaling of costs and/or all bounds, and also warns of excessively large or small maximum nonzero finite costs and bounds.

Hence, users with excessive bounds and costs causing HiGHS to fail can be asked to run HiGHS with appropriate scaling