### PR TITLE
fix that optionChangeAction() was not called when reading options file

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -124,7 +124,7 @@ HighsStatus Highs::readOptions(const std::string& filename) {
     default:
       break;
   }
-  return HighsStatus::kOk;
+  return optionChangeAction();
 }
 
 HighsStatus Highs::passOptions(const HighsOptions& options) {


### PR DESCRIPTION
When reading an options file, the setOptionValue() functions are bypassed, so this call was missing, which resulted in the new user-scalings not being applied.

Btw, is it intentional, that if one sets `user_bound_scale`, then the solution returned is not scaled back, but given for the scaled problem? I suppose the same happens with `user_cost_scale` and dual solution.