### PR TITLE
Fix the O(N^2) bug of passColName and passRowName

### DIFF
--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -117,6 +117,8 @@ struct HighsNameHash {
   std::unordered_map<std::string, int> name2index;
   void form(const std::vector<std::string>& name);
   bool hasDuplicate(const std::vector<std::string>& name);
+  void update(int index, const std::string& old_name,
+              const std::string& new_name);
   void clear();
 };
 

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -591,8 +591,9 @@ HighsStatus Highs::passColName(const HighsInt col, const std::string& name) {
     return HighsStatus::kError;
   }
   this->model_.lp_.col_names_.resize(num_col);
+  this->model_.lp_.col_hash_.update(col, this->model_.lp_.col_names_[col],
+                                    name);
   this->model_.lp_.col_names_[col] = name;
-  this->model_.lp_.col_hash_.clear();
   return HighsStatus::kOk;
 }
 
@@ -611,8 +612,9 @@ HighsStatus Highs::passRowName(const HighsInt row, const std::string& name) {
     return HighsStatus::kError;
   }
   this->model_.lp_.row_names_.resize(num_row);
+  this->model_.lp_.row_hash_.update(row, this->model_.lp_.row_names_[row],
+                                    name);
   this->model_.lp_.row_names_[row] = name;
-  this->model_.lp_.row_hash_.clear();
   return HighsStatus::kOk;
 }
 


### PR DESCRIPTION
Reland https://github.com/ERGO-Code/HiGHS/pull/1780

I also simplify some logic here. The result of `emplace` has contained the duplicate key-value pair if it detects duplication, so we can mark the value as duplicate directly instead of using the slow search-erase-insert combo.