### PR TITLE
No longer removing trailing comments in MPS files

### DIFF
--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -344,16 +344,16 @@ TEST_CASE("filereader-dD2e", "[highs_filereader]") {
   REQUIRE(objective_value == optimal_objective_value);
 }
 
-TEST_CASE("filereader-comment", "[highs_filereader]") {
-  // Check that comments - either whole line with * in first column,
-  // or rest of line following */$ are handled correctly
-  const double optimal_objective_value = -4;
-  std::string model_file =
-      std::string(HIGHS_DIR) + "/check/instances/comment.mps";
-  Highs highs;
-  highs.setOptionValue("output_flag", dev_run);
-  REQUIRE(highs.readModel(model_file) == HighsStatus::kOk);
-  REQUIRE(highs.run() == HighsStatus::kOk);
-  double objective_value = highs.getInfo().objective_function_value;
-  REQUIRE(objective_value == optimal_objective_value);
-}
+// TEST_CASE("filereader-comment", "[highs_filereader]") {
+//   // Check that comments - either whole line with * in first column,
+//   // or rest of line following */$ are handled correctly
+//   const double optimal_objective_value = -4;
+//   std::string model_file =
+//       std::string(HIGHS_DIR) + "/check/instances/comment.mps";
+//   Highs highs;
+//   highs.setOptionValue("output_flag", dev_run);
+//   REQUIRE(highs.readModel(model_file) == HighsStatus::kOk);
+//   REQUIRE(highs.run() == HighsStatus::kOk);
+//   double objective_value = highs.getInfo().objective_function_value;
+//   REQUIRE(objective_value == optimal_objective_value);
+// }

--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -215,19 +215,22 @@ bool HMpsFF::timeout() {
 }
 
 bool HMpsFF::getMpsLine(std::istream& file, std::string& strline, bool& skip) {
+  const bool remove_trailing_comments = false;
   skip = false;
   if (!getline(file, strline)) return false;
   if (is_empty(strline) || strline[0] == '*') {
     skip = true;
   } else {
-    // Remove any trailing comment
-    const size_t p = strline.find_first_of(mps_comment_chars);
-    if (p <= strline.length()) {
-      // A comment character has been found, so erase from it to the end
-      // of the line and check whether the line is now empty
-      strline.erase(p);
-      skip = is_empty(strline);
-      if (skip) return true;
+    if (remove_trailing_comments) {
+      // Remove any trailing comment
+      const size_t p = strline.find_first_of(mps_comment_chars);
+      if (p <= strline.length()) {
+	// A comment character has been found, so erase from it to the end
+	// of the line and check whether the line is now empty
+	strline.erase(p);
+	skip = is_empty(strline);
+	if (skip) return true;
+      }
     }
     strline = trim(strline);
     skip = is_empty(strline);


### PR DESCRIPTION
Now skips the code to removing trailing comments in MPS files as it's fooled by $ or * in row/column names

This will close #1945 