### PR TITLE
Now reading inf, +inf and -inf in options file

### DIFF
--- a/check/TestOptions.cpp
+++ b/check/TestOptions.cpp
@@ -497,3 +497,18 @@ TEST_CASE("highs-options", "[highs_options]") {
   return_status = highs.setOptionValue("time_limit", 1);
   REQUIRE(return_status == HighsStatus::kOk);
 }
+
+TEST_CASE("inf-value-options", "[highs_options]") {
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  std::string options_file =
+      std::string(HIGHS_DIR) + "/check/instances/WithInf.set";
+  REQUIRE(highs.readOptions(options_file) == HighsStatus::kOk);
+  double value;
+  highs.getOptionValue("time_limit", value);
+  REQUIRE(value == kHighsInf);
+  highs.getOptionValue("objective_bound", value);
+  REQUIRE(value == -kHighsInf);
+  highs.getOptionValue("objective_target", value);
+  REQUIRE(value == kHighsInf);
+}

--- a/check/instances/WithInf.set
+++ b/check/instances/WithInf.set
@@ -1,0 +1,3 @@
+time_limit = inf
+objective_bound = -inf
+objective_target = +inf

--- a/src/io/LoadOptions.cpp
+++ b/src/io/LoadOptions.cpp
@@ -46,12 +46,16 @@ HighsLoadOptionsStatus loadOptionsFromFile(
       trim(option, non_chars);
       trim(value, non_chars);
       if (setLocalOptionValue(report_log_options, option, options.log_options,
-                              options.records, value) != OptionStatus::kOk)
+                              options.records, value) != OptionStatus::kOk) {
+        highsLogUser(report_log_options, HighsLogType::kError,
+                     "Cannot read value \"%s\" for option \"%s\"\n",
+                     value.c_str(), option.c_str());
         return HighsLoadOptionsStatus::kError;
+      }
     }
   } else {
     highsLogUser(report_log_options, HighsLogType::kError,
-                 "Options file not found.\n");
+                 "Options file not found\n");
     return HighsLoadOptionsStatus::kError;
   }
 

--- a/src/lp_data/HighsOptions.cpp
+++ b/src/lp_data/HighsOptions.cpp
@@ -495,20 +495,29 @@ OptionStatus setLocalOptionValue(const HighsLogOptions& report_log_options,
                                ((OptionRecordInt*)option_records[index])[0],
                                value_int);
   } else if (type == HighsOptionType::kDouble) {
-    // Check that the string only contains legitimate characters
-    if (value_trim.find_first_not_of("+-.0123456789eE") != std::string::npos)
-      return OptionStatus::kIllegalValue;
-    HighsInt value_int = atoi(value_trim.c_str());
-    double value_double = atof(value_trim.c_str());
-    double value_int_double = value_int;
-    if (value_double == value_int_double) {
-      highsLogDev(report_log_options, HighsLogType::kInfo,
-                  "setLocalOptionValue: Value = \"%s\" converts via atoi as "
-                  "%" HIGHSINT_FORMAT
-                  " "
-                  "so is %g as double, and %g via atof\n",
-                  value_trim.c_str(), value_int, value_int_double,
-                  value_double);
+    // Check that the string only contains legitimate characters -
+    // after handling +/- inf
+    double value_double = 0;
+    tolower(value_trim);
+    if (value_trim == "inf" || value_trim == "+inf") {
+      value_double = kHighsInf;
+    } else if (value_trim == "-inf") {
+      value_double = -kHighsInf;
+    } else {
+      if (value_trim.find_first_not_of("+-.0123456789eE") != std::string::npos)
+        return OptionStatus::kIllegalValue;
+      HighsInt value_int = atoi(value_trim.c_str());
+      value_double = atof(value_trim.c_str());
+      double value_int_double = value_int;
+      if (value_double == value_int_double) {
+        highsLogDev(report_log_options, HighsLogType::kInfo,
+                    "setLocalOptionValue: Value = \"%s\" converts via atoi as "
+                    "%" HIGHSINT_FORMAT
+                    " "
+                    "so is %g as double, and %g via atof\n",
+                    value_trim.c_str(), value_int, value_int_double,
+                    value_double);
+      }
     }
     return setLocalOptionValue(report_log_options,
                                ((OptionRecordDouble*)option_records[index])[0],

--- a/src/util/stringutil.cpp
+++ b/src/util/stringutil.cpp
@@ -10,7 +10,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include "util/stringutil.h"
 
-//#include <algorithm>
+#include <algorithm>  // for std::transform
 #include <cassert>
 
 /*
@@ -69,6 +69,11 @@ void strTrim(char* str) {
 //   );
 //   return str;
 // }
+
+void tolower(std::string& str) {
+  std::transform(str.begin(), str.end(), str.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+}
 
 std::string& ltrim(std::string& str, const std::string& chars) {
   str.erase(0, str.find_first_not_of(chars));

--- a/src/util/stringutil.h
+++ b/src/util/stringutil.h
@@ -25,6 +25,8 @@ void strTrim(char* str);
 */
 // std::string& str_tolower(std::string s);
 
+void tolower(std::string& str);
+
 const std::string non_chars = "\t\n\v\f\r ";
 std::string& ltrim(std::string& str, const std::string& chars = non_chars);
 std::string& rtrim(std::string& str, const std::string& chars = non_chars);


### PR DESCRIPTION
Now allows inf, +inf and -inf (and any such strings containing upper case letters) to be used in the options file, meaning that the output from `Highs::writeOptions()` can be read back in!