### PR TITLE
Builds python wheels for linux/aarch64

### DIFF
--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU # Required for aarch64 builds
-        if: matrix.buildplat == [ubuntu-20.04, manylinux_aarch64] || matrix.buildplat == [ubuntu-20.04, musllinux_aarch64]
+        if: matrix.buildplat[1] == 'manylinux_aarch64' || matrix.buildplat[1] == 'musllinux_aarch64'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -43,11 +43,17 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Build wheels
+      - name: Build wheels (aarch64)
+        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_ARCHS_LINUX: ${{ contains(matrix.buildplat[1], 'aarch64') && 'aarch64' || '' }}
+          CIBW_ARCHS_LINUX: aarch64
+      - name: Build wheels (not aarch64)
+        if: ${{ !contains(matrix.buildplat[1], 'aarch64') }}
+        uses: pypa/cibuildwheel@v2.19
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -43,17 +43,11 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Build wheels (aarch64)
-        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
+      - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_ARCHS_LINUX: aarch64
-      - name: Build wheels (not aarch64)
-        if: ${{ !contains(matrix.buildplat[1], 'aarch64') }}
-        uses: pypa/cibuildwheel@v2.19
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_ARCHS_LINUX: ${{ contains(matrix.buildplat[1], 'aarch64') && 'aarch64' || '' }}
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -3,6 +3,7 @@ name: build-wheels-push
 # on: push
  
 on:
+ workflow_dispatch:
  release:
    types:
      - published
@@ -26,8 +27,10 @@ jobs:
         buildplat:
           - [ubuntu-20.04, manylinux_x86_64]
           - [ubuntu-20.04, manylinux_i686]
+          - [ubuntu-20.04, manylinux_aarch64]
           - [ubuntu-20.04, musllinux_x86_64] # No OpenBlas, no test
           - [ubuntu-20.04, musllinux_i686]
+          - [ubuntu-20.04, musllinux_aarch64]
           - [macos-12, macosx_x86_64]
           - [macos-14, macosx_arm64]
           - [windows-2019, win_amd64]
@@ -36,6 +39,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU # Required for aarch64 builds
+        if: matrix.buildplat == [ubuntu-20.04, manylinux_aarch64] || matrix.buildplat == [ubuntu-20.04, musllinux_aarch64]
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
         env:
@@ -86,29 +94,29 @@ jobs:
   #       with:
   #         repository-url: https://test.pypi.org/legacy/
 
-  upload_pypi:
-    name: >-
-      Publish highspy to PyPI
-    runs-on: ubuntu-latest
-    needs: [build_wheels, build_sdist]
+  # upload_pypi:
+  #   name: >-
+  #     Publish highspy to PyPI
+  #   runs-on: ubuntu-latest
+  #   needs: [build_wheels, build_sdist]
 
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  #   # upload to PyPI on every tag starting with 'v'
+  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
-    environment:
-      name: pypi
-      url: https://pypi.org/p/highspy
+  #   environment:
+  #     name: pypi
+  #     url: https://pypi.org/p/highspy
 
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+  #   permissions:
+  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: artifact
-          path: dist
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         # unpacks default artifact into dist/
+  #         # if `name: artifact` is omitted, the action will create extra parent dir
+  #         name: artifact
+  #         path: dist
 
-      - name: Download all
-        uses: pypa/gh-action-pypi-publish@release/v1
+  #     - name: Download all
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -3,7 +3,6 @@ name: build-wheels-push
 # on: push
  
 on:
- workflow_dispatch:
  release:
    types:
      - published
@@ -40,11 +39,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU # Required for aarch64 builds
-        if: matrix.buildplat[1] == 'manylinux_aarch64' || matrix.buildplat[1] == 'musllinux_aarch64'
+        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Build wheels
+      - name: Build wheels (aarch64)
+        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
+        uses: pypa/cibuildwheel@v2.19
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_ARCHS_LINUX: aarch64
+      - name: Build wheels (not aarch64)
+        if: ${{ !contains(matrix.buildplat[1], 'aarch64') }}
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
@@ -94,29 +100,29 @@ jobs:
   #       with:
   #         repository-url: https://test.pypi.org/legacy/
 
-  # upload_pypi:
-  #   name: >-
-  #     Publish highspy to PyPI
-  #   runs-on: ubuntu-latest
-  #   needs: [build_wheels, build_sdist]
+  upload_pypi:
+    name: >-
+      Publish highspy to PyPI
+    runs-on: ubuntu-latest
+    needs: [build_wheels, build_sdist]
 
-  #   # upload to PyPI on every tag starting with 'v'
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/highspy
+    environment:
+      name: pypi
+      url: https://pypi.org/p/highspy
 
-  #   permissions:
-  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-  #   steps:
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         # unpacks default artifact into dist/
-  #         # if `name: artifact` is omitted, the action will create extra parent dir
-  #         name: artifact
-  #         path: dist
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # unpacks default artifact into dist/
+          # if `name: artifact` is omitted, the action will create extra parent dir
+          name: artifact
+          path: dist
 
-  #     - name: Download all
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Download all
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,17 +38,11 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Build wheels (aarch64)
-        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
+      - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_ARCHS_LINUX: aarch64
-      - name: Build wheels (not aarch64)
-        if: ${{ !contains(matrix.buildplat[1], 'aarch64') }}
-        uses: pypa/cibuildwheel@v2.19
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_ARCHS_LINUX: ${{ contains(matrix.buildplat[1], 'aarch64') && 'aarch64' || '' }}
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -21,8 +21,10 @@ jobs:
         buildplat:
           - [ubuntu-20.04, manylinux_x86_64]
           - [ubuntu-20.04, manylinux_i686]
+          - [ubuntu-20.04, manylinux_aarch64]
           - [ubuntu-20.04, musllinux_x86_64] # No OpenBlas, no test
           - [ubuntu-20.04, musllinux_i686]
+          - [ubuntu-20.04, musllinux_aarch64]
           - [macos-12, macosx_x86_64]
           - [macos-14, macosx_arm64]
           - [windows-2019, win_amd64]
@@ -31,6 +33,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU # Required for aarch64 builds
+        if: matrix.buildplat == [ubuntu-20.04, manylinux_aarch64] || matrix.buildplat == [ubuntu-20.04, musllinux_aarch64]
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19
         env:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU # Required for aarch64 builds
-        if: matrix.buildplat == [ubuntu-20.04, manylinux_aarch64] || matrix.buildplat == [ubuntu-20.04, musllinux_aarch64]
+        if: matrix.buildplat[1] == 'manylinux_aarch64' || matrix.buildplat[1] == 'musllinux_aarch64'
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,11 +38,17 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Build wheels
+      - name: Build wheels (aarch64)
+        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          CIBW_ARCHS_LINUX: ${{ contains(matrix.buildplat[1], 'aarch64') && 'aarch64' || '' }}
+          CIBW_ARCHS_LINUX: aarch64
+      - name: Build wheels (not aarch64)
+        if: ${{ !contains(matrix.buildplat[1], 'aarch64') }}
+        uses: pypa/cibuildwheel@v2.19
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,11 +34,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU # Required for aarch64 builds
-        if: matrix.buildplat[1] == 'manylinux_aarch64' || matrix.buildplat[1] == 'musllinux_aarch64'
+        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-      - name: Build wheels
+      - name: Build wheels (aarch64)
+        if: ${{ contains(matrix.buildplat[1], 'aarch64') }}
+        uses: pypa/cibuildwheel@v2.19
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          CIBW_ARCHS_LINUX: aarch64
+      - name: Build wheels (not aarch64)
+        if: ${{ !contains(matrix.buildplat[1], 'aarch64') }}
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}


### PR DESCRIPTION
# Description

Modifies "build-wheels" workflows to also build for _linux/aarch64_ platform. Due to the lack of a Github runner for this platform, we use QEMU. While this works nicely, we need to split the build step to account for the conditional and the build using QEMU takes 5x as long. :grimacing: 

## Changes

- Adds QEMU setup step  when build matrix is facing `aarch64`
- Adds conditional build step for `aarch64` to explicitly set `CIBW_ARCHS_LINUX`
  - Ternary unfortunately didn't work, so, I wasn't able to keep it in one step. There is probably another way, but I thought that the less I mingle with the other build targets the better. :blush: 
- Did above changes for `build-wheels-push.yml` and `build-wheels.yml` alike

## Notes

I was pinged by @ryanjoneil about wheels for linux/aarch64 (cc @galabovaa ). I had some time to spare tonight, so I just went for it. The approach seems to work nicely for [Pyvroom](https://github.com/VROOM-Project/pyvroom) (see [their workflow](https://github.com/VROOM-Project/pyvroom/blob/main/.github/workflows/release.yml)).

Happy to assist with further work related to this.

Thanks again for this awesome project! :hugs: 