### PR TITLE
Update substitutions if a column is transformed

### DIFF
--- a/src/mip/HighsImplications.h
+++ b/src/mip/HighsImplications.h
@@ -109,6 +109,7 @@ class HighsImplications {
               double vlbconstant);
 
   void columnTransformed(HighsInt col, double scale, double constant) {
+    // Update variable bounds affected by transformation
     if (scale < 0) std::swap(vubs[col], vlbs[col]);
 
     auto transformVbd = [&](HighsInt, VarBound& vbd) {
@@ -120,6 +121,7 @@ class HighsImplications {
     vlbs[col].for_each(transformVbd);
     vubs[col].for_each(transformVbd);
 
+    // Update substitutions affected by transformation
     for (auto& substitution : substitutions) {
       if (substitution.substcol == col) {
         substitution.offset -= constant;

--- a/src/mip/HighsImplications.h
+++ b/src/mip/HighsImplications.h
@@ -119,6 +119,10 @@ class HighsImplications {
 
     vlbs[col].for_each(transformVbd);
     vubs[col].for_each(transformVbd);
+
+    for (auto& substitution : substitutions) {
+      if (substitution.substcol == col) substitution.offset -= constant;
+    }
   }
 
   std::pair<HighsInt, VarBound> getBestVub(HighsInt col,

--- a/src/mip/HighsImplications.h
+++ b/src/mip/HighsImplications.h
@@ -121,7 +121,10 @@ class HighsImplications {
     vubs[col].for_each(transformVbd);
 
     for (auto& substitution : substitutions) {
-      if (substitution.substcol == col) substitution.offset -= constant;
+      if (substitution.substcol == col) {
+        substitution.offset -= substitution.scale * constant;
+        substitution.scale /= scale;
+      }
     }
   }
 

--- a/src/mip/HighsImplications.h
+++ b/src/mip/HighsImplications.h
@@ -122,7 +122,8 @@ class HighsImplications {
 
     for (auto& substitution : substitutions) {
       if (substitution.substcol == col) {
-        substitution.offset -= substitution.scale * constant;
+        substitution.offset -= constant;
+        substitution.offset /= scale;
         substitution.scale /= scale;
       }
     }


### PR DESCRIPTION
If a column is transformed in presolve (complemented and/or shifted), variable bound constraints are updated accordingly. However, substitutions that may be affected are currently not updated. I think this is a bug, and I fixed this.

This should partly fix #1578, in particular the incorrect answer on `Civ4.100.turns` (mentioned [here](https://github.com/ERGO-Code/HiGHS/issues/1578#issuecomment-2223324400)). 

I did not do large-scale testing so far. @jajhall, I am away for the next 2 weeks and I could do the testing when I return.