### PR TITLE
MAINT: Remove SimplexCrashStrategy from `highspy`

### DIFF
--- a/src/highs_bindings.cpp
+++ b/src/highs_bindings.cpp
@@ -8,7 +8,6 @@
 
 #include "Highs.h"
 #include "lp_data/HighsCallback.h"
-#include "simplex/SimplexConst.h"
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -1162,22 +1161,6 @@ PYBIND11_MODULE(_core, m) {
       .value("kSimplexStrategyPrimal", SimplexStrategy::kSimplexStrategyPrimal)
       .value("kSimplexStrategyMax", SimplexStrategy::kSimplexStrategyMax)
       .value("kSimplexStrategyNum", SimplexStrategy::kSimplexStrategyNum)
-      .export_values();
-  py::enum_<SimplexCrashStrategy>(simplex_constants, "SimplexCrashStrategy")
-      .value("kSimplexCrashStrategyMin", SimplexCrashStrategy::kSimplexCrashStrategyMin)
-      .value("kSimplexCrashStrategyOff", SimplexCrashStrategy::kSimplexCrashStrategyOff)
-      .value("kSimplexCrashStrategyLtssfK", SimplexCrashStrategy::kSimplexCrashStrategyLtssfK)
-      .value("kSimplexCrashStrategyLtssf", SimplexCrashStrategy::kSimplexCrashStrategyLtssf)
-      .value("kSimplexCrashStrategyBixby", SimplexCrashStrategy::kSimplexCrashStrategyBixby)
-      .value("kSimplexCrashStrategyLtssfPri", SimplexCrashStrategy::kSimplexCrashStrategyLtssfPri)
-      .value("kSimplexCrashStrategyLtsfK", SimplexCrashStrategy::kSimplexCrashStrategyLtsfK)
-      .value("kSimplexCrashStrategyLtsfPri", SimplexCrashStrategy::kSimplexCrashStrategyLtsfPri)
-      .value("kSimplexCrashStrategyLtsf", SimplexCrashStrategy::kSimplexCrashStrategyLtsf)
-      .value("kSimplexCrashStrategyBixbyNoNonzeroColCosts",
-             SimplexCrashStrategy::kSimplexCrashStrategyBixbyNoNonzeroColCosts)
-      .value("kSimplexCrashStrategyBasic", SimplexCrashStrategy::kSimplexCrashStrategyBasic)
-      .value("kSimplexCrashStrategyTestSing", SimplexCrashStrategy::kSimplexCrashStrategyTestSing)
-      .value("kSimplexCrashStrategyMax", SimplexCrashStrategy::kSimplexCrashStrategyMax)
       .export_values();
   py::enum_<SimplexUnscaledSolutionStrategy>(simplex_constants,
                                              "SimplexUnscaledSolutionStrategy")


### PR DESCRIPTION
Thanks for the quick turnover at #2005; this addresses @jajhall's comment here https://github.com/ERGO-Code/HiGHS/pull/2005#pullrequestreview-2398423172 and corresponding changes have been made to the SciPy bindings.

I'll send in the remaining warnings soon.