### PR TITLE
Fix #1530

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -673,6 +673,7 @@ void HPresolve::recomputeRowDualImpliedBounds(HighsInt col) {
 
     // iterate over row and recompute the implied bounds
     for (const HighsSliceNonzero& nonz : getRowVector(*it)) {
+      // integer columns cannot be used to tighten bounds on dual multipliers
       if (model->integrality_[nonz.index()] != HighsVarType::kInteger)
         updateRowDualImpliedBounds(*it, nonz.index(), nonz.value());
     }

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -645,6 +645,7 @@ void HPresolve::updateColImpliedBounds(HighsInt row, HighsInt col, double val) {
 void HPresolve::recomputeColImpliedBounds(HighsInt row) {
   // recompute implied column bounds affected by a modification in a row
   // (removed / added non-zeros, etc.)
+  if (colImplSourceByRow[row].empty()) return;
   std::set<HighsInt> affectedCols(colImplSourceByRow[row]);
   for (auto it = affectedCols.cbegin(); it != affectedCols.cend(); it++) {
     // set implied bounds to infinite values if they were deduced from the given
@@ -660,8 +661,12 @@ void HPresolve::recomputeColImpliedBounds(HighsInt row) {
 }
 
 void HPresolve::recomputeRowDualImpliedBounds(HighsInt col) {
+  // integer columns should not be source for implied bounds on dual multipliers
+  assert(model->integrality_[col] != HighsVarType::kInteger ||
+         implRowDualSourceByCol[col].empty());
   // recompute implied row dual bounds affected by a modification in a column
   // (removed / added non-zeros, etc.)
+  if (implRowDualSourceByCol[col].empty()) return;
   std::set<HighsInt> affectedRows(implRowDualSourceByCol[col]);
   for (auto it = affectedRows.cbegin(); it != affectedRows.cend(); it++) {
     // set implied bounds to infinite values if they were deduced from the given

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -732,6 +732,7 @@ void HPresolve::shrinkProblem(HighsPostsolveStack& postsolve_stack) {
   implColUpper.resize(model->num_col_);
   colLowerSource.resize(model->num_col_);
   colUpperSource.resize(model->num_col_);
+  implRowDualSourceByCol.resize(model->num_col_);
   colhead.resize(model->num_col_);
   colsize.resize(model->num_col_);
   if (have_col_names) model->col_names_.resize(model->num_col_);
@@ -811,7 +812,6 @@ void HPresolve::shrinkProblem(HighsPostsolveStack& postsolve_stack) {
   implRowDualUpper.resize(model->num_row_);
   rowDualLowerSource.resize(model->num_row_);
   rowDualUpperSource.resize(model->num_row_);
-  implRowDualSourceByCol.resize(model->num_col_);
   colImplSourceByRow.resize(model->num_row_);
   rowroot.resize(model->num_row_);
   rowsize.resize(model->num_row_);

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -661,9 +661,6 @@ void HPresolve::recomputeColImpliedBounds(HighsInt row) {
 }
 
 void HPresolve::recomputeRowDualImpliedBounds(HighsInt col) {
-  // integer columns should not be source for implied bounds on dual multipliers
-  assert(model->integrality_[col] != HighsVarType::kInteger ||
-         implRowDualSourceByCol[col].empty());
   // recompute implied row dual bounds affected by a modification in a column
   // (removed / added non-zeros, etc.)
   if (implRowDualSourceByCol[col].empty()) return;

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2338,9 +2338,9 @@ void HPresolve::substitute(HighsInt row, HighsInt col, double rhs) {
     for (HighsInt rowiter : rowpositions) {
       assert(Arow[rowiter] == row);
 
-      if (Acol[rowiter] != col) 
+      if (Acol[rowiter] != col)
         addToMatrix(colrow, Acol[rowiter], scale * Avalue[rowiter]);
-  }
+    }
 
     // recompute implied column bounds affected by the substitution
     recomputeColImpliedBounds(colrow);

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -670,10 +670,11 @@ void HPresolve::recomputeRowDualImpliedBounds(HighsInt col) {
       changeImplRowDualLower(*it, -kHighsInf, -1);
     if (rowDualUpperSource[*it] == col)
       changeImplRowDualUpper(*it, kHighsInf, -1);
-  }
-  // iterate over column and recompute the implied bounds
-  for (const HighsSliceNonzero& nonz : getColumnVector(col)) {
-    updateRowDualImpliedBounds(nonz.index(), col, nonz.value());
+
+    // iterate over row and recompute the implied bounds
+    for (const HighsSliceNonzero& nonz : getRowVector(*it)) {
+      updateRowDualImpliedBounds(*it, nonz.index(), nonz.value());
+    }
   }
 }
 

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -673,7 +673,8 @@ void HPresolve::recomputeRowDualImpliedBounds(HighsInt col) {
 
     // iterate over row and recompute the implied bounds
     for (const HighsSliceNonzero& nonz : getRowVector(*it)) {
-      updateRowDualImpliedBounds(*it, nonz.index(), nonz.value());
+      if (model->integrality_[nonz.index()] != HighsVarType::kInteger)
+        updateRowDualImpliedBounds(*it, nonz.index(), nonz.value());
     }
   }
 }

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2260,8 +2260,6 @@ void HPresolve::scaleRow(HighsInt row, double scale, bool integral) {
 }
 
 void HPresolve::scaleStoredRow(HighsInt row, double scale, bool integral) {
-  HighsInt rowlen = rowpositions.size();
-
   model->row_upper_[row] *= scale;
   model->row_lower_[row] *= scale;
   implRowDualLower[row] /= scale;
@@ -2272,17 +2270,13 @@ void HPresolve::scaleStoredRow(HighsInt row, double scale, bool integral) {
       model->row_upper_[row] = std::round(model->row_upper_[row]);
     if (model->row_lower_[row] != kHighsInf)
       model->row_lower_[row] = std::round(model->row_lower_[row]);
-    for (HighsInt j = 0; j < rowlen; ++j) {
-      Avalue[rowpositions[j]] *= scale;
-      if (std::abs(Avalue[rowpositions[j]]) <= options->small_matrix_value)
-        unlink(rowpositions[j]);
-    }
-  } else
-    for (HighsInt j = 0; j < rowlen; ++j) {
-      Avalue[rowpositions[j]] *= scale;
-      if (std::abs(Avalue[rowpositions[j]]) <= options->small_matrix_value)
-        unlink(rowpositions[j]);
-    }
+  }
+
+  for (size_t j = 0; j < rowpositions.size(); ++j) {
+    Avalue[rowpositions[j]] *= scale;
+    if (std::abs(Avalue[rowpositions[j]]) <= options->small_matrix_value)
+      unlink(rowpositions[j]);
+  }
 
   impliedRowBounds.sumScaled(row, scale);
   if (scale < 0) {

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4705,7 +4705,7 @@ HPresolve::Result HPresolve::removeDependentFreeCols(
 
 void HPresolve::dualImpliedFreeGetRhsAndRowType(
     HighsInt row, double& rhs, HighsPostsolveStack::RowType& rowType,
-    bool modifyRowDualBounds) {
+    bool relaxRowDualBounds) {
   assert(isDualImpliedFree(row));
   if (model->row_lower_[row] == model->row_upper_[row]) {
     rowType = HighsPostsolveStack::RowType::kEq;
@@ -4714,11 +4714,11 @@ void HPresolve::dualImpliedFreeGetRhsAndRowType(
              implRowDualUpper[row] <= options->dual_feasibility_tolerance) {
     rowType = HighsPostsolveStack::RowType::kLeq;
     rhs = model->row_upper_[row];
-    if (modifyRowDualBounds) changeRowDualUpper(row, kHighsInf);
+    if (relaxRowDualBounds) changeRowDualUpper(row, kHighsInf);
   } else {
     rowType = HighsPostsolveStack::RowType::kGeq;
     rhs = model->row_lower_[row];
-    if (modifyRowDualBounds) changeRowDualLower(row, -kHighsInf);
+    if (relaxRowDualBounds) changeRowDualLower(row, -kHighsInf);
   }
 }
 

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2931,7 +2931,7 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
 
     HighsPostsolveStack::RowType rowType;
     double rhs;
-    impliedDualFreeGetRhsAndRowType(row, rhs, rowType);
+    dualImpliedFreeGetRhsAndRowType(row, rhs, rowType);
 
     postsolve_stack.freeColSubstitution(row, col, rhs, model->col_cost_[col],
                                         rowType, getStoredRow(),
@@ -4703,7 +4703,7 @@ HPresolve::Result HPresolve::removeDependentFreeCols(
   //  return Result::kOk;
 }
 
-void HPresolve::impliedDualFreeGetRhsAndRowType(
+void HPresolve::dualImpliedFreeGetRhsAndRowType(
     HighsInt row, double& rhs, HighsPostsolveStack::RowType& rowType,
     bool modifyRowDualBounds) {
   assert(isDualImpliedFree(row));
@@ -4790,7 +4790,7 @@ HPresolve::Result HPresolve::aggregator(HighsPostsolveStack& postsolve_stack) {
     if (rowsize[row] == 2 || colsize[col] == 2) {
       double rhs;
       HighsPostsolveStack::RowType rowType;
-      impliedDualFreeGetRhsAndRowType(row, rhs, rowType, true);
+      dualImpliedFreeGetRhsAndRowType(row, rhs, rowType, true);
 
       storeRow(row);
 
@@ -4838,7 +4838,7 @@ HPresolve::Result HPresolve::aggregator(HighsPostsolveStack& postsolve_stack) {
     nfail = 0;
     double rhs;
     HighsPostsolveStack::RowType rowType;
-    impliedDualFreeGetRhsAndRowType(row, rhs, rowType, true);
+    dualImpliedFreeGetRhsAndRowType(row, rhs, rowType, true);
 
     postsolve_stack.freeColSubstitution(row, col, rhs, model->col_cost_[col],
                                         rowType, getStoredRow(),

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -665,7 +665,7 @@ void HPresolve::recomputeRowDualImpliedBounds(HighsInt col) {
   std::set<HighsInt> affectedRows(implRowDualSourceByCol[col]);
   for (auto it = affectedRows.cbegin(); it != affectedRows.cend(); it++) {
     // set implied bounds to infinite values if they were deduced from the given
-    // row
+    // column
     if (rowDualLowerSource[*it] == col)
       changeImplRowDualLower(*it, -kHighsInf, -1);
     if (rowDualUpperSource[*it] == col)

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -170,6 +170,10 @@ class HPresolve {
 
   bool isDualImpliedFree(HighsInt row) const;
 
+  void dualImpliedFreeGetRhsAndRowType(HighsInt row, double& rhs,
+                                       HighsPostsolveStack::RowType& rowType,
+                                       bool relaxRowDualBounds = false);
+
   bool isImpliedIntegral(HighsInt col);
 
   bool isImpliedInteger(HighsInt col);
@@ -298,9 +302,6 @@ class HPresolve {
 
   Result colPresolve(HighsPostsolveStack& postsolve_stack, HighsInt col);
 
-  Result solveOneRowComponent(HighsPostsolveStack& postsolve_stack,
-                              HighsInt row);
-
   Result initialRowAndColPresolve(HighsPostsolveStack& postsolve_stack);
 
   HighsModelStatus run(HighsPostsolveStack& postsolve_stack);
@@ -319,10 +320,6 @@ class HPresolve {
   Result removeDependentEquations(HighsPostsolveStack& postsolve_stack);
 
   Result removeDependentFreeCols(HighsPostsolveStack& postsolve_stack);
-
-  void dualImpliedFreeGetRhsAndRowType(HighsInt row, double& rhs,
-                                       HighsPostsolveStack::RowType& rowType,
-                                       bool relaxRowDualBounds = false);
 
   Result aggregator(HighsPostsolveStack& postsolve_stack);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -322,7 +322,7 @@ class HPresolve {
 
   void dualImpliedFreeGetRhsAndRowType(HighsInt row, double& rhs,
                                        HighsPostsolveStack::RowType& rowType,
-                                       bool modifyRowDualBounds = false);
+                                       bool relaxRowDualBounds = false);
 
   Result aggregator(HighsPostsolveStack& postsolve_stack);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -320,7 +320,7 @@ class HPresolve {
 
   Result removeDependentFreeCols(HighsPostsolveStack& postsolve_stack);
 
-  void impliedDualFreeGetRhsAndRowType(HighsInt row, double& rhs,
+  void dualImpliedFreeGetRhsAndRowType(HighsInt row, double& rhs,
                                        HighsPostsolveStack::RowType& rowType,
                                        bool modifyRowDualBounds = false);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -85,6 +85,7 @@ class HPresolve {
   std::vector<HighsInt> rowDualLowerSource;
   std::vector<HighsInt> rowDualUpperSource;
   std::vector<std::set<HighsInt>> colImplSourceByRow;
+  std::vector<std::set<HighsInt>> implRowDualSourceByCol;
 
   // implied bounds on values of primal and dual rows computed from the bounds
   // of primal and dual variables
@@ -158,6 +159,8 @@ class HPresolve {
   void updateColImpliedBounds(HighsInt row, HighsInt col, double val);
 
   void recomputeColImpliedBounds(HighsInt row);
+
+  void recomputeRowDualImpliedBounds(HighsInt col);
 
   void updateRowDualImpliedBounds(HighsInt row, HighsInt col, double val);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -317,6 +317,10 @@ class HPresolve {
 
   Result removeDependentFreeCols(HighsPostsolveStack& postsolve_stack);
 
+  void impliedDualFreeGetRhsAndRowType(HighsInt row, double& rhs,
+                                       HighsPostsolveStack::RowType& rowType,
+                                       bool modifyRowDualBounds = false);
+
   Result aggregator(HighsPostsolveStack& postsolve_stack);
 
   Result removeRowSingletons(HighsPostsolveStack& postsolve_stack);


### PR DESCRIPTION
Fix #1530 
- Dual version of #1491.
- For each column store those rows whose dual implied bounds are derived from it.
- Recompute affected implied dual row bounds after a substitution in a column.
- Code changes have been tested on publicly available instances.
