### PR TITLE
Add two utility methods to presolve

### DIFF
--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -173,6 +173,10 @@ class HPresolve {
                                        HighsPostsolveStack::RowType& rowType,
                                        bool relaxRowDualBounds = false);
 
+  bool isImpliedEquationAtLower(HighsInt row) const;
+
+  bool isImpliedEquationAtUpper(HighsInt row) const;
+
   bool isImpliedIntegral(HighsInt col);
 
   bool isImpliedInteger(HighsInt col);


### PR DESCRIPTION
- Added `isImpliedEquationAtLower` and `isImpliedEquationAtUpper` to check whether a constraint is an implied equation.
- Ran 850+ MIPs to verify that HiGHS behavior is not affected by these changes.