### PR TITLE
Fix 1883

### DIFF
--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -543,9 +543,9 @@ HighsInt Highs_passModel(void* highs, const HighsInt num_col,
  *                  in compressed sparse row form), using `q_start`, `q_index`,
  *                  and `q_value`.The Hessian matrix is provided to HiGHS as the
  *                  lower triangular component in compressed sparse column form.
- *                  The sparse matrix consists of three arrays, `start`, `index`,
- *                  and `value`. `start` is an array of length [num_col]
- *                  containing the starting index of each column in `index`.
+ *                  The sparse matrix consists of three arrays, `start`,
+ * `index`, and `value`. `start` is an array of length [num_col] containing the
+ * starting index of each column in `index`.
  * @param index     An array of length [num_nz] with indices of matrix entries.
  * @param value     An array of length [num_nz] with values of matrix entries.
  *

--- a/src/interfaces/highs_c_api.h
+++ b/src/interfaces/highs_c_api.h
@@ -544,8 +544,9 @@ HighsInt Highs_passModel(void* highs, const HighsInt num_col,
  *                  and `q_value`.The Hessian matrix is provided to HiGHS as the
  *                  lower triangular component in compressed sparse column form.
  *                  The sparse matrix consists of three arrays, `start`,
- * `index`, and `value`. `start` is an array of length [num_col] containing the
- * starting index of each column in `index`.
+ *                  `index`, and `value`. `start` is an array of length
+ *                  [num_col] containing the starting index of each column in
+ *                  `index`.
  * @param index     An array of length [num_nz] with indices of matrix entries.
  * @param value     An array of length [num_nz] with values of matrix entries.
  *

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -1183,7 +1183,9 @@ HPresolve::Result HPresolve::dominatedColumns(
                 checkDomination(-1, j, -1, k)) {
               // case (iii)  lb(x_j) = -inf, -x_j > -x_k: set x_k = ub(x_k)
               ++numFixedCols;
-              fixColToLowerOrUnbounded(postsolve_stack, j);
+              if (fixColToLowerOrUnbounded(postsolve_stack, j)) {
+                // Handle unboundedness
+              }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
             } else if (-ajBestRowMinus <= ak + options->small_matrix_value &&
@@ -1192,7 +1194,9 @@ HPresolve::Result HPresolve::dominatedColumns(
                        checkDomination(-1, j, 1, k)) {
               // case (iv)  lb(x_j) = -inf, -x_j > x_k: set x_k = lb(x_k)
               ++numFixedCols;
-              fixColToLowerOrUnbounded(postsolve_stack, j);
+              if (fixColToLowerOrUnbounded(postsolve_stack, j)) {
+                // Handle unboundedness
+              }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
             }
@@ -1223,7 +1227,9 @@ HPresolve::Result HPresolve::dominatedColumns(
                 checkDomination(1, j, 1, k)) {
               // case (i)  ub(x_j) = inf, x_j > x_k: set x_k = lb(x_k)
               ++numFixedCols;
-              fixColToUpperOrUnbounded(postsolve_stack, j);
+              if (fixColToUpperOrUnbounded(postsolve_stack, j)) {
+                // Handle unboundedness
+              }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
             } else if (ajBestRowPlus <= -ak + options->small_matrix_value &&
@@ -1232,7 +1238,9 @@ HPresolve::Result HPresolve::dominatedColumns(
                        checkDomination(1, j, -1, k)) {
               // case (ii)  ub(x_j) = inf, x_j > -x_k: set x_k = ub(x_k)
               ++numFixedCols;
-              fixColToUpperOrUnbounded(postsolve_stack, j);
+              if (fixColToUpperOrUnbounded(postsolve_stack, j)) {
+                // Handle unboundedness
+              }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
             }
@@ -1271,7 +1279,9 @@ HPresolve::Result HPresolve::dominatedColumns(
             checkDomination(1, j, 1, k)) {
           // case (i)  ub(x_j) = inf, x_j > x_k: set x_k = lb(x_k)
           ++numFixedCols;
-          fixColToLowerOrUnbounded(postsolve_stack, k);
+          if (fixColToLowerOrUnbounded(postsolve_stack, k)) {
+            // Handle unboundedness
+          }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         } else if (model->col_upper_[k] != kHighsInf &&
                    (upperImplied ||
@@ -1284,7 +1294,9 @@ HPresolve::Result HPresolve::dominatedColumns(
                    checkDomination(1, j, -1, k)) {
           // case (ii)  ub(x_j) = inf, x_j > -x_k: set x_k = ub(x_k)
           ++numFixedCols;
-          fixColToUpperOrUnbounded(postsolve_stack, k);
+          if (fixColToUpperOrUnbounded(postsolve_stack, k)) {
+            // Handle unboundedness
+          }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         }
       }
@@ -1313,7 +1325,9 @@ HPresolve::Result HPresolve::dominatedColumns(
             checkDomination(-1, j, -1, k)) {
           // case (iii)  lb(x_j) = -inf, -x_j > -x_k: set x_k = ub(x_k)
           ++numFixedCols;
-          fixColToUpperOrUnbounded(postsolve_stack, k);
+          if (fixColToUpperOrUnbounded(postsolve_stack, k)) {
+            // Handle unboundedness
+          }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         } else if (model->col_lower_[k] != -kHighsInf &&
                    (lowerImplied ||
@@ -1326,7 +1340,9 @@ HPresolve::Result HPresolve::dominatedColumns(
                    checkDomination(-1, j, 1, k)) {
           // case (iv)  lb(x_j) = -inf, -x_j > x_k: set x_k = lb(x_k)
           ++numFixedCols;
-          fixColToLowerOrUnbounded(postsolve_stack, k);
+          if (fixColToLowerOrUnbounded(postsolve_stack, k)) {
+            // Handle unboundedness
+          }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         }
       }
@@ -2837,7 +2853,9 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
   if (colDualLower > options->dual_feasibility_tolerance) {
     if (model->col_lower_[col] == -kHighsInf) return Result::kDualInfeasible;
     if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
-    fixColToLowerOrUnbounded(postsolve_stack, col);
+    if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+      // Handle unboundedness
+    }
     analysis_.logging_on_ = logging_on;
     if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
     return checkLimits(postsolve_stack);
@@ -2846,7 +2864,9 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
   if (colDualUpper < -options->dual_feasibility_tolerance) {
     if (model->col_upper_[col] == kHighsInf) return Result::kDualInfeasible;
     if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
-    fixColToUpperOrUnbounded(postsolve_stack, col);
+    if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
+      // Handle unboundedness
+    }
     analysis_.logging_on_ = logging_on;
     if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
     return checkLimits(postsolve_stack);
@@ -2856,7 +2876,9 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
   if (colDualUpper <= options->dual_feasibility_tolerance) {
     if (model->col_upper_[col] != kHighsInf) {
       if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
-      fixColToUpperOrUnbounded(postsolve_stack, col);
+      if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
+        // Handle unboundedness
+      }
       analysis_.logging_on_ = logging_on;
       if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
     } else if (impliedDualRowBounds.getSumLowerOrig(col) == 0.0 &&
@@ -2895,7 +2917,9 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
   if (colDualLower >= -options->dual_feasibility_tolerance) {
     if (model->col_lower_[col] != -kHighsInf) {
       if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
-      fixColToLowerOrUnbounded(postsolve_stack, col);
+      if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+        // Handle unboundedness
+      }
       analysis_.logging_on_ = logging_on;
       if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
     } else if (impliedDualRowBounds.getSumUpperOrig(col) == 0.0 &&
@@ -3344,11 +3368,15 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
                   // Fix variable
                   if (std::abs(model->col_lower_[x1] - fixVal) <=
                       primal_feastol) {
-                    fixColToLowerOrUnbounded(postsolve_stack, x1);
+                    if (fixColToLowerOrUnbounded(postsolve_stack, x1)) {
+                      // Handle unboundedness
+                    }
                   } else {
                     assert(std::abs(model->col_upper_[x1] - fixVal) <=
                            primal_feastol);
-                    fixColToUpperOrUnbounded(postsolve_stack, x1);
+                    if (fixColToUpperOrUnbounded(postsolve_stack, x1)) {
+                      // Handle unboundedness
+                    }
                   }
                   rowpositions.erase(rowpositions.begin() + x1Cand);
                 } else {
@@ -3862,15 +3890,23 @@ HPresolve::Result HPresolve::emptyCol(HighsPostsolveStack& postsolve_stack,
       return Result::kDualInfeasible;
   }
 
-  if (model->col_cost_[col] > 0)
-    fixColToLowerOrUnbounded(postsolve_stack, col);
-  else if (model->col_cost_[col] < 0 ||
-           std::abs(model->col_upper_[col]) < std::abs(model->col_lower_[col]))
-    fixColToUpperOrUnbounded(postsolve_stack, col);
-  else if (model->col_lower_[col] != -kHighsInf)
-    fixColToLowerOrUnbounded(postsolve_stack, col);
-  else
+  if (model->col_cost_[col] > 0) {
+    if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+      // Handle unboundedness
+    }
+  } else if (model->col_cost_[col] < 0 ||
+             std::abs(model->col_upper_[col]) <
+                 std::abs(model->col_lower_[col])) {
+    if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
+      // Handle unboundedness
+    }
+  } else if (model->col_lower_[col] != -kHighsInf) {
+    if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+      // Handle unboundedness
+    }
+  } else {
     fixColToZero(postsolve_stack, col);
+  }
 
   analysis_.logging_on_ = logging_on;
   if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleEmptyCol);
@@ -3913,7 +3949,9 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
     if (model->col_lower_[col] == -kHighsInf)
       return Result::kDualInfeasible;
     else {
-      fixColToLowerOrUnbounded(postsolve_stack, col);
+      if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+        // Handle unboundedness
+      }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
     }
     return checkLimits(postsolve_stack);
@@ -3923,7 +3961,9 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
     if (model->col_upper_[col] == kHighsInf)
       return Result::kDualInfeasible;
     else {
-      fixColToUpperOrUnbounded(postsolve_stack, col);
+      if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
+        // Handle unboundedness
+      }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
     }
     return checkLimits(postsolve_stack);
@@ -3932,7 +3972,9 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
   // check for weakly dominated column
   if (colDualUpper <= options->dual_feasibility_tolerance) {
     if (model->col_upper_[col] != kHighsInf) {
-      fixColToUpperOrUnbounded(postsolve_stack, col);
+      if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
+        // Handle unboundedness
+      }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
       return checkLimits(postsolve_stack);
     } else if (impliedDualRowBounds.getSumLowerOrig(col) == 0.0) {
@@ -3958,7 +4000,9 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
   } else if (colDualLower >= -options->dual_feasibility_tolerance) {
     // symmetric case for fixing to the lower bound
     if (model->col_lower_[col] != -kHighsInf) {
-      fixColToLowerOrUnbounded(postsolve_stack, col);
+      if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+        // Handle unboundedness
+      }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
       return checkLimits(postsolve_stack);
     } else if (impliedDualRowBounds.getSumUpperOrig(col) == 0.0) {
@@ -4942,7 +4986,7 @@ void HPresolve::substitute(HighsInt substcol, HighsInt staycol, double offset,
 }
 
 bool HPresolve::fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack,
-					   HighsInt col) {
+                                         HighsInt col) {
   double fixval = model->col_lower_[col];
   bool unbounded = fixval == -kHighsInf;
   if (unbounded) return true;
@@ -4986,7 +5030,7 @@ bool HPresolve::fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack,
 }
 
 bool HPresolve::fixColToUpperOrUnbounded(HighsPostsolveStack& postsolve_stack,
-					   HighsInt col) {
+                                         HighsInt col) {
   double fixval = model->col_upper_[col];
   bool unbounded = fixval == kHighsInf;
   if (unbounded) return true;
@@ -5026,7 +5070,7 @@ bool HPresolve::fixColToUpperOrUnbounded(HighsPostsolveStack& postsolve_stack,
   model->col_cost_[col] = 0;
   analysis_.logging_on_ = logging_on;
   if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleFixedCol);
-  return false;  
+  return false;
 }
 
 void HPresolve::fixColToZero(HighsPostsolveStack& postsolve_stack,
@@ -5787,7 +5831,9 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
             HighsInt row = Arow[colhead[duplicateCol]];
             numRowSingletons[row] -= 1;
           }
-          fixColToLowerOrUnbounded(postsolve_stack, duplicateCol);
+          if (fixColToLowerOrUnbounded(postsolve_stack, duplicateCol)) {
+            // Handle unboundedness
+          }
           break;
         case kDominanceDuplicateColToUpper:
           delCol = duplicateCol;
@@ -5795,7 +5841,9 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
             HighsInt row = Arow[colhead[duplicateCol]];
             numRowSingletons[row] -= 1;
           }
-          fixColToUpperOrUnbounded(postsolve_stack, duplicateCol);
+          if (fixColToUpperOrUnbounded(postsolve_stack, duplicateCol)) {
+            // Handle unboundedness
+          }
           break;
         case kDominanceColToLower:
           delCol = col;
@@ -5803,7 +5851,9 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
             HighsInt row = Arow[colhead[col]];
             numRowSingletons[row] -= 1;
           }
-          fixColToLowerOrUnbounded(postsolve_stack, col);
+          if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
+            // Handle unboundedness
+          }
           break;
         case kDominanceColToUpper:
           delCol = col;
@@ -5811,7 +5861,9 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
             HighsInt row = Arow[colhead[col]];
             numRowSingletons[row] -= 1;
           }
-          fixColToUpperOrUnbounded(postsolve_stack, col);
+          if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
+            // Handle unboundedness
+          }
           break;
         case kMergeParallelCols:
           const bool ok_merge = postsolve_stack.duplicateColumn(

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -1185,6 +1185,8 @@ HPresolve::Result HPresolve::dominatedColumns(
               ++numFixedCols;
               if (fixColToLowerOrUnbounded(postsolve_stack, j)) {
                 // Handle unboundedness
+                presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+                return Result::kDualInfeasible;
               }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
@@ -1196,6 +1198,8 @@ HPresolve::Result HPresolve::dominatedColumns(
               ++numFixedCols;
               if (fixColToLowerOrUnbounded(postsolve_stack, j)) {
                 // Handle unboundedness
+                presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+                return Result::kDualInfeasible;
               }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
@@ -1229,6 +1233,8 @@ HPresolve::Result HPresolve::dominatedColumns(
               ++numFixedCols;
               if (fixColToUpperOrUnbounded(postsolve_stack, j)) {
                 // Handle unboundedness
+                presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+                return Result::kDualInfeasible;
               }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
@@ -1240,6 +1246,8 @@ HPresolve::Result HPresolve::dominatedColumns(
               ++numFixedCols;
               if (fixColToUpperOrUnbounded(postsolve_stack, j)) {
                 // Handle unboundedness
+                presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+                return Result::kDualInfeasible;
               }
               HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
               break;
@@ -1281,6 +1289,8 @@ HPresolve::Result HPresolve::dominatedColumns(
           ++numFixedCols;
           if (fixColToLowerOrUnbounded(postsolve_stack, k)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         } else if (model->col_upper_[k] != kHighsInf &&
@@ -1296,6 +1306,8 @@ HPresolve::Result HPresolve::dominatedColumns(
           ++numFixedCols;
           if (fixColToUpperOrUnbounded(postsolve_stack, k)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         }
@@ -1327,6 +1339,8 @@ HPresolve::Result HPresolve::dominatedColumns(
           ++numFixedCols;
           if (fixColToUpperOrUnbounded(postsolve_stack, k)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         } else if (model->col_lower_[k] != -kHighsInf &&
@@ -1342,6 +1356,8 @@ HPresolve::Result HPresolve::dominatedColumns(
           ++numFixedCols;
           if (fixColToLowerOrUnbounded(postsolve_stack, k)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
         }
@@ -2855,6 +2871,8 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
     if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
     if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
       // Handle unboundedness
+      presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+      return Result::kDualInfeasible;
     }
     analysis_.logging_on_ = logging_on;
     if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
@@ -2866,6 +2884,8 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
     if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
     if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
       // Handle unboundedness
+      presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+      return Result::kDualInfeasible;
     }
     analysis_.logging_on_ = logging_on;
     if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
@@ -2878,6 +2898,8 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
       if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
       if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
         // Handle unboundedness
+        presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+        return Result::kDualInfeasible;
       }
       analysis_.logging_on_ = logging_on;
       if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
@@ -2919,6 +2941,8 @@ HPresolve::Result HPresolve::singletonCol(HighsPostsolveStack& postsolve_stack,
       if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleDominatedCol);
       if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
         // Handle unboundedness
+        presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+        return Result::kDualInfeasible;
       }
       analysis_.logging_on_ = logging_on;
       if (logging_on) analysis_.stopPresolveRuleLog(kPresolveRuleDominatedCol);
@@ -3370,12 +3394,18 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
                       primal_feastol) {
                     if (fixColToLowerOrUnbounded(postsolve_stack, x1)) {
                       // Handle unboundedness
+                      presolve_status_ =
+                          HighsPresolveStatus::kUnboundedOrInfeasible;
+                      return Result::kDualInfeasible;
                     }
                   } else {
                     assert(std::abs(model->col_upper_[x1] - fixVal) <=
                            primal_feastol);
                     if (fixColToUpperOrUnbounded(postsolve_stack, x1)) {
                       // Handle unboundedness
+                      presolve_status_ =
+                          HighsPresolveStatus::kUnboundedOrInfeasible;
+                      return Result::kDualInfeasible;
                     }
                   }
                   rowpositions.erase(rowpositions.begin() + x1Cand);
@@ -3893,16 +3923,22 @@ HPresolve::Result HPresolve::emptyCol(HighsPostsolveStack& postsolve_stack,
   if (model->col_cost_[col] > 0) {
     if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
       // Handle unboundedness
+      presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+      return Result::kDualInfeasible;
     }
   } else if (model->col_cost_[col] < 0 ||
              std::abs(model->col_upper_[col]) <
                  std::abs(model->col_lower_[col])) {
     if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
       // Handle unboundedness
+      presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+      return Result::kDualInfeasible;
     }
   } else if (model->col_lower_[col] != -kHighsInf) {
     if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
       // Handle unboundedness
+      presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+      return Result::kDualInfeasible;
     }
   } else {
     fixColToZero(postsolve_stack, col);
@@ -3951,6 +3987,8 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
     else {
       if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
         // Handle unboundedness
+        presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+        return Result::kDualInfeasible;
       }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
     }
@@ -3963,6 +4001,8 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
     else {
       if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
         // Handle unboundedness
+        presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+        return Result::kDualInfeasible;
       }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
     }
@@ -3974,6 +4014,8 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
     if (model->col_upper_[col] != kHighsInf) {
       if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
         // Handle unboundedness
+        presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+        return Result::kDualInfeasible;
       }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
       return checkLimits(postsolve_stack);
@@ -4002,6 +4044,8 @@ HPresolve::Result HPresolve::colPresolve(HighsPostsolveStack& postsolve_stack,
     if (model->col_lower_[col] != -kHighsInf) {
       if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
         // Handle unboundedness
+        presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+        return Result::kDualInfeasible;
       }
       HPRESOLVE_CHECKED_CALL(removeRowSingletons(postsolve_stack));
       return checkLimits(postsolve_stack);
@@ -5833,6 +5877,8 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
           }
           if (fixColToLowerOrUnbounded(postsolve_stack, duplicateCol)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           break;
         case kDominanceDuplicateColToUpper:
@@ -5843,6 +5889,8 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
           }
           if (fixColToUpperOrUnbounded(postsolve_stack, duplicateCol)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           break;
         case kDominanceColToLower:
@@ -5853,6 +5901,8 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
           }
           if (fixColToLowerOrUnbounded(postsolve_stack, col)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           break;
         case kDominanceColToUpper:
@@ -5863,6 +5913,8 @@ HPresolve::Result HPresolve::detectParallelRowsAndCols(
           }
           if (fixColToUpperOrUnbounded(postsolve_stack, col)) {
             // Handle unboundedness
+            presolve_status_ = HighsPresolveStatus::kUnboundedOrInfeasible;
+            return Result::kDualInfeasible;
           }
           break;
         case kMergeParallelCols:

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -223,9 +223,11 @@ class HPresolve {
 
   void markColDeleted(HighsInt col);
 
-  bool fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack, HighsInt col);
+  bool fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack,
+                                HighsInt col);
 
-  bool fixColToUpperOrUnbounded(HighsPostsolveStack& postsolve_stack, HighsInt col);
+  bool fixColToUpperOrUnbounded(HighsPostsolveStack& postsolve_stack,
+                                HighsInt col);
 
   void fixColToZero(HighsPostsolveStack& postsolve_stack, HighsInt col);
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -223,9 +223,9 @@ class HPresolve {
 
   void markColDeleted(HighsInt col);
 
-  void fixColToLower(HighsPostsolveStack& postsolve_stack, HighsInt col);
+  bool fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack, HighsInt col);
 
-  void fixColToUpper(HighsPostsolveStack& postsolve_stack, HighsInt col);
+  bool fixColToUpperOrUnbounded(HighsPostsolveStack& postsolve_stack, HighsInt col);
 
   void fixColToZero(HighsPostsolveStack& postsolve_stack, HighsInt col);
 


### PR DESCRIPTION
`fixColToLower` and `fixColToUpper` merely had an assert if the lower or upper bound was infinite. Now, renamed `fixColToLowerOrUnbounded` and `fixColToUpperOrUnbounded`, they return true if the bound is infinite, in which case `HPresolve::run()` returns `HighsPresolveStatus::kUnboundedOrInfeasible`

This closes #1883 