### PR TITLE
MIP analysis

### DIFF
--- a/cmake/sources-python.cmake
+++ b/cmake/sources-python.cmake
@@ -208,6 +208,7 @@ set(highs_sources_python
     src/mip/HighsImplications.cpp
     src/mip/HighsLpAggregator.cpp
     src/mip/HighsLpRelaxation.cpp
+    src/mip/HighsMipAnalysis.cpp
     src/mip/HighsMipSolver.cpp
     src/mip/HighsMipSolverData.cpp
     src/mip/HighsModkSeparator.cpp
@@ -326,6 +327,7 @@ set(highs_headers_python
     src/mip/HighsImplications.h
     src/mip/HighsLpAggregator.h
     src/mip/HighsLpRelaxation.h
+    src/mip/HighsMipAnalysis.h
     src/mip/HighsMipSolver.h
     src/mip/HighsMipSolverData.h
     src/mip/HighsModkSeparator.h

--- a/cmake/sources-python.cmake
+++ b/cmake/sources-python.cmake
@@ -330,6 +330,7 @@ set(highs_headers_python
     src/mip/HighsMipAnalysis.h
     src/mip/HighsMipSolver.h
     src/mip/HighsMipSolverData.h
+    src/mip/HighsMipTimer.h
     src/mip/HighsModkSeparator.h
     src/mip/HighsNodeQueue.h
     src/mip/HighsObjectiveFunction.h

--- a/cmake/sources-python.cmake
+++ b/cmake/sources-python.cmake
@@ -330,7 +330,6 @@ set(highs_headers_python
     src/mip/HighsMipAnalysis.h
     src/mip/HighsMipSolver.h
     src/mip/HighsMipSolverData.h
-    src/mip/HighsMipTimer.h
     src/mip/HighsModkSeparator.h
     src/mip/HighsNodeQueue.h
     src/mip/HighsObjectiveFunction.h
@@ -343,6 +342,7 @@ set(highs_headers_python
     src/mip/HighsSeparator.h
     src/mip/HighsTableauSeparator.h
     src/mip/HighsTransformedLp.h
+    src/mip/MipTimer.h
     src/model/HighsHessian.h
     src/model/HighsHessianUtils.h
     src/model/HighsModel.h

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -334,7 +334,6 @@ set(highs_headers
     mip/HighsMipAnalysis.h
     mip/HighsMipSolver.h
     mip/HighsMipSolverData.h
-    mip/HighsMipTimer.h
     mip/HighsModkSeparator.h
     mip/HighsNodeQueue.h
     mip/HighsObjectiveFunction.h
@@ -347,6 +346,7 @@ set(highs_headers
     mip/HighsSeparator.h
     mip/HighsTableauSeparator.h
     mip/HighsTransformedLp.h
+    mip/MipTimer.h
     model/HighsHessian.h
     model/HighsHessianUtils.h
     model/HighsModel.h

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -334,6 +334,7 @@ set(highs_headers
     mip/HighsMipAnalysis.h
     mip/HighsMipSolver.h
     mip/HighsMipSolverData.h
+    mip/HighsMipTimer.h
     mip/HighsModkSeparator.h
     mip/HighsNodeQueue.h
     mip/HighsObjectiveFunction.h

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -209,6 +209,7 @@ set(highs_sources
     mip/HighsImplications.cpp
     mip/HighsLpAggregator.cpp
     mip/HighsLpRelaxation.cpp
+    mip/HighsMipAnalysis.cpp
     mip/HighsMipSolver.cpp
     mip/HighsMipSolverData.cpp
     mip/HighsModkSeparator.cpp
@@ -330,6 +331,7 @@ set(highs_headers
     mip/HighsImplications.h
     mip/HighsLpAggregator.h
     mip/HighsLpRelaxation.h
+    mip/HighsMipAnalysis.h
     mip/HighsMipSolver.h
     mip/HighsMipSolverData.h
     mip/HighsModkSeparator.h

--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -225,11 +225,11 @@ bool HMpsFF::getMpsLine(std::istream& file, std::string& strline, bool& skip) {
       // Remove any trailing comment
       const size_t p = strline.find_first_of(mps_comment_chars);
       if (p <= strline.length()) {
-	// A comment character has been found, so erase from it to the end
-	// of the line and check whether the line is now empty
-	strline.erase(p);
-	skip = is_empty(strline);
-	if (skip) return true;
+        // A comment character has been found, so erase from it to the end
+        // of the line and check whether the line is now empty
+        strline.erase(p);
+        skip = is_empty(strline);
+        if (skip) return true;
       }
     }
     strline = trim(strline);

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3301,6 +3301,9 @@ HighsPresolveStatus Highs::runPresolve(const bool force_lp_presolve,
     // Presolved model is extracted now since it's part of solver,
     // which is lost on return
     HighsMipSolver solver(callback_, options_, original_lp, solution_);
+    // Start the MIP solver's total clock so that timeout in presolve
+    // can be identified
+    solver.timer_.start(timer_.total_clock);
     // Only place that HighsMipSolver::runPresolve is called
     solver.runPresolve(options_.presolve_reduction_limit);
     presolve_return_status = solver.getPresolveStatus();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3301,6 +3301,7 @@ HighsPresolveStatus Highs::runPresolve(const bool force_lp_presolve,
     // Presolved model is extracted now since it's part of solver,
     // which is lost on return
     HighsMipSolver solver(callback_, options_, original_lp, solution_);
+    // Only place that HighsMipSolver::runPresolve is called
     solver.runPresolve(options_.presolve_reduction_limit);
     presolve_return_status = solver.getPresolveStatus();
     // Assign values to data members of presolve_

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -555,7 +555,7 @@ struct HighsOptionsStruct {
 #endif
         mip_improving_solution_save(false),
         mip_improving_solution_report_sparse(false),
-        mip_improving_solution_file("") {};
+        mip_improving_solution_file(""){};
 };
 
 // For now, but later change so HiGHS properties are string based so that new

--- a/src/meson.build
+++ b/src/meson.build
@@ -222,7 +222,6 @@ _srcs = [
     'mip/HighsMipAnalysis.cpp',
     'mip/HighsMipSolver.cpp',
     'mip/HighsMipSolverData.cpp',
-    'mip/HighsMipTimer.cpp',
     'mip/HighsDomain.cpp',
     'mip/HighsDynamicRowMatrix.cpp',
     'mip/HighsLpRelaxation.cpp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -222,6 +222,7 @@ _srcs = [
     'mip/HighsMipAnalysis.cpp',
     'mip/HighsMipSolver.cpp',
     'mip/HighsMipSolverData.cpp',
+    'mip/HighsMipTimer.cpp',
     'mip/HighsDomain.cpp',
     'mip/HighsDynamicRowMatrix.cpp',
     'mip/HighsLpRelaxation.cpp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -219,6 +219,7 @@ _srcs = [
     'lp_data/HighsSolve.cpp',
     'lp_data/HighsStatus.cpp',
     'lp_data/HighsOptions.cpp',
+    'mip/HighsMipAnalysis.cpp',
     'mip/HighsMipSolver.cpp',
     'mip/HighsMipSolverData.cpp',
     'mip/HighsDomain.cpp',

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -1045,7 +1045,7 @@ void HighsLpRelaxation::setObjectiveLimit(double objlim) {
 HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
   lpsolver.setOptionValue(
       "time_limit", lpsolver.getRunTime() + mipsolver.options_mip_->time_limit -
-                        mipsolver.timer_.read(mipsolver.timer_.solve_clock));
+                        mipsolver.timer_.read(mipsolver.timer_.total_clock));
   // lpsolver.setOptionValue("output_flag", true);
   HighsStatus callstatus = lpsolver.run();
 

--- a/src/mip/HighsMipAnalysis.cpp
+++ b/src/mip/HighsMipAnalysis.cpp
@@ -1,0 +1,57 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/*    This file is part of the HiGHS linear optimization suite           */
+/*                                                                       */
+/*    Written and engineered 2008-2024 by Julian Hall, Ivet Galabova,    */
+/*    Leona Gottwald and Michael Feldmeier                               */
+/*                                                                       */
+/*    Available as open-source under the MIT License                     */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/**@file simplex/HighsMipAnalysis.cpp
+ * @brief
+ */
+#include "mip/HighsMipAnalysis.h"
+
+#include <cmath>
+
+#include "mip/MipTimer.h"
+
+void HighsMipAnalysis::setup(const HighsLp& lp, const HighsOptions& options) {
+  setupMipTime(options);
+}
+
+void HighsMipAnalysis::setupMipTime(const HighsOptions& options) {
+  analyse_mip_time = true;  // ToDo: Make this conditional
+  //      kHighsAnalysisLevelSolverTime & options.highs_analysis_level;
+  if (analyse_mip_time) {
+    HighsTimerClock clock;
+    clock.timer_pointer_ = timer_;
+    MipTimer mip_timer;
+    mip_timer.initialiseMipClocks(clock);
+    mip_clocks = clock;
+  }
+}
+
+void HighsMipAnalysis::mipTimerStart(const HighsInt mip_clock
+                                     // , const HighsInt thread_id
+) {
+  if (!analyse_mip_time) return;
+  // assert(analyse_mip_time);
+  mip_clocks.timer_pointer_->start(mip_clocks.clock_[mip_clock]);
+}
+
+void HighsMipAnalysis::mipTimerStop(const HighsInt mip_clock
+                                    // , const HighsInt thread_id
+) {
+  if (!analyse_mip_time) return;
+  // assert(analyse_mip_time);
+  mip_clocks.timer_pointer_->stop(mip_clocks.clock_[mip_clock]);
+}
+
+void HighsMipAnalysis::reportMipTimer() {
+  if (!analyse_mip_time) return;
+  //  assert(analyse_mip_time);
+  MipTimer mip_timer;
+  mip_timer.reportMipCoreClock(mip_clocks);
+}

--- a/src/mip/HighsMipAnalysis.h
+++ b/src/mip/HighsMipAnalysis.h
@@ -1,0 +1,42 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/*    This file is part of the HiGHS linear optimization suite           */
+/*                                                                       */
+/*    Written and engineered 2008-2024 by Julian Hall, Ivet Galabova,    */
+/*    Leona Gottwald and Michael Feldmeier                               */
+/*                                                                       */
+/*    Available as open-source under the MIT License                     */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/**@file mip/HighsMipAnalysis.h
+ * @brief Analyse MIP iterations, both for run-time control and data
+ * gathering
+ */
+#ifndef MIP_HIGHSMIPANALYSIS_H_
+#define MIP_HIGHSMIPANALYSIS_H_
+
+#include "lp_data/HighsAnalysis.h"
+#include "lp_data/HighsLp.h"
+#include "util/HighsTimer.h"
+
+class HighsMipAnalysis {
+ public:
+  HighsMipAnalysis() : timer_(nullptr), analyse_mip_time(false) {}
+
+  HighsTimer* timer_;
+  void setup(const HighsLp& lp, const HighsOptions& options);
+
+  void setupMipTime(const HighsOptions& options);
+  void mipTimerStart(const HighsInt mip_clock
+                     //		     , const HighsInt thread_id = 0
+  );
+  void mipTimerStop(const HighsInt mip_clock
+                    //		    , const HighsInt thread_id = 0
+  );
+  void reportMipTimer();
+
+  HighsTimerClock mip_clocks;
+  bool analyse_mip_time;
+};
+
+#endif /* MIP_HIGHSMIPANALYSIS_H_ */

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -21,6 +21,7 @@
 #include "mip/HighsPseudocost.h"
 #include "mip/HighsSearch.h"
 #include "mip/HighsSeparation.h"
+#include "mip/MipTimer.h"
 #include "presolve/HPresolve.h"
 #include "presolve/HighsPostsolveStack.h"
 #include "presolve/PresolveComponent.h"
@@ -116,6 +117,7 @@ void HighsMipSolver::run() {
     analysis_.timer_ = &this->timer_;
     analysis_.setup(*orig_model_, *options_mip_);
   }
+  analysis_.mipTimerStart(kMipClockTotal);
 
   improving_solution_file_ = nullptr;
   if (!submip && options_mip_->mip_improving_solution_file != "")
@@ -577,6 +579,9 @@ void HighsMipSolver::cleanupSolve() {
 
   timer_.stop(timer_.postsolve_clock);
   timer_.stop(timer_.solve_clock);
+  analysis_.mipTimerStop(kMipClockTotal);
+  analysis_.reportMipTimer();
+
   std::string solutionstatus = "-";
 
   if (havesolution) {

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -44,6 +44,7 @@ HighsMipSolver::HighsMipSolver(HighsCallback& callback,
       pscostinit(nullptr),
       clqtableinit(nullptr),
       implicinit(nullptr) {
+
   if (solution.value_valid) {
     // MIP solver doesn't check row residuals, but they should be OK
     // so validate using assert
@@ -108,6 +109,14 @@ void HighsMipSolver::run() {
   // Start the solve_clock for the timer that is local to the HighsMipSolver
   // instance
   timer_.start(timer_.solve_clock);
+
+  if (submip) {
+    analysis_.analyse_mip_time = false;
+  } else {
+    analysis_.timer_ = &this->timer_;
+    analysis_.setup(*orig_model_, *options_mip_);
+  }
+
   improving_solution_file_ = nullptr;
   if (!submip && options_mip_->mip_improving_solution_file != "")
     improving_solution_file_ =

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -116,7 +116,7 @@ void HighsMipSolver::run() {
     analysis_.timer_ = &this->timer_;
     analysis_.setup(*orig_model_, *options_mip_);
   }
-  analysis_.mipTimerStart(kMipClockTotal);
+  //  analysis_.mipTimerStart(kMipClockTotal);
 
   improving_solution_file_ = nullptr;
   if (!submip && options_mip_->mip_improving_solution_file != "")
@@ -581,8 +581,7 @@ void HighsMipSolver::cleanupSolve() {
 
   timer_.stop(timer_.postsolve_clock);
   timer_.stop(timer_.total_clock);
-  analysis_.mipTimerStop(kMipClockTotal);
-  //  analysis_.reportMipTimer();
+  analysis_.reportMipTimer();
 
   std::string solutionstatus = "-";
 
@@ -649,25 +648,24 @@ void HighsMipSolver::cleanupSolve() {
                  "                    %.12g (row viol.)\n",
                  solution_objective_, bound_violation_, integrality_violation_,
                  row_violation_);
-  highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
-               "  Timing            %.2f (total)\n"
-               "                    %.2f (presolve)\n"
-               "                    %.2f (solve)\n"
-               "                    %.2f (postsolve)\n"
-               "  Nodes             %llu\n"
-               "  LP iterations     %llu (total)\n"
-               "                    %llu (strong br.)\n"
-               "                    %llu (separation)\n"
-               "                    %llu (heuristics)\n",
-               timer_.read(timer_.total_clock),
-               timer_.read(timer_.presolve_clock),
-               timer_.read(timer_.solve_clock),
-               timer_.read(timer_.postsolve_clock),
-               (long long unsigned)mipdata_->num_nodes,
-               (long long unsigned)mipdata_->total_lp_iterations,
-               (long long unsigned)mipdata_->sb_lp_iterations,
-               (long long unsigned)mipdata_->sepa_lp_iterations,
-               (long long unsigned)mipdata_->heuristic_lp_iterations);
+  highsLogUser(
+      options_mip_->log_options, HighsLogType::kInfo,
+      "  Timing            %.2f (total)\n"
+      "                    %.2f (presolve)\n"
+      "                    %.2f (solve)\n"
+      "                    %.2f (postsolve)\n"
+      "  Nodes             %llu\n"
+      "  LP iterations     %llu (total)\n"
+      "                    %llu (strong br.)\n"
+      "                    %llu (separation)\n"
+      "                    %llu (heuristics)\n",
+      timer_.read(timer_.total_clock), timer_.read(timer_.presolve_clock),
+      timer_.read(timer_.solve_clock), timer_.read(timer_.postsolve_clock),
+      (long long unsigned)mipdata_->num_nodes,
+      (long long unsigned)mipdata_->total_lp_iterations,
+      (long long unsigned)mipdata_->sb_lp_iterations,
+      (long long unsigned)mipdata_->sepa_lp_iterations,
+      (long long unsigned)mipdata_->heuristic_lp_iterations);
 
   assert(modelstatus_ != HighsModelStatus::kNotset);
 }

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -45,7 +45,6 @@ HighsMipSolver::HighsMipSolver(HighsCallback& callback,
       pscostinit(nullptr),
       clqtableinit(nullptr),
       implicinit(nullptr) {
-
   if (solution.value_valid) {
     // MIP solver doesn't check row residuals, but they should be OK
     // so validate using assert

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -667,6 +667,7 @@ void HighsMipSolver::cleanupSolve() {
   assert(modelstatus_ != HighsModelStatus::kNotset);
 }
 
+// Only called in Highs::runPresolve
 void HighsMipSolver::runPresolve(const HighsInt presolve_reduction_limit) {
   // Start the solve_clock for the timer that is local to the HighsMipSolver
   // instance

--- a/src/mip/HighsMipSolver.h
+++ b/src/mip/HighsMipSolver.h
@@ -14,6 +14,7 @@
 #include "Highs.h"
 #include "lp_data/HighsCallback.h"
 #include "lp_data/HighsOptions.h"
+#include "mip/HighsMipAnalysis.h"
 
 struct HighsMipSolverData;
 class HighsCutPool;
@@ -51,6 +52,8 @@ class HighsMipSolver {
   const HighsImplications* implicinit;
 
   std::unique_ptr<HighsMipSolverData> mipdata_;
+
+  HighsMipAnalysis analysis_;
 
   void run();
 

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -159,7 +159,7 @@ void HighsMipSolverData::startSymmetryDetection(
       double startTime = mipsolver.timer_.getWallTime();
       // highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
       //              "(%4.1fs) Starting symmetry detection\n",
-      //              mipsolver.timer_.read(mipsolver.timer_.solve_clock));
+      //              mipsolver.timer_.read(mipsolver.timer_.total_clock));
       symData->symDetection.run(symData->symmetries);
       symData->detectionTime = mipsolver.timer_.getWallTime() - startTime;
     });
@@ -1215,7 +1215,7 @@ void HighsMipSolverData::printDisplayLine(char source) {
   bool output_flag = *mipsolver.options_mip_->log_options.output_flag;
   if (!output_flag) return;
 
-  double time = mipsolver.timer_.read(mipsolver.timer_.solve_clock);
+  double time = mipsolver.timer_.read(mipsolver.timer_.total_clock);
   if (source == ' ' &&
       time - last_disptime < mipsolver.options_mip_->mip_min_logging_interval)
     return;
@@ -1870,9 +1870,9 @@ bool HighsMipSolverData::checkLimits(int64_t nodeOffset) const {
     return true;
   }
 
-  //  const double time = mipsolver.timer_.read(mipsolver.timer_.solve_clock);
+  //  const double time = mipsolver.timer_.read(mipsolver.timer_.total_clock);
   //  printf("checkLimits: time = %g\n", time);
-  if (mipsolver.timer_.read(mipsolver.timer_.solve_clock) >=
+  if (mipsolver.timer_.read(mipsolver.timer_.total_clock) >=
       options.time_limit) {
     if (mipsolver.modelstatus_ == HighsModelStatus::kNotset) {
       highsLogDev(options.log_options, HighsLogType::kInfo,
@@ -1999,7 +1999,7 @@ bool HighsMipSolverData::interruptFromCallbackWithData(
   double mip_rel_gap;
   limitsToBounds(dual_bound, primal_bound, mip_rel_gap);
   mipsolver.callback_->data_out.running_time =
-      mipsolver.timer_.read(mipsolver.timer_.solve_clock);
+      mipsolver.timer_.read(mipsolver.timer_.total_clock);
   mipsolver.callback_->data_out.objective_function_value =
       mipsolver_objective_value;
   mipsolver.callback_->data_out.mip_node_count = mipsolver.mipdata_->num_nodes;

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -108,7 +108,7 @@ bool HighsPrimalHeuristics::solveSubMip(
   submipoptions.mip_max_stall_nodes = stallnodes;
   submipoptions.mip_pscost_minreliable = 0;
   submipoptions.time_limit -=
-      mipsolver.timer_.read(mipsolver.timer_.solve_clock);
+      mipsolver.timer_.read(mipsolver.timer_.total_clock);
   submipoptions.objective_bound = mipsolver.mipdata_->upper_limit;
 
   if (!mipsolver.submip) {

--- a/src/mip/MipTimer.h
+++ b/src/mip/MipTimer.h
@@ -1,0 +1,67 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/*    This file is part of the HiGHS linear optimization suite           */
+/*                                                                       */
+/*    Written and engineered 2008-2024 by Julian Hall, Ivet Galabova,    */
+/*    Leona Gottwald and Michael Feldmeier                               */
+/*                                                                       */
+/*    Available as open-source under the MIT License                     */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/**@file mip/MipTimer.h
+ * @brief Indices of mip iClocks
+ */
+#ifndef MIP_MIPTIMER_H_
+#define MIP_MIPTIMER_H_
+
+// Clocks for profiling the MIP dual mip solver
+enum iClockMip {
+  kMipClockTotal = 0,
+  kMipClockPresolve,
+  kMipClockSolve,
+  kMipClockPostsolve,
+  kNumMipClock  //!< Number of MIP clocks
+};
+
+class MipTimer {
+ public:
+  void initialiseMipClocks(HighsTimerClock& mip_timer_clock) {
+    HighsTimer* timer_pointer = mip_timer_clock.timer_pointer_;
+    std::vector<HighsInt>& clock = mip_timer_clock.clock_;
+    clock.resize(kNumMipClock);
+    clock[kMipClockTotal] = timer_pointer->total_clock;
+    clock[kMipClockPresolve] = timer_pointer->presolve_clock;
+    clock[kMipClockSolve] = timer_pointer->solve_clock;
+    clock[kMipClockPostsolve] = timer_pointer->postsolve_clock;
+    //    clock[kMipClockTotal] = timer_pointer->clock_def("MIP total");
+  }
+
+  bool reportMipClockList(const char* grepStamp,
+                          const std::vector<HighsInt> mip_clock_list,
+                          const HighsTimerClock& mip_timer_clock,
+                          const double tolerance_percent_report_ = -1) {
+    HighsTimer* timer_pointer = mip_timer_clock.timer_pointer_;
+    const std::vector<HighsInt>& clock = mip_timer_clock.clock_;
+    HighsInt mip_clock_list_size = mip_clock_list.size();
+    std::vector<HighsInt> clockList;
+    clockList.resize(mip_clock_list_size);
+    for (HighsInt en = 0; en < mip_clock_list_size; en++) {
+      clockList[en] = clock[mip_clock_list[en]];
+    }
+    const double ideal_sum_time =
+        timer_pointer->clock_time[clock[kMipClockTotal]];
+    const double tolerance_percent_report =
+        tolerance_percent_report_ >= 0 ? tolerance_percent_report_ : 1e-8;
+    return timer_pointer->reportOnTolerance(
+        grepStamp, clockList, ideal_sum_time, tolerance_percent_report);
+  };
+
+  void reportMipCoreClock(const HighsTimerClock& mip_timer_clock) {
+    //    const std::vector<HighsInt>& clock = mip_timer_clock.clock_;
+    const std::vector<HighsInt> mip_clock_list{
+        kMipClockPresolve, kMipClockSolve, kMipClockPostsolve};
+    reportMipClockList("MipCore", mip_clock_list, mip_timer_clock);
+  };
+};
+
+#endif /* MIP_MIPTIMER_H_ */

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4273,12 +4273,8 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
     // running, and when presolve is called before the LP solver, the
     // HighsClock is running. So have to set run_clock accordingly.
     assert(this->timer);
-    if (this->timer->runningRunHighsClock()) {
-      run_clock = timer->run_highs_clock;
-    } else {
-      assert(this->timer->running(timer->solve_clock));
-      run_clock = timer->solve_clock;
-    }
+    assert(this->timer->runningRunHighsClock());
+    if (this->timer->runningRunHighsClock()) run_clock = timer->run_highs_clock;
 
     HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -43,7 +43,6 @@ class HPresolve {
   HighsTimer* timer;
   HighsMipSolver* mipsolver = nullptr;
   double primal_feastol;
-  HighsInt run_clock = -1;
 
   // triplet storage
   std::vector<double> Avalue;

--- a/src/simplex/HighsSimplexAnalysis.cpp
+++ b/src/simplex/HighsSimplexAnalysis.cpp
@@ -15,12 +15,10 @@
 // #include <cstdio>
 #include <iomanip>
 
-#include "HConfig.h"
 #include "parallel/HighsParallel.h"
 #include "simplex/HighsSimplexAnalysis.h"
 #include "simplex/SimplexTimer.h"
 #include "util/FactorTimer.h"
-#include "util/HFactor.h"
 
 void HighsSimplexAnalysis::setup(const std::string lp_name, const HighsLp& lp,
                                  const HighsOptions& options,

--- a/src/simplex/HighsSimplexAnalysis.h
+++ b/src/simplex/HighsSimplexAnalysis.h
@@ -23,11 +23,6 @@
 #include "lp_data/HighsOptions.h"
 #include "simplex/SimplexConst.h"
 #include "util/HFactor.h"
-#include "util/HVector.h"
-#include "util/HVectorBase.h"
-#include "util/HighsInt.h"
-#include "util/HighsTimer.h"
-#include "util/HighsUtils.h"
 
 enum TRAN_STAGE {
   TRAN_STAGE_FTRAN_LOWER = 0,

--- a/src/util/HFactor.h
+++ b/src/util/HFactor.h
@@ -132,7 +132,7 @@ class HFactor {
         build_timer_(nullptr),
         nwork(0),
         u_merit_x(0),
-        u_total_x(0) {};
+        u_total_x(0){};
 
   /**
    * @brief Copy problem size and pointers of constraint matrix, and set

--- a/src/util/HighsTimer.h
+++ b/src/util/HighsTimer.h
@@ -43,13 +43,14 @@ class HighsTimer {
  public:
   HighsTimer() {
     num_clock = 0;
-    HighsInt i_clock = clock_def("Run HiGHS", "RnH");
+    HighsInt i_clock = clock_def("Run HiGHS");
     assert(i_clock == 0);
     run_highs_clock = i_clock;
+    total_clock = run_highs_clock;
 
-    presolve_clock = clock_def("Presolve", "Pre");
-    solve_clock = clock_def("Solve", "Slv");
-    postsolve_clock = clock_def("Postsolve", "Pst");
+    presolve_clock = clock_def("Presolve");
+    solve_clock = clock_def("Solve");
+    postsolve_clock = clock_def("Postsolve");
   }
 
   /**
@@ -334,7 +335,10 @@ class HighsTimer {
   std::vector<std::string> clock_ch3_names;
   // The index of the RunHighsClock - should always be 0
   HighsInt run_highs_clock;
-  // Fundamental Highs clocks
+  // Synonym for run_highs_clock that makes more sense when (as in MIP
+  // solver) there is an independent timer
+  HighsInt total_clock;
+  // Fundamental clocks
   HighsInt presolve_clock;
   HighsInt solve_clock;
   HighsInt postsolve_clock;


### PR DESCRIPTION
Very early days adding code to analyse MIP performance. Have at least reconciled the difference in the use of `highs_run_clock` and `solve_clock` in different uses of presolve, and the opaque use of  `solve_clock` as total time - presolve+solve+postsolve in the MIP solver