### PR TITLE
Fix issue 2025

### DIFF
--- a/src/highspy/highs.py
+++ b/src/highspy/highs.py
@@ -18,7 +18,7 @@ from ._core import (
 
 # backwards typing support information for HighspyArray
 np_version = tuple(map(int, np.__version__.split('.')))
-if sys.version_info >= (3, 9) and np_version >= (1.22.0):
+if sys.version_info >= (3, 9) and np_version >= (1,22,0):
     ndarray_object_type = np.ndarray[Any, np.dtype[np.object_]]
 else:
     ndarray_object_type = np.ndarray

--- a/src/highspy/highs.py
+++ b/src/highspy/highs.py
@@ -17,7 +17,8 @@ from ._core import (
 )
 
 # backwards typing support information for HighspyArray
-if sys.version_info >= (3, 9):
+np_version = tuple(map(int, np.__version__.split('.')))
+if sys.version_info >= (3, 9) and np_version >= (1.22.0):
     ndarray_object_type = np.ndarray[Any, np.dtype[np.object_]]
 else:
     ndarray_object_type = np.ndarray


### PR DESCRIPTION
At work, we are using a pretty outdated version of numpy. We will upgrade at some point in 2025 but in the meantime, this fixes the issue raised in #2025 

  File "/home/arnaud.baguet/repos/calc/.venv/lib/python3.9/site-packages/highspy/__init__.py", line 44, in <module>
    from .highs import Highs
  File "/home/arnaud.baguet/repos/calc/.venv/lib/python3.9/site-packages/highspy/highs.py", line 21, in <module>
    ndarray_object_type = np.ndarray[Any, np.dtype[np.object_]]
TypeError: 'numpy._DTypeMeta' object is not subscriptable