### PR TITLE
Minor postsolve changes for debugging

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -2019,7 +2019,6 @@ HighsStatus Highs::stopCallback(const HighsCallbackType callback_type) {
                  "Cannot stop callback when user_callback not defined\n");
     return HighsStatus::kWarning;
   }
-  std::vector<bool>& active = this->callback_.active;
   assert(int(this->callback_.active.size()) == kNumCallbackType);
   this->callback_.active[callback_type] = false;
   // Possibly modify the logging callback activity

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -551,7 +551,9 @@ class HighsPostsolveStack {
 
   template <typename T>
   void undoIterateBackwards(std::vector<T>& values,
-                            const std::vector<HighsInt>& index) {
+                            const std::vector<HighsInt>& index,
+                            HighsInt origSize) {
+    values.resize(origSize);
     for (size_t i = index.size(); i > 0; --i) {
       assert(static_cast<size_t>(index[i - 1]) >= i - 1);
       values[index[i - 1]] = values[i - 1];
@@ -570,30 +572,24 @@ class HighsPostsolveStack {
 
     // expand solution to original index space
     assert(origNumCol > 0);
-    solution.col_value.resize(origNumCol);
-    undoIterateBackwards(solution.col_value, origColIndex);
+    undoIterateBackwards(solution.col_value, origColIndex, origNumCol);
 
     assert(origNumRow >= 0);
-    solution.row_value.resize(origNumRow);
-    undoIterateBackwards(solution.row_value, origRowIndex);
+    undoIterateBackwards(solution.row_value, origRowIndex, origNumRow);
 
     if (perform_dual_postsolve) {
       // if dual solution is given, expand dual solution and basis to original
       // index space
-      solution.col_dual.resize(origNumCol);
-      undoIterateBackwards(solution.col_dual, origColIndex);
+      undoIterateBackwards(solution.col_dual, origColIndex, origNumCol);
 
-      solution.row_dual.resize(origNumRow);
-      undoIterateBackwards(solution.row_dual, origRowIndex);
+      undoIterateBackwards(solution.row_dual, origRowIndex, origNumRow);
     }
 
     if (perform_basis_postsolve) {
       // if basis is given, expand basis status values to original index space
-      basis.col_status.resize(origNumCol);
-      undoIterateBackwards(basis.col_status, origColIndex);
+      undoIterateBackwards(basis.col_status, origColIndex, origNumCol);
 
-      basis.row_status.resize(origNumRow);
-      undoIterateBackwards(basis.row_status, origRowIndex);
+      undoIterateBackwards(basis.row_status, origRowIndex, origNumRow);
     }
 
     // now undo the changes
@@ -750,29 +746,23 @@ class HighsPostsolveStack {
     bool perform_basis_postsolve = basis.valid;
 
     // expand solution to original index space
-    solution.col_value.resize(origNumCol);
-    undoIterateBackwards(solution.col_value, origColIndex);
+    undoIterateBackwards(solution.col_value, origColIndex, origNumCol);
 
-    solution.row_value.resize(origNumRow);
-    undoIterateBackwards(solution.row_value, origRowIndex);
+    undoIterateBackwards(solution.row_value, origRowIndex, origNumRow);
 
     if (perform_dual_postsolve) {
       // if dual solution is given, expand dual solution and basis to original
       // index space
-      solution.col_dual.resize(origNumCol);
-      undoIterateBackwards(solution.col_dual, origColIndex);
+      undoIterateBackwards(solution.col_dual, origColIndex, origNumCol);
 
-      solution.row_dual.resize(origNumRow);
-      undoIterateBackwards(solution.row_dual, origRowIndex);
+      undoIterateBackwards(solution.row_dual, origRowIndex, origNumRow);
     }
 
     if (perform_basis_postsolve) {
       // if basis is given, expand basis status values to original index space
-      basis.col_status.resize(origNumCol);
-      undoIterateBackwards(basis.col_status, origColIndex);
+      undoIterateBackwards(basis.col_status, origColIndex, origNumCol);
 
-      basis.row_status.resize(origNumRow);
-      undoIterateBackwards(basis.row_status, origRowIndex);
+      undoIterateBackwards(basis.row_status, origRowIndex, origNumRow);
     }
 
     // now undo the changes

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -553,18 +553,17 @@ class HighsPostsolveStack {
   void undoIterateBackwards(std::vector<T>& values,
                             const std::vector<HighsInt>& index,
                             HighsInt origSize) {
+    values.resize(origSize);
 #ifdef DEBUG_EXTRA
     // Fill vector with NaN for debugging purposes
     std::vector<T> valuesNew;
     valuesNew.resize(origSize, std::numeric_limits<T>::signaling_NaN());
-    values.resize(origSize);
     for (size_t i = index.size(); i > 0; --i) {
       assert(static_cast<size_t>(index[i - 1]) >= i - 1);
       valuesNew[index[i - 1]] = values[i - 1];
     }
     std::copy(valuesNew.cbegin(), valuesNew.cend(), values.begin());
 #else
-    values.resize(origSize);
     for (size_t i = index.size(); i > 0; --i) {
       assert(static_cast<size_t>(index[i - 1]) >= i - 1);
       values[index[i - 1]] = values[i - 1];

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -16,12 +16,12 @@
 #ifndef PRESOLVE_HIGHS_POSTSOLVE_STACK_H_
 #define PRESOLVE_HIGHS_POSTSOLVE_STACK_H_
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <numeric>
 #include <tuple>
 #include <vector>
-#include <algorithm>
 
 #include "lp_data/HConst.h"
 #include "lp_data/HStruct.h"

--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -21,6 +21,7 @@
 #include <numeric>
 #include <tuple>
 #include <vector>
+#include <algorithm>
 
 #include "lp_data/HConst.h"
 #include "lp_data/HStruct.h"


### PR DESCRIPTION
The proposed change is to initialize the postsolved solution with `NaN` when compiler flag `DEBUG_EXTRA` is set, thereby making it easier to find uninitialised data. I used similar changes while working on #1594, for example.