### PR TITLE
Fix minor sanitizer issues and add optional Meson workflow to run the sanitizers

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,43 @@
+name: Test with sanitizers
+on: [workflow_dispatch]
+
+jobs:
+  sanitizer:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        sanitizer: [address, undefined, thread]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+      - name: Install Conda environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: highsdev
+          create-args: >-
+            python==3.8
+            meson
+            pkgconfig
+            ninja
+            zlib
+            catch2
+            numpy
+          cache-environment: true
+          init-shell: >-
+            bash
+            zsh
+      - name: Build and test
+        shell: bash -l {0}
+        run: |
+          meson setup bddir -Duse_zlib=enabled -Dwith_tests=True -Db_sanitize=${{ matrix.sanitizer }}
+          meson test -C bddir -t 10  # Time x10 for the tests
+      - name: Upload log
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: log_${{ matrix.sanitizer }}_${{ matrix.os }}.txt
+          path: bddir/meson-logs/testlog.txt

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -1325,6 +1325,7 @@ void test_ranging() {
   free(row_bound_dn_in_var);
   free(row_bound_dn_ou_var);
 
+  Highs_destroy(highs);
 }
 
 void test_callback() {
@@ -1377,7 +1378,7 @@ void test_callback() {
   Highs_startCallback(highs, kHighsCallbackMipImprovingSolution);
   Highs_run(highs);
   
-
+  Highs_destroy(highs);
 }
 
 /*

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -1854,11 +1854,11 @@ HighsInt Highs_scaleRow(void* highs, const HighsInt row, const double scaleval);
 double Highs_getInfinity(const void* highs);
 
 /**
- * Return the size of HighsInt used by HiGHS.
+ * Return the size of integers used by HiGHS.
  *
  * @param highs     A pointer to the Highs instance.
  *
- * @returns The value of HighsInt used by HiGHS.
+ * @returns The size of integers used by HiGHS.
  */
 HighsInt Highs_getSizeofHighsInt(const void* highs);
 

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -146,9 +146,9 @@ OptionStatus checkOptions(const HighsLogOptions& report_log_options,
       bool* value_pointer = option.value;
       for (HighsInt check_index = 0; check_index < num_options; check_index++) {
         if (check_index == index) continue;
-        OptionRecordBool& check_option =
-            ((OptionRecordBool*)option_records[check_index])[0];
-        if (check_option.type == HighsOptionType::kBool) {
+        if (option_records[check_index]->type == HighsOptionType::kBool) {
+          OptionRecordBool& check_option =
+              ((OptionRecordBool*)option_records[check_index])[0];
           if (check_option.value == value_pointer) {
             highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
@@ -170,9 +170,9 @@ OptionStatus checkOptions(const HighsLogOptions& report_log_options,
       HighsInt* value_pointer = option.value;
       for (HighsInt check_index = 0; check_index < num_options; check_index++) {
         if (check_index == index) continue;
-        OptionRecordInt& check_option =
-            ((OptionRecordInt*)option_records[check_index])[0];
-        if (check_option.type == HighsOptionType::kInt) {
+        if (option_records[check_index]->type == HighsOptionType::kInt) {
+          OptionRecordInt& check_option =
+              ((OptionRecordInt*)option_records[check_index])[0];
           if (check_option.value == value_pointer) {
             highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
@@ -195,9 +195,9 @@ OptionStatus checkOptions(const HighsLogOptions& report_log_options,
       double* value_pointer = option.value;
       for (HighsInt check_index = 0; check_index < num_options; check_index++) {
         if (check_index == index) continue;
-        OptionRecordDouble& check_option =
-            ((OptionRecordDouble*)option_records[check_index])[0];
-        if (check_option.type == HighsOptionType::kDouble) {
+        if (option_records[check_index]->type == HighsOptionType::kDouble) {
+          OptionRecordDouble& check_option =
+              ((OptionRecordDouble*)option_records[check_index])[0];
           if (check_option.value == value_pointer) {
             highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT
@@ -218,9 +218,9 @@ OptionStatus checkOptions(const HighsLogOptions& report_log_options,
       std::string* value_pointer = option.value;
       for (HighsInt check_index = 0; check_index < num_options; check_index++) {
         if (check_index == index) continue;
-        OptionRecordString& check_option =
-            ((OptionRecordString*)option_records[check_index])[0];
-        if (check_option.type == HighsOptionType::kString) {
+        if (option_records[check_index]->type == HighsOptionType::kString) {
+          OptionRecordString& check_option =
+              ((OptionRecordString*)option_records[check_index])[0];
           if (check_option.value == value_pointer) {
             highsLogUser(report_log_options, HighsLogType::kError,
                          "checkOptions: Option %" HIGHSINT_FORMAT

--- a/src/mip/HighsDomain.h
+++ b/src/mip/HighsDomain.h
@@ -255,7 +255,14 @@ class HighsDomain {
 
     std::vector<PartitionCliqueData> partitionCliqueData;
 
-    ObjectivePropagation() = default;
+    ObjectivePropagation() {
+      objFunc = nullptr;
+      cost = nullptr;
+      objectiveLower = 0.0;
+      numInfObjLower = 0;
+      capacityThreshold = 0.0;
+      isPropagated = false;
+    }
     ObjectivePropagation(HighsDomain* domain);
 
     bool isActive() const { return domain != nullptr; }

--- a/src/mip/HighsNodeQueue.h
+++ b/src/mip/HighsNodeQueue.h
@@ -106,8 +106,8 @@ class HighsNodeQueue {
               reinterpret_cast<FreelistNode*>(state->freeListHead)->next;
         } else {
           ptr = reinterpret_cast<T*>(state->currChunkStart);
-          state->currChunkStart += sizeof(FreelistNode);
-          if (state->currChunkStart > state->currChunkEnd) {
+          if (!ptr || state->currChunkStart + sizeof(FreelistNode) >
+                          state->currChunkEnd) {
             auto newChunk = new Chunk;
             newChunk->next = state->chunkListHead;
             state->chunkListHead = newChunk;
@@ -115,6 +115,8 @@ class HighsNodeQueue {
             state->currChunkEnd =
                 state->currChunkStart + sizeof(newChunk->storage);
             ptr = reinterpret_cast<T*>(state->currChunkStart);
+            state->currChunkStart += sizeof(FreelistNode);
+          } else {
             state->currChunkStart += sizeof(FreelistNode);
           }
         }

--- a/src/util/HighsMatrixSlice.h
+++ b/src/util/HighsMatrixSlice.h
@@ -199,7 +199,8 @@ class HighsMatrixSlice<HighsTripletListSlice> {
     iterator(HighsInt node) : currentNode(node) {}
     iterator(const HighsInt* nodeIndex, const double* nodeValue,
              const HighsInt* nodeNext, HighsInt node)
-        : pos_(nodeIndex + node, nodeValue + node),
+        : pos_(node == -1 ? nullptr : nodeIndex + node,
+               node == -1 ? nullptr : nodeValue + node),
           nodeNext(nodeNext),
           currentNode(node) {}
     iterator() = default;


### PR DESCRIPTION
Related to #1576 

Some very minor sanitizer issues remain, as can be seen in the logs that are uploaded [by the Github action here](https://github.com/Coloquinte/Highs-solver/actions/runs/7513161918)
* A small memory leak (could not reproduce locally)
* A typing issue when casting an option
* Null pointer arithmetic when manipulating an empty slice
* A data race between `HighsSplitDeque::WorkerBunk::waitForNewTask` and `HighsSplitDeque::injectTaskAndNotify(HighsTask*)` (could not reproduce on github)