### PR TITLE
Correctly Report Invalid Row Names

### DIFF
--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -564,7 +564,7 @@ HighsStatus writeModelAsMps(const HighsOptions& options,
   HighsStatus row_name_status =
       normaliseNames(options.log_options, "row", lp.num_row_, local_row_names,
                      max_row_name_length);
-  if (row_name_status == HighsStatus::kError) return col_name_status;
+  if (row_name_status == HighsStatus::kError) return row_name_status;
   warning_found = row_name_status == HighsStatus::kWarning || warning_found;
 
   HighsInt max_name_length = std::max(max_col_name_length, max_row_name_length);


### PR DESCRIPTION
Otherwise, HiGHS may silently not write an MPS file when it runs into invalid row names and still return kOK.

I ran into this with a model that has long names with spaces in it.
Presumably a silly typo or copy&paste error.

This is the minimal fix, but some log message indicating what went wrong may also be nice.
Maybe it would be even better to just include this in the `construct_names` case in `normaliseNames`. That way, the MPS would still be written with constructed names, a warning message would be printed and kWarning would be returned.
What do you think?
