### PR TITLE
Fix 1514

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -1426,7 +1426,7 @@ void test_setSolution() {
 }
 */
 int main() {
-  //  minimal_api_illegal_lp();
+  minimal_api_illegal_lp();
   test_callback();
   version_api();
   full_api();

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -75,52 +75,6 @@ void version_api() {
   }
 }
 
-void minimal_api() {
-  HighsInt num_col = 2;
-  HighsInt num_row = 2;
-  HighsInt num_nz = 4;
-  HighsInt a_format = kHighsMatrixFormatRowwise;
-  HighsInt sense = kHighsObjSenseMinimize;
-  double offset = 0;
-  HighsInt i;
-
-  double cc[2] = {1.0, -2.0};
-  double cl[2] = {0.0, 0.0};
-  double cu[2] = {10.0, 10.0};
-  double rl[2] = {0.0, 0.0};
-  double ru[2] = {2.0, 1.0};
-  HighsInt a_start[3] = {0, 2, 4};
-  HighsInt a_index[4] = {0, 1, 0, 1};
-  double a_value[4] = {1.0, 2.0, 1.0, 3.0};
-
-  double* cv = (double*)malloc(sizeof(double) * num_col);
-  double* cd = (double*)malloc(sizeof(double) * num_col);
-  double* rv = (double*)malloc(sizeof(double) * num_row);
-  double* rd = (double*)malloc(sizeof(double) * num_row);
-
-  HighsInt* cbs = (HighsInt*)malloc(sizeof(HighsInt) * num_col);
-  HighsInt* rbs = (HighsInt*)malloc(sizeof(HighsInt) * num_row);
-
-  HighsInt model_status;
-
-  HighsInt return_status = Highs_lpCall(num_col, num_row, num_nz, a_format, sense, offset,
-					cc, cl, cu, rl, ru, a_start, a_index, a_value, cv,
-					cd, rv, rd, cbs, rbs, &model_status);
-  assert( return_status == kHighsStatusOk );
-
-  if (dev_run) {
-    for (i = 0; i < num_col; i++) 
-      printf("x%"HIGHSINT_FORMAT" = %lf\n", i, cv[i]);
-  }
-
-  free(cv);
-  free(cd);
-  free(rv);
-  free(rd);
-  free(cbs);
-  free(rbs);
-}
-
 void minimal_api_lp() {
   // This illustrates the use of Highs_call, the simple C interface to
   // HiGHS. It's designed to solve the general LP problem
@@ -206,11 +160,11 @@ void minimal_api_lp() {
   HighsInt model_status;
 
   HighsInt return_status = Highs_lpCall(num_col, num_row, num_nz, a_format,
-				    sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
-				    a_start, a_index, a_value,
-				    col_value, col_dual, row_value, row_dual,
-				    col_basis_status, row_basis_status,
-				    &model_status);
+					sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
+					a_start, a_index, a_value,
+					col_value, col_dual, row_value, row_dual,
+					col_basis_status, row_basis_status,
+					&model_status);
 
   assert( return_status == kHighsStatusOk );
 
@@ -280,23 +234,24 @@ void minimal_api_mip() {
   HighsInt return_status;
 
   return_status = Highs_mipCall(num_col, num_row, num_nz, a_format,
-					 sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
-					 a_start, a_index, a_value,
-					 integrality,
-					 col_value, row_value,
-					 &model_status);
-  // Should return error
+				sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
+				a_start, a_index, a_value,
+				integrality,
+				col_value, row_value,
+				&model_status);
+  // Should return error, with model status not set
   assert( return_status == kHighsStatusError );
+  assert( model_status == kHighsModelStatusNotset );
 
   // Correct integrality
   integrality[num_col-1] = kHighsVarTypeInteger;
 
   return_status = Highs_mipCall(num_col, num_row, num_nz, a_format,
-					 sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
-					 a_start, a_index, a_value,
-					 integrality,
-					 col_value, row_value,
-					 &model_status);
+				sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
+				a_start, a_index, a_value,
+				integrality,
+				col_value, row_value,
+				&model_status);
   // Should return OK
   assert( return_status == kHighsStatusOk );
 
@@ -367,6 +322,35 @@ void minimal_api_qp() {
     }
   }
   free(col_value);
+}
+
+void minimal_api_illegal_lp() {
+  const double inf = 1e30;
+  HighsInt num_col = 2;
+  HighsInt num_row = 1;
+  HighsInt num_nz = 2;
+  HighsInt a_format = kHighsMatrixFormatRowwise;
+  HighsInt sense = kHighsObjSenseMinimize;
+  double offset = 0;
+  double col_cost[2] = {0.0, -1.0};
+  double col_lower[2] = {-inf, -inf};
+  double col_upper[2] = {inf, inf};
+  double row_lower[1] = {-inf};
+  double row_upper[1] = {2};
+  HighsInt a_start[1] = {0};
+  HighsInt a_index[2] = {0, -1}; // Illegal index
+  double a_value[2] = {1.0, 1.0};
+
+  HighsInt model_status;
+  HighsInt return_status = Highs_lpCall(num_col, num_row, num_nz, a_format,
+					sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
+					a_start, a_index, a_value,
+					NULL, NULL, NULL, NULL, 
+					NULL, NULL, 
+					&model_status);
+  // Should return error, with model status not set
+  assert( return_status == kHighsStatusError );
+  assert( model_status == kHighsModelStatusNotset );
 }
 
 void full_api() {
@@ -1442,9 +1426,9 @@ void test_setSolution() {
 }
 */
 int main() {
+  minimal_api_illegal_lp();
   test_callback();
   version_api();
-  minimal_api();
   full_api();
   minimal_api_lp();
   minimal_api_mip();

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -1426,7 +1426,7 @@ void test_setSolution() {
 }
 */
 int main() {
-  minimal_api_illegal_lp();
+  //  minimal_api_illegal_lp();
   test_callback();
   version_api();
   full_api();

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -587,3 +587,24 @@ TEST_CASE("LP-change-coefficient", "[highs_data]") {
                                     highs.getInfo().objective_function_value);
   REQUIRE(delta_objective_value < 1e-8);
 }
+
+TEST_CASE("LP-row-wise", "[highs_data]") {
+  Highs highs;
+  HighsLp lp;
+  lp.sense_ = ObjSense::kMaximize;
+  lp.num_col_ = 2;
+  lp.num_row_ = 2;
+  lp.col_cost_ = {10, 25};
+  lp.col_lower_ = {0, 0};
+  lp.col_upper_ = {inf, inf};
+  lp.a_matrix_.format_ = MatrixFormat::kRowwise;
+  lp.a_matrix_.start_ = {0, 2, 4};
+  lp.a_matrix_.index_ = {0, 1, 0, 1};
+  lp.a_matrix_.value_ = {1, 2, 1, 4};
+  lp.row_lower_ = {-inf, -inf};
+  lp.row_upper_ = {80, 120};
+  highs.passModel(lp);
+  highs.run();
+
+}
+

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -78,6 +78,35 @@ TEST_CASE("LP-dimension-validation", "[highs_data]") {
 
   if (dev_run) printf("Give valid row_upper.size()\n");
   lp.row_upper_.resize(true_num_row);
+  REQUIRE(highs.passModel(lp) == HighsStatus::kError);
+
+  if (dev_run) printf("Give valid a_matrix_.start_[0]\n");
+  lp.a_matrix_.start_[0] = 0;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kError);
+
+  if (dev_run)
+    printf("Give valid a_matrix_.start_[2] and a_matrix_.start_[3]\n");
+  lp.a_matrix_.start_[2] = 2;
+  lp.a_matrix_.start_[3] = 2;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kError);
+
+  if (dev_run) printf("Give valid a_matrix_.index_[0]\n");
+  // Yields duplicate index, but values are still zero, so both are
+  // discarded and a warning is returned
+  lp.a_matrix_.index_[0] = 0;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kWarning);
+
+  if (dev_run)
+    printf("Give nonzero a_matrix_.value_[0] and a_matrix_.value_[1]\n");
+  // Yields duplicate index, but values are still zero, so both are
+  // discarded and a warning is returned
+  lp.a_matrix_.value_[0] = 1;
+  lp.a_matrix_.value_[1] = 1;
+  // Now the duplicate indices yield an erorr
+  REQUIRE(highs.passModel(lp) == HighsStatus::kError);
+
+  if (dev_run) printf("Give valid a_matrix_.index_[1]\n");
+  lp.a_matrix_.index_[1] = 1;
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
 
   /*
@@ -588,8 +617,9 @@ TEST_CASE("LP-change-coefficient", "[highs_data]") {
   REQUIRE(delta_objective_value < 1e-8);
 }
 
-TEST_CASE("LP-empty-start-error", "[highs_data]") {
+TEST_CASE("LP-illegal-empty-start-ok", "[highs_data]") {
   Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
   HighsLp lp;
   lp.num_col_ = 0;
   lp.num_row_ = 1;
@@ -602,6 +632,7 @@ TEST_CASE("LP-empty-start-error", "[highs_data]") {
 
 TEST_CASE("LP-row-wise", "[highs_data]") {
   Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
   HighsLp lp;
   lp.sense_ = ObjSense::kMaximize;
   lp.num_col_ = 2;
@@ -617,6 +648,4 @@ TEST_CASE("LP-row-wise", "[highs_data]") {
   lp.row_upper_ = {80, 120};
   highs.passModel(lp);
   highs.run();
-
 }
-

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -596,7 +596,8 @@ TEST_CASE("LP-empty-start-error", "[highs_data]") {
   lp.row_lower_ = {-inf};
   lp.row_upper_ = {1};
   lp.a_matrix_.start_ = {1};
-  REQUIRE(highs.passModel(lp) == HighsStatus::kError);
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  REQUIRE(highs.getLp().a_matrix_.start_[0] == 0);
 }
 
 TEST_CASE("LP-row-wise", "[highs_data]") {

--- a/check/TestLpValidation.cpp
+++ b/check/TestLpValidation.cpp
@@ -588,6 +588,17 @@ TEST_CASE("LP-change-coefficient", "[highs_data]") {
   REQUIRE(delta_objective_value < 1e-8);
 }
 
+TEST_CASE("LP-empty-start-error", "[highs_data]") {
+  Highs highs;
+  HighsLp lp;
+  lp.num_col_ = 0;
+  lp.num_row_ = 1;
+  lp.row_lower_ = {-inf};
+  lp.row_upper_ = {1};
+  lp.a_matrix_.start_ = {1};
+  REQUIRE(highs.passModel(lp) == HighsStatus::kError);
+}
+
 TEST_CASE("LP-row-wise", "[highs_data]") {
   Highs highs;
   HighsLp lp;

--- a/check/TestUserScale.cpp
+++ b/check/TestUserScale.cpp
@@ -3,7 +3,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 const double inf = kHighsInf;
 
 void checkModelScaling(const HighsInt user_bound_scale,
@@ -34,9 +34,6 @@ TEST_CASE("user-cost-scale-after-run", "[highs_user_scale]") {
   double max_primal_infeasibility = info.max_primal_infeasibility;
   double max_dual_infeasibility = info.max_dual_infeasibility;
   double sum_dual_infeasibilities = info.sum_dual_infeasibilities;
-  printf("Max primal infeasibility = %g\n", max_primal_infeasibility);
-  printf("Max dual infeasibility = %g\n", max_dual_infeasibility);
-  printf("Sum dual infeasibility = %g\n", sum_dual_infeasibilities);
   double objective_function_value = info.objective_function_value;
 
   HighsInt user_bound_scale = 10;
@@ -96,7 +93,7 @@ TEST_CASE("user-small-cost-scale", "[highs_user_scale]") {
   Highs highs;
   const HighsInfo& info = highs.getInfo();
   const HighsSolution& solution = highs.getSolution();
-  //  highs.setOptionValue("output_flag", dev_run);
+  highs.setOptionValue("output_flag", dev_run);
   highs.setOptionValue("presolve", kHighsOffString);
   HighsLp lp;
   lp.num_col_ = 2;
@@ -118,7 +115,7 @@ TEST_CASE("user-small-cost-scale", "[highs_user_scale]") {
   highs.setOptionValue("user_cost_scale", -30);
   highs.clearSolver();
   highs.run();
-  highs.writeSolution("", 1);
+  if (dev_run) highs.writeSolution("", 1);
   REQUIRE(solution.col_value[0] == 0);
   REQUIRE(solution.col_value[1] == 0);
 

--- a/src/interfaces/highs_c_api.cpp
+++ b/src/interfaces/highs_c_api.cpp
@@ -24,10 +24,11 @@ HighsInt Highs_lpCall(const HighsInt num_col, const HighsInt num_row,
                       HighsInt* row_basis_status, HighsInt* model_status) {
   Highs highs;
   highs.setOptionValue("output_flag", false);
+  *model_status = kHighsModelStatusNotset;
   HighsStatus status = highs.passModel(
       num_col, num_row, num_nz, a_format, sense, offset, col_cost, col_lower,
       col_upper, row_lower, row_upper, a_start, a_index, a_value);
-  if (status != HighsStatus::kOk) return (HighsInt)status;
+  if (status == HighsStatus::kError) return (HighsInt)status;
 
   status = highs.run();
 
@@ -77,10 +78,11 @@ HighsInt Highs_mipCall(const HighsInt num_col, const HighsInt num_row,
                        double* row_value, HighsInt* model_status) {
   Highs highs;
   highs.setOptionValue("output_flag", false);
+  *model_status = kHighsModelStatusNotset;
   HighsStatus status = highs.passModel(
       num_col, num_row, num_nz, a_format, sense, offset, col_cost, col_lower,
       col_upper, row_lower, row_upper, a_start, a_index, a_value, integrality);
-  if (status != HighsStatus::kOk) return (HighsInt)status;
+  if (status == HighsStatus::kError) return (HighsInt)status;
 
   status = highs.run();
 
@@ -120,11 +122,12 @@ HighsInt Highs_qpCall(
     HighsInt* row_basis_status, HighsInt* model_status) {
   Highs highs;
   highs.setOptionValue("output_flag", false);
+  *model_status = kHighsModelStatusNotset;
   HighsStatus status = highs.passModel(
       num_col, num_row, num_nz, q_num_nz, a_format, q_format, sense, offset,
       col_cost, col_lower, col_upper, row_lower, row_upper, a_start, a_index,
       a_value, q_start, q_index, q_value);
-  if (status != HighsStatus::kOk) return (HighsInt)status;
+  if (status == HighsStatus::kError) return (HighsInt)status;
 
   status = highs.run();
 

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -10,8 +10,20 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #ifndef HIGHS_C_API
 #define HIGHS_C_API
-
-// #include "util/HighsInt.h"
+//
+// Welcome to the HiGHS C API!
+//
+// The simplest way to use HiGHS to solve an LP, MIP or QP from C is
+// to pass the problem data to the appropriate method Highs_lpCall,
+// Highs_mipCall or Highs_qpCall, and these methods return the
+// appropriate solution information
+//
+// For sophisticated applications, where esoteric solutiuon
+// information is needed, or if a sequence of modified models need to
+// be solved, use the Highs_create method to generate a pointer to an
+// instance of the C++ Highs class, and then use any of a large number
+// of models for which this pointer is the first parameter.
+//
 #include "lp_data/HighsCallbackStruct.h"
 
 const HighsInt kHighsMaximumStringLength = 512;

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -318,6 +318,8 @@ HighsStatus Highs::passModel(HighsModel model) {
     // rows. Clearly the matrix is empty, so may have no orientation
     // or starts assigned. HiGHS assumes that such a model will have
     // null starts, so make it column-wise
+    highsLogUser(options_.log_options, HighsLogType::kInfo,
+		 "Model has either no columns or no rows, so ignoring user constraint matrix data and initialising empty matrix\n");
     lp.a_matrix_.format_ = MatrixFormat::kColwise;
     lp.a_matrix_.start_.assign(lp.num_col_ + 1, 0);
     lp.a_matrix_.index_.clear();
@@ -339,8 +341,10 @@ HighsStatus Highs::passModel(HighsModel model) {
   // Check that the Hessian format is valid
   if (!hessian.formatOk()) return HighsStatus::kError;
   // Ensure that the LP is column-wise
+  
   if (!lp.a_matrix_.isColwise()) {
     printf("!! Passing rowwise LP !!\n");
+    lp.ensureColwise();
   }
   // Check validity of the LP, normalising its values
   return_status = interpretCallStatus(

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -339,7 +339,9 @@ HighsStatus Highs::passModel(HighsModel model) {
   // Check that the Hessian format is valid
   if (!hessian.formatOk()) return HighsStatus::kError;
   // Ensure that the LP is column-wise
-  lp.ensureColwise();
+  if (!lp.a_matrix_.isColwise()) {
+    printf("!! Passing rowwise LP !!\n");
+  }
   // Check validity of the LP, normalising its values
   return_status = interpretCallStatus(
       options_.log_options, assessLp(lp, options_), return_status, "assessLp");
@@ -349,6 +351,9 @@ HighsStatus Highs::passModel(HighsModel model) {
                                       assessHessian(hessian, options_),
                                       return_status, "assessHessian");
   if (return_status == HighsStatus::kError) return return_status;
+  // Now legality of matrix is established, ensure that it is
+  // column-wise
+  lp.ensureColwise();
   if (hessian.dim_) {
     // Clear any zero Hessian
     if (hessian.numNz() == 0) {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -319,7 +319,8 @@ HighsStatus Highs::passModel(HighsModel model) {
     // or starts assigned. HiGHS assumes that such a model will have
     // null starts, so make it column-wise
     highsLogUser(options_.log_options, HighsLogType::kInfo,
-		 "Model has either no columns or no rows, so ignoring user constraint matrix data and initialising empty matrix\n");
+                 "Model has either no columns or no rows, so ignoring user "
+                 "constraint matrix data and initialising empty matrix\n");
     lp.a_matrix_.format_ = MatrixFormat::kColwise;
     lp.a_matrix_.start_.assign(lp.num_col_ + 1, 0);
     lp.a_matrix_.index_.clear();
@@ -340,24 +341,18 @@ HighsStatus Highs::passModel(HighsModel model) {
     return HighsStatus::kError;
   // Check that the Hessian format is valid
   if (!hessian.formatOk()) return HighsStatus::kError;
-  // Ensure that the LP is column-wise
-  
-  if (!lp.a_matrix_.isColwise()) {
-    printf("!! Passing rowwise LP !!\n");
-    lp.ensureColwise();
-  }
   // Check validity of the LP, normalising its values
   return_status = interpretCallStatus(
       options_.log_options, assessLp(lp, options_), return_status, "assessLp");
   if (return_status == HighsStatus::kError) return return_status;
+  // Now legality of matrix is established, ensure that it is
+  // column-wise
+  lp.ensureColwise();
   // Check validity of any Hessian, normalising its entries
   return_status = interpretCallStatus(options_.log_options,
                                       assessHessian(hessian, options_),
                                       return_status, "assessHessian");
   if (return_status == HighsStatus::kError) return return_status;
-  // Now legality of matrix is established, ensure that it is
-  // column-wise
-  lp.ensureColwise();
   if (hessian.dim_) {
     // Clear any zero Hessian
     if (hessian.numNz() == 0) {

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -43,45 +43,29 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options) {
                                       return_status, "assessLpDimensions");
   if (return_status == HighsStatus::kError) return return_status;
 
-  // If the LP has no columns there is nothing left to test
-  if (lp.num_col_ == 0) {
-    HighsInt lp_num_nz = lp.a_matrix_.numNz();
-    if (lp_num_nz) {
-      highsLogUser(options.log_options, HighsLogType::kError,
-		   "LP with no calumns cannot have a matrix with %d nonzeros\n",
-		   int(lp_num_nz));
-      return HighsStatus::kError;
-    }
-    return HighsStatus::kOk;
+  if (lp.num_col_) {
+    // Assess the LP column costs
+    HighsIndexCollection index_collection;
+    index_collection.dimension_ = lp.num_col_;
+    index_collection.is_interval_ = true;
+    index_collection.from_ = 0;
+    index_collection.to_ = lp.num_col_ - 1;
+    call_status = assessCosts(options, 0, index_collection, lp.col_cost_,
+			      lp.has_infinite_cost_, options.infinite_cost);
+    return_status = interpretCallStatus(options.log_options, call_status,
+					return_status, "assessCosts");
+    if (return_status == HighsStatus::kError) return return_status;
+    // Assess the LP column bounds
+    call_status = assessBounds(options, "Col", 0, index_collection, lp.col_lower_,
+			       lp.col_upper_, options.infinite_bound,
+			       lp.integrality_.data());
+    return_status = interpretCallStatus(options.log_options, call_status,
+					return_status, "assessBounds");
+    if (return_status == HighsStatus::kError) return return_status;
   }
-  if (!lp.a_matrix_.isColwise()) {
-    printf("!! Assessing rowwise LP !!\n");
-  }
-
-  // From here, any LP has lp.num_col_ > 0 and lp.a_matrix_.start_[lp.num_col_]
-  // exists (as the number of nonzeros)
-  assert(lp.num_col_ > 0);
-
-  // Assess the LP column costs
-  HighsIndexCollection index_collection;
-  index_collection.dimension_ = lp.num_col_;
-  index_collection.is_interval_ = true;
-  index_collection.from_ = 0;
-  index_collection.to_ = lp.num_col_ - 1;
-  call_status = assessCosts(options, 0, index_collection, lp.col_cost_,
-                            lp.has_infinite_cost_, options.infinite_cost);
-  return_status = interpretCallStatus(options.log_options, call_status,
-                                      return_status, "assessCosts");
-  if (return_status == HighsStatus::kError) return return_status;
-  // Assess the LP column bounds
-  call_status = assessBounds(options, "Col", 0, index_collection, lp.col_lower_,
-                             lp.col_upper_, options.infinite_bound,
-                             lp.integrality_.data());
-  return_status = interpretCallStatus(options.log_options, call_status,
-                                      return_status, "assessBounds");
-  if (return_status == HighsStatus::kError) return return_status;
   if (lp.num_row_) {
     // Assess the LP row bounds
+    HighsIndexCollection index_collection;
     index_collection.dimension_ = lp.num_row_;
     index_collection.is_interval_ = true;
     index_collection.from_ = 0;
@@ -93,6 +77,20 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options) {
                                         return_status, "assessBounds");
     if (return_status == HighsStatus::kError) return return_status;
   }
+  // If the LP has no columns the matrix must be empty and there is
+  // nothing left to test
+  if (lp.num_col_ == 0) {
+    assert(!lp.a_matrix_.numNz());
+    return HighsStatus::kOk;
+  }
+  if (!lp.a_matrix_.isColwise()) {
+    printf("!! Assessing rowwise LP !!\n");
+  }
+
+  // From here, any LP has lp.num_col_ > 0 and lp.a_matrix_.start_[lp.num_col_]
+  // exists (as the number of nonzeros)
+  assert(lp.num_col_ > 0);
+
   // Assess the LP matrix - even if there are no rows!
   call_status =
       lp.a_matrix_.assess(options.log_options, "LP", options.small_matrix_value,

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -51,16 +51,16 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options) {
     index_collection.from_ = 0;
     index_collection.to_ = lp.num_col_ - 1;
     call_status = assessCosts(options, 0, index_collection, lp.col_cost_,
-			      lp.has_infinite_cost_, options.infinite_cost);
+                              lp.has_infinite_cost_, options.infinite_cost);
     return_status = interpretCallStatus(options.log_options, call_status,
-					return_status, "assessCosts");
+                                        return_status, "assessCosts");
     if (return_status == HighsStatus::kError) return return_status;
     // Assess the LP column bounds
-    call_status = assessBounds(options, "Col", 0, index_collection, lp.col_lower_,
-			       lp.col_upper_, options.infinite_bound,
-			       lp.integrality_.data());
+    call_status = assessBounds(options, "Col", 0, index_collection,
+                               lp.col_lower_, lp.col_upper_,
+                               options.infinite_bound, lp.integrality_.data());
     return_status = interpretCallStatus(options.log_options, call_status,
-					return_status, "assessBounds");
+                                        return_status, "assessBounds");
     if (return_status == HighsStatus::kError) return return_status;
   }
   if (lp.num_row_) {
@@ -83,10 +83,6 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options) {
     assert(!lp.a_matrix_.numNz());
     return HighsStatus::kOk;
   }
-  if (!lp.a_matrix_.isColwise()) {
-    printf("!! Assessing rowwise LP !!\n");
-  }
-
   // From here, any LP has lp.num_col_ > 0 and lp.a_matrix_.start_[lp.num_col_]
   // exists (as the number of nonzeros)
   assert(lp.num_col_ > 0);
@@ -98,22 +94,13 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options) {
   return_status = interpretCallStatus(options.log_options, call_status,
                                       return_status, "assessMatrix");
   if (return_status == HighsStatus::kError) return return_status;
-  HighsInt lp_num_nz = lp.a_matrix_.start_[lp.num_col_];
   // If entries have been removed from the matrix, resize the index
   // and value vectors to prevent bug in presolve
+  HighsInt lp_num_nz = lp.a_matrix_.numNz();
   if ((HighsInt)lp.a_matrix_.index_.size() > lp_num_nz)
     lp.a_matrix_.index_.resize(lp_num_nz);
   if ((HighsInt)lp.a_matrix_.value_.size() > lp_num_nz)
     lp.a_matrix_.value_.resize(lp_num_nz);
-  if ((HighsInt)lp.a_matrix_.index_.size() > lp_num_nz)
-    lp.a_matrix_.index_.resize(lp_num_nz);
-  if ((HighsInt)lp.a_matrix_.value_.size() > lp_num_nz)
-    lp.a_matrix_.value_.resize(lp_num_nz);
-
-  //  if (return_status == HighsStatus::kError)
-  //    return_status = HighsStatus::kError;
-  //  else
-  //    return_status = HighsStatus::kOk;
   if (return_status != HighsStatus::kOk)
     highsLogDev(options.log_options, HighsLogType::kInfo,
                 "assessLp returns HighsStatus = %s\n",

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -44,8 +44,19 @@ HighsStatus assessLp(HighsLp& lp, const HighsOptions& options) {
   if (return_status == HighsStatus::kError) return return_status;
 
   // If the LP has no columns there is nothing left to test
-  if (lp.num_col_ == 0) return HighsStatus::kOk;
-  assert(lp.a_matrix_.isColwise());
+  if (lp.num_col_ == 0) {
+    HighsInt lp_num_nz = lp.a_matrix_.numNz();
+    if (lp_num_nz) {
+      highsLogUser(options.log_options, HighsLogType::kError,
+		   "LP with no calumns cannot have a matrix with %d nonzeros\n",
+		   int(lp_num_nz));
+      return HighsStatus::kError;
+    }
+    return HighsStatus::kOk;
+  }
+  if (!lp.a_matrix_.isColwise()) {
+    printf("!! Assessing rowwise LP !!\n");
+  }
 
   // From here, any LP has lp.num_col_ > 0 and lp.a_matrix_.start_[lp.num_col_]
   // exists (as the number of nonzeros)


### PR DESCRIPTION
As well as not returning from `Highs_lpCall`, `Highs_mipCall` or `Highs_qpCall` if a zero matrix coefficient is ignored, I spotted that for some illegal constraint matrix definitions, ensureColwise() has memory violations. Hence a row-wise user-defined matrix is now assessed first, before transposing it. 