### PR TITLE
fix some compiler warnings

### DIFF
--- a/src/pdlp/cupdlp/cupdlp_step.c
+++ b/src/pdlp/cupdlp/cupdlp_step.c
@@ -17,7 +17,7 @@ void PDHG_primalGradientStep(CUPDLPwork *work, cupdlp_float dPrimalStepSize) {
   CUPDLPiterates *iterates = work->iterates;
   CUPDLPproblem *problem = work->problem;
 
-#ifndef CUPDLP_CPU & USE_KERNELS
+#if !defined(CUPDLP_CPU) & USE_KERNELS
   cupdlp_pgrad_cuda(iterates->xUpdate->data, iterates->x->data, problem->cost,
                     iterates->aty->data, dPrimalStepSize, problem->nCols);
 #else
@@ -44,7 +44,7 @@ void PDHG_dualGradientStep(CUPDLPwork *work, cupdlp_float dDualStepSize) {
   CUPDLPiterates *iterates = work->iterates;
   CUPDLPproblem *problem = work->problem;
 
-#ifndef CUPDLP_CPU & USE_KERNELS
+#if !defined(CUPDLP_CPU) & USE_KERNELS
   cupdlp_dgrad_cuda(iterates->yUpdate->data, iterates->y->data, problem->rhs,
                     iterates->ax->data, iterates->axUpdate->data, dDualStepSize,
                     problem->nRows);
@@ -210,7 +210,7 @@ cupdlp_retcode PDHG_Update_Iterate_Adaptive_Step_Size(CUPDLPwork *pdhg) {
     cupdlp_float dMovement = 0.0;
     cupdlp_float dInteraction = 0.0;
 
-#ifndef CUPDLP_CPU & USE_KERNELS
+#if !defined(CUPDLP_CPU) & USE_KERNELS
     cupdlp_compute_interaction_and_movement(pdhg, &dMovement, &dInteraction);
 #else
     cupdlp_float dX = 0.0;

--- a/src/presolve/HighsPostsolveStack.cpp
+++ b/src/presolve/HighsPostsolveStack.cpp
@@ -72,8 +72,8 @@ void HighsPostsolveStack::LinearTransform::transformToPresolvedSpace(
   primalSol[col] /= scale;
 }
 
-HighsBasisStatus computeRowStatus(double dual,
-                                  HighsPostsolveStack::RowType rowType) {
+static HighsBasisStatus computeRowStatus(double dual,
+                                         HighsPostsolveStack::RowType rowType) {
   if (rowType == HighsPostsolveStack::RowType::kEq)
     return dual < 0 ? HighsBasisStatus::kUpper : HighsBasisStatus::kLower;
   else if (rowType == HighsPostsolveStack::RowType::kGeq)
@@ -130,8 +130,8 @@ void HighsPostsolveStack::FreeColSubstitution::undo(
     basis.row_status[row] = computeRowStatus(solution.row_dual[row], rowType);
 }
 
-HighsBasisStatus computeStatus(double dual, HighsBasisStatus& status,
-                               double dual_feasibility_tolerance) {
+static HighsBasisStatus computeStatus(double dual, HighsBasisStatus& status,
+                                      double dual_feasibility_tolerance) {
   if (dual > dual_feasibility_tolerance)
     status = HighsBasisStatus::kLower;
   else if (dual < -dual_feasibility_tolerance)
@@ -140,7 +140,8 @@ HighsBasisStatus computeStatus(double dual, HighsBasisStatus& status,
   return status;
 }
 
-HighsBasisStatus computeStatus(double dual, double dual_feasibility_tolerance) {
+static HighsBasisStatus computeStatus(double dual,
+                                      double dual_feasibility_tolerance) {
   if (dual > dual_feasibility_tolerance)
     return HighsBasisStatus::kLower;
   else if (dual < -dual_feasibility_tolerance)


### PR DESCRIPTION
`#ifndef CUPDLP_CPU & USE_KERNELS` generates a compiler warning that cannot be suppressed. And it is indeed difficult to see for the compiler what could be meant by `CUPDLP_CPU & USE_KERNELS` not being defined.

Also make some functions that are used locally only static to get rid of missing prototype warnings in C++ code.