### PR TITLE
Restored full C API unit test and corrected/updated documentaiton of Hessian

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -1808,24 +1808,24 @@ void test_setSolution() {
 }
 */
 int main() {
-  //  minimal_api_illegal_lp();
-  //  test_callback();
-  //  version_api();
-  //  full_api();
-  //  minimal_api_lp();
-  //  minimal_api_mip();
-  //  minimal_api_qp();
-  //  full_api_options();
-  //  full_api_lp();
-  //  full_api_mip();
-  //  full_api_qp();
-  //  pass_presolve_get_lp();
-  //  options();
-  //  test_getColsByRange();
-  //  test_passHessian();
-  //  test_ranging();
+  minimal_api_illegal_lp();
+  test_callback();
+  version_api();
+  full_api();
+  minimal_api_lp();
+  minimal_api_mip();
+  minimal_api_qp();
+  full_api_options();
+  full_api_lp();
+  full_api_mip();
+  full_api_qp();
+  pass_presolve_get_lp();
+  options();
+  test_getColsByRange();
+  test_passHessian();
+  test_ranging();
   test_feasibilityRelaxation();
-  //  test_getModel();
+  test_getModel();
   return 0;
 }
   //  test_setSolution();

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -61,6 +61,8 @@ Documenter.makedocs(
                 "structures/classes/index.md",
                 "structures/classes/HighsSparseMatrix.md",
                 "structures/classes/HighsLp.md",
+                "structures/classes/HighsHessian.md",
+                "structures/classes/HighsModel.md",
                 "structures/classes/HighsSolution.md",
                 "structures/classes/HighsBasis.md",
                 "structures/classes/HighsInfo.md",

--- a/docs/src/structures/classes/HighsHessian.md
+++ b/docs/src/structures/classes/HighsHessian.md
@@ -1,0 +1,9 @@
+# HighsHessian
+
+A Hessian matrix is communicated via an instance of the HighsHessian class.
+
+- dim_: Scalar of type integer - Dimension of the Hessian
+- format\_: Scalar of [HessianFormat](@ref) type - Format of the Hessian
+- start\_: Vector of integer type - Start of each compressed column in the Hessian
+- index\_: Vector of integer type - Indices of the nonzeros in the Hessian
+- value\_: Vector of double type - Values of the nonzeros in the Hessian

--- a/docs/src/structures/classes/HighsModel.md
+++ b/docs/src/structures/classes/HighsModel.md
@@ -1,0 +1,7 @@
+# HighsModel
+
+A QP model is communicated via an instance of the HighsModel class
+
+- lp\_: Instance of [HighsLp](@ref) class - LP components of the model
+
+- hessian\_: Instance of [HighsHessian](@ref) class - Hessian matrix

--- a/docs/src/structures/classes/HighsSparseMatrix.md
+++ b/docs/src/structures/classes/HighsSparseMatrix.md
@@ -2,9 +2,9 @@
 
 The constraint matrix of an LP model is communicated via an instance of the HighsSparseMatrix class
 
-- format\_: Scalar of MatrixFormat type - Format of the matrix
+- format\_: Scalar of [MatrixFormat](@ref) type - Format of the matrix
 - num\_col\_ : Scalar of integer type - Number of columns in the matrix
 - num\_row\_: Scalar of integer type - Number of rows in the matrix
-- start\_: Vector of integer type - Start of each compressed vector in the matrixs
+- start\_: Vector of integer type - Start of each compressed vector in the matrix
 - index\_: Vector of integer type - Indices of the nonzeros in the matrix
 - value\_: Vector of double type - Values of the nonzeros in the matrix

--- a/docs/src/structures/classes/index.md
+++ b/docs/src/structures/classes/index.md
@@ -4,6 +4,8 @@ The data members of fundamental classes in HiGHS are defined in this section.
 
  * [HighsSparseMatrix](@ref)
  * [HighsLp](@ref)
+ * [HighsHessian](@ref)
+ * [HighsModel](@ref)
  * [HighsSolution](@ref)
  * [HighsBasis](@ref)
  * [HighsInfo](@ref)

--- a/docs/src/structures/enums.md
+++ b/docs/src/structures/enums.md
@@ -41,6 +41,13 @@ This defines the feasible values of a variable within a model:
  * `kSemiContinuous`: The variable must be zero or take continuous values between its bounds
  * `kSemiInteger`: The variable must be zero or take integer values between its bounds
 
+## HessianFormat
+
+This defines the format of a [HighsHessian](@ref):
+
+ * `kTriangular`: The lower triangular component of the Hessian is stored column-wise or, equivalently, the upper triangular component is stored row-wise 
+ * `kSquare`: The whole Hessian ``Q`` is stored column-wise. This is for input only: internally the lower triangular component of ``(Q+Q^T)/2`` will be stored
+
 ## SolutionStatus
 
 This defines the nature of any primal or dual solution information:

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -229,11 +229,14 @@ HighsInt Highs_mipCall(const HighsInt num_col, const HighsInt num_row,
  * @param q_format  The format of the Hessian matrix in the form of a
  *                  `kHighsHessianStatus` constant. If q_num_nz > 0, this must
  *                  be `kHighsHessianFormatTriangular`.
- * @param q_start   The Hessian matrix is provided in the same format as the
- *                  constraint matrix, using `q_start`, `q_index`, and `q_value`
- *                  in the place of `a_start`, `a_index`, and `a_value`.
+ * @param q_start   The Hessian matrix is provided to HiGHS as the lower
+ *                  triangular component in compressed sparse column form
+ *                  (or, equivalently, as the upper triangular component
+ *                  in compressed sparse row form). The sparse matrix consists
+ *                  of three arrays, `q_start`, `q_index`, and `q_value`.
+ *                  `q_start` is an array of length [num_col].
  * @param q_index   An array of length [q_num_nz] with indices of matrix
- *                  sentries.
+ *                  entries.
  * @param q_value   An array of length [q_num_nz] with values of matrix entries.
  *
  * @returns A `kHighsStatus` constant indicating whether the call succeeded.
@@ -498,10 +501,13 @@ HighsInt Highs_passMip(void* highs, const HighsInt num_col,
  * @param a_index     An array of length [num_nz] with indices of matrix
  *                    entries.
  * @param a_value     An array of length [num_nz] with values of matrix entries.
- * @param q_start     The Hessian matrix is provided in the same format as the
- *                    constraint matrix, using `q_start`, `q_index`, and
- *                    `q_value` in the place of `a_start`, `a_index`, and
- *                    `a_value`. If the model is linear, pass NULL.
+ * @param q_start     The Hessian matrix is provided to HiGHS as the lower
+ *                    triangular component in compressed sparse column form
+ *                    (or, equivalently, as the upper triangular component
+ *                    in compressed sparse row form). The sparse matrix consists
+ *                    of three arrays, `q_start`, `q_index`, and `q_value`.
+ *                    `q_start` is an array of length [num_col]. If the model
+ *                    is linear, pass NULL.
  * @param q_index     An array of length [q_num_nz] with indices of matrix
  *                    entries. If the model is linear, pass NULL.
  * @param q_value     An array of length [q_num_nz] with values of matrix
@@ -531,9 +537,13 @@ HighsInt Highs_passModel(void* highs, const HighsInt num_col,
  * @param num_nz    The number of non-zero elements in the Hessian matrix.
  * @param format    The format of the Hessian matrix as a `kHighsHessianFormat`
  *                  constant. This must be `kHighsHessianFormatTriangular`.
- * @param start     The Hessian matrix is provided to HiGHS as the upper
- *                  triangular component in compressed sparse column form. The
- *                  sparse matrix consists of three arrays, `start`, `index`,
+ * @param start     The Hessian matrix is provided to HiGHS as the lower
+ *                  triangular component in compressed sparse column form
+ *                  (or, equivalently, as the upper triangular component
+ *                  in compressed sparse row form), using `q_start`, `q_index`,
+ *                  and `q_value`.The Hessian matrix is provided to HiGHS as the
+ *                  lower triangular component in compressed sparse column form.
+ *                  The sparse matrix consists of three arrays, `start`, `index`,
  *                  and `value`. `start` is an array of length [num_col]
  *                  containing the starting index of each column in `index`.
  * @param index     An array of length [num_nz] with indices of matrix entries.


### PR DESCRIPTION
Restored full C API unit test and corrected references to format of Hessian in `highs_c_api.h`. Added `HighsHessian.md` and `HighsModel.md` plus documentation of `HessianFormat` in `enums.md`

This will fix error exposed in #1878 