### PR TITLE
Initialize substitution opportunities

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -5524,12 +5524,7 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
         } else {
           // for MIP we do not need dual postsolve so the reduction is valid if
           // the bound is weakly redundant
-          return colScale > 0 ? model->col_upper_[col] == kHighsInf ||
-                                    implColUpper[col] <=
-                                        model->col_upper_[col] + primal_feastol
-                              : model->col_lower_[col] == -kHighsInf ||
-                                    implColLower[col] >=
-                                        model->col_lower_[col] - primal_feastol;
+          return colScale > 0 ? isUpperImplied(col) : isLowerImplied(col);
         }
       };
 
@@ -5543,12 +5538,7 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
                                     implColUpper[col] <
                                         model->col_upper_[col] - primal_feastol;
         } else {
-          return colScale > 0 ? model->col_lower_[col] == -kHighsInf ||
-                                    implColLower[col] >=
-                                        model->col_lower_[col] - primal_feastol
-                              : model->col_upper_[col] == kHighsInf ||
-                                    implColUpper[col] <=
-                                        model->col_upper_[col] + primal_feastol;
+          return colScale > 0 ? isLowerImplied(col) : isUpperImplied(col);
         }
       };
 
@@ -5559,9 +5549,7 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
                  implColUpper[duplicateCol] <
                      model->col_upper_[duplicateCol] - primal_feastol;
         } else {
-          return model->col_upper_[duplicateCol] == kHighsInf ||
-                 implColUpper[duplicateCol] <=
-                     model->col_upper_[duplicateCol] + primal_feastol;
+          return isUpperImplied(duplicateCol);
         }
       };
 
@@ -5572,9 +5560,7 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
                  implColLower[duplicateCol] >
                      model->col_lower_[duplicateCol] + primal_feastol;
         } else {
-          return model->col_lower_[duplicateCol] == -kHighsInf ||
-                 implColLower[duplicateCol] >=
-                     model->col_lower_[duplicateCol] - primal_feastol;
+          return isLowerImplied(duplicateCol);
         }
       };
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -187,6 +187,8 @@ class HPresolve {
   bool checkFillin(HighsHashTable<HighsInt, HighsInt>& fillinCache,
                    HighsInt row, HighsInt col);
 
+  void reinsertEquation(HighsInt row);
+
 #ifndef NDEBUG
   void debugPrintRow(HighsPostsolveStack& postsolve_stack, HighsInt row);
 #endif


### PR DESCRIPTION
Presolve only updates `substitutionOpportunities` after a new implied bound has been found.

If no implied bounds are identified, `substitutionOpportunities` remain empty even though the model passed to presolve may contain equality constraints with free variables.

The proposed change is to initialize `substitutionOpportunities` before any reductions are performed.