### PR TITLE
Fix 1954

### DIFF
--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -1184,11 +1184,6 @@ bool HighsCutGeneration::generateCut(HighsTransformedLp& transLp,
       }
     } while (false);
 
-    // save data that might otherwise be overwritten when calling the cmir
-    // separator
-    bool saveIntegalSupport = integralSupport;
-    bool saveIntegralCoefficients = integralCoefficients;
-
     double minMirEfficacy = minEfficacy;
     if (success) {
       double violation = -double(rhs);
@@ -1210,7 +1205,7 @@ bool HighsCutGeneration::generateCut(HighsTransformedLp& transLp,
         minMirEfficacy += efficacy;
         if (!complementation.empty()) {
           // remove the complementation if it exists, so that the values stored
-          // values are uncomplemented
+          // are uncomplemented
           for (HighsInt i = 0; i != rowlen; ++i) {
             if (complementation[i]) {
               rhs -= upper[i] * vals[i];
@@ -1225,6 +1220,11 @@ bool HighsCutGeneration::generateCut(HighsTransformedLp& transLp,
 
     inds = tmpInds.data();
     vals = tmpVals.data();
+
+    // save data that might otherwise be overwritten when calling the cmir
+    // separator
+    bool saveIntegalSupport = integralSupport;
+    bool saveIntegralCoefficients = integralCoefficients;
 
     bool cmirSuccess =
         cmirCutGenerationHeuristic(minMirEfficacy, onlyInitialCMIRScale);
@@ -1244,6 +1244,7 @@ bool HighsCutGeneration::generateCut(HighsTransformedLp& transLp,
       complementation.clear();
       inds = inds_.data();
       vals = vals_.data();
+      // restore indicators
       integralSupport = saveIntegalSupport;
       integralCoefficients = saveIntegralCoefficients;
     } else
@@ -1423,6 +1424,11 @@ bool HighsCutGeneration::generateConflict(HighsDomain& localdomain,
     inds = tmpInds.data();
     vals = tmpVals.data();
 
+    // save data that might otherwise be overwritten when calling the cmir
+    // separator
+    bool saveIntegalSupport = integralSupport;
+    bool saveIntegralCoefficients = integralCoefficients;
+
     bool cmirSuccess = cmirCutGenerationHeuristic(minEfficacy);
 
     if (cmirSuccess) {
@@ -1438,6 +1444,9 @@ bool HighsCutGeneration::generateConflict(HighsDomain& localdomain,
       complementation.swap(tmpComplementation);
       inds = proofinds.data();
       vals = proofvals.data();
+      // restore indicators
+      integralSupport = saveIntegalSupport;
+      integralCoefficients = saveIntegralCoefficients;
     } else
       // neither cmir nor lifted cut successful
       return false;

--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -1184,6 +1184,11 @@ bool HighsCutGeneration::generateCut(HighsTransformedLp& transLp,
       }
     } while (false);
 
+    // save data that might otherwise be overwritten when calling the cmir
+    // separator
+    bool saveIntegalSupport = integralSupport;
+    bool saveIntegralCoefficients = integralCoefficients;
+
     double minMirEfficacy = minEfficacy;
     if (success) {
       double violation = -double(rhs);
@@ -1239,6 +1244,8 @@ bool HighsCutGeneration::generateCut(HighsTransformedLp& transLp,
       complementation.clear();
       inds = inds_.data();
       vals = vals_.data();
+      integralSupport = saveIntegalSupport;
+      integralCoefficients = saveIntegralCoefficients;
     } else
       // neither cmir nor lifted cut successful
       return false;

--- a/src/mip/HighsPathSeparator.cpp
+++ b/src/mip/HighsPathSeparator.cpp
@@ -351,16 +351,17 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
 
         if (addedSubstitutionRows) continue;
 
+        // generate cut
         double rhs = 0;
-
         success = cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
 
         lpAggregator.getCurrentAggregation(baseRowInds, baseRowVals, true);
         if (!aggregatedPath.empty() || bestOutArcCol != -1 ||
             bestInArcCol != -1)
           aggregatedPath.emplace_back(baseRowInds, baseRowVals);
-        rhs = 0;
 
+        // generate reverse cut
+        rhs = 0;
         success |= cutGen.generateCut(transLp, baseRowInds, baseRowVals, rhs);
 
         if (success || (bestOutArcCol == -1 && bestInArcCol == -1)) break;

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -256,7 +256,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
         vectorsum.add(bestVlb[col].first, vals[i] * bestVlb[col].second.coef);
         // arbitrarily initialize bound type for vlb variable in order to
         // distinguish from already processed integer-constrained variables. the
-        // bound type will be set properly in subsequently.
+        // bound type will be set properly subsequently.
         boundTypes[bestVlb[col].first] = BoundType::kSimpleLb;
         if (vals[i] > 0) {
           boundTypes[col] = oldBoundType;
@@ -269,7 +269,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
         vals[i] = -vals[i];
         // arbitrarily initialize bound type for vub variable in order to
         // distinguish from already processed integer-constrained variables. the
-        // bound type will be set properly in subsequently.
+        // bound type will be set properly subsequently.
         boundTypes[bestVub[col].first] = BoundType::kSimpleLb;
         if (vals[i] > 0) {
           boundTypes[col] = oldBoundType;

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -260,22 +260,24 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
       case BoundType::kVariableLb:
         tmpRhs -= bestVlb[col].second.constant * vals[i];
         vectorsum.add(bestVlb[col].first, vals[i] * bestVlb[col].second.coef);
-        // store integral slack in set
-        if (lprelaxation.isColIntegral(col)) intVariableBndSlacks.insert(col);
         if (vals[i] > 0) {
           boundTypes[col] = oldBoundType;
           vals[i] = 0;
+        } else if (lprelaxation.isColIntegral(col)) {
+          // store integral slack in set
+          intVariableBndSlacks.insert(col);
         }
         break;
       case BoundType::kVariableUb:
         tmpRhs -= bestVub[col].second.constant * vals[i];
         vectorsum.add(bestVub[col].first, vals[i] * bestVub[col].second.coef);
         vals[i] = -vals[i];
-        // store integral slack in set
-        if (lprelaxation.isColIntegral(col)) intVariableBndSlacks.insert(col);
         if (vals[i] > 0) {
           boundTypes[col] = oldBoundType;
           vals[i] = 0;
+        } else if (lprelaxation.isColIntegral(col)) {
+          // store integral slack in set
+          intVariableBndSlacks.insert(col);
         }
     }
   }

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -132,6 +132,9 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
                                    std::vector<double>& solval,
                                    std::vector<HighsInt>& inds, double& rhs,
                                    bool& integersPositive, bool preferVbds) {
+  // vector sum should be empty
+  assert(vectorsum.getNonzeros().empty());
+
   HighsCDouble tmpRhs = rhs;
 
   const HighsMipSolver& mip = lprelaxation.getMipSolver();
@@ -335,10 +338,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
     double ub = getUb(col);
 
     // make sure that variable is bounded
-    if (lb == -kHighsInf && ub == kHighsInf) {
-      vectorsum.clear();
-      return false;
-    }
+    if (lb == -kHighsInf && ub == kHighsInf) return false;
 
     // complement integers to make coefficients positive if both bounds are
     // finite; otherwise, complement integers with closest bound.

--- a/src/mip/HighsTransformedLp.cpp
+++ b/src/mip/HighsTransformedLp.cpp
@@ -261,8 +261,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
         tmpRhs -= bestVlb[col].second.constant * vals[i];
         vectorsum.add(bestVlb[col].first, vals[i] * bestVlb[col].second.coef);
         // store integral slack in set
-        if (lprelaxation.isColIntegral(bestVlb[col].first))
-          intVariableBndSlacks.insert(bestVlb[col].first);
+        if (lprelaxation.isColIntegral(col)) intVariableBndSlacks.insert(col);
         if (vals[i] > 0) {
           boundTypes[col] = oldBoundType;
           vals[i] = 0;
@@ -273,8 +272,7 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
         vectorsum.add(bestVub[col].first, vals[i] * bestVub[col].second.coef);
         vals[i] = -vals[i];
         // store integral slack in set
-        if (lprelaxation.isColIntegral(bestVub[col].first))
-          intVariableBndSlacks.insert(bestVub[col].first);
+        if (lprelaxation.isColIntegral(col)) intVariableBndSlacks.insert(col);
         if (vals[i] > 0) {
           boundTypes[col] = oldBoundType;
           vals[i] = 0;


### PR DESCRIPTION
This PR fixes #1954:
1. Bound types of general-integer variables from variable bound constraints may have been overwritten, e.g. a variable upper bound of the form `x <= b*y + c` where `x` is NOT a continuous variable (for example, a general-integer variable) and `y` is a binary variable were not handled correctly.
2. Testing on 850+ MIPs (on Linux) showed that the fix affects behavior, but the overall results in terms of means of running times look reasonable. 