### PR TITLE
BLD: Silence all warnings in SciPy

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,17 +20,54 @@ host_system = host_machine.system()
 is_windows = host_system == 'windows'
 is_mingw = is_windows and cc.get_id() == 'gcc'
 
+# Granular flags
+# C++
+_cpp_Wno_invalid_offsetof = cppc.get_supported_arguments('-Wno-invalid-offsetof')
+_cpp_Wno_maybe_uninitialized = cppc.get_supported_arguments('-Wno-maybe-uninitialized')
+_cpp_Wno_reorder = cppc.get_supported_arguments('-Wno-reorder')
+_cpp_Wno_reorder_ctor = cppc.get_supported_arguments('-Wno-reorder-ctor')
+_cpp_Wno_sometimes_uninitialized = cppc.get_supported_arguments('-Wno-sometimes-uninitialized')
+_cpp_Wno_unused_but_set_variable = cppc.get_supported_arguments('-Wno-unused-but-set-variable')
+_cpp_Wno_unused_variable = cppc.get_supported_arguments('-Wno-unused-variable')
+_cpp_Wno_use_after_free = cppc.get_supported_arguments('-Wno-use-after-free')
+_cpp_Wno_comment = cppc.get_supported_arguments('-Wno-comment')
+
+
+# C
+Wno_comment = cc.get_supported_arguments('-Wno-comment')
+Wno_invalid_offsetof = cc.get_supported_arguments('-Wno-invalid-offsetof')
+Wno_maybe_uninitialized = cc.get_supported_arguments('-Wno-maybe-uninitialized')
+Wno_sometimes_uninitialized = cc.get_supported_arguments('-Wno-sometimes-uninitialized')
+Wno_unused_label = cc.get_supported_arguments('-Wno-unused-label')
+Wno_use_after_free = cc.get_supported_arguments('-Wno-use-after-free')
+Wno_unused_but_set_variable = cc.get_supported_arguments('-Wno-unused-but-set-variable')
+Wno_unused_variable = cc.get_supported_arguments('-Wno-unused-variable')
+Wno_use_after_free = cc.get_supported_arguments('-Wno-use-after-free')
+
 # Conditional arguments
-_args += cppc.get_supported_arguments([
-  '-Wno-return-type',
-  '-Wno-switch',
-  '-Wno-comment',
-  '-Wno-unused-variable',
-  '-Wno-unused-but-set-variable',
-  '-Wno-unused-const-variable',
-  '-Wno-unused-function',
-  '-Wno-unused-label',
-])
+_highs_cpp_suppressions = [
+  _cpp_Wno_comment,
+  _cpp_Wno_invalid_offsetof,
+  _cpp_Wno_maybe_uninitialized,
+  _cpp_Wno_reorder,
+  _cpp_Wno_reorder_ctor,
+  _cpp_Wno_sometimes_uninitialized,
+  _cpp_Wno_unused_but_set_variable,
+  _cpp_Wno_unused_variable,
+  _cpp_Wno_use_after_free,
+]
+
+_highs_c_suppressions = [
+  Wno_comment,
+  Wno_invalid_offsetof,
+  Wno_maybe_uninitialized,
+  Wno_sometimes_uninitialized,
+  Wno_unused_but_set_variable,
+  Wno_unused_label,
+  Wno_unused_variable,
+  Wno_use_after_free,
+]
+
 
 if cppc.get_id() == 'msvc'
   add_project_arguments(

--- a/src/meson.build
+++ b/src/meson.build
@@ -303,7 +303,6 @@ _srcs = [
 ]
 
 highslib_srcs = [
-  highs_conf_file,
   files(_srcs),
   files(_cupdlp_srcs),
   files(_basiclu_srcs),
@@ -322,10 +321,10 @@ do_install = get_option('do_install')
 
 if not get_option('with_pybind11')
 highslib = library('highs',
-                   highslib_srcs,
+                   highslib_srcs + highs_conf_file,
                    dependencies: _deps,
-                   cpp_args: _args,
-                   c_args: _args,
+                   cpp_args: _highs_cpp_suppressions + _args,
+                   c_args: _highs_c_suppressions + _args,
                    include_directories: _incdirs,
                    gnu_symbol_visibility: symbol_visibility,
                    pic: true,
@@ -379,10 +378,10 @@ if get_option('with_pybind11')
   py = import('python').find_installation(pure: false)
 
   highslib = library('highs',
-                     highslib_srcs,
+                     highslib_srcs + highs_conf_file,
                      dependencies: _deps,
-                     cpp_args: _args,
-                     c_args: _args,
+                     cpp_args: _highs_cpp_suppressions + _args,
+                     c_args: _highs_c_suppressions + _args,
                      include_directories: _incdirs,
                      gnu_symbol_visibility: symbol_visibility,
                      pic: true,


### PR DESCRIPTION
I thought about silencing these only at the SciPy end, but on whole I think it makes sense to be explicit here, since not having a clean build (w.r.t warnings) is a project level issue.

This is the last (mandatory) PR for the SciPy update. Warnings fixes can still be ported from #1987 later without blocking the SciPy update.

Please consider merging as soon as the SciPy CI is green : https://github.com/scipy/scipy/pull/21565

Then the only thing left is over at SciPy (I'll just update the fork) and we'll finally have an up-to-date HiGHS!