### PR TITLE
Some minor changes

### DIFF
--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -220,8 +220,7 @@ void FilereaderLp::writeToFile(FILE* file, const char* format, ...) {
   HighsInt tokenlength =
       vsnprintf(stringbuffer.data(), stringbuffer.size(), format, argptr);
   va_end(argptr);
-  if (static_cast<size_t>(this->linelength + tokenlength) + 1 >=
-      stringbuffer.size()) {
+  if (this->linelength + tokenlength >= LP_MAX_LINE_LENGTH) {
     fprintf(file, "\n");
     fprintf(file, "%s", stringbuffer.data());
     this->linelength = tokenlength;

--- a/src/io/FilereaderLp.cpp
+++ b/src/io/FilereaderLp.cpp
@@ -216,16 +216,17 @@ FilereaderRetcode FilereaderLp::readModelFromFile(const HighsOptions& options,
 void FilereaderLp::writeToFile(FILE* file, const char* format, ...) {
   va_list argptr;
   va_start(argptr, format);
-  char stringbuffer[LP_MAX_LINE_LENGTH + 1] = {};
+  std::array<char, LP_MAX_LINE_LENGTH + 1> stringbuffer = {};
   HighsInt tokenlength =
-      vsnprintf(stringbuffer, sizeof stringbuffer, format, argptr);
+      vsnprintf(stringbuffer.data(), stringbuffer.size(), format, argptr);
   va_end(argptr);
-  if (this->linelength + tokenlength >= LP_MAX_LINE_LENGTH) {
+  if (static_cast<size_t>(this->linelength + tokenlength) + 1 >=
+      stringbuffer.size()) {
     fprintf(file, "\n");
-    fprintf(file, "%s", stringbuffer);
+    fprintf(file, "%s", stringbuffer.data());
     this->linelength = tokenlength;
   } else {
-    fprintf(file, "%s", stringbuffer);
+    fprintf(file, "%s", stringbuffer.data());
     this->linelength += tokenlength;
   }
 }

--- a/src/io/HMPSIO.cpp
+++ b/src/io/HMPSIO.cpp
@@ -78,21 +78,21 @@ FilereaderRetcode readMps(
   highsLogDev(log_options, HighsLogType::kInfo, "readMPS: Opened file  OK\n");
   // Input buffer
   const HighsInt lmax = 128;
-  char line[lmax];
-  char flag[2] = {0, 0};
-  double data[3];
+  std::array<char, lmax> line;
+  std::array<char, 2> flag = {0, 0};
+  std::array<double, 3> data;
 
   HighsInt num_alien_entries = 0;
   HighsVarType integerCol = HighsVarType::kContinuous;
 
   // Load NAME
-  load_mpsLine(file, integerCol, lmax, line, flag, data);
+  load_mpsLine(file, integerCol, lmax, line.data(), flag.data(), data.data());
   highsLogDev(log_options, HighsLogType::kInfo, "readMPS: Read NAME    OK\n");
   // Load OBJSENSE or ROWS
-  load_mpsLine(file, integerCol, lmax, line, flag, data);
+  load_mpsLine(file, integerCol, lmax, line.data(), flag.data(), data.data());
   if (flag[0] == 'O') {
     // Found OBJSENSE
-    load_mpsLine(file, integerCol, lmax, line, flag, data);
+    load_mpsLine(file, integerCol, lmax, line.data(), flag.data(), data.data());
     std::string sense(&line[2], &line[2] + 3);
     // the sense must be "MAX" or "MIN"
     if (sense.compare("MAX") == 0) {
@@ -105,7 +105,7 @@ FilereaderRetcode readMps(
     highsLogDev(log_options, HighsLogType::kInfo,
                 "readMPS: Read OBJSENSE OK\n");
     // Load ROWS
-    load_mpsLine(file, integerCol, lmax, line, flag, data);
+    load_mpsLine(file, integerCol, lmax, line.data(), flag.data(), data.data());
   }
 
   row_names.clear();
@@ -113,7 +113,8 @@ FilereaderRetcode readMps(
   vector<char> rowType;
   map<double, int> rowIndex;
   double objName = 0;
-  while (load_mpsLine(file, integerCol, lmax, line, flag, data)) {
+  while (load_mpsLine(file, integerCol, lmax, line.data(), flag.data(),
+                      data.data())) {
     if (flag[0] == 'N' &&
         (objName == 0 || keep_n_rows == kKeepNRowsDeleteRows)) {
       // N-row: take the first as the objective and possibly ignore any others
@@ -149,7 +150,8 @@ FilereaderRetcode readMps(
   // line - field 5 non-empty. save_flag1 is used to deduce whether
   // the row name and value are from fields 5 and 6, or 3 and 4
   HighsInt save_flag1 = 0;
-  while (load_mpsLine(file, integerCol, lmax, line, flag, data)) {
+  while (load_mpsLine(file, integerCol, lmax, line.data(), flag.data(),
+                      data.data())) {
     HighsInt iRow = rowIndex[data[2]] - 1;
     std::string name = "";
     if (iRow >= 0) name = row_names[iRow];
@@ -218,7 +220,8 @@ FilereaderRetcode readMps(
   num_alien_entries = 0;
   vector<double> RHS(numRow, 0);
   save_flag1 = 0;
-  while (load_mpsLine(file, integerCol, lmax, line, flag, data)) {
+  while (load_mpsLine(file, integerCol, lmax, line.data(), flag.data(),
+                      data.data())) {
     if (data[2] != objName) {
       HighsInt iRow = rowIndex[data[2]] - 1;
       if (iRow >= 0) {
@@ -268,7 +271,8 @@ FilereaderRetcode readMps(
   rowUpper.resize(numRow);
   if (flag[0] == 'R') {
     save_flag1 = 0;
-    while (load_mpsLine(file, integerCol, lmax, line, flag, data)) {
+    while (load_mpsLine(file, integerCol, lmax, line.data(), flag.data(),
+                        data.data())) {
       HighsInt iRow = rowIndex[data[2]] - 1;
       if (iRow >= 0) {
         if (rowType[iRow] == 'L' || (rowType[iRow] == 'E' && data[0] < 0)) {
@@ -338,7 +342,8 @@ FilereaderRetcode readMps(
   colLower.assign(numCol, 0);
   colUpper.assign(numCol, kHighsInf);
   if (flag[0] == 'B') {
-    while (load_mpsLine(file, integerCol, lmax, line, flag, data)) {
+    while (load_mpsLine(file, integerCol, lmax, line.data(), flag.data(),
+                        data.data())) {
       // Find the column index associated with the name "data[2]". If
       // the name is in colIndex then the value stored is the true
       // column index plus one. Otherwise 0 will be returned.
@@ -389,7 +394,8 @@ FilereaderRetcode readMps(
     HighsInt previous_col = -1;
     bool has_diagonal = false;
     Qstart.clear();
-    while (load_mpsLine(file, integerCol, lmax, line, flag, data)) {
+    while (load_mpsLine(file, integerCol, lmax, line.data(), flag.data(),
+                        data.data())) {
       HighsInt iCol0 = colIndex[data[1]] - 1;
       std::string name0 = "";
       if (iCol0 >= 0) name0 = col_names[iCol0];

--- a/src/io/HighsIO.cpp
+++ b/src/io/HighsIO.cpp
@@ -138,7 +138,7 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
                        HighsLogTypeTag[(int)type]);
       // assert that there are no encoding errors
       assert(l >= 0);
-      len += static_cast<size_t>(l);
+      len = static_cast<size_t>(l);
     }
     if (len < msgbuffer.size()) {
       int l = vsnprintf(msgbuffer.data() + len, msgbuffer.size() - len, format,
@@ -146,10 +146,6 @@ void highsLogUser(const HighsLogOptions& log_options_, const HighsLogType type,
       // assert that there are no encoding errors
       assert(l >= 0);
       len += static_cast<size_t>(l);
-    }
-    if (len >= msgbuffer.size()) {
-      // Output was truncated: for now just ensure string is null-terminated
-      msgbuffer[msgbuffer.size() - 1] = '\0';
     }
     if (log_options_.user_log_callback) {
       log_options_.user_log_callback(type, msgbuffer.data(),
@@ -211,10 +207,6 @@ void highsLogDev(const HighsLogOptions& log_options_, const HighsLogType type,
     int len = vsnprintf(msgbuffer.data(), msgbuffer.size(), format, argptr);
     // assert that there are no encoding errors
     assert(len >= 0);
-    if (static_cast<size_t>(len) >= msgbuffer.size()) {
-      // Output was truncated: for now just ensure string is null-terminated
-      msgbuffer[msgbuffer.size() - 1] = '\0';
-    }
     if (log_options_.user_log_callback) {
       log_options_.user_log_callback(type, msgbuffer.data(),
                                      log_options_.user_log_callback_data);
@@ -274,11 +266,6 @@ std::string highsFormatToString(const char* format, ...) {
   int len = vsnprintf(msgbuffer.data(), msgbuffer.size(), format, argptr);
   // assert that there are no encoding errors
   assert(len >= 0);
-
-  if (static_cast<size_t>(len) >= msgbuffer.size()) {
-    // Output was truncated: for now just ensure string is null-terminated
-    msgbuffer[msgbuffer.size() - 1] = '\0';
-  }
   va_end(argptr);
   return std::string(msgbuffer.data());
 }

--- a/src/mip/HighsDomain.cpp
+++ b/src/mip/HighsDomain.cpp
@@ -180,7 +180,7 @@ void HighsDomain::ConflictPoolPropagation::conflictAdded(HighsInt conflict) {
   }
   switch (numWatched) {
     case 0: {
-      std::pair<HighsInt, HighsInt> latestActive[2];
+      std::array<std::pair<HighsInt, HighsInt>, 2> latestActive;
       HighsInt numActive = 0;
       for (HighsInt i = start; i != end; ++i) {
         HighsInt pos = conflictEntries[i].boundtype == HighsBoundType::kLower
@@ -306,7 +306,7 @@ void HighsDomain::ConflictPoolPropagation::propagateConflict(
 
   WatchedLiteral* watched = watchedLiterals_.data() + 2 * conflict;
 
-  HighsInt inactive[2];
+  std::array<HighsInt, 2> inactive;
   HighsInt numInactive = 0;
   for (HighsInt i = start; i != end; ++i) {
     if (domain->isActive(entries[i])) continue;

--- a/src/mip/HighsDomain.cpp
+++ b/src/mip/HighsDomain.cpp
@@ -276,7 +276,7 @@ void HighsDomain::ConflictPoolPropagation::updateActivityUbChange(
     HighsInt conflict = i >> 1;
 
     const HighsDomainChange& domchg = watchedLiterals_[i].domchg;
-    HighsInt numInactiveDelta =
+    uint8_t numInactiveDelta =
         (domchg.boundval < newbound) - (domchg.boundval < oldbound);
     if (numInactiveDelta != 0) {
       conflictFlag_[conflict] += numInactiveDelta;

--- a/src/mip/HighsGFkSolve.h
+++ b/src/mip/HighsGFkSolve.h
@@ -317,7 +317,7 @@ class HighsGFkSolve {
 
     // check if a solution exists by scanning the linearly dependent rows for
     // nonzero right hand sides
-    bool hasSolution[kNumRhs];
+    std::array<bool, kNumRhs> hasSolution;
     HighsInt numRhsWithSolution = 0;
     for (int rhsIndex = 0; rhsIndex < kNumRhs; ++rhsIndex) {
       hasSolution[rhsIndex] = true;
@@ -341,7 +341,7 @@ class HighsGFkSolve {
     // now iterate a subset of the basic solutions.
     // When a column leaves the basis we do not allow it to enter again so that
     // we iterate at most one solution for each nonbasic column
-    std::vector<SolutionEntry> solution[kNumRhs];
+    std::array<std::vector<SolutionEntry>, kNumRhs> solution;
     for (int rhsIndex = 0; rhsIndex < kNumRhs; ++rhsIndex)
       if (hasSolution[rhsIndex]) solution[rhsIndex].reserve(numCol);
 
@@ -384,7 +384,7 @@ class HighsGFkSolve {
       for (HighsInt i = numFactorRows - 1; i >= 0; --i) {
         HighsInt row = factorRowPerm[i];
 
-        unsigned int solval[kNumRhs];
+        std::array<unsigned int, kNumRhs> solval;
 
         for (int rhsIndex = 0; rhsIndex < kNumRhs; ++rhsIndex) {
           if (!hasSolution[rhsIndex]) continue;

--- a/src/mip/HighsImplications.cpp
+++ b/src/mip/HighsImplications.cpp
@@ -79,7 +79,7 @@ bool HighsImplications::computeImplications(HighsInt col, bool val) {
 
   pdqsort(implics.begin(), binstart);
 
-  HighsCliqueTable::CliqueVar clique[2];
+  std::array<HighsCliqueTable::CliqueVar, 2> clique;
   clique[0] = HighsCliqueTable::CliqueVar(col, val);
 
   for (auto i = binstart; i != implics.end(); ++i) {
@@ -88,7 +88,7 @@ bool HighsImplications::computeImplications(HighsInt col, bool val) {
     else
       clique[1] = HighsCliqueTable::CliqueVar(i->column, 1);
 
-    cliquetable.addClique(mipsolver, clique, 2);
+    cliquetable.addClique(mipsolver, clique.data(), 2);
     if (globaldomain.infeasible() || globaldomain.isFixed(col)) return true;
   }
 
@@ -519,8 +519,8 @@ void HighsImplications::separateImpliedBounds(
     HighsCutPool& cutpool, double feastol) {
   HighsDomain& globaldomain = mipsolver.mipdata_->domain;
 
-  HighsInt inds[2];
-  double vals[2];
+  std::array<HighsInt, 2> inds;
+  std::array<double, 2> vals;
   double rhs;
 
   HighsInt numboundchgs = 0;
@@ -586,7 +586,8 @@ void HighsImplications::separateImpliedBounds(
       if (infeas) {
         vals[0] = 1.0;
         inds[0] = col;
-        cutpool.addCut(mipsolver, inds, vals, 1, 0.0, false, true, false);
+        cutpool.addCut(mipsolver, inds.data(), vals.data(), 1, 0.0, false, true,
+                       false);
         continue;
       }
 
@@ -621,7 +622,7 @@ void HighsImplications::separateImpliedBounds(
 
         if (viol > feastol) {
           // printf("added implied bound cut to pool\n");
-          cutpool.addCut(mipsolver, inds, vals, 2, rhs,
+          cutpool.addCut(mipsolver, inds.data(), vals.data(), 2, rhs,
                          mipsolver.variableType(implics[i].column) !=
                              HighsVarType::kContinuous,
                          false, false, false);
@@ -637,7 +638,8 @@ void HighsImplications::separateImpliedBounds(
       if (infeas) {
         vals[0] = -1.0;
         inds[0] = col;
-        cutpool.addCut(mipsolver, inds, vals, 1, -1.0, false, true, false);
+        cutpool.addCut(mipsolver, inds.data(), vals.data(), 1, -1.0, false,
+                       true, false);
         continue;
       }
 
@@ -671,7 +673,7 @@ void HighsImplications::separateImpliedBounds(
 
         if (viol > feastol) {
           // printf("added implied bound cut to pool\n");
-          cutpool.addCut(mipsolver, inds, vals, 2, rhs,
+          cutpool.addCut(mipsolver, inds.data(), vals.data(), 2, rhs,
                          mipsolver.variableType(implics[i].column) !=
                              HighsVarType::kContinuous,
                          false, false, false);

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -174,7 +174,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
   HighsInt currentPath[maxPathLen];
   std::vector<std::pair<std::vector<HighsInt>, std::vector<double>>>
       aggregatedPath;
-  double scales[2];
+  std::array<double, 2> scales;
   for (HighsInt i = 0; i != lp.num_row_; ++i) {
     switch (rowtype[i]) {
       case RowType::kUnusuable:

--- a/src/parallel/HighsSplitDeque.h
+++ b/src/parallel/HighsSplitDeque.h
@@ -176,7 +176,7 @@ class HighsSplitDeque {
   static_assert(sizeof(StealerData) <= 64,
                 "sizeof(StealerData) exceeds cache line size");
   static_assert(sizeof(WorkerBunkData) <= 64,
-                "sizeof(GlobalQueueData) exceeds cache line size");
+                "sizeof(WorkerBunkData) exceeds cache line size");
 
   alignas(64) OwnerData ownerData;
   alignas(64) std::atomic<bool> splitRequest;

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -123,7 +123,8 @@ class HighsHashTree {
       assert(other.size <= capacity());
       memcpy((void*)this, (void*)&other,
              (char*)&other.hashes[other.size + 1] - (char*)&other);
-      std::move(&other.entries[0], &other.entries[size], &entries[0]);
+      std::move(other.entries.begin(), std::next(other.entries.begin(), size),
+                entries.begin());
     }
 
     int get_num_entries() const { return size; }
@@ -190,7 +191,9 @@ class HighsHashTree {
 
       --size;
       if (pos < size) {
-        std::move(&entries[pos + 1], &entries[size + 1], &entries[pos]);
+        std::move(std::next(entries.begin(), pos + 1),
+                  std::next(entries.begin(), size + 1),
+                  std::next(entries.begin(), pos));
         memmove(&hashes[pos], &hashes[pos + 1],
                 sizeof(hashes[0]) * (size - pos));
         if (get_first_chunk16(hashes[startPos]) != hashChunk)
@@ -254,7 +257,9 @@ class HighsHashTree {
 
     void move_backward(const int& first, const int& last) {
       // move elements backwards
-      std::move_backward(&entries[first], &entries[last], &entries[last + 1]);
+      std::move_backward(std::next(entries.begin(), first),
+                         std::next(entries.begin(), last),
+                         std::next(entries.begin(), last + 1));
       memmove(&hashes[first + 1], &hashes[first],
               sizeof(hashes[0]) * (last - first));
     }

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -113,8 +113,8 @@ class HighsHashTree {
     // to do a linear scan and key comparisons at all
     Occupation occupation;
     int size;
-    uint64_t hashes[capacity() + 1];
-    Entry entries[capacity()];
+    std::array<uint64_t, capacity() + 1> hashes;
+    std::array<Entry, capacity()> entries;
 
     InnerLeaf() : occupation(0), size(0) { hashes[0] = 0; }
 

--- a/src/util/HighsHashTree.h
+++ b/src/util/HighsHashTree.h
@@ -843,7 +843,7 @@ class HighsHashTree {
                 hash, hashPos + 1, entry);
           } else {
             // there are many collisions, determine the exact sizes first
-            uint8_t sizes[InnerLeaf<4>::capacity() + 1] = {};
+            std::array<uint8_t, InnerLeaf<4>::capacity() + 1> sizes = {};
             sizes[occupation.num_set_until(hashChunk) - 1] += 1;
             for (int i = 0; i < leaf->size; ++i) {
               int pos =


### PR DESCRIPTION
- Use `std::array` instead of C arrays
- Character strings produced by `snprintf` and `vsnprintf` are null-terminated, so no need to check
- Fix typo in `src/parallel/HighsSplitDeque.h`
- Testing on 400+ MIP instances revealed no issues