### PR TITLE
fix Markdown list syntax in solvers.md

### DIFF
--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -21,8 +21,8 @@ J. A. J. Hall, Mathematical Programming Computation, 10 (1), 119-142,
 
 * Setting the option [__solver__](@ref option-solver) to "simplex" forces the simplex solver to be used
 * The option [__simplex\_strategy__](@ref option-simplex_strategy)
-determines whether the primal solver or one of the parallel solvers is
-to be used.
+  determines whether the primal solver or one of the parallel solvers is
+  to be used.
 
 #### Interior point
 


### PR DESCRIPTION
This is a minor correction of PR https://github.com/ERGO-Code/HiGHS/pull/1916 which added a new solvers.md page to the doc (available at https://ergo-code.github.io/HiGHS/dev/solvers/).

The list item "The option simplex_strategy..." was cut by the line break