### PR TITLE
writePrimalSolution: flush file after each call (#1880)

### DIFF
--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -243,6 +243,7 @@ void writePrimalSolution(FILE* file, const HighsLogOptions& log_options,
     ss << "\n";
     highsFprintfString(file, log_options, ss.str());
   }
+  fflush(file);
 }
 
 void writeModelSolution(FILE* file, const HighsLogOptions& log_options,


### PR DESCRIPTION
When setting

mip_improving_solution_save=true
mip_improving_solution_file=solution.sol

each new solution is written to solution.sol. The problem is that the solution can be incomplete while highs is still running or when it gets killed. To allow other programs to read the latest solution while the solver is still running, highs should flush the file after each solution is written.