### PR TITLE
Fix #1334

### DIFF
--- a/src/mip/HighsCliqueTable.cpp
+++ b/src/mip/HighsCliqueTable.cpp
@@ -1164,6 +1164,9 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
               coef = globaldom.col_upper_[col] - implcolub;
               constant = implcolub;
             } else {
+              // make sure that upper bound is not infinite to avoid adding VUB
+              // with coefficient '-inf' and constant 'inf'
+              if (globaldom.col_upper_[col] == kHighsInf) continue;
               coef = implcolub - globaldom.col_upper_[col];
               constant = globaldom.col_upper_[col];
             }
@@ -1186,6 +1189,9 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
               coef = globaldom.col_lower_[col] - implcollb;
               constant = implcollb;
             } else {
+              // make sure that lower bound is not infinite to avoid adding VLB
+              // with coefficient 'inf' and constant '-inf'
+              if (globaldom.col_lower_[col] == -kHighsInf) continue;
               coef = implcollb - globaldom.col_lower_[col];
               constant = globaldom.col_lower_[col];
             }

--- a/src/mip/HighsCliqueTable.cpp
+++ b/src/mip/HighsCliqueTable.cpp
@@ -1165,7 +1165,7 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
               constant = implcolub;
             } else {
               // make sure that upper bound is not infinite to avoid adding VUB
-              // with coefficient '-inf' and constant 'inf'
+              // with coefficient '-kHighsInf' and constant 'kHighsInf'
               if (globaldom.col_upper_[col] == kHighsInf) continue;
               coef = implcolub - globaldom.col_upper_[col];
               constant = globaldom.col_upper_[col];
@@ -1190,7 +1190,7 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
               constant = implcollb;
             } else {
               // make sure that lower bound is not infinite to avoid adding VLB
-              // with coefficient 'inf' and constant '-inf'
+              // with coefficient 'kHighsInf' and constant '-kHighsInf'
               if (globaldom.col_lower_[col] == -kHighsInf) continue;
               coef = implcollb - globaldom.col_lower_[col];
               constant = globaldom.col_lower_[col];

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -373,6 +373,8 @@ bool HighsImplications::runProbing(HighsInt col, HighsInt& numReductions) {
 
 void HighsImplications::addVUB(HighsInt col, HighsInt vubcol, double vubcoef,
                                double vubconstant) {
+  assert(vubconstant != kHighsInf);
+
   VarBound vub{vubcoef, vubconstant};
 
   mipsolver.mipdata_->debugSolution.checkVub(col, vubcol, vubcoef, vubconstant);
@@ -396,6 +398,8 @@ void HighsImplications::addVUB(HighsInt col, HighsInt vubcol, double vubcoef,
 
 void HighsImplications::addVLB(HighsInt col, HighsInt vlbcol, double vlbcoef,
                                double vlbconstant) {
+  assert(vlbconstant != -kHighsInf);
+
   VarBound vlb{vlbcoef, vlbconstant};
 
   mipsolver.mipdata_->debugSolution.checkVlb(col, vlbcol, vlbcoef, vlbconstant);

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -373,7 +373,9 @@ bool HighsImplications::runProbing(HighsInt col, HighsInt& numReductions) {
 
 void HighsImplications::addVUB(HighsInt col, HighsInt vubcol, double vubcoef,
                                double vubconstant) {
-  assert(vubconstant != kHighsInf);
+  // assume that VUBs do not have infinite coefficients and infinite constant
+  // terms since such VUBs effectively evaluate to NaN.
+  assert(std::abs(vubcoef) != kHighsInf || std::abs(vubconstant) != kHighsInf);
 
   VarBound vub{vubcoef, vubconstant};
 
@@ -398,7 +400,9 @@ void HighsImplications::addVUB(HighsInt col, HighsInt vubcol, double vubcoef,
 
 void HighsImplications::addVLB(HighsInt col, HighsInt vlbcol, double vlbcoef,
                                double vlbconstant) {
-  assert(vlbconstant != -kHighsInf);
+  // assume that VLBs do not have infinite coefficients and infinite constant
+  // terms since such VLBs effectively evaluate to NaN.
+  assert(std::abs(vlbcoef) != kHighsInf || std::abs(vlbconstant) != kHighsInf);
 
   VarBound vlb{vlbcoef, vlbconstant};
 


### PR DESCRIPTION
HiGHS infers variable lower / upper bound (VLB / VUB) constraints in the clique table code.  For example, a variable upper bound looks like x <= a * y + c where x is a cont. and y is a binary variable.

Fix #1334 
- If a = -kHighsInf and c = kHighsInf, the actual bound on x given by the VUB constraint above evaluates to NaN.
- I added assertions to detect this in the future.
- Qualification on publicly available instances is ongoing. However, I think this bug fix may be non-controversial, and thus I decided to create this PR now.