### PR TITLE
Update cxxopts

### DIFF
--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -1,11 +1,11 @@
 name: build-wheels-push
 
-on: push
+# on: push
  
-# on:
-#  release:
-#    types:
-#      - published
+on:
+ release:
+   types:
+     - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -13,7 +13,7 @@ if(FAST_BUILD)
       set(win_version_file)
     endif()
 
-    target_sources(highs-bin PRIVATE RunHighs.cpp ${win_version_file})
+    target_sources(highs-bin PRIVATE RunHighs.cpp HighsRuntimeOptions.h ${win_version_file})
 
     target_include_directories(highs-bin PRIVATE
       $<BUILD_INTERFACE:${HIGHS_SOURCE_DIR}/app>

--- a/app/HighsRuntimeOptions.h
+++ b/app/HighsRuntimeOptions.h
@@ -245,7 +245,7 @@ bool loadOptions(const HighsLogOptions& report_log_options, int argc,
         return false;
     }
 
-  } catch (const cxxopts::OptionException& e) {
+  } catch (const cxxopts::exceptions::exception& e) {
     highsLogUser(report_log_options, HighsLogType::kError,
                  "Error parsing options: %s\n", e.what());
     return false;

--- a/app/RunHighs.cpp
+++ b/app/RunHighs.cpp
@@ -13,7 +13,7 @@
  */
 #include "Highs.h"
 // #include "io/HighsIO.h"
-#include "lp_data/HighsRuntimeOptions.h"
+#include "HighsRuntimeOptions.h"
 
 // uncomment if we will be shutting down task executor from exe
 // #include "parallel/HighsParallel.h"

--- a/cmake/sources-python.cmake
+++ b/cmake/sources-python.cmake
@@ -308,7 +308,6 @@ set(highs_headers_python
     src/lp_data/HighsModelUtils.h
     src/lp_data/HighsOptions.h
     src/lp_data/HighsRanging.h
-    src/lp_data/HighsRuntimeOptions.h
     src/lp_data/HighsSolution.h
     src/lp_data/HighsSolutionDebug.h
     src/lp_data/HighsSolve.h

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -312,7 +312,6 @@ set(highs_headers
     lp_data/HighsModelUtils.h
     lp_data/HighsOptions.h
     lp_data/HighsRanging.h
-    lp_data/HighsRuntimeOptions.h
     lp_data/HighsSolution.h
     lp_data/HighsSolutionDebug.h
     lp_data/HighsSolve.h


### PR DESCRIPTION
Update the outdated version of the cpp options library for command line options for the highs executable 
Move the runtime options header out of the library and into the executable directory

old version of cxxopts 2.2.0
new version of cxxopts: 3.2.0