### PR TITLE
Fix 1813

### DIFF
--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -137,6 +137,11 @@ void HighsMipSolver::run() {
   mipdata_->runSetup();
 restart:
   if (modelstatus_ == HighsModelStatus::kNotset) {
+    // Check limits have not been reached before evaluating root node
+    if (mipdata_->checkLimits()) {
+      cleanupSolve();
+      return;
+    }
     mipdata_->evaluateRootNode();
     // age 5 times to remove stored but never violated cuts after root
     // separation
@@ -146,7 +151,7 @@ restart:
     mipdata_->cutpool.performAging();
     mipdata_->cutpool.performAging();
   }
-  if (mipdata_->nodequeue.empty()) {
+  if (mipdata_->nodequeue.empty() || mipdata_->checkLimits()) {
     cleanupSolve();
     return;
   }

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -115,6 +115,10 @@ void HighsMipSolver::run() {
   mipdata_ = decltype(mipdata_)(new HighsMipSolverData(*this));
   mipdata_->init();
   mipdata_->runPresolve(options_mip_->presolve_reduction_limit);
+  if (!submip)
+    highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                 "MIP-Timing: After %6.4fs - completed mipdata_->runPresolve\n",
+                 timer_.read(timer_.solve_clock));
   // Identify whether time limit has been reached (in presolve)
   if (modelstatus_ == HighsModelStatus::kNotset &&
       timer_.read(timer_.solve_clock) >= options_mip_->time_limit)
@@ -134,7 +138,15 @@ void HighsMipSolver::run() {
     return;
   }
 
+  if (!submip)
+    highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                 "MIP-Timing: After %6.4fs - reached   mipdata_->runSetup()\n",
+                 timer_.read(timer_.solve_clock));
   mipdata_->runSetup();
+  if (!submip)
+    highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                 "MIP-Timing: After %6.4fs - completed mipdata_->runSetup()\n",
+                 timer_.read(timer_.solve_clock));
 restart:
   if (modelstatus_ == HighsModelStatus::kNotset) {
     // Check limits have not been reached before evaluating root node
@@ -142,7 +154,17 @@ restart:
       cleanupSolve();
       return;
     }
+    if (!submip)
+      highsLogUser(
+          options_mip_->log_options, HighsLogType::kInfo,
+          "MIP-Timing: After %6.4fs - reached   mipdata_->evaluateRootNode()\n",
+          timer_.read(timer_.solve_clock));
     mipdata_->evaluateRootNode();
+    if (!submip)
+      highsLogUser(
+          options_mip_->log_options, HighsLogType::kInfo,
+          "MIP-Timing: After %6.4fs - completed mipdata_->evaluateRootNode()\n",
+          timer_.read(timer_.solve_clock));
     // age 5 times to remove stored but never violated cuts after root
     // separation
     mipdata_->cutpool.performAging();

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1870,6 +1870,8 @@ bool HighsMipSolverData::checkLimits(int64_t nodeOffset) const {
     return true;
   }
 
+  //  const double time = mipsolver.timer_.read(mipsolver.timer_.solve_clock);
+  //  printf("checkLimits: time = %g\n", time);
   if (mipsolver.timer_.read(mipsolver.timer_.solve_clock) >=
       options.time_limit) {
     if (mipsolver.modelstatus_ == HighsModelStatus::kNotset) {


### PR DESCRIPTION
Identified that `HighsMipSolverData::checkLimits` is not called for a long time before `mipdata_->evaluateRootNode();`. Specifically, `mipdata_->runSetup();` executes without a call to `HighsMipSolverData::checkLimits`

MIP profiling will expose this and lead to insertion of calls to `HighsMipSolverData::checkLimits`