### PR TITLE
Fix 1531

### DIFF
--- a/check/TestPresolve.cpp
+++ b/check/TestPresolve.cpp
@@ -81,21 +81,26 @@ TEST_CASE("presolve", "[highs_test_presolve]") {
 
 TEST_CASE("empty-row", "[highs_test_presolve]") {
   Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
   HighsLp lp;
   lp.num_col_ = 3;
   lp.num_row_ = 1;
-  lp.col_cost_ = { -7.0, -6.0, -5.0 };
-  lp.col_lower_ = { -73.0, -83.0, -94.0 };
-  lp.col_upper_ = { 62.0, 96.0, 62.0 };
-  lp.row_lower_ = { -19.0 };
-  lp.row_upper_ = { 11.0 };
+  lp.col_cost_ = {-7.0, -6.0, -5.0};
+  lp.col_lower_ = {-73.0, -83.0, -94.0};
+  lp.col_upper_ = {62.0, 96.0, 62.0};
+  lp.row_lower_ = {-19.0};
+  lp.row_upper_ = {11.0};
   lp.a_matrix_.format_ = MatrixFormat::kRowwise;
-  lp.a_matrix_.start_ = { 0, 0 };
-  //  lp.a_index_ = { };
-  //  lp.a_value_ = { };
+  lp.a_matrix_.start_ = {0, 0};
+  // LP has empty constraint matrix so doesn't need to be presolved,
+  // and shouldn't be since this would cause vacuous null pointer
+  // operation in util/HighsMatrixSlice.h (see #1531)
   highs.passModel(lp);
   highs.run();
-  
+  const HighsSolution& solution = highs.getSolution();
+  const HighsBasis& basis = highs.getBasis();
+  REQUIRE(HighsInt(solution.row_value.size()) == lp.num_row_);
+  REQUIRE(HighsInt(basis.row_status.size()) == lp.num_row_);
 }
 
 void presolveSolvePostsolve(const std::string& model_file,

--- a/check/TestPresolve.cpp
+++ b/check/TestPresolve.cpp
@@ -79,6 +79,25 @@ TEST_CASE("presolve", "[highs_test_presolve]") {
   REQUIRE(presolved_model.isEmpty());
 }
 
+TEST_CASE("empty-row", "[highs_test_presolve]") {
+  Highs highs;
+  HighsLp lp;
+  lp.num_col_ = 3;
+  lp.num_row_ = 1;
+  lp.col_cost_ = { -7.0, -6.0, -5.0 };
+  lp.col_lower_ = { -73.0, -83.0, -94.0 };
+  lp.col_upper_ = { 62.0, 96.0, 62.0 };
+  lp.row_lower_ = { -19.0 };
+  lp.row_upper_ = { 11.0 };
+  lp.a_matrix_.format_ = MatrixFormat::kRowwise;
+  lp.a_matrix_.start_ = { 0, 0 };
+  //  lp.a_index_ = { };
+  //  lp.a_value_ = { };
+  highs.passModel(lp);
+  highs.run();
+  
+}
+
 void presolveSolvePostsolve(const std::string& model_file,
                             const bool solve_relaxation) {
   Highs highs0;

--- a/check/TestSpecialLps.cpp
+++ b/check/TestSpecialLps.cpp
@@ -605,7 +605,10 @@ void unconstrained(Highs& highs) {
   lp.a_matrix_.start_ = {0, 0, 0};
   lp.a_matrix_.format_ = MatrixFormat::kColwise;
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
-  REQUIRE(highs.setOptionValue("presolve", "off") == HighsStatus::kOk);
+  // No need to turn off presolve, since unconstrained LPs are
+  // automatically solved directly
+  //
+  //  REQUIRE(highs.setOptionValue("presolve", "off") == HighsStatus::kOk);
   REQUIRE(highs.run() == HighsStatus::kOk);
   REQUIRE(highs.getModelStatus() == HighsModelStatus::kOptimal);
   REQUIRE(highs.getObjectiveValue() == 1);

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1169,7 +1169,7 @@ HighsStatus Highs::run() {
   };
 
   const bool unconstrained_lp = incumbent_lp.a_matrix_.numNz() == 0;
-  assert(!incumbent_lp.num_row_ || unconstrained_lp);
+  assert(incumbent_lp.num_row_ || unconstrained_lp);
   if (basis_.valid || options_.presolve == kHighsOffString ||
       unconstrained_lp) {
     // There is a valid basis for the problem, presolve is off, or LP
@@ -3047,9 +3047,6 @@ HighsPresolveStatus Highs::runPresolve(const bool force_lp_presolve,
   // Ensure that the LP is column-wise
   HighsLp& original_lp = model_.lp_;
   original_lp.ensureColwise();
-
-  printf("Called Highs::runPresolve for LP with dimensions (%d, %d)\n",
-         int(original_lp.num_col_), int(original_lp.num_row_));
 
   if (original_lp.num_col_ == 0 && original_lp.num_row_ == 0)
     return HighsPresolveStatus::kNullError;

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4347,6 +4347,10 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
   postsolve_stack.debug_prev_col_upper = 0;
   postsolve_stack.debug_prev_row_lower = 0;
   postsolve_stack.debug_prev_row_upper = 0;
+  // Presolve should not be called with a model that has non nonzeros
+  // in the constraint matrix
+  assert(model->a_matrix_.numNz());
+
   switch (presolve(postsolve_stack)) {
     case Result::kStopped:
     case Result::kOk:
@@ -4932,9 +4936,6 @@ void HPresolve::fixColToUpper(HighsPostsolveStack& postsolve_stack,
 
   // mark the column as deleted first so that it is not registered as singleton
   // column upon removing its nonzeros
-  if (!model->a_matrix_.numNz()) {
-    printf("Fixing column with empty matrix\n");
-  }
   postsolve_stack.fixedColAtUpper(col, fixval, model->col_cost_[col],
                                   getColumnVector(col));
   markColDeleted(col);

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4347,9 +4347,9 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
   postsolve_stack.debug_prev_col_upper = 0;
   postsolve_stack.debug_prev_row_lower = 0;
   postsolve_stack.debug_prev_row_upper = 0;
-  // Presolve should not be called with a model that has non nonzeros
-  // in the constraint matrix
-  assert(model->a_matrix_.numNz());
+  // Presolve should only be called with a model that has a non-empty
+  // constraint matrix unless it has no rows
+  assert(model->a_matrix_.numNz() || model->num_row_ == 0);
 
   switch (presolve(postsolve_stack)) {
     case Result::kStopped:

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4932,6 +4932,9 @@ void HPresolve::fixColToUpper(HighsPostsolveStack& postsolve_stack,
 
   // mark the column as deleted first so that it is not registered as singleton
   // column upon removing its nonzeros
+  if (!model->a_matrix_.numNz()) {
+    printf("Fixing column with empty matrix\n");
+  }
   postsolve_stack.fixedColAtUpper(col, fixval, model->col_cost_[col],
                                   getColumnVector(col));
   markColDeleted(col);


### PR DESCRIPTION
When presented with an LP with rows, but zero constraint matrix, no long call presolve, but solve the problem as an unconstrained LP, checking for feasibility when row activity is zero.