### PR TITLE
Fix compiler warnings from HiGHS 1.8.1

### DIFF
--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -2501,7 +2501,8 @@ bool HighsMipSolverData::interruptFromCallbackWithData(
   return mipsolver.callback_->callbackAction(callback_type, message);
 }
 
-double possInfRelDiff(const double v0, const double v1, const double den) {
+static double possInfRelDiff(const double v0, const double v1,
+                             const double den) {
   double rel_diff;
   if (std::fabs(v0) == kHighsInf) {
     if (std::fabs(v1) == kHighsInf) {

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -37,10 +37,10 @@
 
 HighsPrimalHeuristics::HighsPrimalHeuristics(HighsMipSolver& mipsolver)
     : mipsolver(mipsolver),
-      lp_iterations(0),
       total_repair_lp(0),
       total_repair_lp_feasible(0),
       total_repair_lp_iterations(0),
+      lp_iterations(0),
       randgen(mipsolver.options_mip_->random_seed) {
   successObservations = 0;
   numSuccessObservations = 0;


### PR DESCRIPTION
- `possInfRelDiff` had no previous declaration, but it seems it can be made local (static) to the compilation unit
- fix order of constructor arguments to match member definition order