### PR TITLE
FIx handling of semidefinite instances in QP solver

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3366,7 +3366,7 @@ HighsStatus Highs::callSolveQp() {
   Settings settings;
   Statistics stats;
 
-  settings.reportingfequency = 1000;
+  settings.reportingfequency = 100;
 
   settings.endofiterationevent.subscribe([this](Statistics& stats) {
     int rep = stats.iteration.size() - 1;
@@ -3404,6 +3404,8 @@ HighsStatus Highs::callSolveQp() {
                       ? HighsModelStatus::kInfeasible
                   : qp_model_status == QpModelStatus::ITERATIONLIMIT
                       ? HighsModelStatus::kIterationLimit
+                  : qp_model_status == QpModelStatus::LARGE_NULLSPACE
+                      ? HighsModelStatus::kSolveError
                   : qp_model_status == QpModelStatus::TIMELIMIT
                       ? HighsModelStatus::kTimeLimit
                       : HighsModelStatus::kNotset;

--- a/src/qpsolver/a_quass.cpp
+++ b/src/qpsolver/a_quass.cpp
@@ -13,6 +13,17 @@ QpAsmStatus solveqp(Instance& instance, Settings& settings, Statistics& stats, Q
 
   // perturb instance, store perturbance information
 
+  // regularize
+  for (HighsInt i=0; i<instance.num_var; i++) {
+    for (HighsInt index = instance.Q.mat.start[i];
+         index < instance.Q.mat.start[i + 1]; index++) {
+      if (instance.Q.mat.index[index] == i) {
+        instance.Q.mat.value[index] +=
+            settings.hessianregularizationfactor;
+      }
+    }
+  }
+
   // compute initial feasible point
   QpHotstartInformation startinfo(instance.num_var, instance.num_con);
   computestartingpoint_highs(instance, settings, stats, modelstatus, startinfo, qp_timer);

--- a/src/qpsolver/factor.hpp
+++ b/src/qpsolver/factor.hpp
@@ -177,6 +177,11 @@ class CholeskyFactor {
       recompute();
     }
 
+    if (current_k != rhs.dim) {
+      printf("dimension mismatch\n");
+      return;
+    }
+
     for (HighsInt r = 0; r < rhs.dim; r++) {
       for (HighsInt j = 0; j < r; j++) {
         rhs.value[r] -= rhs.value[j] * L[j * current_k_max + r];

--- a/src/qpsolver/qpconst.hpp
+++ b/src/qpsolver/qpconst.hpp
@@ -11,6 +11,7 @@ enum class QpModelStatus {
   INFEASIBLE,
   ITERATIONLIMIT,
   TIMELIMIT,
+  LARGE_NULLSPACE,
   ERROR
 };
 

--- a/src/qpsolver/vector.hpp
+++ b/src/qpsolver/vector.hpp
@@ -65,7 +65,7 @@ struct Vector {
     return vec;
   }
 
-  void report(std::string name = "") {
+  void report(std::string name = "") const {
     if (name != "") {
       printf("%s: ", name.c_str());
     }


### PR DESCRIPTION
Most semidefinite instances (e.g. in Maros-Meszaros) are now working fine.
Exit gracefully if initial nullspace is large (>= 4000), since there is no realistic chance to solve.