### PR TITLE
Moved pdlp_iteration_count back to where it was inserted, breaking the C API

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,41 +1,17 @@
 ## Build changes
 
-### HiGHS on nixpkgs
-
-HiGHS now has a `flake.nix` to build the binary, allowing `nix` users to try it out
-
-### Python build update
-
-Highspy with setuptools from v1.7.0 only worked on Python 3.12
-For v1.7.0 we have dropped setuptools and switched to scikit-build-core
-
-### Windows versions
-
-Fixed version info of shared library
-Added version info to executable
-
 ## Code changes
 
-Inserting `pdlp_iteration_count` into various structs (for v1.7.0) breaks the C API, so it has been moved to the end of those structs
+The accessor function Highs_getCallbackDataOutItem in the C API means
+that `pdlp_iteration_count` can be moved back to where it was inserted
+into the `HighsCallbackDataOut` struct in v1.7.0, which broke the C
+API. This fixes #1812
 
-`setBasis` has been added to `highspy`
+Some duplicate code has been eliminated from the MIP solver, and
+modifications made to eliminate compiler warnings
 
-`writePresolvedModel` has been added
+Declaration of the (deprecated) method `char* highsCompilationDate()`
+has been corrected
 
-Saved MIP solution pool is populated when presolve reduces MIP to empty
-
-Compilation date has been removed improve build reproducibility. Methods to print compilation dates are deprecated
-
-Logging and error return when user-supplied solution or basis is rejected on vector dimensions
-
-Memory allocation errors in presolve are caught and `Highs::run()` returns `HighsStatus::kError` with `model_status_ = HighsModelStatus::kMemoryLimit`
-
-QP solver logging is now neater and quieter
-
-Any Hessian for the incumbent model is modified with zero entries when adding columns to the model, and rows/columns are removed when columns are deleted from the model.
-
-Minor bug fix in MIP presolve
-
-QP solver will now hot start given a basis and solution
-
+Fixed bug when describing integrality status during the human-readable solution write
 

--- a/src/lp_data/HighsCallbackStruct.h
+++ b/src/lp_data/HighsCallbackStruct.h
@@ -29,6 +29,7 @@ typedef struct {
   double running_time;
   HighsInt simplex_iteration_count;
   HighsInt ipm_iteration_count;
+  HighsInt pdlp_iteration_count;
   double objective_function_value;
   int64_t mip_node_count;
   double mip_primal_bound;
@@ -43,7 +44,6 @@ typedef struct {
   double* cutpool_value;
   double* cutpool_lower;
   double* cutpool_upper;
-  HighsInt pdlp_iteration_count;
 } HighsCallbackDataOut;
 
 typedef struct {


### PR DESCRIPTION
This is expected to fix #1812