### PR TITLE
Fix assertion failure in getVariableKktFailures

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -3063,13 +3063,14 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
     }
   }
 
-  if (rowsize[row] == 2 && model->row_lower_[row] == model->row_upper_[row] &&
-      analysis_.allow_rule_[kPresolveRuleDoubletonEquation])
-    return doubletonEq(postsolve_stack, row);
-
   // Get row bounds
   double rowUpper = model->row_upper_[row];
   double rowLower = model->row_lower_[row];
+
+  // Handle doubleton equations
+  if (rowsize[row] == 2 && rowLower == rowUpper &&
+      analysis_.allow_rule_[kPresolveRuleDoubletonEquation])
+    return doubletonEq(postsolve_stack, row);
 
   // todo: do additional single row presolve for mip here. It may assume a
   // non-redundant and non-infeasible row when considering variable and implied

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -120,7 +120,9 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
   numDeletedCols = 0;
   numDeletedRows = 0;
 
-  // store original row type
+  // Store original row type. Note that this row type will be incorrect for free
+  // (redundant) rows. However, such rows should be immediately detected and
+  // removed by the row presolve.
   origRowType.resize(model->num_row_);
   for (HighsInt i = 0; i != model->num_row_; ++i) {
     if (model->row_lower_[i] == model->row_upper_[i]) {
@@ -128,7 +130,6 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
     } else if (model->row_upper_[i] != kHighsInf) {
       origRowType[i] = HighsPostsolveStack::RowType::kLeq;
     } else {
-      assert(model->row_lower_[i] != -kHighsInf);
       origRowType[i] = HighsPostsolveStack::RowType::kGeq;
     }
   }

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -3075,24 +3075,23 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
     }
   }
 
-  // Remember original row type for doubleton equation elimination
-  HighsPostsolveStack::RowType rowType;
-  if (rowLower == rowUpper) {
-    rowType = HighsPostsolveStack::RowType::kEq;
-  } else if (rowUpper != kHighsInf) {
-    rowType = HighsPostsolveStack::RowType::kLeq;
-  } else {
-    rowType = HighsPostsolveStack::RowType::kGeq;
+  if (rowsize[row] == 2 && model->row_lower_[row] == model->row_upper_[row] &&
+      analysis_.allow_rule_[kPresolveRuleDoubletonEquation]) {
+    // Remember original row type for doubleton equation elimination
+    HighsPostsolveStack::RowType rowType;
+    if (rowLower == rowUpper) {
+      rowType = HighsPostsolveStack::RowType::kEq;
+    } else if (rowUpper != kHighsInf) {
+      rowType = HighsPostsolveStack::RowType::kLeq;
+    } else {
+      rowType = HighsPostsolveStack::RowType::kGeq;
+    }
+    return doubletonEq(postsolve_stack, row, rowType);
   }
 
   // Get (potentially modified) row bounds
   rowUpper = model->row_upper_[row];
   rowLower = model->row_lower_[row];
-
-  if (rowsize[row] == 2 && rowLower == rowUpper) {
-    if (analysis_.allow_rule_[kPresolveRuleDoubletonEquation])
-      return doubletonEq(postsolve_stack, row, rowType);
-  }
 
   // todo: do additional single row presolve for mip here. It may assume a
   // non-redundant and non-infeasible row when considering variable and implied

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -119,7 +119,6 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
   changedColIndices.reserve(model->num_col_);
   numDeletedCols = 0;
   numDeletedRows = 0;
-
   // Take value passed in as reduction limit, allowing different
   // values to be used for initial presolve, and after restart
   reductionLimit =

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -121,16 +121,15 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
   numDeletedRows = 0;
 
   // store original row type
-  origRowType.resize(model->num_row_, -1);
+  origRowType.resize(model->num_row_);
   for (HighsInt i = 0; i != model->num_row_; ++i) {
     if (model->row_lower_[i] == model->row_upper_[i]) {
-      origRowType[i] = static_cast<HighsInt>(HighsPostsolveStack::RowType::kEq);
+      origRowType[i] = HighsPostsolveStack::RowType::kEq;
     } else if (model->row_upper_[i] != kHighsInf) {
-      origRowType[i] =
-          static_cast<HighsInt>(HighsPostsolveStack::RowType::kLeq);
-    } else if (model->row_lower_[i] != -kHighsInf) {
-      origRowType[i] =
-          static_cast<HighsInt>(HighsPostsolveStack::RowType::kGeq);
+      origRowType[i] = HighsPostsolveStack::RowType::kLeq;
+    } else {
+      assert(model->row_lower_[i] != -kHighsInf);
+      origRowType[i] = HighsPostsolveStack::RowType::kGeq;
     }
   }
 
@@ -2499,7 +2498,6 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
   assert(!rowDeleted[row]);
   assert(rowsize[row] == 2);
   assert(model->row_lower_[row] == model->row_upper_[row]);
-  assert(origRowType[row] != -1);
 
   // printf("doubleton equation: ");
   // debugPrintRow(row);
@@ -2661,8 +2659,7 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
   postsolve_stack.doubletonEquation(
       row, substcol, staycol, substcoef, staycoef, rhs, substLower, substUpper,
       model->col_cost_[substcol], lowerTightened, upperTightened,
-      static_cast<HighsPostsolveStack::RowType>(origRowType[row]),
-      getColumnVector(substcol));
+      origRowType[row], getColumnVector(substcol));
 
   // finally modify matrix
   markColDeleted(substcol);

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -121,14 +121,16 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
   numDeletedRows = 0;
 
   // store original row type
-  origRowType.resize(model->num_row_);
+  origRowType.resize(model->num_row_, -1);
   for (HighsInt i = 0; i != model->num_row_; ++i) {
     if (model->row_lower_[i] == model->row_upper_[i]) {
-      origRowType[i] = HighsPostsolveStack::RowType::kEq;
+      origRowType[i] = static_cast<HighsInt>(HighsPostsolveStack::RowType::kEq);
     } else if (model->row_upper_[i] != kHighsInf) {
-      origRowType[i] = HighsPostsolveStack::RowType::kLeq;
-    } else {
-      origRowType[i] = HighsPostsolveStack::RowType::kGeq;
+      origRowType[i] =
+          static_cast<HighsInt>(HighsPostsolveStack::RowType::kLeq);
+    } else if (model->row_lower_[i] != -kHighsInf) {
+      origRowType[i] =
+          static_cast<HighsInt>(HighsPostsolveStack::RowType::kGeq);
     }
   }
 
@@ -2497,6 +2499,7 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
   assert(!rowDeleted[row]);
   assert(rowsize[row] == 2);
   assert(model->row_lower_[row] == model->row_upper_[row]);
+  assert(origRowType[row] != -1);
 
   // printf("doubleton equation: ");
   // debugPrintRow(row);
@@ -2658,7 +2661,8 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
   postsolve_stack.doubletonEquation(
       row, substcol, staycol, substcoef, staycoef, rhs, substLower, substUpper,
       model->col_cost_[substcol], lowerTightened, upperTightened,
-      origRowType[row], getColumnVector(substcol));
+      static_cast<HighsPostsolveStack::RowType>(origRowType[row]),
+      getColumnVector(substcol));
 
   // finally modify matrix
   markColDeleted(substcol);

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2494,11 +2494,11 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
       if (model->integrality_[Acol[nzPos2]] == HighsVarType::kInteger) {
         // both columns integer. For substitution choose smaller absolute
         // coefficient value, or sparser column if values are equal
-        if (std::abs(Avalue[nzPos1]) <
-            std::abs(Avalue[nzPos2]) - options->small_matrix_value) {
+        if (std::fabs(Avalue[nzPos1]) <
+            std::fabs(Avalue[nzPos2]) - options->small_matrix_value) {
           return true;
-        } else if (std::abs(Avalue[nzPos2]) <
-                   std::abs(Avalue[nzPos1]) - options->small_matrix_value) {
+        } else if (std::fabs(Avalue[nzPos2]) <
+                   std::fabs(Avalue[nzPos1]) - options->small_matrix_value) {
           return false;
         } else if (colsize[Acol[nzPos1]] < colsize[Acol[nzPos2]]) {
           return true;
@@ -2564,11 +2564,11 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
       model->integrality_[staycol] == HighsVarType::kInteger) {
     // check integrality conditions
     double roundCoef = std::round(staycoef / substcoef) * substcoef;
-    if (std::abs(roundCoef - staycoef) > options->small_matrix_value)
+    if (std::fabs(roundCoef - staycoef) > options->small_matrix_value)
       return Result::kOk;
     staycoef = roundCoef;
     double roundRhs = std::round(rhs / substcoef) * substcoef;
-    if (std::abs(rhs - roundRhs) > primal_feastol)
+    if (std::fabs(rhs - roundRhs) > primal_feastol)
       return Result::kPrimalInfeasible;
     rhs = roundRhs;
   }

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2626,17 +2626,11 @@ HPresolve::Result HPresolve::doubletonEq(HighsPostsolveStack& postsolve_stack,
   }
 
   // possibly tighten bounds of the column that stays
-  bool lowerTightened = false;
-  bool upperTightened = false;
-  if (stayImplLower > oldStayLower + primal_feastol) {
-    lowerTightened = true;
-    changeColLower(staycol, stayImplLower);
-  }
+  bool lowerTightened = stayImplLower > oldStayLower + primal_feastol;
+  if (lowerTightened) changeColLower(staycol, stayImplLower);
 
-  if (stayImplUpper < oldStayUpper - primal_feastol) {
-    upperTightened = true;
-    changeColUpper(staycol, stayImplUpper);
-  }
+  bool upperTightened = stayImplUpper < oldStayUpper - primal_feastol;
+  if (upperTightened) changeColUpper(staycol, stayImplUpper);
 
   postsolve_stack.doubletonEquation(
       row, substcol, staycol, substcoef, staycoef, rhs, substLower, substUpper,

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -292,7 +292,8 @@ class HPresolve {
 
   Result dominatedColumns(HighsPostsolveStack& postsolve_stack);
 
-  Result doubletonEq(HighsPostsolveStack& postsolve_stack, HighsInt row);
+  Result doubletonEq(HighsPostsolveStack& postsolve_stack, HighsInt row,
+                     HighsPostsolveStack::RowType rowType);
 
   Result singletonRow(HighsPostsolveStack& postsolve_stack, HighsInt row);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -99,6 +99,8 @@ class HPresolve {
 
   std::vector<std::pair<HighsInt, HighsInt>> substitutionOpportunities;
 
+  std::vector<HighsPostsolveStack::RowType> origRowType;
+
   // set with the sizes and indices of equation rows sorted by the size and a
   // vector to access there iterator positions in the set by index for quick
   // removal
@@ -292,8 +294,7 @@ class HPresolve {
 
   Result dominatedColumns(HighsPostsolveStack& postsolve_stack);
 
-  Result doubletonEq(HighsPostsolveStack& postsolve_stack, HighsInt row,
-                     HighsPostsolveStack::RowType rowType);
+  Result doubletonEq(HighsPostsolveStack& postsolve_stack, HighsInt row);
 
   Result singletonRow(HighsPostsolveStack& postsolve_stack, HighsInt row);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -99,7 +99,7 @@ class HPresolve {
 
   std::vector<std::pair<HighsInt, HighsInt>> substitutionOpportunities;
 
-  std::vector<HighsInt> origRowType;
+  std::vector<HighsPostsolveStack::RowType> origRowType;
 
   // set with the sizes and indices of equation rows sorted by the size and a
   // vector to access there iterator positions in the set by index for quick

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -99,7 +99,7 @@ class HPresolve {
 
   std::vector<std::pair<HighsInt, HighsInt>> substitutionOpportunities;
 
-  std::vector<HighsPostsolveStack::RowType> origRowType;
+  std::vector<HighsInt> origRowType;
 
   // set with the sizes and indices of equation rows sorted by the size and a
   // vector to access there iterator positions in the set by index for quick

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -99,8 +99,6 @@ class HPresolve {
 
   std::vector<std::pair<HighsInt, HighsInt>> substitutionOpportunities;
 
-  std::vector<HighsPostsolveStack::RowType> origRowType;
-
   // set with the sizes and indices of equation rows sorted by the size and a
   // vector to access there iterator positions in the set by index for quick
   // removal
@@ -294,7 +292,8 @@ class HPresolve {
 
   Result dominatedColumns(HighsPostsolveStack& postsolve_stack);
 
-  Result doubletonEq(HighsPostsolveStack& postsolve_stack, HighsInt row);
+  Result doubletonEq(HighsPostsolveStack& postsolve_stack, HighsInt row,
+                     HighsPostsolveStack::RowType rowType);
 
   Result singletonRow(HighsPostsolveStack& postsolve_stack, HighsInt row);
 

--- a/src/presolve/HighsPostsolveStack.cpp
+++ b/src/presolve/HighsPostsolveStack.cpp
@@ -72,6 +72,16 @@ void HighsPostsolveStack::LinearTransform::transformToPresolvedSpace(
   primalSol[col] /= scale;
 }
 
+HighsBasisStatus computeRowStatus(double dual,
+                                  HighsPostsolveStack::RowType rowType) {
+  if (rowType == HighsPostsolveStack::RowType::kEq)
+    return dual < 0 ? HighsBasisStatus::kUpper : HighsBasisStatus::kLower;
+  else if (rowType == HighsPostsolveStack::RowType::kGeq)
+    return HighsBasisStatus::kLower;
+  else
+    return HighsBasisStatus::kUpper;
+}
+
 void HighsPostsolveStack::FreeColSubstitution::undo(
     const HighsOptions& options, const std::vector<Nonzero>& rowValues,
     const std::vector<Nonzero>& colValues, HighsSolution& solution,
@@ -115,16 +125,8 @@ void HighsPostsolveStack::FreeColSubstitution::undo(
   if (!basis.valid) return;
 
   basis.col_status[col] = HighsBasisStatus::kBasic;
-  if (isModelRow) {
-    if (rowType == RowType::kEq)
-      basis.row_status[row] = solution.row_dual[row] < 0
-                                  ? HighsBasisStatus::kUpper
-                                  : HighsBasisStatus::kLower;
-    else if (rowType == RowType::kGeq)
-      basis.row_status[row] = HighsBasisStatus::kLower;
-    else
-      basis.row_status[row] = HighsBasisStatus::kUpper;
-  }
+  if (isModelRow)
+    basis.row_status[row] = computeRowStatus(solution.row_dual[row], rowType);
 }
 
 HighsBasisStatus computeStatus(double dual, HighsBasisStatus& status,
@@ -169,10 +171,10 @@ void HighsPostsolveStack::DoubletonEquation::undo(
 
   // compute the current dual values of the row and the substituted column
   // before deciding on which column becomes basic
-  // for each entry in a row i of the substituted column we added the doubleton
-  // equation row with scale -a_i/substCoef. Therefore the dual multiplier of
-  // this row i implicitly increases the dual multiplier of this doubleton
-  // equation row with that scale.
+  // for each entry in a row i of the substituted column we added the
+  // doubleton equation row with scale -a_i/substCoef. Therefore the dual
+  // multiplier of this row i implicitly increases the dual multiplier of this
+  // doubleton equation row with that scale.
   HighsCDouble rowDual = 0.0;
   solution.row_dual[row] = 0;
   for (const auto& colVal : colValues) {
@@ -182,8 +184,8 @@ void HighsPostsolveStack::DoubletonEquation::undo(
   rowDual /= coefSubst;
   solution.row_dual[row] = double(rowDual);
 
-  // the equation was also added to the objective, so the current values need to
-  // be changed
+  // the equation was also added to the objective, so the current values need
+  // to be changed
   solution.col_dual[colSubst] = substCost;
   solution.col_dual[col] += substCost * coef / coefSubst;
 
@@ -221,10 +223,7 @@ void HighsPostsolveStack::DoubletonEquation::undo(
 
   if (!basis.valid) return;
 
-  if (solution.row_dual[row] < 0)
-    basis.row_status[row] = HighsBasisStatus::kLower;
-  else
-    basis.row_status[row] = HighsBasisStatus::kUpper;
+  basis.row_status[row] = computeRowStatus(solution.row_dual[row], rowType);
 }
 
 void HighsPostsolveStack::EqualityRowAddition::undo(
@@ -259,8 +258,8 @@ void HighsPostsolveStack::EqualityRowAdditions::undo(
   if (!solution.dual_valid) return;
 
   // the dual multiplier of the rows where the eq row was added implicitly
-  // increases the dual multiplier of the equation with the scale that was used
-  // for adding the equation
+  // increases the dual multiplier of the equation with the scale that was
+  // used for adding the equation
   HighsCDouble eqRowDual = solution.row_dual[addedEqRow];
   for (const auto& targetRow : targetRows) {
     assert(static_cast<size_t>(targetRow.index) < solution.row_dual.size());

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -104,6 +104,7 @@ class HighsPostsolveStack {
     HighsInt col;
     bool lowerTightened;
     bool upperTightened;
+    RowType rowType;
 
     void undo(const HighsOptions& options,
               const std::vector<Nonzero>& colValues, HighsSolution& solution,
@@ -322,6 +323,7 @@ class HighsPostsolveStack {
                          double coefSubst, double coef, double rhs,
                          double substLower, double substUpper, double substCost,
                          bool lowerTightened, bool upperTightened,
+                         RowType rowType,
                          const HighsMatrixSlice<ColStorageFormat>& colVec) {
     colValues.clear();
     for (const HighsSliceNonzero& colVal : colVec)
@@ -330,7 +332,7 @@ class HighsPostsolveStack {
     reductionValues.push(DoubletonEquation{
         coef, coefSubst, rhs, substLower, substUpper, substCost,
         row == -1 ? -1 : origRowIndex[row], origColIndex[colSubst],
-        origColIndex[col], lowerTightened, upperTightened});
+        origColIndex[col], lowerTightened, upperTightened, rowType});
     reductionValues.push(colValues);
     reductionAdded(ReductionType::kDoubletonEquation);
   }


### PR DESCRIPTION
When I set the flag `force_debug` [here](https://github.com/ERGO-Code/HiGHS/blob/6410710acf6ef49f2294a864c5127d2e54237bf7/src/lp_data/Highs.cpp#L1447) to `true` and solve the LP relaxation of problem `vpm1` from MIPLIB3.0, I get an assertion failure in `getVariableKktFailures` on win64:

```
    Highs highs;

    // Read problem vpm1 from MIPLIB3.0 and make it an LP
    highs.clearSolver();
    std::string filename = "vpm1.mps";
    highs.readModel(filename);
    std::vector<HighsInt> vars(highs.getNumCol(), 1);
    std::vector<HighsVarType> integral(highs.getNumCol(), HighsVarType::kContinuous);
    highs.changeColsIntegrality(vars.data(), integral.data());

    // Run
    highs.run();
```

Postsolve assumes that a doubleton row was an equality constraint. However, row bounds may have been modified (in the row presolve method).