### PR TITLE
Row presolve: Add lambda to check forcing rows

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4968,8 +4968,7 @@ void HPresolve::substitute(HighsInt substcol, HighsInt staycol, double offset,
 bool HPresolve::fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack,
                                          HighsInt col) {
   double fixval = model->col_lower_[col];
-  bool unbounded = fixval == -kHighsInf;
-  if (unbounded) return true;
+  if (fixval == -kHighsInf) return true;
 
   const bool logging_on = analysis_.logging_on_;
   if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleFixedCol);
@@ -5012,8 +5011,7 @@ bool HPresolve::fixColToLowerOrUnbounded(HighsPostsolveStack& postsolve_stack,
 bool HPresolve::fixColToUpperOrUnbounded(HighsPostsolveStack& postsolve_stack,
                                          HighsInt col) {
   double fixval = model->col_upper_[col];
-  bool unbounded = fixval == kHighsInf;
-  if (unbounded) return true;
+  if (fixval == kHighsInf) return true;
 
   const bool logging_on = analysis_.logging_on_;
   if (logging_on) analysis_.startPresolveRuleLog(kPresolveRuleFixedCol);


### PR DESCRIPTION
- Add lambda to `HPresolve::rowPresolve` to check if a forcing row can be removed. This reduces the amount of similar code and shortens it.
- Testing on 850+ MIPs showed that changes do not cause any behavior changes.