### PR TITLE
Supportcase22

### DIFF
--- a/check/TestCheckSolution.cpp
+++ b/check/TestCheckSolution.cpp
@@ -1,4 +1,5 @@
-#include <cstdio>
+//#include <cstdio>
+#include <iostream>
 
 #include "HCheckConfig.h"
 #include "Highs.h"
@@ -393,6 +394,52 @@ TEST_CASE("check-set-illegal-solution", "[highs_check_solution]") {
   REQUIRE(highs.setSolution(solution) == HighsStatus::kError);
   solution.col_value.assign(lp.num_col_, 0);
   REQUIRE(highs.setSolution(solution) == HighsStatus::kOk);
+}
+
+TEST_CASE("read-miplib-solution", "[highs_check_solution]") {
+  HighsLp lp;
+  lp.num_col_ = 5;
+  lp.num_row_ = 1;
+  lp.sense_ = ObjSense::kMaximize;
+  lp.col_cost_ = {8, 5, 3, 11, 7};
+  lp.col_lower_.assign(lp.num_col_, 0);
+  lp.col_upper_.assign(lp.num_col_, 1);
+  lp.integrality_.assign(lp.num_col_, HighsVarType::kInteger);
+  lp.row_lower_ = {-kHighsInf};
+  lp.row_upper_ = {11};
+  lp.a_matrix_.format_ = MatrixFormat::kRowwise;
+  lp.a_matrix_.start_ = {0, 5};
+  lp.a_matrix_.index_ = {0, 1, 2, 3, 4};
+  lp.a_matrix_.value_ = {4, 3, 1, 5, 4};
+  Highs h;
+  h.setOptionValue("output_flag", dev_run);
+  h.setOptionValue("presolve", kHighsOffString);
+  REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+  REQUIRE(h.run() == HighsStatus::kOk);
+  //  REQUIRE(h.writeSolution("", kSolutionStylePretty) == HighsStatus::kOk);
+  const std::vector<double>& col_value = h.getSolution().col_value;
+  std::string miplib_sol_file = "miplib.sol";
+  FILE* file = fopen(miplib_sol_file.c_str(), "w");
+  REQUIRE(file != 0);
+  fprintf(file, "=obj= 22\n");
+  for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
+    std::string col_name = "c" + std::to_string(int(iCol));
+    lp.col_names_.push_back(col_name);
+    if (std::fabs(col_value[iCol]) < 1e-2) continue;
+    std::string line = col_name + " 1\n";
+    fprintf(file, "%s", line.c_str());
+  }
+  fclose(file);
+  // Can't read file yet, as model has no column names
+  REQUIRE(h.readSolution(miplib_sol_file) == HighsStatus::kError);
+
+  // Pass model again now that column names have been defined
+
+  REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+  //  REQUIRE(h.writeModel("miplib.mps") == HighsStatus::kOk);
+  REQUIRE(h.readSolution(miplib_sol_file) == HighsStatus::kOk);
+  REQUIRE(h.run() == HighsStatus::kOk);
+  std::remove(miplib_sol_file.c_str());
 }
 
 void runWriteReadCheckSolution(Highs& highs, const std::string model,

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3283,7 +3283,7 @@ HighsStatus Highs::readSolution(const std::string& filename,
 
 HighsStatus Highs::assessPrimalSolution(bool& valid, bool& integral,
                                         bool& feasible) const {
-  return assessLpPrimalSolution(options_, model_.lp_, solution_, valid,
+  return assessLpPrimalSolution("", options_, model_.lp_, solution_, valid,
                                 integral, feasible);
 }
 
@@ -3568,7 +3568,7 @@ HighsStatus Highs::completeSolutionFromDiscreteAssignment() {
     bool valid, integral, feasible;
     // Determine whether this solution is integer feasible
     HighsStatus return_status = assessLpPrimalSolution(
-        options_, lp, solution_, valid, integral, feasible);
+        "", options_, lp, solution_, valid, integral, feasible);
     assert(return_status != HighsStatus::kError);
     assert(valid);
     // If the current solution is integer feasible, then it can be

--- a/src/lp_data/HighsLpUtils.cpp
+++ b/src/lp_data/HighsLpUtils.cpp
@@ -2065,9 +2065,13 @@ HighsStatus readSolutionFile(const std::string filename,
   read_basis.row_status.resize(lp_num_row);
   std::string section_name;
   if (!readSolutionFileIdIgnoreLineOk(section_name, in_file))
-    return readSolutionFileErrorReturn(in_file);  // Model (status) or =obj= (value)
+    return readSolutionFileErrorReturn(
+        in_file);  // Model (status) or =obj= (value)
   const bool miplib_sol = section_name == "=obj=";
-  printf("Read \"%s\" as first term of first line of solution file: miplib_sol = %d\n", section_name.c_str(), miplib_sol);
+  printf(
+      "Read \"%s\" as first term of first line of solution file: miplib_sol = "
+      "%d\n",
+      section_name.c_str(), miplib_sol);
   bool sparse = false;
   if (!miplib_sol) {
     if (!readSolutionFileIgnoreLineOk(in_file))
@@ -2081,7 +2085,7 @@ HighsStatus readSolutionFile(const std::string filename,
     // Read in the primal solution values: return warning if there is none
     if (keyword == "None")
       return readSolutionFileReturn(HighsStatus::kWarning, solution, basis,
-				    read_solution, read_basis, in_file);
+                                    read_solution, read_basis, in_file);
     // If there are primal solution values then keyword is the status
     // and the next line is objective
     if (!readSolutionFileIgnoreLineOk(in_file))
@@ -2103,11 +2107,11 @@ HighsStatus readSolutionFile(const std::string filename,
       assert(num_col <= lp_num_col);
     } else {
       if (num_col != lp_num_col) {
-	highsLogUser(log_options, HighsLogType::kError,
-		     "readSolutionFile: Solution file is for %" HIGHSINT_FORMAT
-		     " columns, not %" HIGHSINT_FORMAT "\n",
-		     num_col, lp_num_col);
-	return readSolutionFileErrorReturn(in_file);
+        highsLogUser(log_options, HighsLogType::kError,
+                     "readSolutionFile: Solution file is for %" HIGHSINT_FORMAT
+                     " columns, not %" HIGHSINT_FORMAT "\n",
+                     num_col, lp_num_col);
+        return readSolutionFileErrorReturn(in_file);
       }
     }
   }
@@ -2295,7 +2299,8 @@ bool readSolutionFileIdIgnoreLineOk(std::string& id, std::ifstream& in_file) {
   return true;
 }
 
-bool readSolutionFileIdDoubleLineOk(std::string& id, double& value, std::ifstream& in_file) {
+bool readSolutionFileIdDoubleLineOk(std::string& id, double& value,
+                                    std::ifstream& in_file) {
   if (in_file.eof()) return false;
   in_file >> id;  // Id
   if (in_file.eof()) return false;

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -216,7 +216,8 @@ bool readSolutionFileKeywordLineOk(std::string& keyword,
                                    std::ifstream& in_file);
 bool readSolutionFileHashKeywordIntLineOk(std::string& keyword, HighsInt& value,
                                           std::ifstream& in_file);
-bool readSolutionFileIdDoubleLineOk(double& value, std::ifstream& in_file);
+bool readSolutionFileIdIgnoreLineOk(std::string& id, std::ifstream& in_file);
+bool readSolutionFileIdDoubleLineOk(std::string& id, double& value, std::ifstream& in_file);
 bool readSolutionFileIdDoubleIntLineOk(double& value, HighsInt& index,
                                        std::ifstream& in_file);
 

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -217,7 +217,8 @@ bool readSolutionFileKeywordLineOk(std::string& keyword,
 bool readSolutionFileHashKeywordIntLineOk(std::string& keyword, HighsInt& value,
                                           std::ifstream& in_file);
 bool readSolutionFileIdIgnoreLineOk(std::string& id, std::ifstream& in_file);
-bool readSolutionFileIdDoubleLineOk(std::string& id, double& value, std::ifstream& in_file);
+bool readSolutionFileIdDoubleLineOk(std::string& id, double& value,
+                                    std::ifstream& in_file);
 bool readSolutionFileIdDoubleIntLineOk(double& value, HighsInt& index,
                                        std::ifstream& in_file);
 

--- a/src/lp_data/HighsLpUtils.h
+++ b/src/lp_data/HighsLpUtils.h
@@ -201,7 +201,7 @@ void getLpMatrixCoefficient(const HighsLp& lp, const HighsInt row,
 void analyseLp(const HighsLogOptions& log_options, const HighsLp& lp);
 
 HighsStatus readSolutionFile(const std::string filename,
-                             const HighsOptions& options, const HighsLp& lp,
+                             const HighsOptions& options, HighsLp& lp,
                              HighsBasis& basis, HighsSolution& solution,
                              const HighsInt style);
 
@@ -227,7 +227,8 @@ void assessColPrimalSolution(const HighsOptions& options, const double primal,
                              const HighsVarType type, double& col_infeasibility,
                              double& integer_infeasibility);
 
-HighsStatus assessLpPrimalSolution(const HighsOptions& options,
+HighsStatus assessLpPrimalSolution(const std::string message,
+                                   const HighsOptions& options,
                                    const HighsLp& lp,
                                    const HighsSolution& solution, bool& valid,
                                    bool& integral, bool& feasible);

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -49,7 +49,8 @@ HighsMipSolver::HighsMipSolver(HighsCallback& callback,
     // so validate using assert
 #ifndef NDEBUG
     bool valid, integral, feasible;
-    assessLpPrimalSolution(options, lp, solution, valid, integral, feasible);
+    assessLpPrimalSolution("For debugging: ", options, lp, solution, valid,
+                           integral, feasible);
     assert(valid);
 #endif
     bound_violation_ = 0;


### PR DESCRIPTION
Rather than misreading a MIPLIB solution file (without reporting failure!), HiGHS now identifies solution files beginning `=obj=` as being in the MIPLIB format and reads them as such. 