### PR TITLE
Add presolve utility for detecting dominated columns

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -3784,15 +3784,17 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
       // in reverse, it will first restore the column primal and dual values
       // as the dual values are required to find the proper dual multiplier for
       // the row and the column that we put in the basis.
-      Result res = checkForcingRow(row, HighsInt{1}, model->row_lower_[row],
-                                   HighsPostsolveStack::RowType::kGeq);
-      if (rowDeleted[row]) return res;
+      HPRESOLVE_CHECKED_CALL(
+          checkForcingRow(row, HighsInt{1}, model->row_lower_[row],
+                          HighsPostsolveStack::RowType::kGeq));
+      if (rowDeleted[row]) return Result::kOk;
 
     } else if (impliedRowLower >= model->row_upper_[row] - primal_feastol) {
       // forcing row in the other direction
-      Result res = checkForcingRow(row, HighsInt{-1}, model->row_upper_[row],
-                                   HighsPostsolveStack::RowType::kLeq);
-      if (rowDeleted[row]) return res;
+      HPRESOLVE_CHECKED_CALL(
+          checkForcingRow(row, HighsInt{-1}, model->row_upper_[row],
+                          HighsPostsolveStack::RowType::kLeq));
+      if (rowDeleted[row]) return Result::kOk;
     }
   }
 

--- a/src/presolve/HPresolve.h
+++ b/src/presolve/HPresolve.h
@@ -315,6 +315,9 @@ class HPresolve {
 
   Result singletonCol(HighsPostsolveStack& postsolve_stack, HighsInt col);
 
+  void substituteFreeCol(HighsPostsolveStack& postsolve_stack, HighsInt row,
+                         HighsInt col, bool relaxRowDualBounds = false);
+
   Result rowPresolve(HighsPostsolveStack& postsolve_stack, HighsInt row);
 
   Result colPresolve(HighsPostsolveStack& postsolve_stack, HighsInt col);


### PR DESCRIPTION
- Presolve contains (almost) identical code to detect dominated columns in `HPresolve::colPresolve` and `HPresolve::singletonCol`. This PR adds an utility for this.
- Testing on 850+ MIPs showed that the code changes do not affect HiGHS behavior at all.