### PR TITLE
Initialize some arrays

### DIFF
--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -216,7 +216,7 @@ FilereaderRetcode FilereaderLp::readModelFromFile(const HighsOptions& options,
 void FilereaderLp::writeToFile(FILE* file, const char* format, ...) {
   va_list argptr;
   va_start(argptr, format);
-  char stringbuffer[LP_MAX_LINE_LENGTH + 1];
+  char stringbuffer[LP_MAX_LINE_LENGTH + 1] = {};
   HighsInt tokenlength =
       vsnprintf(stringbuffer, sizeof stringbuffer, format, argptr);
   va_end(argptr);

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -33,7 +33,7 @@ void highsLogHeader(const HighsLogOptions& log_options,
 
 std::array<char, 32> highsDoubleToString(const double val,
                                          const double tolerance) {
-  std::array<char, 32> printString;
+  std::array<char, 32> printString = {};
   double l =
       std::abs(val) == kHighsInf
           ? 1.0
@@ -41,55 +41,55 @@ std::array<char, 32> highsDoubleToString(const double val,
              std::log10(std::max(tolerance, std::abs(val)) / (tolerance)));
   switch (int(l)) {
     case 0:
-      std::snprintf(printString.data(), 32, "%c", '0');
+      std::snprintf(printString.data(), printString.size(), "%c", '0');
       break;
     case 1:
-      std::snprintf(printString.data(), 32, "%.1g", val);
+      std::snprintf(printString.data(), printString.size(), "%.1g", val);
       break;
     case 2:
-      std::snprintf(printString.data(), 32, "%.2g", val);
+      std::snprintf(printString.data(), printString.size(), "%.2g", val);
       break;
     case 3:
-      std::snprintf(printString.data(), 32, "%.3g", val);
+      std::snprintf(printString.data(), printString.size(), "%.3g", val);
       break;
     case 4:
-      std::snprintf(printString.data(), 32, "%.4g", val);
+      std::snprintf(printString.data(), printString.size(), "%.4g", val);
       break;
     case 5:
-      std::snprintf(printString.data(), 32, "%.5g", val);
+      std::snprintf(printString.data(), printString.size(), "%.5g", val);
       break;
     case 6:
-      std::snprintf(printString.data(), 32, "%.6g", val);
+      std::snprintf(printString.data(), printString.size(), "%.6g", val);
       break;
     case 7:
-      std::snprintf(printString.data(), 32, "%.7g", val);
+      std::snprintf(printString.data(), printString.size(), "%.7g", val);
       break;
     case 8:
-      std::snprintf(printString.data(), 32, "%.8g", val);
+      std::snprintf(printString.data(), printString.size(), "%.8g", val);
       break;
     case 9:
-      std::snprintf(printString.data(), 32, "%.9g", val);
+      std::snprintf(printString.data(), printString.size(), "%.9g", val);
       break;
     case 10:
-      std::snprintf(printString.data(), 32, "%.10g", val);
+      std::snprintf(printString.data(), printString.size(), "%.10g", val);
       break;
     case 11:
-      std::snprintf(printString.data(), 32, "%.11g", val);
+      std::snprintf(printString.data(), printString.size(), "%.11g", val);
       break;
     case 12:
-      std::snprintf(printString.data(), 32, "%.12g", val);
+      std::snprintf(printString.data(), printString.size(), "%.12g", val);
       break;
     case 13:
-      std::snprintf(printString.data(), 32, "%.13g", val);
+      std::snprintf(printString.data(), printString.size(), "%.13g", val);
       break;
     case 14:
-      std::snprintf(printString.data(), 32, "%.14g", val);
+      std::snprintf(printString.data(), printString.size(), "%.14g", val);
       break;
     case 15:
-      std::snprintf(printString.data(), 32, "%.15g", val);
+      std::snprintf(printString.data(), printString.size(), "%.15g", val);
       break;
     default:
-      std::snprintf(printString.data(), 32, "%.16g", val);
+      std::snprintf(printString.data(), printString.size(), "%.16g", val);
   }
 
   return printString;
@@ -131,7 +131,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
     }
   } else {
     int len = 0;
-    char msgbuffer[kIoBufferSize];
+    char msgbuffer[kIoBufferSize] = {};
     if (prefix)
       len = snprintf(msgbuffer, sizeof(msgbuffer), "%-9s",
                      HighsLogTypeTag[(int)type]);
@@ -199,7 +199,7 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
     }
   } else {
     int len;
-    char msgbuffer[kIoBufferSize];
+    char msgbuffer[kIoBufferSize] = {};
     len = vsnprintf(msgbuffer, sizeof(msgbuffer), format, argptr);
     if (len >= (int)sizeof(msgbuffer)) {
       // Output was truncated: for now just ensure string is null-terminated
@@ -261,7 +261,7 @@ std::string highsFormatToString(const char* format, ...) {
   va_list argptr;
   va_start(argptr, format);
   int len;
-  char msgbuffer[kIoBufferSize];
+  char msgbuffer[kIoBufferSize] = {};
   len = vsnprintf(msgbuffer, sizeof(msgbuffer), format, argptr);
 
   if (len >= (int)sizeof(msgbuffer)) {

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -33,7 +33,8 @@ void highsLogHeader(const HighsLogOptions& log_options,
 
 std::array<char, 32> highsDoubleToString(const double val,
                                          const double tolerance) {
-  std::array<char, 32> printString = {};
+  decltype(highsDoubleToString(std::declval<double>(),
+                               std::declval<double>())) printString = {};
   double l =
       std::abs(val) == kHighsInf
           ? 1.0

--- a/src/lp_data/HighsModelUtils.cpp
+++ b/src/lp_data/HighsModelUtils.cpp
@@ -203,8 +203,8 @@ void writeLpObjective(FILE* file, const HighsLogOptions& log_options,
 
 void writeObjectiveValue(FILE* file, const HighsLogOptions& log_options,
                          const double objective_value) {
-  std::array<char, 32> objStr = highsDoubleToString(
-      objective_value, kHighsSolutionValueToStringTolerance);
+  auto objStr = highsDoubleToString(objective_value,
+                                    kHighsSolutionValueToStringTolerance);
   std::string s = highsFormatToString("Objective %s\n", objStr.data());
   highsFprintfString(file, log_options, s);
 }
@@ -231,8 +231,8 @@ void writePrimalSolution(FILE* file, const HighsLogOptions& log_options,
   highsFprintfString(file, log_options, ss.str());
   for (HighsInt ix = 0; ix < lp.num_col_; ix++) {
     if (sparse && !primal_solution[ix]) continue;
-    std::array<char, 32> valStr = highsDoubleToString(
-        primal_solution[ix], kHighsSolutionValueToStringTolerance);
+    auto valStr = highsDoubleToString(primal_solution[ix],
+                                      kHighsSolutionValueToStringTolerance);
     // Create a column name
     ss.str(std::string());
     ss << "C" << ix;
@@ -284,8 +284,8 @@ void writeModelSolution(FILE* file, const HighsLogOptions& log_options,
     ss << highsFormatToString("# Rows %" HIGHSINT_FORMAT "\n", lp.num_row_);
     highsFprintfString(file, log_options, ss.str());
     for (HighsInt ix = 0; ix < lp.num_row_; ix++) {
-      std::array<char, 32> valStr = highsDoubleToString(
-          solution.row_value[ix], kHighsSolutionValueToStringTolerance);
+      auto valStr = highsDoubleToString(solution.row_value[ix],
+                                        kHighsSolutionValueToStringTolerance);
       // Create a row name
       ss.str(std::string());
       ss << "R" << ix;
@@ -309,8 +309,8 @@ void writeModelSolution(FILE* file, const HighsLogOptions& log_options,
     ss << highsFormatToString("# Columns %" HIGHSINT_FORMAT "\n", lp.num_col_);
     highsFprintfString(file, log_options, ss.str());
     for (HighsInt ix = 0; ix < lp.num_col_; ix++) {
-      std::array<char, 32> valStr = highsDoubleToString(
-          solution.col_dual[ix], kHighsSolutionValueToStringTolerance);
+      auto valStr = highsDoubleToString(solution.col_dual[ix],
+                                        kHighsSolutionValueToStringTolerance);
       ss.str(std::string());
       ss << "C" << ix;
       const std::string name = have_col_names ? lp.col_names_[ix] : ss.str();
@@ -322,8 +322,8 @@ void writeModelSolution(FILE* file, const HighsLogOptions& log_options,
     ss << highsFormatToString("# Rows %" HIGHSINT_FORMAT "\n", lp.num_row_);
     highsFprintfString(file, log_options, ss.str());
     for (HighsInt ix = 0; ix < lp.num_row_; ix++) {
-      std::array<char, 32> valStr = highsDoubleToString(
-          solution.row_dual[ix], kHighsSolutionValueToStringTolerance);
+      auto valStr = highsDoubleToString(solution.row_dual[ix],
+                                        kHighsSolutionValueToStringTolerance);
       ss.str(std::string());
       ss << "R" << ix;
       const std::string name = have_row_names ? lp.row_names_[ix] : ss.str();
@@ -435,9 +435,8 @@ void writeSolutionFile(FILE* file, const HighsOptions& options,
     ss << highsFormatToString("Model status: %s\n",
                               utilModelStatusToString(model_status).c_str());
     highsFprintfString(file, log_options, ss.str());
-    std::array<char, 32> objStr =
-        highsDoubleToString((double)info.objective_function_value,
-                            kHighsSolutionValueToStringTolerance);
+    auto objStr = highsDoubleToString((double)info.objective_function_value,
+                                      kHighsSolutionValueToStringTolerance);
     highsFprintfString(file, log_options, "\n");
     ss.str(std::string());
     ss << highsFormatToString("Objective value: %s\n", objStr.data());
@@ -469,7 +468,7 @@ void writeGlpsolCostRow(FILE* file, const HighsLogOptions& log_options,
   ss.str(std::string());
   if (raw) {
     double double_value = objective_function_value;
-    std::array<char, 32> double_string = highsDoubleToString(
+    auto double_string = highsDoubleToString(
         double_value, kGlpsolSolutionValueToStringTolerance);
     // Last term of 0 for dual should (also) be blank when not MIP
     ss << highsFormatToString("i %d %s%s%s\n", (int)row_id, is_mip ? "" : "b ",
@@ -754,7 +753,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       }
     }
     double double_value = has_objective ? info.objective_function_value : 0;
-    std::array<char, 32> double_string =
+    auto double_string =
         highsDoubleToString(double_value, kHighsSolutionValueToStringTolerance);
     ss << highsFormatToString(" %s\n", double_string.data());
     highsFprintfString(file, log_options, ss.str());
@@ -795,7 +794,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       if (is_mip) {
         // Complete the line if for a MIP
         double double_value = have_value ? solution.row_value[iRow] : 0;
-        std::array<char, 32> double_string = highsDoubleToString(
+        auto double_string = highsDoubleToString(
             double_value, kHighsSolutionValueToStringTolerance);
         ss << highsFormatToString("%s\n", double_string.data());
         highsFprintfString(file, log_options, ss.str());
@@ -847,7 +846,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (raw) {
       ss << highsFormatToString("%s ", status_char.c_str());
       double double_value = have_value ? solution.row_value[iRow] : 0;
-      std::array<char, 32> double_string = highsDoubleToString(
+      auto double_string = highsDoubleToString(
           double_value, kHighsSolutionValueToStringTolerance);
       ss << highsFormatToString("%s ", double_string.data());
     } else {
@@ -866,7 +865,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (have_dual) {
       if (raw) {
         double double_value = solution.row_dual[iRow];
-        std::array<char, 32> double_string = highsDoubleToString(
+        auto double_string = highsDoubleToString(
             double_value, kHighsSolutionValueToStringTolerance);
         ss << highsFormatToString("%s", double_string.data());
       } else {
@@ -920,7 +919,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
       ss << highsFormatToString("%s%d ", line_prefix.c_str(), (int)(iCol + 1));
       if (is_mip) {
         double double_value = have_value ? solution.col_value[iCol] : 0;
-        std::array<char, 32> double_string = highsDoubleToString(
+        auto double_string = highsDoubleToString(
             double_value, kHighsSolutionValueToStringTolerance);
         ss << highsFormatToString("%s\n", double_string.data());
         highsFprintfString(file, log_options, ss.str());
@@ -976,7 +975,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (raw) {
       ss << highsFormatToString("%s ", status_char.c_str());
       double double_value = have_value ? solution.col_value[iCol] : 0;
-      std::array<char, 32> double_string = highsDoubleToString(
+      auto double_string = highsDoubleToString(
           double_value, kHighsSolutionValueToStringTolerance);
       ss << highsFormatToString("%s ", double_string.data());
     } else {
@@ -995,7 +994,7 @@ void writeGlpsolSolution(FILE* file, const HighsOptions& options,
     if (have_dual) {
       if (raw) {
         double double_value = solution.col_dual[iCol];
-        std::array<char, 32> double_string = highsDoubleToString(
+        auto double_string = highsDoubleToString(
             double_value, kHighsSolutionValueToStringTolerance);
         ss << highsFormatToString("%s", double_string.data());
       } else {

--- a/src/lp_data/HighsRanging.cpp
+++ b/src/lp_data/HighsRanging.cpp
@@ -631,8 +631,8 @@ void writeRangingFile(FILE* file, const HighsLp& lp,
   std::array<char, 32> dn_value;
   std::array<char, 32> up_value;
 
-  std::array<char, 32> objective = highsDoubleToString(
-      objective_function_value, kRangingValueToStringTolerance);
+  auto objective = highsDoubleToString(objective_function_value,
+                                       kRangingValueToStringTolerance);
   fprintf(file, "Objective %s\n", objective.data());
   if (pretty) {
     fprintf(file,

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -593,8 +593,7 @@ void HighsMipSolver::cleanupSolve() {
     std::strcpy(gapString.data(), "inf");
   else {
     double printTol = std::max(std::min(1e-2, 1e-1 * gap_), 1e-6);
-    std::array<char, 32> gapValString =
-        highsDoubleToString(100.0 * gap_, printTol);
+    auto gapValString = highsDoubleToString(100.0 * gap_, printTol);
     double gapTol = options_mip_->mip_rel_gap;
 
     if (options_mip_->mip_abs_gap > options_mip_->mip_feasibility_tolerance) {
@@ -609,8 +608,7 @@ void HighsMipSolver::cleanupSolve() {
                     gapValString.data());
     else if (gapTol != kHighsInf) {
       printTol = std::max(std::min(1e-2, 1e-1 * gapTol), 1e-6);
-      std::array<char, 32> gapTolString =
-          highsDoubleToString(100.0 * gapTol, printTol);
+      auto gapTolString = highsDoubleToString(100.0 * gapTol, printTol);
       std::snprintf(gapString.data(), gapString.size(),
                     "%s%% (tolerance: %s%%)", gapValString.data(),
                     gapTolString.data());

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -587,7 +587,7 @@ void HighsMipSolver::cleanupSolve() {
   else
     gap_ = kHighsInf;
 
-  std::array<char, 128> gapString;
+  std::array<char, 128> gapString = {};
 
   if (gap_ == kHighsInf)
     std::strcpy(gapString.data(), "inf");

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1144,7 +1144,7 @@ bool HighsMipSolverData::addIncumbent(const std::vector<double>& sol,
 
 static std::array<char, 22> convertToPrintString(int64_t val) {
   double l = std::log10(std::max(1.0, double(val)));
-  std::array<char, 22> printString;
+  std::array<char, 22> printString = {};
   switch (int(l)) {
     case 0:
     case 1:
@@ -1152,15 +1152,17 @@ static std::array<char, 22> convertToPrintString(int64_t val) {
     case 3:
     case 4:
     case 5:
-      std::snprintf(printString.data(), 22, "%" PRId64, val);
+      std::snprintf(printString.data(), printString.size(), "%" PRId64, val);
       break;
     case 6:
     case 7:
     case 8:
-      std::snprintf(printString.data(), 22, "%" PRId64 "k", val / 1000);
+      std::snprintf(printString.data(), printString.size(), "%" PRId64 "k",
+                    val / 1000);
       break;
     default:
-      std::snprintf(printString.data(), 22, "%" PRId64 "m", val / 1000000);
+      std::snprintf(printString.data(), printString.size(), "%" PRId64 "m",
+                    val / 1000000);
   }
 
   return printString;
@@ -1168,7 +1170,7 @@ static std::array<char, 22> convertToPrintString(int64_t val) {
 
 static std::array<char, 22> convertToPrintString(double val,
                                                  const char* trailingStr = "") {
-  std::array<char, 22> printString;
+  std::array<char, 22> printString = {};
   double l = std::abs(val) == kHighsInf
                  ? 0.0
                  : std::log10(std::max(1e-6, std::abs(val)));
@@ -1177,23 +1179,28 @@ static std::array<char, 22> convertToPrintString(double val,
     case 1:
     case 2:
     case 3:
-      std::snprintf(printString.data(), 22, "%.10g%s", val, trailingStr);
+      std::snprintf(printString.data(), printString.size(), "%.10g%s", val,
+                    trailingStr);
       break;
     case 4:
-      std::snprintf(printString.data(), 22, "%.11g%s", val, trailingStr);
+      std::snprintf(printString.data(), printString.size(), "%.11g%s", val,
+                    trailingStr);
       break;
     case 5:
-      std::snprintf(printString.data(), 22, "%.12g%s", val, trailingStr);
+      std::snprintf(printString.data(), printString.size(), "%.12g%s", val,
+                    trailingStr);
       break;
     case 6:
     case 7:
     case 8:
     case 9:
     case 10:
-      std::snprintf(printString.data(), 22, "%.13g%s", val, trailingStr);
+      std::snprintf(printString.data(), printString.size(), "%.13g%s", val,
+                    trailingStr);
       break;
     default:
-      std::snprintf(printString.data(), 22, "%.9g%s", val, trailingStr);
+      std::snprintf(printString.data(), printString.size(), "%.9g%s", val,
+                    trailingStr);
   }
 
   return printString;
@@ -1263,7 +1270,7 @@ void HighsMipSolverData::printDisplayLine(char source) {
     else
       gap = 100. * (ub - lb) / fabs(ub);
 
-    std::array<char, 22> gap_string;
+    std::array<char, 22> gap_string = {};
     if (gap >= 9999.)
       std::strcpy(gap_string.data(), "Large");
     else

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1143,8 +1143,8 @@ bool HighsMipSolverData::addIncumbent(const std::vector<double>& sol,
 }
 
 static std::array<char, 22> convertToPrintString(int64_t val) {
+  decltype(convertToPrintString(std::declval<int64_t>())) printString = {};
   double l = std::log10(std::max(1.0, double(val)));
-  std::array<char, 22> printString = {};
   switch (int(l)) {
     case 0:
     case 1:
@@ -1170,7 +1170,8 @@ static std::array<char, 22> convertToPrintString(int64_t val) {
 
 static std::array<char, 22> convertToPrintString(double val,
                                                  const char* trailingStr = "") {
-  std::array<char, 22> printString = {};
+  decltype(convertToPrintString(std::declval<double>(),
+                                std::declval<char*>())) printString = {};
   double l = std::abs(val) == kHighsInf
                  ? 0.0
                  : std::log10(std::max(1e-6, std::abs(val)));
@@ -1244,11 +1245,9 @@ void HighsMipSolverData::printDisplayLine(char source) {
 
   ++num_disp_lines;
 
-  std::array<char, 22> print_nodes = convertToPrintString(num_nodes);
-  std::array<char, 22> queue_nodes =
-      convertToPrintString(nodequeue.numActiveNodes());
-  std::array<char, 22> print_leaves =
-      convertToPrintString(num_leaves - num_leaves_before_run);
+  auto print_nodes = convertToPrintString(num_nodes);
+  auto queue_nodes = convertToPrintString(nodequeue.numActiveNodes());
+  auto print_leaves = convertToPrintString(num_leaves - num_leaves_before_run);
 
   double explored = 100 * double(pruned_treeweight);
 
@@ -1258,8 +1257,7 @@ void HighsMipSolverData::printDisplayLine(char source) {
   double ub = kHighsInf;
   double gap = kHighsInf;
 
-  std::array<char, 22> print_lp_iters =
-      convertToPrintString(total_lp_iterations);
+  auto print_lp_iters = convertToPrintString(total_lp_iterations);
   if (upper_bound != kHighsInf) {
     ub = upper_bound + offset;
 
@@ -1284,7 +1282,7 @@ void HighsMipSolverData::printDisplayLine(char source) {
     } else
       ub_string = convertToPrintString((int)mipsolver.orig_model_->sense_ * ub);
 
-    std::array<char, 22> lb_string =
+    auto lb_string =
         convertToPrintString((int)mipsolver.orig_model_->sense_ * lb);
 
     highsLogUser(
@@ -1305,7 +1303,7 @@ void HighsMipSolverData::printDisplayLine(char source) {
     } else
       ub_string = convertToPrintString((int)mipsolver.orig_model_->sense_ * ub);
 
-    std::array<char, 22> lb_string =
+    auto lb_string =
         convertToPrintString((int)mipsolver.orig_model_->sense_ * lb);
 
     highsLogUser(


### PR DESCRIPTION
Valgrind complains about uninitialized values, for example, used by `snprintf`. These changes initialize some arrays to fix this.