### PR TITLE
Quass performance improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ if(NOT FAST_BUILD)
   enable_cxx_compiler_flag_if_supported("-Wno-unused-parameter")
   enable_cxx_compiler_flag_if_supported("-Wno-format-truncation")
   enable_cxx_compiler_flag_if_supported("-pedantic")
+  enable_cxx_compiler_flag_if_supported("-g")
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86\_64|i686)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,6 @@ if(NOT FAST_BUILD)
   enable_cxx_compiler_flag_if_supported("-Wno-unused-parameter")
   enable_cxx_compiler_flag_if_supported("-Wno-format-truncation")
   enable_cxx_compiler_flag_if_supported("-pedantic")
-  enable_cxx_compiler_flag_if_supported("-g")
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86\_64|i686)")

--- a/src/qpsolver/basis.cpp
+++ b/src/qpsolver/basis.cpp
@@ -5,7 +5,8 @@
 
 Basis::Basis(Runtime& rt, std::vector<HighsInt> active,
              std::vector<BasisStatus> status, std::vector<HighsInt> inactive)
-    : runtime(rt),
+    : Ztprod_res(rt.instance.num_var),
+      runtime(rt),
       buffer_column_aq(rt.instance.num_var),
       buffer_row_ep(rt.instance.num_var) {
   buffer_vec2hvec.setup(rt.instance.num_var);
@@ -275,14 +276,14 @@ Vector Basis::recomputex(const Instance& inst) {
 
 Vector& Basis::Ztprod(const Vector& rhs, Vector& target, bool buffer,
                       HighsInt q) {
-  Vector res_ = ftran(rhs, buffer, q);
+  ftran(rhs, Ztprod_res, buffer, q);
 
   target.reset();
   for (size_t i = 0; i < nonactiveconstraintsidx.size(); i++) {
     HighsInt nonactive = nonactiveconstraintsidx[i];
     HighsInt idx = constraintindexinbasisfactor[nonactive];
     target.index[i] = static_cast<HighsInt>(i);
-    target.value[i] = res_.value[idx];
+    target.value[i] = Ztprod_res.value[idx];
   }
   target.resparsify();
   return target;

--- a/src/qpsolver/basis.cpp
+++ b/src/qpsolver/basis.cpp
@@ -6,6 +6,7 @@
 Basis::Basis(Runtime& rt, std::vector<HighsInt> active,
              std::vector<BasisStatus> status, std::vector<HighsInt> inactive)
     : Ztprod_res(rt.instance.num_var),
+      buffer_Zprod(rt.instance.num_var),
       runtime(rt),
       buffer_column_aq(rt.instance.num_var),
       buffer_row_ep(rt.instance.num_var) {
@@ -290,16 +291,17 @@ Vector& Basis::Ztprod(const Vector& rhs, Vector& target, bool buffer,
 }
 
 Vector& Basis::Zprod(const Vector& rhs, Vector& target) {
-  Vector temp(target.dim);
+  buffer_Zprod.reset();
+  buffer_Zprod.dim = target.dim;
   for (HighsInt i = 0; i < rhs.num_nz; i++) {
     HighsInt nz = rhs.index[i];
     HighsInt nonactive = nonactiveconstraintsidx[nz];
     HighsInt idx = constraintindexinbasisfactor[nonactive];
-    temp.index[i] = idx;
-    temp.value[idx] = rhs.value[nz];
+    buffer_Zprod.index[i] = idx;
+    buffer_Zprod.value[idx] = rhs.value[nz];
   }
-  temp.num_nz = rhs.num_nz;
-  return btran(temp, target);
+  buffer_Zprod.num_nz = rhs.num_nz;
+  return btran(buffer_Zprod, target);
 }
 
 // void Basis::write(std::string filename) {

--- a/src/qpsolver/basis.hpp
+++ b/src/qpsolver/basis.hpp
@@ -17,6 +17,7 @@
 class Basis {
   HVector buffer_vec2hvec;
   Vector Ztprod_res;
+  Vector buffer_Zprod;
 
   HVector& vec2hvec(const Vector& vec) {
     buffer_vec2hvec.clear();

--- a/src/qpsolver/basis.hpp
+++ b/src/qpsolver/basis.hpp
@@ -16,6 +16,7 @@
 
 class Basis {
   HVector buffer_vec2hvec;
+  Vector Ztprod_res;
 
   HVector& vec2hvec(const Vector& vec) {
     buffer_vec2hvec.clear();

--- a/src/qpsolver/dantzigpricing.hpp
+++ b/src/qpsolver/dantzigpricing.hpp
@@ -55,7 +55,6 @@ class DantzigPricing : public Pricing {
       : runtime(rt), basis(bas), redcosts(rc){};
 
   HighsInt price(const Vector& x, const Vector& gradient) {
-    // Vector lambda = basis.ftran(gradient);
     HighsInt minidx = chooseconstrainttodrop(redcosts.getReducedCosts());
     return minidx;
   }

--- a/src/qpsolver/devexharrispricing.hpp
+++ b/src/qpsolver/devexharrispricing.hpp
@@ -11,7 +11,7 @@ class DevexHarrisPricing : public Pricing {
  private:
   Runtime& runtime;
   Basis& basis;
-
+  ReducedCosts& redcosts;
   std::vector<double> weights;
 
   HighsInt chooseconstrainttodrop(const Vector& lambda) {
@@ -52,14 +52,14 @@ class DevexHarrisPricing : public Pricing {
   }
 
  public:
-  DevexHarrisPricing(Runtime& rt, Basis& bas)
+  DevexHarrisPricing(Runtime& rt, Basis& bas, ReducedCosts& rc)
       : runtime(rt),
-        basis(bas),
-        weights(std::vector<double>(rt.instance.num_var, 1.0)){};
+        basis(bas), 
+        redcosts(rc),
+        weights(std::vector<double>(rt.instance.num_var, 1.0)) {};
 
   HighsInt price(const Vector& x, const Vector& gradient) {
-    Vector lambda = basis.ftran(gradient);
-    HighsInt minidx = chooseconstrainttodrop(lambda);
+    HighsInt minidx = chooseconstrainttodrop(redcosts.getReducedCosts());
     return minidx;
   }
 

--- a/src/qpsolver/quass.cpp
+++ b/src/qpsolver/quass.cpp
@@ -367,8 +367,8 @@ void Quass::solve(const Vector& x0, const Vector& ra, Basis& b0, HighsTimer& tim
       computesearchdirection_minor(runtime, basis, factor, redgrad, p);
       computerowmove(runtime, basis, p, rowmove);
       tidyup(p, rowmove, basis, runtime);
+      runtime.instance.Q.mat_vec(p, buffer_Qp);
     }
-
     if (p.norm2() < runtime.settings.pnorm_zero_threshold ||
         maxsteplength == 0.0 || (false && fabs(gradient.getGradient().dot(p)) < runtime.settings.improvement_zero_threshold)) {
       atfsep = true;
@@ -414,11 +414,11 @@ void Quass::solve(const Vector& x0, const Vector& ra, Basis& b0, HighsTimer& tim
         redgrad.update(stepres.alpha, false);
       }
 
-      gradient.update(buffer_Qp, stepres.alpha);
-      redcosts.update();
-
       runtime.primal.saxpy(stepres.alpha, p);
       runtime.rowactivity.saxpy(stepres.alpha, rowmove);
+
+      gradient.update(buffer_Qp, stepres.alpha);
+      redcosts.update();
     }
   }
 

--- a/src/qpsolver/quass.cpp
+++ b/src/qpsolver/quass.cpp
@@ -79,7 +79,7 @@ static void computerowmove(Runtime& runtime, Basis& basis, Vector& p,
 static Vector& computesearchdirection_minor(Runtime& rt, Basis& bas,
                                      CholeskyFactor& cf,
                                      ReducedGradient& redgrad, Vector& p) {
-  Vector g2 = -redgrad.get();
+  Vector g2 = -redgrad.get(); // TODO PERF: buffer Vector
   g2.sanitize();
   cf.solve(g2);
 
@@ -93,7 +93,7 @@ static Vector& computesearchdirection_major(Runtime& runtime, Basis& basis,
                                      CholeskyFactor& factor, const Vector& yp,
                                      Gradient& gradient, Vector& gyp, Vector& l,
                                      Vector& m, Vector& p) {
-  Vector yyp = yp;
+  Vector yyp = yp; // TODO PERF: buffer Vector
   // if (gradient.getGradient().dot(yp) > 0.0) {
   //   yyp.scale(-1.0);
   // }
@@ -102,7 +102,7 @@ static Vector& computesearchdirection_major(Runtime& runtime, Basis& basis,
     basis.Ztprod(gyp, m);
     l = m;
     factor.solveL(l);
-    Vector v = l;
+    Vector v = l; // TODO PERF: buffer Vector
     factor.solveLT(v);
     basis.Zprod(v, p);
     if (gradient.getGradient().dot(yyp) < 0.0) {
@@ -146,7 +146,7 @@ static QpSolverStatus reduce(Runtime& rt, Basis& basis, const HighsInt newactive
   }
 
   // TODO: this operation is inefficient.
-  Vector aq = rt.instance.A.t().extractcol(newactivecon);
+  Vector aq = rt.instance.A.t().extractcol(newactivecon); // TODO PERF: buffer Vector
   basis.Ztprod(aq, buffer_d, true, newactivecon);
 
   maxabsd = 0;
@@ -428,7 +428,7 @@ void Quass::solve(const Vector& x0, const Vector& ra, Basis& b0, HighsTimer& tim
   runtime.instance.sumnumprimalinfeasibilities(
       runtime.primal, runtime.instance.A.mat_vec(runtime.primal));
 
-  Vector lambda = redcosts.getReducedCosts();
+  Vector& lambda = redcosts.getReducedCosts();
   for (auto e : basis.getactive()) {
     HighsInt indexinbasis = basis.getindexinfactor()[e];
     if (e >= runtime.instance.num_con) {

--- a/src/qpsolver/quass.cpp
+++ b/src/qpsolver/quass.cpp
@@ -297,6 +297,8 @@ void Quass::solve(const Vector& x0, const Vector& ra, Basis& b0, HighsTimer& tim
 
   regularize(runtime);
 
+  runtime.relaxed_for_ratiotest = ratiotest_relax_instance(runtime);
+
   if (basis.getnuminactive() > 4000) {
     printf("nullspace too larg %d\n", basis.getnuminactive());
     runtime.status = QpModelStatus::LARGE_NULLSPACE;

--- a/src/qpsolver/ratiotest.cpp
+++ b/src/qpsolver/ratiotest.cpp
@@ -94,15 +94,9 @@ static RatiotestResult ratiotest_twopass(Runtime& runtime, const Vector& p,
   return result;
 }
 
-RatiotestResult ratiotest(Runtime& runtime, const Vector& p,
-                          const Vector& rowmove, double alphastart) {
-  switch (runtime.settings.ratiotest) {
-    case RatiotestStrategy::Textbook:
-      return ratiotest_textbook(runtime, p, rowmove, runtime.instance,
-                                alphastart);
-    case RatiotestStrategy::TwoPass:
-    default:  // to fix -Wreturn-type warning
-      Instance relaxed_instance = runtime.instance;
+
+Instance ratiotest_relax_instance(Runtime& runtime) {
+  Instance relaxed_instance = runtime.instance;
       for (double& bound : relaxed_instance.con_lo) {
         if (bound != -std::numeric_limits<double>::infinity()) {
           bound -= runtime.settings.ratiotest_d;
@@ -126,7 +120,18 @@ RatiotestResult ratiotest(Runtime& runtime, const Vector& p,
           bound += runtime.settings.ratiotest_d;
         }
       }
-      return ratiotest_twopass(runtime, p, rowmove, relaxed_instance,
+  return relaxed_instance;
+}
+
+RatiotestResult ratiotest(Runtime& runtime, const Vector& p,
+                          const Vector& rowmove, double alphastart) {
+  switch (runtime.settings.ratiotest) {
+    case RatiotestStrategy::Textbook:
+      return ratiotest_textbook(runtime, p, rowmove, runtime.instance,
+                                alphastart);
+    case RatiotestStrategy::TwoPass:
+    default:  // to fix -Wreturn-type warning
+      return ratiotest_twopass(runtime, p, rowmove, runtime.relaxed_for_ratiotest,
                                alphastart);
   }
 }

--- a/src/qpsolver/ratiotest.hpp
+++ b/src/qpsolver/ratiotest.hpp
@@ -14,4 +14,6 @@ struct RatiotestResult {
 RatiotestResult ratiotest(Runtime& runtime, const Vector& p,
                           const Vector& rowmove, double alphastart);
 
+Instance ratiotest_relax_instance(Runtime& runtime);
+
 #endif

--- a/src/qpsolver/runtime.hpp
+++ b/src/qpsolver/runtime.hpp
@@ -9,6 +9,7 @@
 
 struct Runtime {
   Instance instance;
+  Instance relaxed_for_ratiotest;
   Instance scaled;
   Instance perturbed;
   Settings settings;

--- a/src/qpsolver/settings.hpp
+++ b/src/qpsolver/settings.hpp
@@ -37,7 +37,7 @@ struct Settings {
   Eventhandler<Statistics&> endofiterationevent;
 
   HighsInt reinvertfrequency = 100;
-  HighsInt gradientrecomputefrequency = 1;
+  HighsInt gradientrecomputefrequency = 100;
   HighsInt reducedgradientrecomputefrequency =
       std::numeric_limits<HighsInt>::infinity();
   HighsInt reducedhessianrecomputefrequency =

--- a/src/qpsolver/steepestedgepricing.hpp
+++ b/src/qpsolver/steepestedgepricing.hpp
@@ -11,7 +11,7 @@ class SteepestEdgePricing : public Pricing {
  private:
   Runtime& runtime;
   Basis& basis;
-
+  ReducedCosts& redcosts;
   std::vector<double> weights;
 
   HighsInt chooseconstrainttodrop(const Vector& lambda) {
@@ -52,14 +52,14 @@ class SteepestEdgePricing : public Pricing {
   }
 
  public:
-  SteepestEdgePricing(Runtime& rt, Basis& bas)
+  SteepestEdgePricing(Runtime& rt, Basis& bas, ReducedCosts& rc)
       : runtime(rt),
         basis(bas),
-        weights(std::vector<double>(rt.instance.num_var, 1.0)){};
+        redcosts(rc),
+        weights(std::vector<double>(rt.instance.num_var, 1.0)) {};
 
   HighsInt price(const Vector& x, const Vector& gradient) {
-    Vector lambda = basis.ftran(gradient);
-    HighsInt minidx = chooseconstrainttodrop(lambda);
+    HighsInt minidx = chooseconstrainttodrop(redcosts.getReducedCosts());
     return minidx;
   }
 


### PR DESCRIPTION
A couple of easy performance improvements for the QP solver found after running callgrind on a couple of instances and analyzing through kcachegrind:
- a lot of Vectors reallocations are avoided buy providing buffers (a couple fixes like this will follow)
- a bug was fixed that updated gradient information wrong. Now gradients are by defaul updated rather than recomputed. This is a performance improvement in major iterations, as a matrix-vector product is avoided.
- for the two-step ratio test, the "relaxed" instance is now only computed once.  Fixing this oversight alone improves performance by up to 15%.

Overall performance improves from 5-25% depending on instance-specific behaviour