### PR TITLE
Fix 1710

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2728,7 +2728,13 @@ HPresolve::Result HPresolve::singletonRow(HighsPostsolveStack& postsolve_stack,
   // check whether the bounds are equal in tolerances
   if (ub <= lb + primal_feastol) {
     // bounds could be infeasible or equal in tolerances, first check infeasible
-    if (ub < lb - primal_feastol) return Result::kPrimalInfeasible;
+    //
+    // #1710
+    //    if (ub < lb - primal_feastol) return Result::kPrimalInfeasible;
+    if (ub < lb - primal_feastol) {
+      printf("HPresolve::singletonRow: Identified infeasibility\n");
+      return Result::kPrimalInfeasible;
+    }
 
     // bounds are equal in tolerances, if they have a slight infeasibility below
     // those tolerances or they have a slight numerical distance which changes

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2728,13 +2728,7 @@ HPresolve::Result HPresolve::singletonRow(HighsPostsolveStack& postsolve_stack,
   // check whether the bounds are equal in tolerances
   if (ub <= lb + primal_feastol) {
     // bounds could be infeasible or equal in tolerances, first check infeasible
-    //
-    // #1710
-    //    if (ub < lb - primal_feastol) return Result::kPrimalInfeasible;
-    if (ub < lb - primal_feastol) {
-      printf("HPresolve::singletonRow: Identified infeasibility\n");
-      return Result::kPrimalInfeasible;
-    }
+    if (ub < lb - primal_feastol) return Result::kPrimalInfeasible;
 
     // bounds are equal in tolerances, if they have a slight infeasibility below
     // those tolerances or they have a slight numerical distance which changes
@@ -4202,7 +4196,12 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
           highsLogDev(options->log_options, HighsLogType::kInfo,
                       "Sparsify removed %.1f%% of nonzeros\n", nzReduction);
 
-          fastPresolveLoop(postsolve_stack);
+          // #1710 exposes that this should not be
+          //
+          // fastPresolveLoop(postsolve_stack);
+          //
+          // but
+          HPRESOLVE_CHECKED_CALL(fastPresolveLoop(postsolve_stack));
         }
         trySparsify = false;
       }


### PR DESCRIPTION
Infeasibility detected when removing singleton row deep below `HPresolve::fastPresolveLoop` in `if (trySparsify)` is not being detected. Needs `HPRESOLVE_CHECKED_CALL(fastPresolveLoop(postsolve_stack))` - like all the other calls to `HPresolve::fastPresolveLoop` 

This will close #1710, but not #942 