### PR TITLE
OpenBSD - Update strict_fstream.hpp

### DIFF
--- a/extern/zstr/strict_fstream.hpp
+++ b/extern/zstr/strict_fstream.hpp
@@ -64,7 +64,7 @@ static std::string strerror()
     } else {
         return "Unknown error (" + std::to_string(err_num) + ")";
     }
-#elif ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__) || defined(__FreeBSD__)) && ! _GNU_SOURCE) || defined(__MUSL__)
+#elif ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)) && ! _GNU_SOURCE) || defined(__MUSL__)
 // XSI-compliant strerror_r()
     const int err_num = errno; // See above
     if (strerror_r(err_num, buff.data(), buff.size()) == 0) {


### PR DESCRIPTION
The OpenBSD definition of "strerror_r", similar to FreeBSD, returns an `int` rather than a `char *`. This commit includes `__OpenBSD__` in the list of defines to check for this function call.