### PR TITLE
Deleted highsSignalHandler

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -50,12 +50,7 @@ HighsInt highsVersionPatch() { return HIGHS_VERSION_PATCH; }
 const char* highsGithash() { return HIGHS_GITHASH; }
 const char* highsCompilationDate() { return HIGHS_COMPILATION_DATE; }
 
-void highsSignalHandler(int signum) {
-  //  std::cout << "Interrupt signal (" << signum << ") received.\n";
-  exit(signum);
-}
-
-Highs::Highs() { signal(SIGINT, highsSignalHandler); }
+Highs::Highs() {}
 
 HighsStatus Highs::clear() {
   resetOptions();


### PR DESCRIPTION
There was an abortive attempt to put a CRTL-C handler into HiGHS but the development code (Lines 52 onwards in `lp_data/Highs.cpp`) wasn't removed. 

Now deleted