### PR TITLE
Use HighsInt in call_highs_from_c example

### DIFF
--- a/examples/call_highs_from_c.c
+++ b/examples/call_highs_from_c.c
@@ -63,11 +63,12 @@ void minimal_api() {
   // bound on x_1, it serves to illustrate a non-trivial packed
   // column-wise matrix.
   //
-  const int num_col = 2;
-  const int num_row = 3;
-  const int num_nz = 5;
+  // The HighsInt type is either int or long, depending on the HiGHS build
+  const HighsInt num_col = 2;
+  const HighsInt num_row = 3;
+  const HighsInt num_nz = 5;
   // Define the optimization sense and objective offset
-  int sense = kHighsObjSenseMinimize;
+  HighsInt sense = kHighsObjSenseMinimize;
   const double offset = 3;
 
   // Define the column costs, lower bounds and upper bounds
@@ -78,9 +79,9 @@ void minimal_api() {
   const double row_lower[3] = {-1.0e30, 5.0, 6.0};
   const double row_upper[3] = {7.0, 15.0, 1.0e30};
   // Define the constraint matrix column-wise
-  const int a_format = kHighsMatrixFormatColwise;
-  const int a_start[2] = {0, 2};
-  const int a_index[5] = {1, 2, 0, 1, 2};
+  const HighsInt a_format = kHighsMatrixFormatColwise;
+  const HighsInt a_start[2] = {0, 2};
+  const HighsInt a_index[5] = {1, 2, 0, 1, 2};
   const double a_value[5] = {1.0, 3.0, 1.0, 2.0, 2.0};
 
   double objective_value;
@@ -89,11 +90,11 @@ void minimal_api() {
   double* row_value = (double*)malloc(sizeof(double) * num_row);
   double* row_dual = (double*)malloc(sizeof(double) * num_row);
 
-  int* col_basis_status = (int*)malloc(sizeof(int) * num_col);
-  int* row_basis_status = (int*)malloc(sizeof(int) * num_row);
+  HighsInt* col_basis_status = (HighsInt*)malloc(sizeof(HighsInt) * num_col);
+  HighsInt* row_basis_status = (HighsInt*)malloc(sizeof(HighsInt) * num_row);
 
-  int model_status;
-  int run_status;
+  HighsInt model_status;
+  HighsInt run_status;
 
   run_status = Highs_lpCall(num_col, num_row, num_nz, a_format,
 			   sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
@@ -105,17 +106,17 @@ void minimal_api() {
   assert(run_status == kHighsStatusOk);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("\nRun status = %d; Model status = %d\n", run_status, model_status);
+  printf("\nRun status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   objective_value = offset;
   // Report the column primal and dual values, and basis status
-  for (int i = 0; i < num_col; i++) {
-    printf("Col%d = %lf; dual = %lf; status = %d\n", i, col_value[i], col_dual[i], col_basis_status[i]);
+  for (HighsInt i = 0; i < num_col; i++) {
+    printf("Col%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "\n", i, col_value[i], col_dual[i], col_basis_status[i]);
     objective_value += col_value[i]*col_cost[i];
   }
   // Report the row primal and dual values, and basis status
-  for (int i = 0; i < num_row; i++) {
-    printf("Row%d = %lf; dual = %lf; status = %d\n", i, row_value[i], row_dual[i], row_basis_status[i]);
+  for (HighsInt i = 0; i < num_row; i++) {
+    printf("Row%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "\n", i, row_value[i], row_dual[i], row_basis_status[i]);
   }
   printf("Optimal objective value = %g\n", objective_value);
 
@@ -131,24 +132,24 @@ void minimal_api() {
   assert(run_status == kHighsStatusOk);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("\nRun status = %d; Model status = %d\n", run_status, model_status);
+  printf("\nRun status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Compute the objective value
   objective_value = offset;
-  for (int i = 0; i < num_col; i++) objective_value += col_value[i]*col_cost[i];
+  for (HighsInt i = 0; i < num_col; i++) objective_value += col_value[i]*col_cost[i];
   // Report the column primal and dual values, and basis status
-  for (int i = 0; i < num_col; i++) {
-    printf("Col%d = %lf; dual = %lf; status = %d\n", i, col_value[i], col_dual[i], col_basis_status[i]);
+  for (HighsInt i = 0; i < num_col; i++) {
+    printf("Col%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "\n", i, col_value[i], col_dual[i], col_basis_status[i]);
   }
   // Report the row primal and dual values, and basis status
-  for (int i = 0; i < num_row; i++) {
-    printf("Row%d = %lf; dual = %lf; status = %d\n", i, row_value[i], row_dual[i], row_basis_status[i]);
+  for (HighsInt i = 0; i < num_row; i++) {
+    printf("Row%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "\n", i, row_value[i], row_dual[i], row_basis_status[i]);
   }
   printf("Optimal objective value = %g\n", objective_value);
   // 
   // Indicate that the optimal solution for both columns must be
   // integer valued and solve the model as a MIP
-  int integrality[2] = {1, 1};
+  HighsInt integrality[2] = {1, 1};
   run_status = Highs_mipCall(num_col, num_row, num_nz, a_format,
 			     sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
 			     a_start, a_index, a_value,
@@ -159,18 +160,18 @@ void minimal_api() {
   assert(run_status == kHighsStatusOk);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("\nRun status = %d; Model status = %d\n", run_status, model_status);
+  printf("\nRun status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Compute the objective value
   objective_value = offset;
-  for (int i = 0; i < num_col; i++) objective_value += col_value[i]*col_cost[i];
+  for (HighsInt i = 0; i < num_col; i++) objective_value += col_value[i]*col_cost[i];
   // Report the column primal values
-  for (int i = 0; i < num_col; i++) {
-    printf("Col%d = %lf\n", i, col_value[i]);
+  for (HighsInt i = 0; i < num_col; i++) {
+    printf("Col%" HIGHSINT_FORMAT " = %lf\n", i, col_value[i]);
   }
   // Report the row primal values
-  for (int i = 0; i < num_row; i++) {
-    printf("Row%d = %lf\n", i, row_value[i]);
+  for (HighsInt i = 0; i < num_row; i++) {
+    printf("Row%" HIGHSINT_FORMAT " = %lf\n", i, row_value[i]);
   }
   printf("Optimal objective value = %g\n", objective_value);
 
@@ -189,11 +190,11 @@ void minimal_api_qp() {
   //
   // subject to x_1 + x_2 + x_3 >= 1; x>=0
   
-  const int num_col = 3;
-  const int num_row = 1;
-  const int num_nz = 3;
+  const HighsInt num_col = 3;
+  const HighsInt num_row = 1;
+  const HighsInt num_nz = 3;
   // Define the optimization sense and objective offset
-  int sense = kHighsObjSenseMinimize;
+  HighsInt sense = kHighsObjSenseMinimize;
   const double offset = 0;
 
   // Define the column costs, lower bounds and upper bounds
@@ -204,15 +205,15 @@ void minimal_api_qp() {
   const double row_lower[1] = {1};
   const double row_upper[1] = {1.0e30};
   // Define the constraint matrix row-wise
-  const int a_format = kHighsMatrixFormatRowwise;
-  const int a_start[2] = {0, 3};
-  const int a_index[3] = {0, 1, 2};
+  const HighsInt a_format = kHighsMatrixFormatRowwise;
+  const HighsInt a_start[2] = {0, 3};
+  const HighsInt a_index[3] = {0, 1, 2};
   const double a_value[3] = {1.0, 1.0, 1.0};
 
-  const int q_format = kHighsHessianFormatTriangular;
-  const int q_num_nz = 4;
-  const int q_start[3] = {0, 2, 3};
-  const int q_index[4] = {0, 2, 1, 2};
+  const HighsInt q_format = kHighsHessianFormatTriangular;
+  const HighsInt q_num_nz = 4;
+  const HighsInt q_start[3] = {0, 2, 3};
+  const HighsInt q_index[4] = {0, 2, 1, 2};
   const double q_value[4] = {2.0, -1.0, 0.2, 2.0};
 
   double objective_value;
@@ -221,11 +222,11 @@ void minimal_api_qp() {
   double* row_value = (double*)malloc(sizeof(double) * num_row);
   double* row_dual = (double*)malloc(sizeof(double) * num_row);
 
-  int* col_basis_status = (int*)malloc(sizeof(int) * num_col);
-  int* row_basis_status = (int*)malloc(sizeof(int) * num_row);
+  HighsInt* col_basis_status = (HighsInt*)malloc(sizeof(HighsInt) * num_col);
+  HighsInt* row_basis_status = (HighsInt*)malloc(sizeof(HighsInt) * num_row);
 
-  int model_status;
-  int run_status;
+  HighsInt model_status;
+  HighsInt run_status;
 
   run_status = Highs_qpCall(num_col, num_row, num_nz, q_num_nz, a_format, q_format, 
 			   sense, offset, col_cost, col_lower, col_upper, row_lower, row_upper,
@@ -238,34 +239,34 @@ void minimal_api_qp() {
   assert(run_status == kHighsStatusOk);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("\nRun status = %d; Model status = %d\n", run_status, model_status);
+  printf("\nRun status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Compute the objective value
   objective_value = offset;
-  for (int i = 0; i < num_col; i++) objective_value += col_value[i]*col_cost[i];
-  for (int i = 0; i < num_col; i++) {
-    int from_el = q_start[i];
-    int to_el;
+  for (HighsInt i = 0; i < num_col; i++) objective_value += col_value[i]*col_cost[i];
+  for (HighsInt i = 0; i < num_col; i++) {
+    HighsInt from_el = q_start[i];
+    HighsInt to_el;
     if (i+1<num_col) {
       to_el = q_start[i+1];
     } else {
       to_el = q_num_nz;
     }
-    for (int el = from_el; el < to_el; el++) {
-      int j = q_index[el];
+    for (HighsInt el = from_el; el < to_el; el++) {
+      HighsInt j = q_index[el];
       objective_value += 0.5*col_value[i]*col_value[j]*q_value[el];
     }
   }
 
   // Report the column primal and dual values, and basis status
-  for (int i = 0; i < num_col; i++) {
+  for (HighsInt i = 0; i < num_col; i++) {
     //    printf("Col%d = %lf; dual = %lf; status = %d\n", i, col_value[i], col_dual[i], col_basis_status[i]);
-    printf("Col%d = %lf; dual = %lf\n", i, col_value[i], col_dual[i]);
+    printf("Col%" HIGHSINT_FORMAT " = %lf; dual = %lf\n", i, col_value[i], col_dual[i]);
   }
   // Report the row primal and dual values, and basis status
-  for (int i = 0; i < num_row; i++) {
+  for (HighsInt i = 0; i < num_row; i++) {
     //    printf("Row%d = %lf; dual = %lf; status = %d\n", i, row_value[i], row_dual[i], row_basis_status[i]);
-    printf("Row%d = %lf; dual = %lf\n", i, row_value[i], row_dual[i]);
+    printf("Row%" HIGHSINT_FORMAT " = %lf; dual = %lf\n", i, row_value[i], row_dual[i]);
   }
   printf("Optimal objective value = %g\n", objective_value);
 
@@ -303,9 +304,9 @@ void minimal_api_mps() {
 
 void full_api() {
   printf("\nHiGHS version %s\n", Highs_version());
-  printf("      Major version %d\n", Highs_versionMajor());
-  printf("      Minor version %d\n", Highs_versionMinor());
-  printf("      Patch version %d\n", Highs_versionPatch());
+  printf("      Major version %" HIGHSINT_FORMAT "\n", Highs_versionMajor());
+  printf("      Minor version %" HIGHSINT_FORMAT "\n", Highs_versionMinor());
+  printf("      Patch version %" HIGHSINT_FORMAT "\n", Highs_versionPatch());
   printf("      Githash %s\n", Highs_githash());
   printf("      compilation date %s\n", Highs_compilationDate());
   // This example does exactly the same as the minimal example above,
@@ -319,11 +320,11 @@ void full_api() {
   //
   // It then solves it as a maximization, then as a MIP.
   //
-  const int num_col = 2;
-  const int num_row = 3;
-  const int num_nz = 5;
+  const HighsInt num_col = 2;
+  const HighsInt num_row = 3;
+  const HighsInt num_nz = 5;
   // Define the optimization sense and objective offset
-  int sense = kHighsObjSenseMinimize;
+  HighsInt sense = kHighsObjSenseMinimize;
   const double offset = 3;
 
   // Define the column costs, lower bounds and upper bounds
@@ -334,19 +335,19 @@ void full_api() {
   const double row_lower[3] = {-1.0e30, 5.0, 6.0};
   const double row_upper[3] = {7.0, 15.0, 1.0e30};
   // Define the constraint matrix column-wise
-  const int a_format = kHighsMatrixFormatColwise;
-  const int a_start[2] = {0, 2};
-  const int a_index[5] = {1, 2, 0, 1, 2};
+  const HighsInt a_format = kHighsMatrixFormatColwise;
+  const HighsInt a_start[2] = {0, 2};
+  const HighsInt a_index[5] = {1, 2, 0, 1, 2};
   const double a_value[5] = {1.0, 3.0, 1.0, 2.0, 2.0};
 
-  int run_status;
-  int model_status;
+  HighsInt run_status;
+  HighsInt model_status;
   double objective_function_value;
-  int simplex_iteration_count;
+  HighsInt simplex_iteration_count;
   int64_t mip_node_count;
-  int primal_solution_status;
-  int dual_solution_status;
-  int basis_validity;
+  HighsInt primal_solution_status;
+  HighsInt dual_solution_status;
+  HighsInt basis_validity;
 
   // Create a Highs instance
   void* highs = Highs_create();
@@ -366,7 +367,7 @@ void full_api() {
   model_status = Highs_getModelStatus(highs);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("Run status = %d; Model status = %d\n", run_status, model_status);
+  printf("Run status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Get scalar information about the solution
   Highs_getDoubleInfoValue(highs, "objective_function_value", &objective_function_value);
@@ -386,8 +387,8 @@ void full_api() {
   double* row_value = (double*)malloc(sizeof(double) * num_row);
   double* row_dual = (double*)malloc(sizeof(double) * num_row);
 
-  int* col_basis_status = (int*)malloc(sizeof(int) * num_col);
-  int* row_basis_status = (int*)malloc(sizeof(int) * num_row);
+  HighsInt* col_basis_status = (HighsInt*)malloc(sizeof(HighsInt) * num_col);
+  HighsInt* row_basis_status = (HighsInt*)malloc(sizeof(HighsInt) * num_row);
 
   // Get the primal and dual solution
   Highs_getSolution(highs, col_value, col_dual, row_value, row_dual);
@@ -395,20 +396,20 @@ void full_api() {
   Highs_getBasis(highs, col_basis_status, row_basis_status);
 
   // Report the column primal and dual values, and basis status
-  for (int i = 0; i < num_col; i++) {
-    printf("Col%d = %lf; dual = %lf; status = %d; \n", i, col_value[i], col_dual[i], col_basis_status[i]);
+  for (HighsInt i = 0; i < num_col; i++) {
+    printf("Col%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "; \n", i, col_value[i], col_dual[i], col_basis_status[i]);
   }
   // Report the row primal and dual values, and basis status
-  for (int i = 0; i < num_row; i++) {
-    printf("Row%d = %lf; dual = %lf; status = %d; \n", i, row_value[i], row_dual[i], row_basis_status[i]);
+  for (HighsInt i = 0; i < num_row; i++) {
+    printf("Row%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "; \n", i, row_value[i], row_dual[i], row_basis_status[i]);
   }
-  printf("Objective value = %g; Iteration count = %d\n", objective_function_value, simplex_iteration_count);
+  printf("Objective value = %g; Iteration count = %" HIGHSINT_FORMAT "\n", objective_function_value, simplex_iteration_count);
 
   // Illustrate extraction of model data
-  int check_sense;
+  HighsInt check_sense;
   run_status = Highs_getObjectiveSense(highs, &check_sense);
   assert(run_status==0);
-  printf("LP problem has objective sense = %d\n", check_sense);
+  printf("LP problem has objective sense = %" HIGHSINT_FORMAT "\n", check_sense);
   assert(check_sense == sense);
  
   // Illustrate change of model data
@@ -422,7 +423,7 @@ void full_api() {
   model_status = Highs_getModelStatus(highs);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("Run status = %d; Model status = %d\n", run_status, model_status);
+  printf("Run status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Get scalar information about the solution
   Highs_getDoubleInfoValue(highs, "objective_function_value", &objective_function_value);
@@ -444,33 +445,33 @@ void full_api() {
   Highs_getBasis(highs, col_basis_status, row_basis_status);
 
   // Report the column primal and dual values, and basis status
-  for (int i = 0; i < num_col; i++) {
-    printf("Col%d = %lf; dual = %lf; status = %d; \n", i, col_value[i], col_dual[i], col_basis_status[i]);
+  for (HighsInt i = 0; i < num_col; i++) {
+    printf("Col%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "; \n", i, col_value[i], col_dual[i], col_basis_status[i]);
   }
   // Report the row primal and dual values, and basis status
-  for (int i = 0; i < num_row; i++) {
-    printf("Row%d = %lf; dual = %lf; status = %d; \n", i, row_value[i], row_dual[i], row_basis_status[i]);
+  for (HighsInt i = 0; i < num_row; i++) {
+    printf("Row%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "; \n", i, row_value[i], row_dual[i], row_basis_status[i]);
   }
-  printf("Objective value = %g; Iteration count = %d\n", objective_function_value, simplex_iteration_count);
+  printf("Objective value = %g; Iteration count = %" HIGHSINT_FORMAT "\n", objective_function_value, simplex_iteration_count);
   
   // Now illustrate how LPs can be built within HiGHS by constructing
   // the same maximization problem. First clear the incumbent model
   Highs_clearModel(highs);
 
   // Demonstrate that the incumbent model is empty
-  const int check_num_col = Highs_getNumCol(highs);
-  const int check_num_row = Highs_getNumRow(highs);
-  const int check_num_nz = Highs_getNumNz(highs);
+  const HighsInt check_num_col = Highs_getNumCol(highs);
+  const HighsInt check_num_row = Highs_getNumRow(highs);
+  const HighsInt check_num_nz = Highs_getNumNz(highs);
   assert(check_num_col == 0);
   assert(check_num_row == 0);
   assert(check_num_nz == 0);
-  printf("\nCleared model has %d columns, %d rows and %d nonzeros\n",
+  printf("\nCleared model has %" HIGHSINT_FORMAT " columns, %" HIGHSINT_FORMAT " rows and %" HIGHSINT_FORMAT " nonzeros\n",
 	 check_num_col, check_num_row, check_num_nz);
 
   // Define the constraint matrix row-wise, as it is added to the LP
   // with the rows
-  const int ar_start[3] = {0, 1, 3};
-  const int ar_index[5] = {1, 0, 1, 0, 1};
+  const HighsInt ar_start[3] = {0, 1, 3};
+  const HighsInt ar_index[5] = {1, 0, 1, 0, 1};
   const double ar_value[5] = {1.0, 1.0, 2.0, 3.0, 2.0};
 
   // Add two columns to the empty LP
@@ -488,16 +489,16 @@ void full_api() {
   // Illustrate extraction of model data
   run_status = Highs_getObjectiveSense(highs, &check_sense);
   assert(run_status==0);
-  printf("LP problem has objective sense = %d\n", check_sense);
+  printf("LP problem has objective sense = %" HIGHSINT_FORMAT "\n", check_sense);
   assert(check_sense == kHighsObjSenseMaximize);
 
   // Illustrate a change of option
 
   // Check what type of option value you should provide
-  int option_type;
+  HighsInt option_type;
   const char* option_string = "primal_feasibility_tolerance";
   run_status = Highs_getOptionType(highs, option_string, &option_type);
-  printf("Option %s is of type %d\n", option_string, option_type);
+  printf("Option %s is of type %" HIGHSINT_FORMAT "\n", option_string, option_type);
   assert(run_status == kHighsStatusOk);
   assert(option_type == 2);
 
@@ -520,13 +521,13 @@ void full_api() {
   model_status = Highs_getModelStatus(highs);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("\nRun status = %d; Model status = %d\n", run_status, model_status);
+  printf("\nRun status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Check what type of info values are
-  int info_type;
+  HighsInt info_type;
   const char* info_string = "objective_function_value";
   run_status = Highs_getInfoType(highs, info_string, &info_type);
-  printf("Info %s is of type %d\n", info_string, info_type);
+  printf("Info %s is of type %" HIGHSINT_FORMAT "\n", info_string, info_type);
   assert(run_status == kHighsStatusOk);
   assert(info_type == kHighsInfoTypeDouble);
 
@@ -547,19 +548,19 @@ void full_api() {
   Highs_getBasis(highs, col_basis_status, row_basis_status);
 
   // Report the column primal and dual values, and basis status
-  for (int i = 0; i < num_col; i++) {
-    printf("Col%d = %lf; dual = %lf; status = %d; \n", i, col_value[i], col_dual[i], col_basis_status[i]);
+  for (HighsInt i = 0; i < num_col; i++) {
+    printf("Col%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "; \n", i, col_value[i], col_dual[i], col_basis_status[i]);
   }
   // Report the row primal and dual values, and basis status
-  for (int i = 0; i < num_row; i++) {
-    printf("Row%d = %lf; dual = %lf; status = %d; \n", i, row_value[i], row_dual[i], row_basis_status[i]);
+  for (HighsInt i = 0; i < num_row; i++) {
+    printf("Row%" HIGHSINT_FORMAT " = %lf; dual = %lf; status = %" HIGHSINT_FORMAT "; \n", i, row_value[i], row_dual[i], row_basis_status[i]);
   }
-  printf("Objective value = %g; Iteration count = %d\n", objective_function_value, simplex_iteration_count);
+  printf("Objective value = %g; Iteration count = %" HIGHSINT_FORMAT "\n", objective_function_value, simplex_iteration_count);
   
   // 
   // Indicate that the optimal solution for both columns must be
   // integer valued and solve the model as a MIP
-  int integrality[2] = {1, 1};
+  HighsInt integrality[2] = {1, 1};
   Highs_changeColsIntegralityByRange(highs, 0, 1, integrality);
 
   // Solve the incumbent model quietly
@@ -572,7 +573,7 @@ void full_api() {
   model_status = Highs_getModelStatus(highs);
   assert(model_status == kHighsModelStatusOptimal);
 
-  printf("\nRun status = %d; Model status = %d\n", run_status, model_status);
+  printf("\nRun status = %" HIGHSINT_FORMAT "; Model status = %" HIGHSINT_FORMAT "\n", run_status, model_status);
 
   // Get scalar information about the solution
   Highs_getDoubleInfoValue(highs, "objective_function_value", &objective_function_value);
@@ -594,12 +595,12 @@ void full_api() {
   Highs_getSolution(highs, col_value, col_dual, row_value, row_dual);
 
   // Report the column primal values
-  for (int i = 0; i < num_col; i++)
-    printf("Col%d = %lf\n", i, col_value[i]);
+  for (HighsInt i = 0; i < num_col; i++)
+    printf("Col%" HIGHSINT_FORMAT " = %lf\n", i, col_value[i]);
   // Report the row primal values
-  for (int i = 0; i < num_row; i++)
-    printf("Row%d = %lf\n", i, row_value[i]);
-  printf("Objective value = %g; Iteration count = %d\n", objective_function_value, simplex_iteration_count);
+  for (HighsInt i = 0; i < num_row; i++)
+    printf("Row%" HIGHSINT_FORMAT " = %lf\n", i, row_value[i]);
+  printf("Objective value = %g; Iteration count = %" HIGHSINT_FORMAT "\n", objective_function_value, simplex_iteration_count);
 
   free(col_value);
   free(col_dual);


### PR DESCRIPTION
If HiGHS is configured with HIGHSINT64, then the `call_highs_from_c` example fails to build, with errors such as these:
```
/builddir/build/BUILD/HiGHS-1.7.0/examples/call_highs_from_c.c: In function ‘minimal_api’:
/builddir/build/BUILD/HiGHS-1.7.0/examples/call_highs_from_c.c:100:28: error: passing argument 12 of ‘Highs_lpCall’ from incompatible pointer type [-Wincompatible-pointer-types]
  100 |                            a_start, a_index, a_value,
      |                            ^~~~~~~
      |                            |
      |                            const int *
In file included from /builddir/build/BUILD/HiGHS-1.7.0/examples/call_highs_from_c.c:1:
/builddir/build/BUILD/HiGHS-1.7.0/src/interfaces/highs_c_api.h:165:64: note: expected ‘const HighsInt *’ {aka ‘const long int *’} but argument is of type ‘const int *’
  165 |                       const double* row_upper, const HighsInt* a_start,
      |                                                ~~~~~~~~~~~~~~~~^~~~~~~
/builddir/build/BUILD/HiGHS-1.7.0/examples/call_highs_from_c.c:100:37: error: passing argument 13 of ‘Highs_lpCall’ from incompatible pointer type [-Wincompatible-pointer-types]
  100 |                            a_start, a_index, a_value,
      |                                     ^~~~~~~
      |                                     |
      |                                     const int *
/builddir/build/BUILD/HiGHS-1.7.0/src/interfaces/highs_c_api.h:166:39: note: expected ‘const HighsInt *’ {aka ‘const long int *’} but argument is of type ‘const int *’
  166 |                       const HighsInt* a_index, const double* a_value,
      |                       ~~~~~~~~~~~~~~~~^~~~~~~
```

This commit uses HighsInt where appropriate to make the example build.