### PR TITLE
Fix the O(N^2) bug of passColName and passRowName

### DIFF
--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -558,7 +558,7 @@ HighsStatus Highs::passColName(const HighsInt col, const std::string& name) {
   }
   this->model_.lp_.col_names_.resize(num_col);
   this->model_.lp_.col_names_[col] = name;
-  this->model_.lp_.col_hash_.clear();
+  this->model_.lp_.col_hash_.name2index[name] = col;
   return HighsStatus::kOk;
 }
 
@@ -578,7 +578,7 @@ HighsStatus Highs::passRowName(const HighsInt row, const std::string& name) {
   }
   this->model_.lp_.row_names_.resize(num_row);
   this->model_.lp_.row_names_[row] = name;
-  this->model_.lp_.row_hash_.clear();
+  this->model_.lp_.row_hash_.name2index[name] = row;
   return HighsStatus::kOk;
 }
 


### PR DESCRIPTION
This fixes a performance issue when `Highs_addCol` and `Highs_passColName` are called in sequence to add new variables.

After `Highs_addCol` is called, there is `n` columns and the `cols_hash_` also has `n` elements because of https://github.com/ERGO-Code/HiGHS/blob/13363c9f1252b015cf6527132eb9cf8f4b5bf020/src/lp_data/HighsInterface.cpp#L201 and https://github.com/ERGO-Code/HiGHS/blob/13363c9f1252b015cf6527132eb9cf8f4b5bf020/src/lp_data/HighsLp.cpp#L315

`cols_hash_` will be rebuilt if it is empty.

Then, if `Highs_passColName` is called to set the name of column `n`, `cols_hash_` is cleared.

Now when `Highs_addCol` and `Highs_passColName` are called in sequence to add `N` columns, `cols_hash_` has to be rebuilt for `N` times with length `1,2,...,N`, which makes the complexity $O(N^2)$.

In fact, when we call `Highs_passColName`, `cols_hash_` can update one element instead of clearing all contents.

The bug is discovered in https://github.com/coin-or/python-mip/issues/372 .