### PR TITLE
Simplify for loops

### DIFF
--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -2050,8 +2050,7 @@ void HPresolve::storeRow(HighsInt row) {
   rowpositions.clear();
 
   auto rowVec = getSortedRowVector(row);
-  auto rowVecEnd = rowVec.end();
-  for (auto iter = rowVec.begin(); iter != rowVecEnd; ++iter)
+  for (auto iter = rowVec.begin(); iter != rowVec.end(); ++iter)
     rowpositions.push_back(iter.position());
 }
 

--- a/src/simplex/HEkkDualRow.cpp
+++ b/src/simplex/HEkkDualRow.cpp
@@ -587,7 +587,7 @@ void HEkkDualRow::createFreemove(HVector* row_ep) {
                 : ekk_instance_.info_.update_count < 20 ? 3e-8
                                                         : 1e-6;
     HighsInt move_out = workDelta < 0 ? -1 : 1;
-    for (HighsInt iVar : freeList) {
+    for (const HighsInt& iVar : freeList) {
       assert(iVar < ekk_instance_.lp_.num_col_ + ekk_instance_.lp_.num_row_);
       double alpha = ekk_instance_.lp_.a_matrix_.computeDot(*row_ep, iVar);
       if (fabs(alpha) > Ta) {
@@ -601,7 +601,7 @@ void HEkkDualRow::createFreemove(HVector* row_ep) {
 }
 void HEkkDualRow::deleteFreemove() {
   if (!freeList.empty()) {
-    for (HighsInt iVar : freeList) {
+    for (const HighsInt& iVar : freeList) {
       assert(iVar < ekk_instance_.lp_.num_col_ + ekk_instance_.lp_.num_row_);
       ekk_instance_.basis_.nonbasicMove_[iVar] = 0;
     }

--- a/src/simplex/HEkkDualRow.cpp
+++ b/src/simplex/HEkkDualRow.cpp
@@ -587,9 +587,7 @@ void HEkkDualRow::createFreemove(HVector* row_ep) {
                 : ekk_instance_.info_.update_count < 20 ? 3e-8
                                                         : 1e-6;
     HighsInt move_out = workDelta < 0 ? -1 : 1;
-    set<HighsInt>::iterator sit;
-    for (sit = freeList.begin(); sit != freeList.end(); sit++) {
-      HighsInt iVar = *sit;
+    for (HighsInt iVar : freeList) {
       assert(iVar < ekk_instance_.lp_.num_col_ + ekk_instance_.lp_.num_row_);
       double alpha = ekk_instance_.lp_.a_matrix_.computeDot(*row_ep, iVar);
       if (fabs(alpha) > Ta) {
@@ -603,9 +601,7 @@ void HEkkDualRow::createFreemove(HVector* row_ep) {
 }
 void HEkkDualRow::deleteFreemove() {
   if (!freeList.empty()) {
-    set<HighsInt>::iterator sit;
-    for (sit = freeList.begin(); sit != freeList.end(); sit++) {
-      HighsInt iVar = *sit;
+    for (HighsInt iVar : freeList) {
       assert(iVar < ekk_instance_.lp_.num_col_ + ekk_instance_.lp_.num_row_);
       ekk_instance_.basis_.nonbasicMove_[iVar] = 0;
     }


### PR DESCRIPTION
I accidentally found two for loops in `src/simplex/HEkkDualRow.cpp` that could be rewritten as ranged-based for loops, which would simplify the code, I think.