### PR TITLE
MAINT: declare that `highspy._core` supports free-threaded CPython

### DIFF
--- a/src/highs_bindings.cpp
+++ b/src/highs_bindings.cpp
@@ -642,7 +642,7 @@ HighsStatus highs_setCallback(
         data.ptr());
 }
 
-PYBIND11_MODULE(_core, m) {
+PYBIND11_MODULE(_core, m, py::mod_gil_not_used()) {
   // To keep a smaller diff, for reviewers, the declarations are not moved, but
   // keep in mind:
   // C++ enum classes :: don't need .export_values()


### PR DESCRIPTION
This allows `highspy` to be imported in a free-threaded CPython interpreter (see [PEP 703](https://peps.python.org/pep-0703/), https://py-free-threading.github.io/) without raising a warning and re-enabling the GIL. We've tested thread-safety of this extension module reasonably well in SciPy now, and everything seems fine on all tested platforms (Linux, macOS, Windows and x86-64/arm64).

The one-line change matches the Pybind11 example at https://py-free-threading.github.io/porting/#declaring-free-threaded-support.