### PR TITLE
Fix 1962

### DIFF
--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -555,7 +555,9 @@ struct HighsOptionsStruct {
 #endif
         mip_improving_solution_save(false),
         mip_improving_solution_report_sparse(false),
-        mip_improving_solution_file("") {};
+	// clang-format off
+	mip_improving_solution_file("") {};
+  // clang-format on
 };
 
 // For now, but later change so HiGHS properties are string based so that new

--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -555,7 +555,7 @@ struct HighsOptionsStruct {
 #endif
         mip_improving_solution_save(false),
         mip_improving_solution_report_sparse(false),
-	// clang-format off
+        // clang-format off
 	mip_improving_solution_file("") {};
   // clang-format on
 };

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -127,7 +127,9 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
             return HighsStatus::kError;
           }
         }  // options.run_crossover == kHighsOnString
-      }    // unwelcome_ipx_status
+	// clang-format off
+      }  // unwelcome_ipx_status
+      // clang-format on
     } else {
       // PDLP has been used, so check whether claim of optimality
       // satisfies the HiGHS criteria

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -127,7 +127,7 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
             return HighsStatus::kError;
           }
         }  // options.run_crossover == kHighsOnString
-	 // clang-format off
+	   // clang-format off
       }  // unwelcome_ipx_status
       // clang-format on
     } else {

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -127,7 +127,7 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
             return HighsStatus::kError;
           }
         }  // options.run_crossover == kHighsOnString
-	// clang-format off
+	 // clang-format off
       }  // unwelcome_ipx_status
       // clang-format on
     } else {

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -127,7 +127,7 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
             return HighsStatus::kError;
           }
         }  // options.run_crossover == kHighsOnString
-	   // clang-format off
+           // clang-format off
       }  // unwelcome_ipx_status
       // clang-format on
     } else {

--- a/src/util/HFactor.h
+++ b/src/util/HFactor.h
@@ -132,7 +132,9 @@ class HFactor {
         build_timer_(nullptr),
         nwork(0),
         u_merit_x(0),
+	// clang-format off
         u_total_x(0) {};
+  // clang-format on
 
   /**
    * @brief Copy problem size and pointers of constraint matrix, and set

--- a/src/util/HFactor.h
+++ b/src/util/HFactor.h
@@ -132,7 +132,7 @@ class HFactor {
         build_timer_(nullptr),
         nwork(0),
         u_merit_x(0),
-	// clang-format off
+        // clang-format off
         u_total_x(0) {};
   // clang-format on
 


### PR DESCRIPTION
Removed the requirement for an unbounded LP to have a basis in `HighsLpRelaxation::run` so unbounded root node can be identified.

Added a logging line so that action can be identified in the event of regression
