### PR TITLE
Feature: Add a simple nix setup to build the highs binary

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,7 @@ bazel*
 build_webdemo
 
 CMakeSettings.json
+
+# Nix
+.direnv/
+result

--- a/README.md
+++ b/README.md
@@ -83,6 +83,23 @@ _These binaries are provided by the Julia community and are not officially suppo
 
 See https://ergo-code.github.io/HiGHS/stable/installation/#Precompiled-Binaries.
 
+### Build with Nix
+
+There is a nix flake that provides the `highs` binary:
+
+```shell
+nix run .
+```
+
+You can even run [without installing
+anything](https://determinate.systems/posts/nix-run/), supposing you have
+installed [nix](https://nixos.org/download.html):
+
+```shell
+nix run github:ERGO-Code/HiGHS
+```
+
+_The nix build files are provided by the community and are not officially supported by the HiGHS development team._
 
 ## Interfaces
 
@@ -98,14 +115,14 @@ The python package `highspy` is a thin wrapper around HiGHS and is available on 
 $ pip install highspy
 ```
 
-Alternatively, `highspy` can be built from source.  Download the HiGHS source code and run 
+Alternatively, `highspy` can be built from source.  Download the HiGHS source code and run
 
 ```sh
-pip install . 
+pip install .
 ```
-from the root directory. 
+from the root directory.
 
-The HiGHS C++ library no longer needs to be separately installed. The python package `highspy` depends on the `numpy` package and `numpy` will be installed as well, if it is not already present. 
+The HiGHS C++ library no longer needs to be separately installed. The python package `highspy` depends on the `numpy` package and `numpy` will be installed as well, if it is not already present.
 
 The installation can be tested using the small example [call_highs_from_python_highspy.py](https://github.com/ERGO-Code/HiGHS/blob/master/examples/call_highs_from_python_highspy.py).
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709961763,
+        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixos-unstable";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+  outputs = { nixpkgs, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      highs = (with pkgs; stdenv.mkDerivation {
+          pname = "highs";
+          version = "1.6.0";
+          src = pkgs.lib.cleanSource ./.;
+          nativeBuildInputs = [
+            clang
+            cmake
+          ];
+        }
+      );
+    in rec {
+      defaultApp = flake-utils.lib.mkApp {
+        drv = defaultPackage;
+      };
+      defaultPackage = highs;
+      devShell = pkgs.mkShell {
+        buildInputs = [
+          highs
+        ];
+      };
+    }
+  );
+}
+


### PR DESCRIPTION
I notice HiGHS [is not on nixpkgs](https://search.nixos.org/packages?channel=23.11&from=0&size=50&sort=relevance&type=packages&query=HiGHS), so until such time I thought I'd add a `flake.nix` to build the binary.

It also means it's much easier for nix users to just try it out.

Note that I don't do anything with the Python side here; it could be an interesting addition later to _also_ build the python package; but I'll leave that for another piece of work.

Hope this is of use!