### PR TITLE
Uninitialized dual in postsolve

### DIFF
--- a/src/presolve/HighsPostsolveStack.cpp
+++ b/src/presolve/HighsPostsolveStack.cpp
@@ -101,6 +101,7 @@ void HighsPostsolveStack::FreeColSubstitution::undo(
 
   // compute the row dual value such that reduced cost of basic column is 0
   if (isModelRow) {
+    solution.row_dual[row] = 0;
     HighsCDouble dualval = colCost;
     for (const auto& colVal : colValues) {
       assert(static_cast<size_t>(colVal.index) < solution.row_dual.size());


### PR DESCRIPTION
A dual associated with a removed row is uninitialized in postsolve. This causes large dual residuals one some problems (e.g. LP relaxation of vpm1 from MIPLIB3.0).