### PR TITLE
Fix crash in HPresolve::shrinkProblem

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -827,6 +827,8 @@ void HPresolve::shrinkProblem(HighsPostsolveStack& postsolve_stack) {
       changedRowIndices.end());
 
   for (auto& rowColPair : substitutionOpportunities) {
+    // skip deleted elements
+    if (rowColPair.first == -1) continue;
     rowColPair.first = newRowIndex[rowColPair.first];
     rowColPair.second = newColIndex[rowColPair.second];
   }


### PR DESCRIPTION
I observed a crash in `HPresolve::shrinkProblem` if `substitutionOpportunities` contains elements that were marked for deletion (with -1).