### PR TITLE
Added mip_max_start_nodes` to avoid excessive cost when a MIP is solved to complete a partial solution.

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,6 +8,7 @@ Added `int64_t mip_total_lp_iterations` to `HighsCallbackDataOut` and modified a
 
 Introduced `const double kHighsUndefined` as value of undefined values in a user solution. It's equal to `kHighsInf`
 
-Added `Highs::setSolution(const HighsInt num_entries, const HighsInt* index, const double* value);` to allow a sparse primal solution to be defined.
+Added `Highs::setSolution(const HighsInt num_entries, const HighsInt* index, const double* value);` to allow a sparse primal solution to be defined. When a MIP is solved to do this, the value of (new) option `mip_max_start_nodes` is used for `mip_max_nodes` to avoid excessive cost
+
 
 

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -401,6 +401,7 @@ struct HighsOptionsStruct {
   bool mip_allow_restart;
   HighsInt mip_max_nodes;
   HighsInt mip_max_stall_nodes;
+  HighsInt mip_max_start_nodes;
   HighsInt mip_max_leaves;
   HighsInt mip_max_improving_sols;
   HighsInt mip_lp_age_limit;
@@ -527,6 +528,7 @@ struct HighsOptionsStruct {
         mip_allow_restart(false),
         mip_max_nodes(0),
         mip_max_stall_nodes(0),
+        mip_max_start_nodes(0),
         mip_max_leaves(0),
         mip_max_improving_sols(0),
         mip_lp_age_limit(0),
@@ -916,6 +918,13 @@ class HighsOptions : public HighsOptionsStruct {
         "MIP solver max number of nodes where estimate is above cutoff bound",
         advanced, &mip_max_stall_nodes, 0, kHighsIInf, kHighsIInf);
     records.push_back(record_int);
+
+    record_int = new OptionRecordInt(
+        "mip_max_start_nodes",
+        "MIP solver max number of nodes when completing a partial MIP start",
+        advanced, &mip_max_start_nodes, 0, 500, kHighsIInf);
+    records.push_back(record_int);
+
 #ifdef HIGHS_DEBUGSOL
     record_string = new OptionRecordString(
         "mip_debug_solution_file",
@@ -944,7 +953,7 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_string);
 
     record_int = new OptionRecordInt(
-        "mip_max_leaves", "MIP solver max number of leave nodes", advanced,
+        "mip_max_leaves", "MIP solver max number of leaf nodes", advanced,
         &mip_max_leaves, 0, kHighsIInf, kHighsIInf);
     records.push_back(record_int);
 

--- a/src/presolve/HighsSymmetry.cpp
+++ b/src/presolve/HighsSymmetry.cpp
@@ -1078,7 +1078,7 @@ bool HighsSymmetryDetection::distinguishVertex(HighsInt targetCell) {
 
 void HighsSymmetryDetection::backtrack(HighsInt backtrackStackNewEnd,
                                        HighsInt backtrackStackEnd) {
-  // we assume that we always backtrack from a leave node, i.e. a discrete
+  // we assume that we always backtrack from a leaf node, i.e. a discrete
   // partition therefore we do not need to remember the values of the hash
   // contributions as it is the indentity for each position and all new cells
   // are on the cell creation stack.
@@ -1805,7 +1805,7 @@ void HighsSymmetryDetection::run(HighsSymmetries& symmetries) {
           // than the current best leave, because its prefix length is smaller
           // than the best leaves and it would have been already pruned if
           // it's certificate value was larger unless it is equal to the first
-          // leave nodes certificate value which is caught by the first case
+          // leaf nodes certificate value which is caught by the first case
           // of the if condition. Hence, having a lexicographically smaller
           // certificate value than the best leave is the only way to get
           // here.


### PR DESCRIPTION
Added option `mip_max_start_nodes` to be used for `mip_max_nodes` when a MIP is solved to complete a partial solution to avoid excessive cost.