### PR TITLE
Explicitly set c++11 in CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,15 @@ if (BUILD_CXX)
     option(STDCALL "Build highs with the __stdcall convention" OFF)
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR 
+    CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR  
+    CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") 
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++11") 
+  endif()  
+
+
   # Basic type
   include(CMakePushCheckState)
   cmake_push_check_state(RESET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,6 @@ if (BUILD_CXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++11") 
   endif()  
 
-
   # Basic type
   include(CMakePushCheckState)
   cmake_push_check_state(RESET)


### PR DESCRIPTION
Required for dotnet on AWS linux 