### PR TITLE
Updates to readme | Python installation and restructured headers/nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - [Google Colab Example](#google-colab-example)
   - [Reference](#reference)
 
-About HiGHS
+## About HiGHS
 -----------
 
 HiGHS is a high performance serial and parallel solver for large scale sparse
@@ -35,12 +35,15 @@ Find out more about HiGHS at https://www.highs.dev.
 
 Although HiGHS is freely available under the MIT license, we would be pleased to learn about users' experience and give advice via email sent to highsopt@gmail.com.
 
-Documentation
+## Documentation
 -------------
 
 Documentation is available at https://ergo-code.github.io/HiGHS/.
 
-Precompiled binaries
+## Installation
+-------------
+
+### Precompiled binaries
 --------------------
 
 Precompiled static executables are available for a variety of platforms at
@@ -50,7 +53,7 @@ _These binaries are provided by the Julia community and are not officially suppo
 
 See https://ergo-code.github.io/HiGHS/stable/installation/#Precompiled-Binaries.
 
-Compilation
+### Compilation
 -----------
 
 HiGHS uses CMake as build system, and requires at least version 3.15. First setup a build folder and call CMake as follows
@@ -86,7 +89,7 @@ HiGHS is installed using the command
 
 with the optional setting of `--prefix <prefix>  = The installation prefix CMAKE_INSTALL_PREFIX` if it is to be installed anywhere other than the default location.
 
-Meson
+### Meson
 -----
 
 HiGHs can also use the `meson` build interface:
@@ -97,23 +100,43 @@ meson test -C bbdir
 ```
 
 
-Interfaces
-----------
 
-There are HiGHS interfaces for C, C#, FORTRAN, and Python in [HiGHS/src/interfaces](https://github.com/ERGO-Code/HiGHS/blob/master/src/interfaces), with example driver files in [HiGHS/examples](https://github.com/ERGO-Code/HiGHS/blob/master/examples). More on language and modelling interfaces can be found at https://ergo-code.github.io/HiGHS/stable/interfaces/other/.
 
-We are happy to give a reasonable level of support via email sent to highsopt@gmail.com.
+### Python
 
-Python
-------
+There are two ways to install the Python interface. Building directly 
+from Git assumes that you have already installed the HiGHS library. 
+Installing from PyPI through your Python packagemanager will also 
+install the HiGHS library if not already present. 
 
-There are two ways to build the Python interface to HiGHS.
+#### From PyPi
 
-__From PyPi__
+HiGHS is available as `highspy` on [PyPi](https://pypi.org/project/highspy/).
+This will not only install the Python interface, but also the HiGHS library 
+itself.
 
-HiGHS has been added to PyPi, so should be installable using the command
+If `highspy` is not already installed, run:
 
-    pip install highspy
+```bash
+$ pip install highspy
+```
+
+#### Build directly from Git
+
+In order to build the Python interface, build and install the HiGHS
+library as described above, ensure the shared library is in the
+`LD_LIBRARY_PATH` environment variable, and then run
+
+    pip install ./
+
+from the HiGHS directory.
+
+You may also require
+
+* `pip install pybind11`
+* `pip install pyomo`
+
+#### Testing
 
 The installation can be tested using the example [minimal.py](https://github.com/ERGO-Code/HiGHS/blob/master/examples/minimal.py), yielding the output
 
@@ -131,28 +154,25 @@ The installation can be tested using the example [minimal.py](https://github.com
 
 or the more didactic [call_highs_from_python.py](https://github.com/ERGO-Code/HiGHS/blob/master/examples/call_highs_from_python.py).
 
-__Directly__
 
-In order to build the Python interface, build and install the HiGHS
-library as described above, ensure the shared library is in the
-`LD_LIBRARY_PATH` environment variable, and then run
 
-    pip install ./
+## Interfaces
+----------
 
-from the HiGHS directory.
+There are HiGHS interfaces for C, C#, FORTRAN, and Python in [HiGHS/src/interfaces](https://github.com/ERGO-Code/HiGHS/blob/master/src/interfaces), with example driver files in [HiGHS/examples](https://github.com/ERGO-Code/HiGHS/blob/master/examples). More on language and modelling interfaces can be found at https://ergo-code.github.io/HiGHS/stable/interfaces/other/.
 
-You may also require
+We are happy to give a reasonable level of support via email sent to highsopt@gmail.com.
 
-* `pip install pybind11`
-* `pip install pyomo`
 
-The Python interface can then be tested as above.
-
-Google Colab Example
+### Google Colab Example
 -----------------------------
 The [Google Colab Example Notebook](https://colab.research.google.com/drive/1JmHF53OYfU-0Sp9bzLw-D2TQyRABSjHb?usp=sharing) demonstrates how to call HiGHS via the Python interface `highspy`.
 
-Reference
+
+
+
+
+## Reference
 ---------
 
 If you use HiGHS in an academic context, please acknowledge this and cite the following article.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@
   - [Table of Contents](#table-of-contents)
   - [About HiGHS](#about-highs)
   - [Documentation](#documentation)
-  - [Precompiled binaries](#precompiled-binaries)
-  - [Compilation](#compilation)
-  - [Meson](#meson)
+  - [Installation](#installation)
+    - [Precompiled binaries](#precompiled-binaries)
+    - [Compilation](#compilation)
+    - [Meson](#meson)
+    - [Python](#python)
   - [Interfaces](#interfaces)
-  - [Python](#python)
-  - [Google Colab Example](#google-colab-example)
+    - [Python](#python-1)
+      - [From PyPi](#from-pypi)
+      - [Build directly from Git](#build-directly-from-git)
+      - [Testing](#testing)
+      - [Google Colab Example](#google-colab-example)
   - [Reference](#reference)
 
 ## About HiGHS
@@ -36,12 +41,12 @@ Find out more about HiGHS at https://www.highs.dev.
 Although HiGHS is freely available under the MIT license, we would be pleased to learn about users' experience and give advice via email sent to highsopt@gmail.com.
 
 ## Documentation
--------------
 
 Documentation is available at https://ergo-code.github.io/HiGHS/.
 
 ## Installation
--------------
+
+There are various ways to install the HiGHS library. These are detailed below.
 
 ### Precompiled binaries
 --------------------
@@ -54,7 +59,7 @@ _These binaries are provided by the Julia community and are not officially suppo
 See https://ergo-code.github.io/HiGHS/stable/installation/#Precompiled-Binaries.
 
 ### Compilation
------------
+---------------
 
 HiGHS uses CMake as build system, and requires at least version 3.15. First setup a build folder and call CMake as follows
 
@@ -68,7 +73,7 @@ Then compile the code using
 
 This installs the executable `bin/highs`.
 
-As an alternative it is also possible to let cmake create the build folder and thus build everything from the HiGHS directory, as follows
+As an alternative it is also possible to let `cmake` create the build folder and thus build everything from the HiGHS directory, as follows
 
     cmake -S . -B build
     cmake --build build
@@ -100,14 +105,28 @@ meson test -C bbdir
 ```
 
 
+### Python
+-----
 
+Installing from PyPI through your Python package manager of choice (e.g., `pip`) will also 
+install the HiGHS library if not already present. HiGHS is available as `highspy` on [PyPi](https://pypi.org/project/highspy/).
+
+If `highspy` is not already installed, run:
+
+```bash
+$ pip install highspy
+```
+
+## Interfaces
+There are HiGHS interfaces for C, C#, FORTRAN, and Python in [HiGHS/src/interfaces](https://github.com/ERGO-Code/HiGHS/blob/master/src/interfaces), with example driver files in [HiGHS/examples](https://github.com/ERGO-Code/HiGHS/blob/master/examples). More on language and modelling interfaces can be found at https://ergo-code.github.io/HiGHS/stable/interfaces/other/.
+
+We are happy to give a reasonable level of support via email sent to highsopt@gmail.com.
 
 ### Python
 
 There are two ways to install the Python interface. Building directly 
 from Git assumes that you have already installed the HiGHS library. 
-Installing from PyPI through your Python packagemanager will also 
-install the HiGHS library if not already present. 
+Installing from PyPI through your Python package manager of choice (e.g., `pip`) will also install the HiGHS library if not already present. 
 
 #### From PyPi
 
@@ -154,26 +173,13 @@ The installation can be tested using the example [minimal.py](https://github.com
 
 or the more didactic [call_highs_from_python.py](https://github.com/ERGO-Code/HiGHS/blob/master/examples/call_highs_from_python.py).
 
+#### Google Colab Example
 
-
-## Interfaces
-----------
-
-There are HiGHS interfaces for C, C#, FORTRAN, and Python in [HiGHS/src/interfaces](https://github.com/ERGO-Code/HiGHS/blob/master/src/interfaces), with example driver files in [HiGHS/examples](https://github.com/ERGO-Code/HiGHS/blob/master/examples). More on language and modelling interfaces can be found at https://ergo-code.github.io/HiGHS/stable/interfaces/other/.
-
-We are happy to give a reasonable level of support via email sent to highsopt@gmail.com.
-
-
-### Google Colab Example
------------------------------
 The [Google Colab Example Notebook](https://colab.research.google.com/drive/1JmHF53OYfU-0Sp9bzLw-D2TQyRABSjHb?usp=sharing) demonstrates how to call HiGHS via the Python interface `highspy`.
 
 
-
-
-
 ## Reference
----------
+
 
 If you use HiGHS in an academic context, please acknowledge this and cite the following article.
 


### PR DESCRIPTION
Hi guys,

First of all, awesome work on the solver. I use it on a regular basis for energy system modelling, and feel grateful to be able to use your work. 

Me and some other colleagues found it difficult to make up from the readme that installing the Python interface will also install the HiGHS-library. It's insinuated in the docs, and works in practice. 

Please let me know if this restructuring of the readme is useful to you. Personally I think it is more accessible like this to the inexperienced programmers (for sure those who can only use Python) and want to make use of HiGHS but are uncertain if compiling HiGHS themselves lays within their capabilities. 

Thanks again,

Seth  