### PR TITLE
Refactor HighsTimer

### DIFF
--- a/src/Highs.h
+++ b/src/Highs.h
@@ -411,7 +411,7 @@ class Highs {
   /**
    * @brief Get the run time of HiGHS
    */
-  double getRunTime() { return timer_.readRunHighsClock(); }
+  double getRunTime() { return timer_.read(); }
 
   /**
    * Methods for model output

--- a/src/ipm/IpxWrapper.cpp
+++ b/src/ipm/IpxWrapper.cpp
@@ -115,7 +115,7 @@ HighsStatus solveLpIpx(const HighsOptions& options, HighsTimer& timer,
   parameters.analyse_basis_data =
       kHighsAnalysisLevelNlaData & options.highs_analysis_level;
   // Determine the run time allowed for IPX
-  parameters.time_limit = options.time_limit - timer.readRunHighsClock();
+  parameters.time_limit = options.time_limit - timer.read();
   parameters.ipm_maxiter =
       options.ipm_iteration_limit - highs_info.ipm_iteration_count;
   // Determine if crossover is to be run or not

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3459,9 +3459,9 @@ HighsPresolveStatus Highs::runPresolve(const bool force_lp_presolve,
     // Presolved model is extracted now since it's part of solver,
     // which is lost on return
     HighsMipSolver solver(callback_, options_, original_lp, solution_);
-    // Start the MIP solver's total clock so that timeout in presolve
-    // can be identified
-    solver.timer_.start(timer_.total_clock);
+    // Start the MIP solver's timer so that timeout in presolve can be
+    // identified
+    solver.timer_.start();
     // Only place that HighsMipSolver::runPresolve is called
     solver.runPresolve(options_.presolve_reduction_limit);
     presolve_return_status = solver.getPresolveStatus();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1048,7 +1048,7 @@ HighsStatus Highs::solve() {
   // Zero the iteration counts
   zeroIterationCounts();
   // Start the HiGHS run clock
-  timer_.startRunHighsClock();
+  timer_.start();
   // Return immediately if the model has no columns
   if (!model_.lp_.num_col_) {
     setHighsModelStatusAndClearSolutionAndBasis(HighsModelStatus::kModelEmpty);
@@ -1166,7 +1166,7 @@ HighsStatus Highs::solve() {
   //
   // Record the initial time and set the component times and postsolve
   // iteration count to -1 to identify whether they are not required
-  double initial_time = timer_.readRunHighsClock();
+  double initial_time = timer_.read();
   double this_presolve_time = -1;
   double this_solve_presolved_lp_time = -1;
   double this_postsolve_time = -1;
@@ -1222,7 +1222,7 @@ HighsStatus Highs::solve() {
         return returnFromRun(crossover_status, undo_mods);
       assert(options_.simplex_strategy == kSimplexStrategyPrimal);
     }
-    // timer_.stopRunHighsClock();
+    // timer_.stop();
     // run();
 
     // todo: add "dual" values
@@ -1629,7 +1629,7 @@ HighsStatus Highs::solve() {
   // HiGHS info is valid
   if (!no_incumbent_lp_solution_or_basis) info_.valid = true;
 
-  double lp_solve_final_time = timer_.readRunHighsClock();
+  double lp_solve_final_time = timer_.read();
   double this_solve_time = lp_solve_final_time - initial_time;
   if (postsolve_iteration_count < 0) {
     highsLogDev(log_options, HighsLogType::kInfo, "Postsolve  : \n");
@@ -3431,9 +3431,9 @@ HighsPresolveStatus Highs::runPresolve(const bool force_lp_presolve,
   if (original_lp.num_col_ == 0 && original_lp.num_row_ == 0)
     return HighsPresolveStatus::kNullError;
 
-  // Ensure that the RunHighsClock is running
-  if (!timer_.runningRunHighsClock()) timer_.startRunHighsClock();
-  double start_presolve = timer_.readRunHighsClock();
+  // Ensure that the timer is running
+  if (!timer_.running()) timer_.start();
+  double start_presolve = timer_.read();
 
   // Set time limit.
   if (options_.time_limit > 0 && options_.time_limit < kHighsInf) {
@@ -3475,7 +3475,7 @@ HighsPresolveStatus Highs::runPresolve(const bool force_lp_presolve,
     presolve_.init(original_lp, timer_);
     presolve_.options_ = &options_;
     if (options_.time_limit > 0 && options_.time_limit < kHighsInf) {
-      double current = timer_.readRunHighsClock();
+      double current = timer_.read();
       double time_init = current - start_presolve;
       double left = presolve_.options_->time_limit - time_init;
       if (left <= 0) {
@@ -4530,7 +4530,7 @@ HighsStatus Highs::returnFromHighs(HighsStatus highs_return_status) {
     assert(called_return_from_run);
   }
   // Stop the HiGHS run clock if it is running
-  if (timer_.runningRunHighsClock()) timer_.stopRunHighsClock();
+  if (timer_.running()) timer_.stop();
   const bool dimensions_ok =
       lpDimensionsOk("returnFromHighs", model_.lp_, options_.log_options);
   if (!dimensions_ok) {
@@ -4594,7 +4594,7 @@ void Highs::reportSolvedLpQpStats() {
     highsLogUser(log_options, HighsLogType::kInfo,
                  "Relative P-D gap    : %17.10e\n", relative_primal_dual_gap);
   }
-  double run_time = timer_.readRunHighsClock();
+  double run_time = timer_.read();
   highsLogUser(log_options, HighsLogType::kInfo,
                "HiGHS run time      : %13.2f\n", run_time);
 }

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -1045,7 +1045,7 @@ void HighsLpRelaxation::setObjectiveLimit(double objlim) {
 HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
   lpsolver.setOptionValue(
       "time_limit", lpsolver.getRunTime() + mipsolver.options_mip_->time_limit -
-                        mipsolver.timer_.read(mipsolver.timer_.total_clock));
+                        mipsolver.timer_.read());
   // lpsolver.setOptionValue("output_flag", true);
   const bool valid_basis = lpsolver.getBasis().valid;
   const HighsInt simplex_solve_clock = valid_basis

--- a/src/mip/HighsLpRelaxation.cpp
+++ b/src/mip/HighsLpRelaxation.cpp
@@ -1043,9 +1043,9 @@ void HighsLpRelaxation::setObjectiveLimit(double objlim) {
 }
 
 HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
-  lpsolver.setOptionValue(
-      "time_limit", lpsolver.getRunTime() + mipsolver.options_mip_->time_limit -
-                        mipsolver.timer_.read());
+  lpsolver.setOptionValue("time_limit", lpsolver.getRunTime() +
+                                            mipsolver.options_mip_->time_limit -
+                                            mipsolver.timer_.read());
   // lpsolver.setOptionValue("output_flag", true);
   const bool valid_basis = lpsolver.getBasis().valid;
   const HighsInt simplex_solve_clock = valid_basis

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -161,8 +161,7 @@ void HighsMipSolver::run() {
   analysis_.mipTimerStop(kMipClockRunSetup);
   if (analysis_.analyse_mip_time & !submip)
     highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
-                 "MIP-Timing: %11.2g - completed setup\n",
-                 timer_.read());
+                 "MIP-Timing: %11.2g - completed setup\n", timer_.read());
 restart:
   if (modelstatus_ == HighsModelStatus::kNotset) {
     // Check limits have not been reached before evaluating root node
@@ -802,8 +801,7 @@ void HighsMipSolver::cleanupSolve() {
                "                    %llu (strong br.)\n"
                "                    %llu (separation)\n"
                "                    %llu (heuristics)\n",
-               timer_.read(),
-               analysis_.mipTimerRead(kMipClockPresolve),
+               timer_.read(), analysis_.mipTimerRead(kMipClockPresolve),
                analysis_.mipTimerRead(kMipClockSolve),
                analysis_.mipTimerRead(kMipClockPostsolve),
                int(max_submip_level), (long long unsigned)mipdata_->num_nodes,

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -113,9 +113,7 @@ void HighsMipSolver::run() {
     analysis_.timer_ = &this->timer_;
     analysis_.setup(*orig_model_, *options_mip_);
   }
-  // Start the total_clock for the timer that is local to the HighsMipSolver
-  // instance
-  timer_.start(timer_.total_clock);
+  timer_.start();
 
   improving_solution_file_ = nullptr;
   if (!submip && options_mip_->mip_improving_solution_file != "")
@@ -136,7 +134,7 @@ void HighsMipSolver::run() {
                  "MIP-Timing: %11.2g - completed presolve\n", timer_.read());
   // Identify whether time limit has been reached (in presolve)
   if (modelstatus_ == HighsModelStatus::kNotset &&
-      timer_.read(timer_.total_clock) >= options_mip_->time_limit)
+      timer_.read() >= options_mip_->time_limit)
     modelstatus_ = HighsModelStatus::kTimeLimit;
 
   if (modelstatus_ != HighsModelStatus::kNotset) {
@@ -164,7 +162,7 @@ void HighsMipSolver::run() {
   if (analysis_.analyse_mip_time & !submip)
     highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                  "MIP-Timing: %11.2g - completed setup\n",
-                 timer_.read(timer_.total_clock));
+                 timer_.read());
 restart:
   if (modelstatus_ == HighsModelStatus::kNotset) {
     // Check limits have not been reached before evaluating root node
@@ -186,7 +184,7 @@ restart:
     if (analysis_.analyse_mip_time & !submip)
       highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                    "MIP-Timing: %11.2g - starting evaluate root node\n",
-                   timer_.read(timer_.total_clock));
+                   timer_.read());
     analysis_.mipTimerStart(kMipClockEvaluateRootNode);
     mipdata_->evaluateRootNode();
     analysis_.mipTimerStop(kMipClockEvaluateRootNode);
@@ -198,7 +196,7 @@ restart:
     if (analysis_.analyse_mip_time & !submip)
       highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                    "MIP-Timing: %11.2g - completed evaluate root node\n",
-                   timer_.read(timer_.total_clock));
+                   timer_.read());
     // age 5 times to remove stored but never violated cuts after root
     // separation
     analysis_.mipTimerStart(kMipClockPerformAging0);
@@ -718,7 +716,7 @@ void HighsMipSolver::cleanupSolve() {
   }
 
   analysis_.mipTimerStop(kMipClockPostsolve);
-  timer_.stop(timer_.total_clock);
+  timer_.stop();
 
   std::string solutionstatus = "-";
 
@@ -804,7 +802,7 @@ void HighsMipSolver::cleanupSolve() {
                "                    %llu (strong br.)\n"
                "                    %llu (separation)\n"
                "                    %llu (heuristics)\n",
-               timer_.read(timer_.total_clock),
+               timer_.read(),
                analysis_.mipTimerRead(kMipClockPresolve),
                analysis_.mipTimerRead(kMipClockSolve),
                analysis_.mipTimerRead(kMipClockPostsolve),

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1091,10 +1091,8 @@ try_again:
       }
     }
     this->total_repair_lp++;
-    double time_available =
-        std::max(mipsolver.options_mip_->time_limit -
-                     mipsolver.timer_.read(),
-                 0.1);
+    double time_available = std::max(
+        mipsolver.options_mip_->time_limit - mipsolver.timer_.read(), 0.1);
     Highs tmpSolver;
     const bool debug_report = false;
     if (debug_report) {
@@ -2380,8 +2378,7 @@ bool HighsMipSolverData::checkLimits(int64_t nodeOffset) const {
   //  const double time = mipsolver.timer_.read();
   //  printf("checkLimits: time = %g\n", time);
   if (options.time_limit < kHighsInf &&
-      mipsolver.timer_.read() >=
-          options.time_limit) {
+      mipsolver.timer_.read() >= options.time_limit) {
     if (mipsolver.modelstatus_ == HighsModelStatus::kNotset) {
       highsLogDev(options.log_options, HighsLogType::kInfo,
                   "Reached time limit\n");
@@ -2487,8 +2484,7 @@ bool HighsMipSolverData::interruptFromCallbackWithData(
   double primal_bound;
   double mip_rel_gap;
   limitsToBounds(dual_bound, primal_bound, mip_rel_gap);
-  mipsolver.callback_->data_out.running_time =
-      mipsolver.timer_.read();
+  mipsolver.callback_->data_out.running_time = mipsolver.timer_.read();
   mipsolver.callback_->data_out.objective_function_value =
       mipsolver_objective_value;
   mipsolver.callback_->data_out.mip_node_count = mipsolver.mipdata_->num_nodes;

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1093,7 +1093,7 @@ try_again:
     this->total_repair_lp++;
     double time_available =
         std::max(mipsolver.options_mip_->time_limit -
-                     mipsolver.timer_.read(mipsolver.timer_.total_clock),
+                     mipsolver.timer_.read(),
                  0.1);
     Highs tmpSolver;
     const bool debug_report = false;
@@ -1598,7 +1598,7 @@ void HighsMipSolverData::printDisplayLine(const int solution_source) {
   bool output_flag = *mipsolver.options_mip_->log_options.output_flag;
   if (!output_flag) return;
 
-  double time = mipsolver.timer_.read(mipsolver.timer_.total_clock);
+  double time = mipsolver.timer_.read();
   if (solution_source == kSolutionSourceNone &&
       time - last_disptime < mipsolver.options_mip_->mip_min_logging_interval)
     return;
@@ -2377,10 +2377,10 @@ bool HighsMipSolverData::checkLimits(int64_t nodeOffset) const {
     return true;
   }
 
-  //  const double time = mipsolver.timer_.read(mipsolver.timer_.total_clock);
+  //  const double time = mipsolver.timer_.read();
   //  printf("checkLimits: time = %g\n", time);
   if (options.time_limit < kHighsInf &&
-      mipsolver.timer_.read(mipsolver.timer_.total_clock) >=
+      mipsolver.timer_.read() >=
           options.time_limit) {
     if (mipsolver.modelstatus_ == HighsModelStatus::kNotset) {
       highsLogDev(options.log_options, HighsLogType::kInfo,
@@ -2488,7 +2488,7 @@ bool HighsMipSolverData::interruptFromCallbackWithData(
   double mip_rel_gap;
   limitsToBounds(dual_bound, primal_bound, mip_rel_gap);
   mipsolver.callback_->data_out.running_time =
-      mipsolver.timer_.read(mipsolver.timer_.total_clock);
+      mipsolver.timer_.read();
   mipsolver.callback_->data_out.objective_function_value =
       mipsolver_objective_value;
   mipsolver.callback_->data_out.mip_node_count = mipsolver.mipdata_->num_nodes;
@@ -2617,7 +2617,7 @@ void HighsMipSolverData::updatePrimalDualIntegral(const double from_lower_bound,
       assert(gap_consistent);
     }
     if (to_gap < kHighsInf) {
-      double time = mipsolver.timer_.read(mipsolver.timer_.total_clock);
+      double time = mipsolver.timer_.read();
       if (from_gap < kHighsInf) {
         // Need to update the P-D integral
         double time_diff = time - pdi.prev_time;

--- a/src/mip/HighsModkSeparator.h
+++ b/src/mip/HighsModkSeparator.h
@@ -54,7 +54,7 @@ class HighsModkSeparator : public HighsSeparator {
                           HighsCutPool& cutpool) override;
 
   HighsModkSeparator(const HighsMipSolver& mipsolver)
-      : HighsSeparator(mipsolver, "Mod-k sepa", "Mod") {}
+      : HighsSeparator(mipsolver, "Mod-k sepa") {}
 };
 
 #endif

--- a/src/mip/HighsPathSeparator.h
+++ b/src/mip/HighsPathSeparator.h
@@ -31,7 +31,7 @@ class HighsPathSeparator : public HighsSeparator {
                           HighsCutPool& cutpool) override;
 
   HighsPathSeparator(const HighsMipSolver& mipsolver)
-      : HighsSeparator(mipsolver, "PathAggr sepa", "Agg") {
+      : HighsSeparator(mipsolver, "PathAggr sepa") {
     randgen.initialise(mipsolver.options_mip_->random_seed);
   }
 };

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -109,7 +109,7 @@ bool HighsPrimalHeuristics::solveSubMip(
   submipoptions.mip_max_stall_nodes = stallnodes;
   submipoptions.mip_pscost_minreliable = 0;
   submipoptions.time_limit -=
-      mipsolver.timer_.read(mipsolver.timer_.total_clock);
+      mipsolver.timer_.read();
   submipoptions.objective_bound = mipsolver.mipdata_->upper_limit;
 
   if (!mipsolver.submip) {

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -108,8 +108,7 @@ bool HighsPrimalHeuristics::solveSubMip(
   submipoptions.mip_max_nodes = maxnodes;
   submipoptions.mip_max_stall_nodes = stallnodes;
   submipoptions.mip_pscost_minreliable = 0;
-  submipoptions.time_limit -=
-      mipsolver.timer_.read();
+  submipoptions.time_limit -= mipsolver.timer_.read();
   submipoptions.objective_bound = mipsolver.mipdata_->upper_limit;
 
   if (!mipsolver.submip) {

--- a/src/mip/HighsSeparation.cpp
+++ b/src/mip/HighsSeparation.cpp
@@ -23,8 +23,8 @@
 #include "mip/HighsTransformedLp.h"
 
 HighsSeparation::HighsSeparation(const HighsMipSolver& mipsolver) {
-  implBoundClock = mipsolver.timer_.clock_def("Implbound sepa", "Ibd");
-  cliqueClock = mipsolver.timer_.clock_def("Clique sepa", "Clq");
+  implBoundClock = mipsolver.timer_.clock_def("Implbound sepa");
+  cliqueClock = mipsolver.timer_.clock_def("Clique sepa");
   separators.emplace_back(new HighsTableauSeparator(mipsolver));
   separators.emplace_back(new HighsPathSeparator(mipsolver));
   separators.emplace_back(new HighsModkSeparator(mipsolver));

--- a/src/mip/HighsSeparator.cpp
+++ b/src/mip/HighsSeparator.cpp
@@ -14,9 +14,9 @@
 #include "mip/HighsMipSolver.h"
 
 HighsSeparator::HighsSeparator(const HighsMipSolver& mipsolver,
-                               const char* name, const char* ch3_name)
+                               const char* name)
     : numCutsFound(0), numCalls(0) {
-  clockIndex = mipsolver.timer_.clock_def(name, ch3_name);
+  clockIndex = mipsolver.timer_.clock_def(name);
 }
 
 void HighsSeparator::run(HighsLpRelaxation& lpRelaxation,

--- a/src/mip/HighsSeparator.h
+++ b/src/mip/HighsSeparator.h
@@ -30,8 +30,7 @@ class HighsSeparator {
   int clockIndex;
 
  public:
-  HighsSeparator(const HighsMipSolver& mipsolver, const char* name,
-                 const char* ch3_name);
+  HighsSeparator(const HighsMipSolver& mipsolver, const char* name);
 
   virtual void separateLpSolution(HighsLpRelaxation& lpRelaxation,
                                   HighsLpAggregator& lpAggregator,

--- a/src/mip/HighsTableauSeparator.h
+++ b/src/mip/HighsTableauSeparator.h
@@ -28,7 +28,7 @@ class HighsTableauSeparator : public HighsSeparator {
                           HighsCutPool& cutpool) override;
 
   HighsTableauSeparator(const HighsMipSolver& mipsolver)
-      : HighsSeparator(mipsolver, "Tableau sepa", "Tbl"), numTries(0) {}
+      : HighsSeparator(mipsolver, "Tableau sepa"), numTries(0) {}
 };
 
 #endif

--- a/src/mip/MipTimer.h
+++ b/src/mip/MipTimer.h
@@ -84,7 +84,7 @@ class MipTimer {
     HighsTimer* timer_pointer = mip_timer_clock.timer_pointer_;
     std::vector<HighsInt>& clock = mip_timer_clock.clock_;
     clock.resize(kNumMipClock);
-    clock[kMipClockTotal] = timer_pointer->total_clock;
+    clock[kMipClockTotal] = 0;
     clock[kMipClockPresolve] = timer_pointer->clock_def("MIP presolve");
     clock[kMipClockSolve] = timer_pointer->clock_def("MIP solve");
     clock[kMipClockPostsolve] = timer_pointer->clock_def("MIP postsolve");

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -4109,7 +4109,7 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
     // the timer is well defined, and that its total time clock is
     // running
     assert(this->timer);
-    assert(this->timer->runningRunHighsClock());
+    assert(this->timer->running());
 
     HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
 

--- a/src/qpsolver/feasibility_highs.hpp
+++ b/src/qpsolver/feasibility_highs.hpp
@@ -61,7 +61,7 @@ static void computeStartingPointHighs(
     highs.setOptionValue("presolve", "on");
     // Set the residual time limit
     const double use_time_limit =
-        std::max(settings.time_limit - timer.readRunHighsClock(), 0.001);
+        std::max(settings.time_limit - timer.read(), 0.001);
     highs.setOptionValue("time_limit", use_time_limit);
 
     HighsLp lp;

--- a/src/qpsolver/quass.cpp
+++ b/src/qpsolver/quass.cpp
@@ -31,7 +31,7 @@ static void loginformation(Runtime& rt, Basis& basis, CholeskyFactor& factor,
   rt.statistics.nullspacedimension.push_back(rt.instance.num_var -
                                              basis.getnumactive());
   rt.statistics.objval.push_back(rt.instance.objval(rt.primal));
-  rt.statistics.time.push_back(timer.readRunHighsClock());
+  rt.statistics.time.push_back(timer.read());
   SumNum sm =
       rt.instance.sumnumprimalinfeasibilities(rt.primal, rt.rowactivity);
   rt.statistics.sum_primal_infeasibilities.push_back(sm.sum);
@@ -337,7 +337,7 @@ void Quass::solve(const QpVector& x0, const QpVector& ra, Basis& b0,
     }
 
     // check time limit
-    if (timer.readRunHighsClock() >= runtime.settings.time_limit) {
+    if (timer.read() >= runtime.settings.time_limit) {
       runtime.status = QpModelStatus::kTimeLimit;
       break;
     }
@@ -350,7 +350,7 @@ void Quass::solve(const QpVector& x0, const QpVector& ra, Basis& b0,
     }
 
     // LOGGING
-    double run_time = timer.readRunHighsClock();
+    double run_time = timer.read();
     if ((runtime.statistics.num_iterations %
                  runtime.settings.reportingfequency ==
              0 ||

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -3468,7 +3468,7 @@ bool HEkk::bailout() {
            model_status_ == HighsModelStatus::kObjectiveBound ||
            model_status_ == HighsModelStatus::kObjectiveTarget);
   } else if (options_->time_limit < kHighsInf &&
-             timer_->readRunHighsClock() > options_->time_limit) {
+             timer_->read() > options_->time_limit) {
     solve_bailout_ = true;
     model_status_ = HighsModelStatus::kTimeLimit;
   } else if (iteration_count_ >= options_->simplex_iteration_limit) {

--- a/src/simplex/HighsSimplexAnalysis.cpp
+++ b/src/simplex/HighsSimplexAnalysis.cpp
@@ -380,7 +380,7 @@ void HighsSimplexAnalysis::userInvertReport(const bool force) {
 
 void HighsSimplexAnalysis::userInvertReport(const bool header,
                                             const bool force) {
-  const double highs_run_time = timer_->readRunHighsClock();
+  const double highs_run_time = timer_->read();
   if (!force && highs_run_time < last_user_log_time + delta_user_log_time)
     return;
   analysis_log = std::unique_ptr<std::stringstream>(new std::stringstream());

--- a/src/simplex/SimplexTimer.h
+++ b/src/simplex/SimplexTimer.h
@@ -120,116 +120,101 @@ class SimplexTimer {
     HighsTimer* timer_pointer = simplex_timer_clock.timer_pointer_;
     std::vector<HighsInt>& clock = simplex_timer_clock.clock_;
     clock.resize(SimplexNumClock);
-    clock[SimplexTotalClock] = timer_pointer->clock_def("Simplex total", "STT");
-    clock[SimplexIzDseWtClock] = timer_pointer->clock_def("Iz DSE Wt", "IWT");
-    clock[SimplexDualPhase1Clock] =
-        timer_pointer->clock_def("Dual Phase 1", "DP1");
-    clock[SimplexDualPhase2Clock] =
-        timer_pointer->clock_def("Dual Phase 2", "DP2");
+    clock[SimplexTotalClock] = timer_pointer->clock_def("Simplex total");
+    clock[SimplexIzDseWtClock] = timer_pointer->clock_def("Iz DSE Wt");
+    clock[SimplexDualPhase1Clock] = timer_pointer->clock_def("Dual Phase 1");
+    clock[SimplexDualPhase2Clock] = timer_pointer->clock_def("Dual Phase 2");
     clock[SimplexPrimalPhase1Clock] =
-        timer_pointer->clock_def("Primal Phase 1", "PP1");
+        timer_pointer->clock_def("Primal Phase 1");
     clock[SimplexPrimalPhase2Clock] =
-        timer_pointer->clock_def("Primal Phase 2", "PP2");
-    clock[Group1Clock] = timer_pointer->clock_def("GROUP1", "GP1");
-    clock[IterateClock] = timer_pointer->clock_def("ITERATE", "ITR");
-    clock[IterateDualRebuildClock] =
-        timer_pointer->clock_def("DUAL REBUILD", "DRB");
+        timer_pointer->clock_def("Primal Phase 2");
+    clock[Group1Clock] = timer_pointer->clock_def("GROUP1");
+    clock[IterateClock] = timer_pointer->clock_def("ITERATE");
+    clock[IterateDualRebuildClock] = timer_pointer->clock_def("DUAL REBUILD");
     clock[IteratePrimalRebuildClock] =
-        timer_pointer->clock_def("PRIMAL REBUILD", "PRB");
-    clock[IterateChuzrClock] = timer_pointer->clock_def("CHUZR", "CZR");
-    clock[IterateChuzcClock] = timer_pointer->clock_def("CHUZC", "CZC");
-    clock[IterateFtranClock] = timer_pointer->clock_def("FTRAN", "FTR");
-    clock[IterateVerifyClock] = timer_pointer->clock_def("VERIFY", "VRF");
-    clock[IterateDualClock] = timer_pointer->clock_def("DUAL", "UDU");
-    clock[IteratePrimalClock] = timer_pointer->clock_def("PRIMAL", "UPR");
-    clock[IterateDevexIzClock] = timer_pointer->clock_def("DEVEX_IZ", "DVI");
-    clock[IteratePivotsClock] = timer_pointer->clock_def("PIVOTS", "PIV");
+        timer_pointer->clock_def("PRIMAL REBUILD");
+    clock[IterateChuzrClock] = timer_pointer->clock_def("CHUZR");
+    clock[IterateChuzcClock] = timer_pointer->clock_def("CHUZC");
+    clock[IterateFtranClock] = timer_pointer->clock_def("FTRAN");
+    clock[IterateVerifyClock] = timer_pointer->clock_def("VERIFY");
+    clock[IterateDualClock] = timer_pointer->clock_def("DUAL");
+    clock[IteratePrimalClock] = timer_pointer->clock_def("PRIMAL");
+    clock[IterateDevexIzClock] = timer_pointer->clock_def("DEVEX_IZ");
+    clock[IteratePivotsClock] = timer_pointer->clock_def("PIVOTS");
     clock[initialiseSimplexLpBasisAndFactorClock] =
-        timer_pointer->clock_def("IZ_SIMPLEX_LP_DEF", "ISD");
+        timer_pointer->clock_def("IZ_SIMPLEX_LP_DEF");
     clock[allocateSimplexArraysClock] =
-        timer_pointer->clock_def("ALLOC_SIMPLEX_ARRS", "ASA");
+        timer_pointer->clock_def("ALLOC_SIMPLEX_ARRS");
     clock[initialiseSimplexCostBoundsClock] =
-        timer_pointer->clock_def("IZ_SIMPLEX_CO_BD", "ICB");
-    clock[ScaleClock] = timer_pointer->clock_def("SCALE", "SCL");
-    clock[CrashClock] = timer_pointer->clock_def("CRASH", "CSH");
-    clock[BasisConditionClock] =
-        timer_pointer->clock_def("BASIS_CONDITION", "CON");
-    clock[matrixSetupClock] = timer_pointer->clock_def("MATRIX_SETUP", "FST");
-    clock[setNonbasicMoveClock] =
-        timer_pointer->clock_def("SET_NONBASICMOVE", "SNM");
-    clock[DseIzClock] = timer_pointer->clock_def("DSE_IZ", "DEI");
-    clock[InvertClock] = timer_pointer->clock_def("INVERT", "INV");
-    clock[PermWtClock] = timer_pointer->clock_def("PERM_WT", "PWT");
-    clock[ComputeDualClock] = timer_pointer->clock_def("COMPUTE_DUAL", "CPD");
-    clock[CorrectDualClock] = timer_pointer->clock_def("CORRECT_DUAL", "CRD");
-    clock[ComputePrimalClock] =
-        timer_pointer->clock_def("COMPUTE_PRIMAL", "CPP");
-    clock[CollectPrIfsClock] =
-        timer_pointer->clock_def("COLLECT_PR_IFS", "IFS");
-    clock[ComputePrIfsClock] =
-        timer_pointer->clock_def("COMPUTE_PR_IFS", "PIF");
-    clock[ComputeDuIfsClock] =
-        timer_pointer->clock_def("COMPUTE_DU_IFS", "DIF");
-    clock[ComputeDuObjClock] =
-        timer_pointer->clock_def("COMPUTE_DU_OBJ", "DOB");
-    clock[ComputePrObjClock] =
-        timer_pointer->clock_def("COMPUTE_PR_OBJ", "POB");
-    clock[ReportRebuildClock] =
-        timer_pointer->clock_def("REPORT_REBUILD", "RPR");
-    clock[ChuzrDualClock] = timer_pointer->clock_def("CHUZR_DUAL", "CRD");
-    clock[Chuzr1Clock] = timer_pointer->clock_def("CHUZR1", "CR1");
-    clock[Chuzr2Clock] = timer_pointer->clock_def("CHUZR2", "CR2");
-    clock[ChuzcPrimalClock] = timer_pointer->clock_def("CHUZC_PRIMAL", "CCP");
+        timer_pointer->clock_def("IZ_SIMPLEX_CO_BD");
+    clock[ScaleClock] = timer_pointer->clock_def("SCALE");
+    clock[CrashClock] = timer_pointer->clock_def("CRASH");
+    clock[BasisConditionClock] = timer_pointer->clock_def("BASIS_CONDITION");
+    clock[matrixSetupClock] = timer_pointer->clock_def("MATRIX_SETUP");
+    clock[setNonbasicMoveClock] = timer_pointer->clock_def("SET_NONBASICMOVE");
+    clock[DseIzClock] = timer_pointer->clock_def("DSE_IZ");
+    clock[InvertClock] = timer_pointer->clock_def("INVERT");
+    clock[PermWtClock] = timer_pointer->clock_def("PERM_WT");
+    clock[ComputeDualClock] = timer_pointer->clock_def("COMPUTE_DUAL");
+    clock[CorrectDualClock] = timer_pointer->clock_def("CORRECT_DUAL");
+    clock[ComputePrimalClock] = timer_pointer->clock_def("COMPUTE_PRIMAL");
+    clock[CollectPrIfsClock] = timer_pointer->clock_def("COLLECT_PR_IFS");
+    clock[ComputePrIfsClock] = timer_pointer->clock_def("COMPUTE_PR_IFS");
+    clock[ComputeDuIfsClock] = timer_pointer->clock_def("COMPUTE_DU_IFS");
+    clock[ComputeDuObjClock] = timer_pointer->clock_def("COMPUTE_DU_OBJ");
+    clock[ComputePrObjClock] = timer_pointer->clock_def("COMPUTE_PR_OBJ");
+    clock[ReportRebuildClock] = timer_pointer->clock_def("REPORT_REBUILD");
+    clock[ChuzrDualClock] = timer_pointer->clock_def("CHUZR_DUAL");
+    clock[Chuzr1Clock] = timer_pointer->clock_def("CHUZR1");
+    clock[Chuzr2Clock] = timer_pointer->clock_def("CHUZR2");
+    clock[ChuzcPrimalClock] = timer_pointer->clock_def("CHUZC_PRIMAL");
     clock[ChuzcHyperInitialiselClock] =
-        timer_pointer->clock_def("CHUZC_HYPER_IZ", "CHI");
+        timer_pointer->clock_def("CHUZC_HYPER_IZ");
     clock[ChuzcHyperBasicFeasibilityChangeClock] =
-        timer_pointer->clock_def("CHUZC_HYPER_FEAS", "CHF");
-    clock[ChuzcHyperDualClock] =
-        timer_pointer->clock_def("CHUZC_HYPER_DUAL", "CHD");
-    clock[ChuzcHyperClock] = timer_pointer->clock_def("CHUZC_HYPER", "CHC");
-    clock[Chuzc0Clock] = timer_pointer->clock_def("CHUZC0", "CC0");
-    clock[PriceChuzc1Clock] = timer_pointer->clock_def("PRICE_CHUZC1", "PC1");
-    clock[Chuzc1Clock] = timer_pointer->clock_def("CHUZC1", "CC1");
-    clock[Chuzc2Clock] = timer_pointer->clock_def("CHUZC2", "CC2");
-    clock[Chuzc3Clock] = timer_pointer->clock_def("CHUZC3", "CC3");
-    clock[Chuzc4Clock] = timer_pointer->clock_def("CHUZC4", "CC4");
-    clock[Chuzc4a0Clock] = timer_pointer->clock_def("CHUZC4a0", "C40");
-    clock[Chuzc4a1Clock] = timer_pointer->clock_def("CHUZC4a1", "C41");
-    clock[Chuzc4bClock] = timer_pointer->clock_def("CHUZC4b", "C4b");
-    clock[Chuzc4cClock] = timer_pointer->clock_def("CHUZC4c", "C4c");
-    clock[Chuzc4dClock] = timer_pointer->clock_def("CHUZC4d", "C4d");
-    clock[Chuzc4eClock] = timer_pointer->clock_def("CHUZC4e", "C4e");
-    clock[Chuzc5Clock] = timer_pointer->clock_def("CHUZC5", "CC5");
-    clock[DevexWtClock] = timer_pointer->clock_def("DEVEX_WT", "DWT");
-    clock[BtranClock] = timer_pointer->clock_def("BTRAN", "REP");
+        timer_pointer->clock_def("CHUZC_HYPER_FEAS");
+    clock[ChuzcHyperDualClock] = timer_pointer->clock_def("CHUZC_HYPER_DUAL");
+    clock[ChuzcHyperClock] = timer_pointer->clock_def("CHUZC_HYPER");
+    clock[Chuzc0Clock] = timer_pointer->clock_def("CHUZC0");
+    clock[PriceChuzc1Clock] = timer_pointer->clock_def("PRICE_CHUZC1");
+    clock[Chuzc1Clock] = timer_pointer->clock_def("CHUZC1");
+    clock[Chuzc2Clock] = timer_pointer->clock_def("CHUZC2");
+    clock[Chuzc3Clock] = timer_pointer->clock_def("CHUZC3");
+    clock[Chuzc4Clock] = timer_pointer->clock_def("CHUZC4");
+    clock[Chuzc4a0Clock] = timer_pointer->clock_def("CHUZC4a0");
+    clock[Chuzc4a1Clock] = timer_pointer->clock_def("CHUZC4a1");
+    clock[Chuzc4bClock] = timer_pointer->clock_def("CHUZC4b");
+    clock[Chuzc4cClock] = timer_pointer->clock_def("CHUZC4c");
+    clock[Chuzc4dClock] = timer_pointer->clock_def("CHUZC4d");
+    clock[Chuzc4eClock] = timer_pointer->clock_def("CHUZC4e");
+    clock[Chuzc5Clock] = timer_pointer->clock_def("CHUZC5");
+    clock[DevexWtClock] = timer_pointer->clock_def("DEVEX_WT");
+    clock[BtranClock] = timer_pointer->clock_def("BTRAN");
     clock[BtranBasicFeasibilityChangeClock] =
-        timer_pointer->clock_def("BTRAN_FEAS", "BT1");
-    clock[BtranFullClock] = timer_pointer->clock_def("BTRAN_FULL", "BTF");
-    clock[PriceClock] = timer_pointer->clock_def("PRICE", "RAP");
+        timer_pointer->clock_def("BTRAN_FEAS");
+    clock[BtranFullClock] = timer_pointer->clock_def("BTRAN_FULL");
+    clock[PriceClock] = timer_pointer->clock_def("PRICE");
     clock[PriceBasicFeasibilityChangeClock] =
-        timer_pointer->clock_def("PRICE_FEAS", "PC1");
-    clock[PriceFullClock] = timer_pointer->clock_def("PRICE_FULL", "PCF");
-    clock[FtranClock] = timer_pointer->clock_def("FTRAN", "COL");
-    clock[FtranDseClock] = timer_pointer->clock_def("FTRAN_DSE", "DSE");
-    clock[BtranPseClock] = timer_pointer->clock_def("BTRAN_PSE", "PSE");
-    clock[FtranMixParClock] = timer_pointer->clock_def("FTRAN_MIX_PAR", "FMP");
-    clock[FtranMixFinalClock] =
-        timer_pointer->clock_def("FTRAN_MIX_FINAL", "FMF");
-    clock[FtranBfrtClock] = timer_pointer->clock_def("FTRAN_BFRT", "BFR");
-    clock[UpdateRowClock] = timer_pointer->clock_def("UPDATE_ROW", "UPR");
-    clock[UpdateDualClock] = timer_pointer->clock_def("UPDATE_DUAL", "UPD");
+        timer_pointer->clock_def("PRICE_FEAS");
+    clock[PriceFullClock] = timer_pointer->clock_def("PRICE_FULL");
+    clock[FtranClock] = timer_pointer->clock_def("FTRAN");
+    clock[FtranDseClock] = timer_pointer->clock_def("FTRAN_DSE");
+    clock[BtranPseClock] = timer_pointer->clock_def("BTRAN_PSE");
+    clock[FtranMixParClock] = timer_pointer->clock_def("FTRAN_MIX_PAR");
+    clock[FtranMixFinalClock] = timer_pointer->clock_def("FTRAN_MIX_FINAL");
+    clock[FtranBfrtClock] = timer_pointer->clock_def("FTRAN_BFRT");
+    clock[UpdateRowClock] = timer_pointer->clock_def("UPDATE_ROW");
+    clock[UpdateDualClock] = timer_pointer->clock_def("UPDATE_DUAL");
     clock[UpdateDualBasicFeasibilityChangeClock] =
-        timer_pointer->clock_def("UPDATE_DUAL_FEAS", "UD1");
-    clock[UpdatePrimalClock] = timer_pointer->clock_def("UPDATE_PRIMAL", "UPP");
-    clock[DevexIzClock] = timer_pointer->clock_def("DEVEX_IZ", "DIZ");
+        timer_pointer->clock_def("UPDATE_DUAL_FEAS");
+    clock[UpdatePrimalClock] = timer_pointer->clock_def("UPDATE_PRIMAL");
+    clock[DevexIzClock] = timer_pointer->clock_def("DEVEX_IZ");
     clock[DevexUpdateWeightClock] =
-        timer_pointer->clock_def("UPDATE_DVX_WEIGHT", "UDW");
-    clock[DseUpdateWeightClock] =
-        timer_pointer->clock_def("UPDATE_DSE_WEIGHT", "USW");
-    clock[UpdatePivotsClock] = timer_pointer->clock_def("UPDATE_PIVOTS", "UPP");
-    clock[UpdateFactorClock] = timer_pointer->clock_def("UPDATE_FACTOR", "UPF");
-    clock[UpdateMatrixClock] = timer_pointer->clock_def("UPDATE_MATRIX", "UPM");
-    clock[UpdateRowEpClock] = timer_pointer->clock_def("UPDATE_ROW_EP", "UPR");
+        timer_pointer->clock_def("UPDATE_DVX_WEIGHT");
+    clock[DseUpdateWeightClock] = timer_pointer->clock_def("UPDATE_DSE_WEIGHT");
+    clock[UpdatePivotsClock] = timer_pointer->clock_def("UPDATE_PIVOTS");
+    clock[UpdateFactorClock] = timer_pointer->clock_def("UPDATE_FACTOR");
+    clock[UpdateMatrixClock] = timer_pointer->clock_def("UPDATE_MATRIX");
+    clock[UpdateRowEpClock] = timer_pointer->clock_def("UPDATE_ROW_EP");
   }
 
   bool reportSimplexClockList(const char* grepStamp,

--- a/src/util/FactorTimer.h
+++ b/src/util/FactorTimer.h
@@ -88,76 +88,54 @@ class FactorTimer {
     HighsTimer* timer_pointer = factor_timer_clock.timer_pointer_;
     std::vector<HighsInt>& clock = factor_timer_clock.clock_;
     clock.resize(FactorNumClock);
-    clock[FactorInvert] = timer_pointer->clock_def("INVERT", "INV");
-    clock[FactorInvertSimple] =
-        timer_pointer->clock_def("INVERT Simple", "IVS");
-    clock[FactorInvertKernel] =
-        timer_pointer->clock_def("INVERT Kernel", "IVK");
-    clock[FactorInvertDeficient] =
-        timer_pointer->clock_def("INVERT Deficient", "IVD");
-    clock[FactorInvertFinish] =
-        timer_pointer->clock_def("INVERT Finish", "IVF");
-    clock[FactorFtran] = timer_pointer->clock_def("FTRAN", "FTR");
-    clock[FactorFtranLower] = timer_pointer->clock_def("FTRAN Lower", "FTL");
-    clock[FactorFtranLowerAPF] =
-        timer_pointer->clock_def("FTRAN Lower APF", "FLA");
-    clock[FactorFtranLowerDse] =
-        timer_pointer->clock_def("FTRAN Lower Dse", "FLD");
-    clock[FactorFtranLowerSps] =
-        timer_pointer->clock_def("FTRAN Lower Sps", "FLS");
+    clock[FactorInvert] = timer_pointer->clock_def("INVERT");
+    clock[FactorInvertSimple] = timer_pointer->clock_def("INVERT Simple");
+    clock[FactorInvertKernel] = timer_pointer->clock_def("INVERT Kernel");
+    clock[FactorInvertDeficient] = timer_pointer->clock_def("INVERT Deficient");
+    clock[FactorInvertFinish] = timer_pointer->clock_def("INVERT Finish");
+    clock[FactorFtran] = timer_pointer->clock_def("FTRAN");
+    clock[FactorFtranLower] = timer_pointer->clock_def("FTRAN Lower");
+    clock[FactorFtranLowerAPF] = timer_pointer->clock_def("FTRAN Lower APF");
+    clock[FactorFtranLowerDse] = timer_pointer->clock_def("FTRAN Lower Dse");
+    clock[FactorFtranLowerSps] = timer_pointer->clock_def("FTRAN Lower Sps");
     clock[FactorFtranLowerHyper] =
-        timer_pointer->clock_def("FTRAN Lower Hyper", "FLH");
-    clock[FactorFtranUpper] = timer_pointer->clock_def("FTRAN Upper", "FTU");
-    clock[FactorFtranUpperFT] =
-        timer_pointer->clock_def("FTRAN Upper FT", "FUF");
-    clock[FactorFtranUpperMPF] =
-        timer_pointer->clock_def("FTRAN Upper MPF", "FUM");
-    clock[FactorFtranUpperDse] =
-        timer_pointer->clock_def("FTRAN Upper Dse", "FUD");
-    clock[FactorFtranUpperSps0] =
-        timer_pointer->clock_def("FTRAN Upper Sps0", "FUS");
-    clock[FactorFtranUpperSps1] =
-        timer_pointer->clock_def("FTRAN Upper Sps1", "FUS");
-    clock[FactorFtranUpperSps2] =
-        timer_pointer->clock_def("FTRAN Upper Sps2", "FUS");
+        timer_pointer->clock_def("FTRAN Lower Hyper");
+    clock[FactorFtranUpper] = timer_pointer->clock_def("FTRAN Upper");
+    clock[FactorFtranUpperFT] = timer_pointer->clock_def("FTRAN Upper FT");
+    clock[FactorFtranUpperMPF] = timer_pointer->clock_def("FTRAN Upper MPF");
+    clock[FactorFtranUpperDse] = timer_pointer->clock_def("FTRAN Upper Dse");
+    clock[FactorFtranUpperSps0] = timer_pointer->clock_def("FTRAN Upper Sps0");
+    clock[FactorFtranUpperSps1] = timer_pointer->clock_def("FTRAN Upper Sps1");
+    clock[FactorFtranUpperSps2] = timer_pointer->clock_def("FTRAN Upper Sps2");
     clock[FactorFtranUpperHyper0] =
-        timer_pointer->clock_def("FTRAN Upper Hyper0", "FUH");
+        timer_pointer->clock_def("FTRAN Upper Hyper0");
     clock[FactorFtranUpperHyper1] =
-        timer_pointer->clock_def("FTRAN Upper Hyper1", "FUH");
+        timer_pointer->clock_def("FTRAN Upper Hyper1");
     clock[FactorFtranUpperHyper2] =
-        timer_pointer->clock_def("FTRAN Upper Hyper2", "FUH");
+        timer_pointer->clock_def("FTRAN Upper Hyper2");
     clock[FactorFtranUpperHyper3] =
-        timer_pointer->clock_def("FTRAN Upper Hyper3", "FUH");
+        timer_pointer->clock_def("FTRAN Upper Hyper3");
     clock[FactorFtranUpperHyper4] =
-        timer_pointer->clock_def("FTRAN Upper Hyper4", "FUH");
+        timer_pointer->clock_def("FTRAN Upper Hyper4");
     clock[FactorFtranUpperHyper5] =
-        timer_pointer->clock_def("FTRAN Upper Hyper5", "FUH");
-    clock[FactorFtranUpperPF] =
-        timer_pointer->clock_def("FTRAN Upper PF", "FUP");
-    clock[FactorBtran] = timer_pointer->clock_def("BTRAN", "BTR");
-    clock[FactorBtranLower] = timer_pointer->clock_def("BTRAN Lower", "BTL");
-    clock[FactorBtranLowerDse] =
-        timer_pointer->clock_def("BTRAN Lower Dse", "BLD");
-    clock[FactorBtranLowerSps] =
-        timer_pointer->clock_def("BTRAN Lower Sps", "BLS");
+        timer_pointer->clock_def("FTRAN Upper Hyper5");
+    clock[FactorFtranUpperPF] = timer_pointer->clock_def("FTRAN Upper PF");
+    clock[FactorBtran] = timer_pointer->clock_def("BTRAN");
+    clock[FactorBtranLower] = timer_pointer->clock_def("BTRAN Lower");
+    clock[FactorBtranLowerDse] = timer_pointer->clock_def("BTRAN Lower Dse");
+    clock[FactorBtranLowerSps] = timer_pointer->clock_def("BTRAN Lower Sps");
     clock[FactorBtranLowerHyper] =
-        timer_pointer->clock_def("BTRAN Lower Hyper", "BLH");
-    clock[FactorBtranLowerAPF] =
-        timer_pointer->clock_def("BTRAN Lower APF", "BLA");
-    clock[FactorBtranUpper] = timer_pointer->clock_def("BTRAN Upper", "BTU");
-    clock[FactorBtranUpperPF] =
-        timer_pointer->clock_def("BTRAN Upper PF", "BUP");
-    clock[FactorBtranUpperDse] =
-        timer_pointer->clock_def("BTRAN Upper Dse", "BUD");
-    clock[FactorBtranUpperSps] =
-        timer_pointer->clock_def("BTRAN Upper Sps", "BUS");
+        timer_pointer->clock_def("BTRAN Lower Hyper");
+    clock[FactorBtranLowerAPF] = timer_pointer->clock_def("BTRAN Lower APF");
+    clock[FactorBtranUpper] = timer_pointer->clock_def("BTRAN Upper");
+    clock[FactorBtranUpperPF] = timer_pointer->clock_def("BTRAN Upper PF");
+    clock[FactorBtranUpperDse] = timer_pointer->clock_def("BTRAN Upper Dse");
+    clock[FactorBtranUpperSps] = timer_pointer->clock_def("BTRAN Upper Sps");
     clock[FactorBtranUpperHyper] =
-        timer_pointer->clock_def("BTRAN Upper Hyper", "BUH");
-    clock[FactorBtranUpperFT] =
-        timer_pointer->clock_def("BTRAN Upper FT", "BUF");
-    clock[FactorBtranUpperMPF] =
-        timer_pointer->clock_def("BTRAN Upper MPS", "BUM");
-    clock[FactorReinvert] = timer_pointer->clock_def("ReINVERT", "RIV");
+        timer_pointer->clock_def("BTRAN Upper Hyper");
+    clock[FactorBtranUpperFT] = timer_pointer->clock_def("BTRAN Upper FT");
+    clock[FactorBtranUpperMPF] = timer_pointer->clock_def("BTRAN Upper MPS");
+    clock[FactorReinvert] = timer_pointer->clock_def("ReINVERT");
   };
 
   void reportFactorClockList(const char* grepStamp,

--- a/src/util/HFactor.cpp
+++ b/src/util/HFactor.cpp
@@ -359,7 +359,7 @@ HighsInt HFactor::build(HighsTimerClock* factor_timer_clock_pointer) {
   // HPresolve::removeDependentEquations
   HighsTimer build_timer;
   build_timer_ = &build_timer;
-  build_timer.startRunHighsClock();
+  build_timer.start();
 
   const bool report_lu = false;
   // Ensure that the A matrix is valid for factorization
@@ -892,7 +892,7 @@ HighsInt HFactor::buildKernel() {
     }
     // Determine whether to return due to exceeding the time limit
     if (check_for_timeout && search_k % timer_frequency == 0) {
-      double current_time = build_timer_->readRunHighsClock();
+      double current_time = build_timer_->read();
       double time_difference = current_time - previous_iteration_time;
       previous_iteration_time = current_time;
       double iteration_time = time_difference / (1.0 * timer_frequency);

--- a/src/util/HighsTimer.h
+++ b/src/util/HighsTimer.h
@@ -34,7 +34,6 @@ struct HighsClockRecord {
   double start;
   double time;
   std::string name;
-  std::string ch3_name;
 };
 */
 /**
@@ -46,7 +45,6 @@ class HighsTimer {
     num_clock = 0;
     HighsInt i_clock = clock_def("Run HiGHS");
     assert(i_clock == 0);
-    run_highs_clock = i_clock;
 
     presolve_clock = clock_def("Presolve");
     solve_clock = clock_def("Solve");
@@ -57,15 +55,13 @@ class HighsTimer {
    * @brief Define a clock
    */
   HighsInt clock_def(
-      const char* name,  //!< Full-length name (<=16 characters) for the clock
-      const char* ch3_name = "N/A"  //!< 3-character name for the clock
-  ) {
+      const char* name)  //!< Full-length name (<=16 characters) for the clock
+  {
     HighsInt i_clock = num_clock;
     clock_num_call.push_back(0);
     clock_start.push_back(initial_clock_start);
     clock_time.push_back(0);
     clock_names.push_back(name);
-    clock_ch3_names.push_back(ch3_name);
     num_clock++;
     return i_clock;
   }
@@ -80,7 +76,6 @@ class HighsTimer {
       x_clock.start = 0;
       x_clock.time = 0;
       x_clock.name = "";
-      x_clock.ch3_name = "";
     }
     */
 
@@ -105,13 +100,11 @@ class HighsTimer {
     this->clock_num_call.clear();
     this->clock_start.clear();
     this->clock_names.clear();
-    this->clock_ch3_names.clear();
-    HighsInt i_clock = clock_def("Run HiGHS", "RnH");
+    HighsInt i_clock = clock_def("Run HiGHS");
     assert(i_clock == 0);
-    this->run_highs_clock = i_clock;
-    this->presolve_clock = clock_def("Presolve", "Pre");
-    this->solve_clock = clock_def("Solve", "Slv");
-    this->postsolve_clock = clock_def("Postsolve", "Pst");
+    this->presolve_clock = clock_def("Presolve");
+    this->solve_clock = clock_def("Solve");
+    this->postsolve_clock = clock_def("Postsolve");
   }
 
   /**
@@ -364,7 +357,6 @@ class HighsTimer {
   std::vector<double> clock_start;
   std::vector<double> clock_time;
   std::vector<std::string> clock_names;
-  std::vector<std::string> clock_ch3_names;
   // Fundamental clocks
   HighsInt presolve_clock;
   HighsInt solve_clock;

--- a/src/util/HighsTimer.h
+++ b/src/util/HighsTimer.h
@@ -47,7 +47,6 @@ class HighsTimer {
     HighsInt i_clock = clock_def("Run HiGHS");
     assert(i_clock == 0);
     run_highs_clock = i_clock;
-    total_clock = run_highs_clock;
 
     presolve_clock = clock_def("Presolve");
     solve_clock = clock_def("Solve");
@@ -388,9 +387,6 @@ class HighsTimer {
   std::vector<std::string> clock_ch3_names;
   // The index of the RunHighsClock - should always be 0
   HighsInt run_highs_clock;
-  // Synonym for run_highs_clock that makes more sense when (as in MIP
-  // solver) there is an independent timer
-  HighsInt total_clock;
   // Fundamental clocks
   HighsInt presolve_clock;
   HighsInt solve_clock;

--- a/src/util/HighsTimer.h
+++ b/src/util/HighsTimer.h
@@ -233,26 +233,6 @@ class HighsTimer {
   }
 
   /**
-   * @brief Start the RunHighs clock
-   */
-  void startRunHighsClock() { start(run_highs_clock); }
-
-  /**
-   * @brief Stop the RunHighs clock
-   */
-  void stopRunHighsClock() { stop(run_highs_clock); }
-
-  /**
-   * @brief Read the RunHighs clock
-   */
-  double readRunHighsClock() { return read(run_highs_clock); }
-
-  /**
-   * @brief Test whether the RunHighs clock is running
-   */
-  bool runningRunHighsClock() { return running(run_highs_clock); }
-
-  /**
    * @brief Report timing information for the clock indices in the list
    */
   bool report(const char* grep_stamp,  //!< Character string used to extract
@@ -275,7 +255,7 @@ class HighsTimer {
              //!< before an individual clock is reported
   ) {
     size_t num_clock_list_entries = clock_list.size();
-    double current_run_highs_time = readRunHighsClock();
+    double current_run_highs_time = read();
     bool non_null_report = false;
 
     // Check validity of the clock list and check no clocks are still
@@ -385,8 +365,6 @@ class HighsTimer {
   std::vector<double> clock_time;
   std::vector<std::string> clock_names;
   std::vector<std::string> clock_ch3_names;
-  // The index of the RunHighsClock - should always be 0
-  HighsInt run_highs_clock;
   // Fundamental clocks
   HighsInt presolve_clock;
   HighsInt solve_clock;


### PR DESCRIPTION
Eliminated `total_clock` and `highs_run_clock` from `HighsTimer` as they are hard-coded to be zero, which is now the default value of the clock to be used in fundamental `HighsTimer` methods. 

Eliminated the 3-character clock name, that hasn't been used since Qi's original crude timing output was removed