### PR TITLE
Fix endless restart loop

### DIFF
--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -583,13 +583,16 @@ void HighsMipSolverData::runSetup() {
   for (HighsInt i = 0; i != mipsolver.numCol(); ++i) {
     switch (mipsolver.variableType(i)) {
       case HighsVarType::kContinuous:
+        if (domain.isFixed(i)) continue;
         continuous_cols.push_back(i);
         break;
       case HighsVarType::kImplicitInteger:
+        if (domain.isFixed(i)) continue;
         implint_cols.push_back(i);
         integral_cols.push_back(i);
         break;
       case HighsVarType::kInteger:
+        if (domain.isFixed(i)) continue;
         integer_cols.push_back(i);
         integral_cols.push_back(i);
         maxTreeSizeLog2 += (HighsInt)std::ceil(


### PR DESCRIPTION
Using problem `subset_select_B_on_139_off_138.mps` from [here](https://github.com/ERGO-Code/HiGHS/issues/1273#issuecomment-1560025730) and setting `presolve_reduction_limit` to 4, HiGHS gets stuck in an endless restart loop.

It seems that the code does consider fixed variables during restarts again, i.e. it adds them to the vectors `integer_cols`, etc.