### PR TITLE
add Python 3.13 to build matrix for wheels

### DIFF
--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -34,7 +34,7 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
-        python: ["cp38", "cp39","cp310", "cp311","cp312"]
+        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,7 +29,7 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2019, win_amd64]
           - [windows-2019, win32]
-        python: ["cp38", "cp39","cp310", "cp311","cp312"]
+        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Should solve https://github.com/ERGO-Code/HiGHS/issues/2008, though I haven't tested.