### PR TITLE
Treating `|x|<1` as a special case in `floor(HighsCDouble x)` and `ceil(HighsCDouble x)`

### DIFF
--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -257,9 +257,10 @@ if ((NOT FAST_BUILD OR ALL_TESTS) AND NOT (BUILD_EXTRA_UNIT_ONLY))
         "standgub\; 1.25769949\;"
         )
   elseif(WIN32)
-    # on windows e226 model status is unknown, rel gap e00
+    # on windows e226 model status is unknown
+    # on windows 25fv47 model status can be unknown, with objective 5.5018458957e+03
     set(pdlpInstances
-        "25fv47\; 5.50184588\;"
+        "25fv47\; 5.5018458\;"
         "adlittle\; 2.25494963\;"
         "afiro\;-4.64753142\;"
         "avgas\;-7.749999999\;"

--- a/check/TestCheckSolution.cpp
+++ b/check/TestCheckSolution.cpp
@@ -1,4 +1,4 @@
-//#include <cstdio>
+// #include <cstdio>
 #include <iostream>
 
 #include "HCheckConfig.h"

--- a/check/TestHighsIntegers.cpp
+++ b/check/TestHighsIntegers.cpp
@@ -1,5 +1,6 @@
 #include "HCheckConfig.h"
 #include "catch.hpp"
+#include "util/HighsCDouble.h"
 #include "util/HighsIntegers.h"
 
 const bool dev_run = false;
@@ -37,4 +38,19 @@ TEST_CASE("HighsIntegers", "[util]") {
   REQUIRE(integralscalar == primes[0] * primes[1] * primes[2] * primes[3]);
 
   if (dev_run) printf("integral scalar is %g\n", integralscalar);
+}
+
+TEST_CASE("HighsCdouble-ceil", "[util]") {
+  // For fix-2041
+  HighsCDouble a = 1e-23;
+  double ceil_a;
+  double double_a;
+  ceil_a = double(ceil(a));
+  double_a = double(a);
+  if (dev_run) {
+    printf("ceil_a = %23.18g\n", ceil_a);
+    printf("double_a = %23.18g\n", double_a);
+  }
+  REQUIRE(ceil_a >= double_a);
+  REQUIRE(ceil(a) >= a);
 }

--- a/check/TestHighsIntegers.cpp
+++ b/check/TestHighsIntegers.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 #include "util/HighsCDouble.h"
 #include "util/HighsIntegers.h"
+#include "util/HighsRandom.h"
 
 const bool dev_run = false;
 
@@ -40,18 +41,106 @@ TEST_CASE("HighsIntegers", "[util]") {
   if (dev_run) printf("integral scalar is %g\n", integralscalar);
 }
 
-TEST_CASE("HighsCdouble-ceil", "[util]") {
-  // For fix-2041
-  HighsCDouble a = 1e-23;
-  a = 1e-12;
-  double ceil_a;
-  double double_a;
-  ceil_a = double(ceil(a));
-  double_a = double(a);
-  if (dev_run) {
-    printf("ceil_a = %23.18g\n", ceil_a);
-    printf("double_a = %23.18g\n", double_a);
+void testCeil(HighsCDouble x) {
+  double ceil_x;
+  double double_x;
+  ceil_x = double(ceil(x));
+  double_x = double(x);
+  REQUIRE(ceil_x >= double_x);
+  REQUIRE(ceil(x) >= x);
+}
+
+void testFloor(HighsCDouble x) {
+  double floor_x;
+  double double_x;
+  floor_x = double(floor(x));
+  double_x = double(x);
+  REQUIRE(floor_x <= double_x);
+  REQUIRE(floor(x) <= x);
+}
+TEST_CASE("HighsCDouble-ceil", "[util]") {
+  HighsCDouble x;
+  x = -1e-34;
+  testCeil(x);
+  x = -1e-32;
+  testCeil(x);
+  x = -1e-30;
+  testCeil(x);
+  x = -1e-23;
+  testCeil(x);
+  x = -1e-12;
+  testCeil(x);
+  x = -1e-1;
+  testCeil(x);
+  x = -0.99;
+  testCeil(x);
+
+  x = 0.99;
+  testCeil(x);
+  x = 1e-1;
+  testCeil(x);
+  x = 1e-12;
+  testCeil(x);
+  // This and rest failed in #2041
+  x = 1e-23;
+  testCeil(x);
+  x = 1e-30;
+  testCeil(x);
+  x = 1e-32;
+  testCeil(x);
+  x = 1e-34;
+  testCeil(x);
+
+  HighsRandom rand;
+  for (HighsInt k = 0; k < 1000; k++) {
+    double man = rand.fraction();
+    HighsInt power = 2 - rand.integer(5);
+    double exp = std::pow(10, power);
+    x = man * exp;
+    testCeil(x);
   }
-  REQUIRE(ceil_a >= double_a);
-  REQUIRE(ceil(a) >= a);
+}
+
+TEST_CASE("HighsCDouble-floor", "[util]") {
+  HighsCDouble x;
+
+  x = 1e-34;
+  testFloor(x);
+  x = 1e-32;
+  testFloor(x);
+  x = 1e-30;
+  testFloor(x);
+  x = 1e-23;
+  testFloor(x);
+  x = 1e-12;
+  testFloor(x);
+  x = 1e-1;
+  testFloor(x);
+  x = 0.99;
+  testFloor(x);
+
+  x = -0.99;
+  testFloor(x);
+  x = -1e-1;
+  testFloor(x);
+  x = -1e-12;
+  testFloor(x);
+  // This and rest failed in #2041
+  x = -1e-23;
+  testFloor(x);
+  x = -1e-30;
+  testFloor(x);
+  x = -1e-32;
+  testFloor(x);
+  x = -1e-34;
+  testFloor(x);
+
+  HighsRandom rand;
+  for (HighsInt k = 0; k < 1000; k++) {
+    double man = rand.fraction();
+    HighsInt power = 2 - rand.integer(5);
+    double exp = std::pow(10, power);
+    x = man * exp;
+    testFloor(x);
+  }
 }

--- a/check/TestHighsIntegers.cpp
+++ b/check/TestHighsIntegers.cpp
@@ -43,6 +43,7 @@ TEST_CASE("HighsIntegers", "[util]") {
 TEST_CASE("HighsCdouble-ceil", "[util]") {
   // For fix-2041
   HighsCDouble a = 1e-23;
+  a = 1e-12;
   double ceil_a;
   double double_a;
   ceil_a = double(ceil(a));

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -679,16 +679,16 @@ TEST_CASE("IP-infeasible-unbounded", "[highs_test_mip_solver]") {
       highs.run();
       HighsModelStatus required_model_status;
       if (k == 0) {
-	// Presolve off
+        // Presolve off
         if (l == 0) {
-	  // MIP solver proves infeasiblilty
+          // MIP solver proves infeasiblilty
           required_model_status = HighsModelStatus::kInfeasible;
         } else {
-	  // Relaxation is unbounded, but origin is feasible
+          // Relaxation is unbounded, but origin is feasible
           required_model_status = HighsModelStatus::kUnbounded;
         }
       } else {
-	// Presolve on, and identifies primal infeasible or unbounded
+        // Presolve on, and identifies primal infeasible or unbounded
         required_model_status = HighsModelStatus::kUnboundedOrInfeasible;
       }
       REQUIRE(highs.getModelStatus() == required_model_status);

--- a/src/util/HighsCDouble.h
+++ b/src/util/HighsCDouble.h
@@ -289,6 +289,12 @@ class HighsCDouble {
   }
 
   friend HighsCDouble floor(const HighsCDouble& x) {
+    // Treat |x| < 1 as special case, as per (for example)
+    // https://github.com/shibatch/tlfloat: see #2041
+    if (abs(x) < 1) {
+      if (x == 0 || x > 0) return HighsCDouble(0.0);
+      return HighsCDouble(-1.0);
+    }
     double floor_x = std::floor(double(x));
     HighsCDouble res;
 
@@ -297,17 +303,16 @@ class HighsCDouble {
   }
 
   friend HighsCDouble ceil(const HighsCDouble& x) {
+    // Treat |x| < 1 as special case, as per (for example)
+    // https://github.com/shibatch/tlfloat: see #2041
+    if (abs(x) < 1) {
+      if (x == 0 || x < 0) return HighsCDouble(0.0);
+      return HighsCDouble(1.0);
+    }
     double ceil_x = std::ceil(double(x));
     HighsCDouble res;
 
-    HighsCDouble x_m_ceil_x = x - ceil_x;
-    double double_x_m_ceil_x = double(x_m_ceil_x);
-    double ceil_double_x_m_ceil_x = std::ceil(double_x_m_ceil_x);
-    HighsCDouble local_res;
-
-    two_sum(local_res.hi, local_res.lo, ceil_x, ceil_double_x_m_ceil_x);
-    res = local_res;
-    //    two_sum(res.hi, res.lo, ceil_x, std::ceil(double(x - ceil_x)));
+    two_sum(res.hi, res.lo, ceil_x, std::ceil(double(x - ceil_x)));
     return res;
   }
 

--- a/src/util/HighsCDouble.h
+++ b/src/util/HighsCDouble.h
@@ -300,7 +300,14 @@ class HighsCDouble {
     double ceil_x = std::ceil(double(x));
     HighsCDouble res;
 
-    two_sum(res.hi, res.lo, ceil_x, std::ceil(double(x - ceil_x)));
+    HighsCDouble x_m_ceil_x = x - ceil_x;
+    double double_x_m_ceil_x = double(x_m_ceil_x);
+    double ceil_double_x_m_ceil_x = std::ceil(double_x_m_ceil_x);
+    HighsCDouble local_res;
+
+    two_sum(local_res.hi, local_res.lo, ceil_x, ceil_double_x_m_ceil_x);
+    res = local_res;
+    //    two_sum(res.hi, res.lo, ceil_x, std::ceil(double(x - ceil_x)));
     return res;
   }
 


### PR DESCRIPTION
This will close #2041 