### PR TITLE
Updates to the Meson build to fix portability issues and warnings 

### DIFF
--- a/check/meson.build
+++ b/check/meson.build
@@ -63,7 +63,7 @@ foreach test : test_array
                      test.get(1),
                      highs_conf_file],
           dependencies : _deps,
-          link_with : _linkto ,
+          link_with : highslib,
           cpp_args : _args,
           include_directories: _incdirs,
                  ),
@@ -75,6 +75,6 @@ if get_option('with_c')
   test('test_capi',
       executable('capi_unit_tests', 'TestCAPI.c',
     include_directories: _incdirs,
-    link_with : _linkto ,
+    link_with : highslib,
   ))
 endif

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('highs', 'cpp',
+project('highs', 'cpp', 'c',
   version : '1.6.0',
   meson_version: '>= 1.1.0',
   default_options : ['warning_level=1',
@@ -13,7 +13,6 @@ _deps = [] # Dependencies
 _linkto = [] # All the sub-libraries
 _incdirs = [] # All the includes
 
-add_languages('c', required: true)
 cc = meson.get_compiler('c')
 cppc = meson.get_compiler('cpp')
 
@@ -72,9 +71,7 @@ if is_mingw
 endif
 
 # --------------------- Dependencies
-# Required
-threads_dep = dependency('threads',
-                        required: false)
+threads_dep = dependency('threads', required: false)
 _deps += threads_dep
 
 # Determine whether it is necessary to link libatomic. This could be the case

--- a/meson.build
+++ b/meson.build
@@ -21,13 +21,16 @@ is_windows = host_system == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
 
 # Conditional arguments
-if host_system == 'linux'
-  _args += '-Wno-return-type'
-  _args += '-Wno-switch'
-  _args += '-Wno-unused-variable'
-  _args += '-Wno-unused-but-set-variable'
-  _args += '-Wno-unused-const-variable'
-endif
+_args += cppc.get_supported_arguments([
+  '-Wno-return-type',
+  '-Wno-switch',
+  '-Wno-comment',
+  '-Wno-unused-variable',
+  '-Wno-unused-but-set-variable',
+  '-Wno-unused-const-variable',
+  '-Wno-unused-function',
+  '-Wno-unused-label',
+])
 
 if cppc.get_id() == 'msvc'
   add_project_arguments(
@@ -58,10 +61,10 @@ endif
 cpu_family = host_machine.cpu_family()
 
 if cpu_family in ['x86_64', 'i686'] and not is_windows
-    add_project_arguments('-mpopcnt', language: 'cpp')
+    add_project_arguments(cppc.get_supported_arguments('-mpopcnt'), language: 'cpp')
 endif
 if cpu_family in ['ppc64', 'powerpc64'] and not meson.is_cross_build()
-    add_project_arguments('-mpopcntd', language: 'cpp')
+    add_project_arguments(cppc.get_supported_arguments('-mpopcntd'), language: 'cpp')
 endif
 
 if is_mingw

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,6 @@ project('highs', 'cpp', 'c',
 # Add C++ compiler options
 _args = [] # Extra arguments
 _deps = [] # Dependencies
-_linkto = [] # All the sub-libraries
 _incdirs = [] # All the includes
 
 cc = meson.get_compiler('c')

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('highs', 'cpp', 'c',
-  version : '1.6.0',
+  version : '1.7.0',
   meson_version: '>= 1.1.0',
   default_options : ['warning_level=1',
                      'cpp_std=c++17',

--- a/src/meson.build
+++ b/src/meson.build
@@ -303,12 +303,20 @@ highslib_srcs = [
 ]
 
 
+symbol_visibility = 'default'
+if get_option('default_library') == 'static'
+  # Ensure that if we link a static library into a shared library,
+  # private symbols don't get re-exported.
+  symbol_visibility = 'inlineshidden'
+endif
+
 highslib = library('highs',
                    highslib_srcs,
                    dependencies: _deps,
                    cpp_args: _args,
                    c_args: _args,
                    include_directories: _incdirs,
+                   gnu_symbol_visibility: symbol_visibility,
                    pic: true,
                    install: true)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -308,7 +308,6 @@ highslib = library('highs',
                    dependencies: _deps,
                    cpp_args: _args,
                    c_args: _args,
-                   link_with: _linkto,
                    include_directories: _incdirs,
                    pic: true,
                    install: true)
@@ -325,7 +324,7 @@ if get_option('with_fortran')
                         _fsrcs,
                         dependencies: _deps,
                         cpp_args: _args,
-                        link_with: [ _linkto, highslib ],
+                        link_with: highslib,
                         include_directories: _incdirs,
                         pic: true,
                         install: true)
@@ -341,7 +340,7 @@ if get_option('with_csharp')
                         _cs_srcs,
                         dependencies: _deps,
                         cpp_args: _args,
-                        link_with: [ _linkto, highslib ],
+                        link_with: highslib,
                         include_directories: _incdirs,
                         pic: true,
                         install: true)
@@ -361,16 +360,13 @@ if get_option('with_c')
                         _c_src,
                         dependencies: _deps,
                         cpp_args: _args,
-                        link_with: [ _linkto, highslib ],
+                        link_with: highslib,
                         include_directories: _incdirs,
                         pic: true,
                         install: true)
 endif
 
-
-_linkto += highslib
-
-highs_dep = declare_dependency(link_with: _linkto,
+highs_dep = declare_dependency(link_with: highslib,
                                dependencies: _deps,
                                include_directories: _incdirs,
                                )

--- a/src/meson.build
+++ b/src/meson.build
@@ -380,9 +380,11 @@ highs_dep = declare_dependency(link_with: highslib,
                                )
 
 if get_option('with_pybind11')
-  py_mod = import('python')
-  py = py_mod.find_installation(pure: false)
+  py = import('python').find_installation(pure: false)
+
   pyb11_dep = [
+    # py_dep is auto-added for Python >= 3.9, so it can be dropped here when
+    # that is the minimum supported Python version
     py.dependency(),
     dependency('pybind11')
   ]

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,9 +36,12 @@ build_date = datetime.datetime.utcfromtimestamp(
 build_date_str = build_date.strftime('%Y-%m-%d')
 print(build_date_str)
     '''
+    # Note: this is not guaranteed to work on Windows. This should be removed
+    #       (as proposed in gh-1735), and otherwise moved into a .py script with
+    #       a `#!/usr/bin/env python3` shebang, and `python3 -c` dropped.
     today_cmd = run_command('python3', '-c',
                             python_getdate,
-                           check: false)
+                            check: false)
     today_str = today_cmd.stdout().strip()
 endif
 conf_data.set_quoted('HIGHS_COMPILATION_DATE',


### PR DESCRIPTION
Each commit has a commit message with more context. This reduces the build warnings to a small amount, only the ones that may need inspection or are perhaps better fixed rather than silenced (things like `-Wunused-variable` are safe to silence though).

The changes to compiler flag handling are necessary for portability. The symbol visibility one avoids re-exporting ~2,000 private symbols in the shared libraries that link against a static `libhighs.a`. It also reduced binary size, by ~300 kb on macOS in a release build.