### PR TITLE
An attempt to fix potential deadlock issues in Windows.

### DIFF
--- a/src/parallel/HighsTaskExecutor.h
+++ b/src/parallel/HighsTaskExecutor.h
@@ -89,7 +89,6 @@ class HighsTaskExecutor {
   }
 
   static void run_worker(int workerId, HighsTaskExecutor* ptr) {
-
     threadLocalExecutorHandle().ptr = ptr;
 
     // check if main thread has shutdown before thread has started


### PR DESCRIPTION
Removes synchronization with worker threads on shutdown. Also removes the "search" for the main executor in the worker threads.

Instead we simply pass the main executor to the thread as a parameter.  We also pass the underlying shared_ptr to avoid potential edge cases where reference count drops to zero before some threads initialize.

I made the run_worker static to avoid any confusion about `this` vs `executor->ptr`, and so it uses the shared_ptr to reference the shared memory.

The last worker thread will delete the shared memory, via the shared_ptr reference count.

This **might** fix issues mentioned in #1886 and #1044.