### PR TITLE
Fix 2125

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,3 +17,5 @@ Fixed bug in presolve when pointers stored in HighsMatrixSlice get invalidated w
 Primal and dual residual tolerances - applied following IPM or PDLP solution - now documented as options
 
 Highs::getCols (Highs::getRows) now runs in linear time if the internal constraint matrix is stored column-wise (row-wise). Added ensureColwise/Rowwise to the Highs class, the C API and highspy so that users can set the internal constraint matrix storage orientation
+
+When columns and rows are deleted from the incumbent LP after a basic solution has been found, HiGHS no longer invalidates the basis. Now it maintains the basic and nonbasic status of the remaining variables and constraints. When the model is re-solved, this information is used to construct a starting basis.

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -66,6 +66,8 @@ struct HighsBasis {
   std::string debug_origin_name = "None";
   std::vector<HighsBasisStatus> col_status;
   std::vector<HighsBasisStatus> row_status;
+  void deleteCols(const HighsIndexCollection& index_collection);
+  void deleteRows(const HighsIndexCollection& index_collection);
   void invalidate();
   void clear();
 };

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -66,8 +66,8 @@ struct HighsBasis {
   std::string debug_origin_name = "None";
   std::vector<HighsBasisStatus> col_status;
   std::vector<HighsBasisStatus> row_status;
-  void deleteCols(const HighsIndexCollection& index_collection);
-  void deleteRows(const HighsIndexCollection& index_collection);
+  void print() const;
+  void printScalars() const;
   void invalidate();
   void clear();
 };

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -58,6 +58,16 @@ struct HotStart {
 };
 
 struct HighsBasis {
+  // Logical flags for a HiGHS basis:
+  //
+  // valid: has been factored by HiGHS
+  //
+  // alien: a basis that's been set externally, so cannot be assumed
+  // to even have the right number of basic and nonbasic variables
+  //
+  // useful: a basis that may be useful
+  //
+  // Need useful since, by default, a basis is alien but not useful
   bool valid = false;
   bool alien = true;
   bool useful = false;
@@ -67,8 +77,8 @@ struct HighsBasis {
   std::string debug_origin_name = "None";
   std::vector<HighsBasisStatus> col_status;
   std::vector<HighsBasisStatus> row_status;
-  void print() const;
-  void printScalars() const;
+  void print(std::string message = "") const;
+  void printScalars(std::string message = "") const;
   void invalidate();
   void clear();
 };

--- a/src/lp_data/HStruct.h
+++ b/src/lp_data/HStruct.h
@@ -60,6 +60,7 @@ struct HotStart {
 struct HighsBasis {
   bool valid = false;
   bool alien = true;
+  bool useful = false;
   bool was_alien = true;
   HighsInt debug_id = -1;
   HighsInt debug_update_count = -1;

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1265,6 +1265,15 @@ HighsStatus Highs::solve() {
   // is available, simplex should surely be chosen.
   const bool solver_will_use_basis = options_.solver == kSimplexString ||
                                      options_.solver == kHighsChooseString;
+  const bool has_basis = 
+    basis_.col_status.size() == static_cast<size_t>(model_.lp_.num_col_) &&
+    basis_.row_status.size() == static_cast<size_t>(model_.lp_.num_row_);
+  if (has_basis && !basis_.valid) {
+    basis_.print();
+    printf("Highs::solve() has_basis && !basis_.valid\n");
+    assert(111==123);
+  }
+
   if ((basis_.valid || options_.presolve == kHighsOffString ||
        unconstrained_lp) &&
       solver_will_use_basis) {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1282,7 +1282,7 @@ HighsStatus Highs::solve() {
         "LP without presolve, or with basis, or unconstrained";
     // If there is a valid HiGHS basis, refine any status values that
     // are simply HighsBasisStatus::kNonbasic
-    if (basis_.valid) refineBasis(incumbent_lp, solution_, basis_);
+    if (basis_.useful) refineBasis(incumbent_lp, solution_, basis_);
     solveLp(incumbent_lp,
             "Solving LP without presolve, or with basis, or unconstrained",
             this_solve_original_lp_time);

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1268,13 +1268,14 @@ HighsStatus Highs::solve() {
                                      options_.solver == kHighsChooseString;
   const bool has_basis = basis_.useful;
   if (has_basis) {
-    assert(basis_.col_status.size() == static_cast<size_t>(incumbent_lp.num_col_));
-    assert(basis_.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));
+    assert(basis_.col_status.size() ==
+           static_cast<size_t>(incumbent_lp.num_col_));
+    assert(basis_.row_status.size() ==
+           static_cast<size_t>(incumbent_lp.num_row_));
   }
   if (basis_.valid) assert(basis_.useful);
 
-  if ((has_basis || options_.presolve == kHighsOffString ||
-       unconstrained_lp) &&
+  if ((has_basis || options_.presolve == kHighsOffString || unconstrained_lp) &&
       solver_will_use_basis) {
     // There is a valid basis for the problem, presolve is off, or LP
     // has no constraint matrix, and the solver will use the basis

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1266,19 +1266,14 @@ HighsStatus Highs::solve() {
   // is available, simplex should surely be chosen.
   const bool solver_will_use_basis = options_.solver == kSimplexString ||
                                      options_.solver == kHighsChooseString;
-  const bool has_basis = basis_.valid && basis_.useful;
+  const bool has_basis = basis_.valid || basis_.useful;
   if (has_basis) {
     assert(basis_.col_status.size() == static_cast<size_t>(incumbent_lp.num_col_));
     assert(basis_.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));
   }
   if (basis_.valid) assert(basis_.useful);
-  if (has_basis && !basis_.valid) {
-    basis_.print();
-    printf("Highs::solve() has_basis && !basis_.valid\n");
-    assert(111==123);
-  }
 
-  if ((basis_.valid || options_.presolve == kHighsOffString ||
+  if ((has_basis || options_.presolve == kHighsOffString ||
        unconstrained_lp) &&
       solver_will_use_basis) {
     // There is a valid basis for the problem, presolve is off, or LP

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1266,7 +1266,7 @@ HighsStatus Highs::solve() {
   // is available, simplex should surely be chosen.
   const bool solver_will_use_basis = options_.solver == kSimplexString ||
                                      options_.solver == kHighsChooseString;
-  const bool has_basis = basis_.valid || basis_.useful;
+  const bool has_basis = basis_.useful;
   if (has_basis) {
     assert(basis_.col_status.size() == static_cast<size_t>(incumbent_lp.num_col_));
     assert(basis_.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -587,13 +587,16 @@ void Highs::deleteColsInterface(HighsIndexCollection& index_collection) {
 
   lp.deleteCols(index_collection);
   model_.hessian_.deleteCols(index_collection);
-  assert(lp.num_col_ <= original_num_col);
-  if (lp.num_col_ < original_num_col) {
-    // Nontrivial deletion so reset the model_status and invalidate
-    // the Highs basis
-    model_status_ = HighsModelStatus::kNotset;
-    basis.valid = false;
-  }
+  // Bail out if no columns were actually deleted
+  if (lp.num_col_ == original_num_col) return;
+
+  assert(lp.num_col_ < original_num_col);
+
+  // Nontrivial deletion so reset the model_status and invalidate
+  // the Highs basis
+  model_status_ = HighsModelStatus::kNotset;
+  basis.valid = false;
+
   if (lp.scale_.has_scaling) {
     deleteScale(lp.scale_.col, index_collection);
     lp.scale_.col.resize(lp.num_col_);
@@ -632,13 +635,16 @@ void Highs::deleteRowsInterface(HighsIndexCollection& index_collection) {
   HighsInt original_num_row = lp.num_row_;
 
   lp.deleteRows(index_collection);
-  assert(lp.num_row_ <= original_num_row);
-  if (lp.num_row_ < original_num_row) {
-    // Nontrivial deletion so reset the model_status and invalidate
-    // the Highs basis
-    model_status_ = HighsModelStatus::kNotset;
-    basis.valid = false;
-  }
+  // Bail out if no rows were actually deleted
+  if (lp.num_row_ == original_num_row) return;
+
+  assert(lp.num_row_ < original_num_row);
+
+  // Nontrivial deletion so reset the model_status and invalidate
+  // the Highs basis
+  model_status_ = HighsModelStatus::kNotset;
+  basis.valid = false;
+
   if (lp.scale_.has_scaling) {
     deleteScale(lp.scale_.row, index_collection);
     lp.scale_.row.resize(lp.num_row_);

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -729,7 +729,6 @@ void Highs::deleteRowsInterface(HighsIndexCollection& index_collection) {
   } else {
     assert(!basis.valid);
   }
-  basis.valid = false;
 
   if (lp.scale_.has_scaling) {
     deleteScale(lp.scale_.row, index_collection);

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -472,7 +472,7 @@ HighsStatus Highs::addRowsInterface(HighsInt ext_num_new_row,
   HighsBasis& basis = basis_;
   HighsScale& scale = lp.scale_;
   bool& useful_basis = basis.useful;
-  
+
   bool& lp_has_scaling = lp.scale_.has_scaling;
 
   // Check that if nonzeros are to be added then the model has a positive number
@@ -578,10 +578,9 @@ HighsStatus Highs::addRowsInterface(HighsInt ext_num_new_row,
 }
 
 void deleteBasisEntries(std::vector<HighsBasisStatus>& status,
-			bool& deleted_basic,
-			bool& deleted_nonbasic,
-			const HighsIndexCollection& index_collection,
-			const HighsInt entry_dim) {
+                        bool& deleted_basic, bool& deleted_nonbasic,
+                        const HighsIndexCollection& index_collection,
+                        const HighsInt entry_dim) {
   assert(ok(index_collection));
   assert(static_cast<size_t>(entry_dim) == status.size());
   HighsInt from_k;
@@ -603,11 +602,12 @@ void deleteBasisEntries(std::vector<HighsBasisStatus>& status,
     // Account for the initial entries being kept
     if (k == from_k) new_num_entry = delete_from_entry;
     // Identify whether a basic or a nonbasic entry has been deleted
-    for (HighsInt entry = delete_from_entry; entry <= delete_to_entry; entry++) {
+    for (HighsInt entry = delete_from_entry; entry <= delete_to_entry;
+         entry++) {
       if (status[entry] == HighsBasisStatus::kBasic) {
-	deleted_basic = true;
+        deleted_basic = true;
       } else {
-	deleted_nonbasic = true;
+        deleted_nonbasic = true;
       }
     }
     if (delete_to_entry >= entry_dim - 1) break;
@@ -620,30 +620,24 @@ void deleteBasisEntries(std::vector<HighsBasisStatus>& status,
   status.resize(new_num_entry);
 }
 
-void deleteBasisCols(HighsBasis& basis, 
-		     const HighsIndexCollection& index_collection,
-		     const HighsInt original_num_col) {
+void deleteBasisCols(HighsBasis& basis,
+                     const HighsIndexCollection& index_collection,
+                     const HighsInt original_num_col) {
   bool deleted_basic;
   bool deleted_nonbasic;
-  deleteBasisEntries(basis.col_status, 
-		     deleted_basic,
-		     deleted_nonbasic,
-		     index_collection, original_num_col);
-  if (deleted_basic) 
-    basis.valid = false;
+  deleteBasisEntries(basis.col_status, deleted_basic, deleted_nonbasic,
+                     index_collection, original_num_col);
+  if (deleted_basic) basis.valid = false;
 }
 
-void deleteBasisRows(HighsBasis& basis, 
-		     const HighsIndexCollection& index_collection,
-		     const HighsInt original_num_row) {
+void deleteBasisRows(HighsBasis& basis,
+                     const HighsIndexCollection& index_collection,
+                     const HighsInt original_num_row) {
   bool deleted_basic;
   bool deleted_nonbasic;
-  deleteBasisEntries(basis.row_status,
-		     deleted_basic,
-		     deleted_nonbasic,
-		     index_collection, original_num_row);
-  if (deleted_nonbasic) 
-    basis.valid = false;
+  deleteBasisEntries(basis.row_status, deleted_basic, deleted_nonbasic,
+                     index_collection, original_num_row);
+  if (deleted_nonbasic) basis.valid = false;
 }
 
 void Highs::deleteColsInterface(HighsIndexCollection& index_collection) {
@@ -674,7 +668,7 @@ void Highs::deleteColsInterface(HighsIndexCollection& index_collection) {
   } else {
     assert(!basis.valid);
   }
- 
+
   if (lp.scale_.has_scaling) {
     deleteScale(lp.scale_.col, index_collection);
     lp.scale_.col.resize(lp.num_col_);
@@ -2044,13 +2038,13 @@ HighsStatus Highs::elasticityFilterReturn(
 
   run_status = this->deleteCols(original_num_col, lp.num_col_ - 1);
   assert(run_status == HighsStatus::kOk);
-  // 
+  //
   // Now that deleteRows and deleteCols may yield a valid basis, the
   // lack of dual values triggers an assert in
   // getKktFailures. Ultimately (#2081) the dual values will be
   // available but, for now, make the basis invalid.
   basis_.valid = false;
-  
+
   run_status =
       this->changeColsCost(0, original_num_col - 1, original_col_cost.data());
   assert(run_status == HighsStatus::kOk);

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1319,6 +1319,7 @@ HighsStatus ipxBasicSolutionToHighsBasicSolution(
   highs_solution.value_valid = true;
   highs_solution.dual_valid = true;
   highs_basis.valid = true;
+  highs_basis.useful = true;
   return HighsStatus::kOk;
 }
 
@@ -1606,6 +1607,7 @@ void HighsSolution::clear() {
 void HighsObjectiveSolution::clear() { this->col_value.clear(); }
 
 void HighsBasis::print() const {
+  if (!this->useful) return;
   this->printScalars();
   for (HighsInt iCol = 0; iCol < HighsInt(this->col_status.size()); iCol++)
     printf("Basis: col_status[%2d] = %d\n", int(iCol), int(this->col_status[iCol]));
@@ -1616,6 +1618,7 @@ void HighsBasis::print() const {
 void HighsBasis::printScalars() const {
   printf("Basis: valid = %d\n", this->valid);
   printf("Basis: alien = %d\n", this->alien);
+  printf("Basis: useful = %d\n", this->useful);
   printf("Basis: was_alien = %d\n", this->was_alien);
   printf("Basis: debug_id = %d\n", int(this->debug_id));
   printf("Basis: debug_update_count = %d\n", int(this->debug_update_count));
@@ -1625,6 +1628,7 @@ void HighsBasis::printScalars() const {
 void HighsBasis::invalidate() {
   this->valid = false;
   this->alien = true;
+  this->useful = false;
   this->was_alien = true;
   this->debug_id = -1;
   this->debug_update_count = -1;

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -677,7 +677,7 @@ double computeObjectiveValue(const HighsLp& lp, const HighsSolution& solution) {
 // and any solution values
 void refineBasis(const HighsLp& lp, const HighsSolution& solution,
                  HighsBasis& basis) {
-  assert(basis.valid);
+  assert(basis.useful);
   assert(isBasisRightSize(lp, basis));
   const bool have_highs_solution = solution.value_valid;
 

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1605,6 +1605,23 @@ void HighsSolution::clear() {
 
 void HighsObjectiveSolution::clear() { this->col_value.clear(); }
 
+void HighsBasis::print() const {
+  this->printScalars();
+  for (HighsInt iCol = 0; iCol < HighsInt(this->col_status.size()); iCol++)
+    printf("Basis: col_status[%2d] = %d\n", int(iCol), int(this->col_status[iCol]));
+  for (HighsInt iRow = 0; iRow < HighsInt(this->row_status.size()); iRow++)
+    printf("Basis: row_status[%2d] = %d\n", int(iRow), int(this->row_status[iRow]));
+}
+
+void HighsBasis::printScalars() const {
+  printf("Basis: valid = %d\n", this->valid);
+  printf("Basis: alien = %d\n", this->alien);
+  printf("Basis: was_alien = %d\n", this->was_alien);
+  printf("Basis: debug_id = %d\n", int(this->debug_id));
+  printf("Basis: debug_update_count = %d\n", int(this->debug_update_count));
+  printf("Basis: debug_origin_name = %s\n", this->debug_origin_name.c_str());
+}
+
 void HighsBasis::invalidate() {
   this->valid = false;
   this->alien = true;

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1357,9 +1357,15 @@ HighsStatus formSimplexLpBasisAndFactor(HighsLpSolverObject& solver_object,
   // If new scaling is performed, the hot start information is
   // no longer valid
   if (new_scaling) ekk_instance.clearHotStart();
-  if (basis.alien) {
-    // An alien basis needs to be checked for rank deficiency, and
-    // possibly completed if it is rectangular
+  const bool check_basis = basis.alien ||
+    (!basis.valid && basis.useful);
+  if (check_basis) {
+    // The basis needs to be checked for rank deficiency, and possibly
+    // completed if it is rectangular
+    //
+    // If it's not valid but useful, but not alien,
+    // accommodateAlienBasis will assert, so make the basis alien
+    basis.alien = true;
     assert(!only_from_known_basis);
     accommodateAlienBasis(solver_object);
     basis.alien = false;
@@ -1606,23 +1612,24 @@ void HighsSolution::clear() {
 
 void HighsObjectiveSolution::clear() { this->col_value.clear(); }
 
-void HighsBasis::print() const {
+void HighsBasis::print(std::string message) const {
   if (!this->useful) return;
-  this->printScalars();
+  this->printScalars(message);
   for (HighsInt iCol = 0; iCol < HighsInt(this->col_status.size()); iCol++)
     printf("Basis: col_status[%2d] = %d\n", int(iCol), int(this->col_status[iCol]));
   for (HighsInt iRow = 0; iRow < HighsInt(this->row_status.size()); iRow++)
     printf("Basis: row_status[%2d] = %d\n", int(iRow), int(this->row_status[iRow]));
 }
 
-void HighsBasis::printScalars() const {
-  printf("Basis: valid = %d\n", this->valid);
-  printf("Basis: alien = %d\n", this->alien);
-  printf("Basis: useful = %d\n", this->useful);
-  printf("Basis: was_alien = %d\n", this->was_alien);
-  printf("Basis: debug_id = %d\n", int(this->debug_id));
-  printf("Basis: debug_update_count = %d\n", int(this->debug_update_count));
-  printf("Basis: debug_origin_name = %s\n", this->debug_origin_name.c_str());
+void HighsBasis::printScalars(std::string message) const {
+  printf("\nBasis: %s\n", message.c_str());
+  printf(" valid = %d\n", this->valid);
+  printf(" alien = %d\n", this->alien);
+  printf(" useful = %d\n", this->useful);
+  printf(" was_alien = %d\n", this->was_alien);
+  printf(" debug_id = %d\n", int(this->debug_id));
+  printf(" debug_update_count = %d\n", int(this->debug_update_count));
+  printf(" debug_origin_name = %s\n", this->debug_origin_name.c_str());
 }
 
 void HighsBasis::invalidate() {

--- a/src/lp_data/HighsSolution.cpp
+++ b/src/lp_data/HighsSolution.cpp
@@ -1357,8 +1357,7 @@ HighsStatus formSimplexLpBasisAndFactor(HighsLpSolverObject& solver_object,
   // If new scaling is performed, the hot start information is
   // no longer valid
   if (new_scaling) ekk_instance.clearHotStart();
-  const bool check_basis = basis.alien ||
-    (!basis.valid && basis.useful);
+  const bool check_basis = basis.alien || (!basis.valid && basis.useful);
   if (check_basis) {
     // The basis needs to be checked for rank deficiency, and possibly
     // completed if it is rectangular
@@ -1616,9 +1615,11 @@ void HighsBasis::print(std::string message) const {
   if (!this->useful) return;
   this->printScalars(message);
   for (HighsInt iCol = 0; iCol < HighsInt(this->col_status.size()); iCol++)
-    printf("Basis: col_status[%2d] = %d\n", int(iCol), int(this->col_status[iCol]));
+    printf("Basis: col_status[%2d] = %d\n", int(iCol),
+           int(this->col_status[iCol]));
   for (HighsInt iRow = 0; iRow < HighsInt(this->row_status.size()); iRow++)
-    printf("Basis: row_status[%2d] = %d\n", int(iRow), int(this->row_status[iRow]));
+    printf("Basis: row_status[%2d] = %d\n", int(iRow),
+           int(this->row_status[iRow]));
 }
 
 void HighsBasis::printScalars(std::string message) const {

--- a/src/lp_data/HighsSolve.cpp
+++ b/src/lp_data/HighsSolve.cpp
@@ -390,6 +390,7 @@ HighsStatus solveUnconstrainedLp(const HighsOptions& options, const HighsLp& lp,
   solution.value_valid = true;
   solution.dual_valid = true;
   basis.valid = true;
+  basis.useful = true;
   highs_info.basis_validity = kBasisValidityValid;
   setSolutionStatus(highs_info);
   if (highs_info.num_primal_infeasibilities) {

--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -1265,6 +1265,7 @@ void HighsMipSolverData::performRestart() {
     root_basis.row_status.resize(postSolveStack.getOrigNumRow(),
                                  HighsBasisStatus::kBasic);
     root_basis.valid = true;
+    root_basis.useful = true;
 
     for (HighsInt i = 0; i < mipsolver.model_->num_col_; ++i)
       root_basis.col_status[postSolveStack.getOrigColIndex(i)] =
@@ -1379,6 +1380,7 @@ void HighsMipSolverData::basisTransfer() {
     firstrootbasis.row_status.assign(numRow, HighsBasisStatus::kNonbasic);
     firstrootbasis.valid = true;
     firstrootbasis.alien = true;
+    firstrootbasis.useful = true;
 
     for (HighsInt i = 0; i < numRow; ++i) {
       HighsBasisStatus status =
@@ -1929,6 +1931,7 @@ restart:
     firstrootbasis.row_status.assign(mipsolver.numRow(),
                                      HighsBasisStatus::kBasic);
     firstrootbasis.valid = true;
+    firstrootbasis.useful = true;
   }
 
   if (cutpool.getNumCuts() != 0) {

--- a/src/presolve/HPresolve.cpp
+++ b/src/presolve/HPresolve.cpp
@@ -6330,6 +6330,7 @@ void HPresolve::debug(const HighsLp& lp, const HighsOptions& options) {
     temp_sol.row_value.resize(model.num_row_);
     calculateRowValuesQuad(model, sol);
     temp_basis.valid = true;
+    temp_basis.useful = true;
     refineBasis(model, temp_sol, temp_basis);
     Highs highs;
     highs.passOptions(options);

--- a/src/qpsolver/a_quass.cpp
+++ b/src/qpsolver/a_quass.cpp
@@ -116,6 +116,7 @@ static QpAsmStatus quass2highs(Instance& instance, Settings& settings,
   }
   highs_basis.valid = true;
   highs_basis.alien = false;
+  highs_basis.useful = true;
   return qp_asm_return_status;
 }
 

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -142,10 +142,8 @@ inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
     // that is not validated
     assert(basis.col_status.size() == static_cast<size_t>(incumbent_lp.num_col_));
     assert(basis.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));
-    basis.print("Before formSimplexLpBasisAndFactor");
     HighsStatus return_status = formSimplexLpBasisAndFactor(solver_object);
     if (return_status != HighsStatus::kOk) return returnFromSolveLpSimplex(solver_object, HighsStatus::kError);
-    basis.print("After  formSimplexLpBasisAndFactor");
     basis.valid = true;
   }
   // Move the LP to EKK, updating other EKK pointers and any simplex

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -136,6 +136,18 @@ inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
   // If new scaling is performed, the hot start information is
   // no longer valid
   if (new_scaling) ekk_instance.clearHotStart();
+  // 
+  if (!status.has_basis && !basis.valid && basis.useful) {
+    // There is no simplex basis, but there is a useful HiGHS basis
+    // that is not validated
+    assert(basis.col_status.size() == static_cast<size_t>(incumbent_lp.num_col_));
+    assert(basis.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));
+    basis.print("Before formSimplexLpBasisAndFactor");
+    HighsStatus return_status = formSimplexLpBasisAndFactor(solver_object);
+    if (return_status != HighsStatus::kOk) return returnFromSolveLpSimplex(solver_object, HighsStatus::kError);
+    basis.print("After  formSimplexLpBasisAndFactor");
+    basis.valid = true;
+  }
   // Move the LP to EKK, updating other EKK pointers and any simplex
   // NLA pointers, since they may have moved if the LP has been
   // modified

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -144,6 +144,9 @@ inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
     assert(basis.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));
     HighsStatus return_status = formSimplexLpBasisAndFactor(solver_object);
     if (return_status != HighsStatus::kOk) return returnFromSolveLpSimplex(solver_object, HighsStatus::kError);
+    // formSimplexLpBasisAndFactor may introduce variables with
+    // HighsBasisStatus::kNonbasic, so refine it
+    refineBasis(incumbent_lp, solution, basis);
     basis.valid = true;
   }
   // Move the LP to EKK, updating other EKK pointers and any simplex

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -136,14 +136,17 @@ inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
   // If new scaling is performed, the hot start information is
   // no longer valid
   if (new_scaling) ekk_instance.clearHotStart();
-  // 
+  //
   if (!status.has_basis && !basis.valid && basis.useful) {
     // There is no simplex basis, but there is a useful HiGHS basis
     // that is not validated
-    assert(basis.col_status.size() == static_cast<size_t>(incumbent_lp.num_col_));
-    assert(basis.row_status.size() == static_cast<size_t>(incumbent_lp.num_row_));
+    assert(basis.col_status.size() ==
+           static_cast<size_t>(incumbent_lp.num_col_));
+    assert(basis.row_status.size() ==
+           static_cast<size_t>(incumbent_lp.num_row_));
     HighsStatus return_status = formSimplexLpBasisAndFactor(solver_object);
-    if (return_status != HighsStatus::kOk) return returnFromSolveLpSimplex(solver_object, HighsStatus::kError);
+    if (return_status != HighsStatus::kOk)
+      return returnFromSolveLpSimplex(solver_object, HighsStatus::kError);
     // formSimplexLpBasisAndFactor may introduce variables with
     // HighsBasisStatus::kNonbasic, so refine it
     refineBasis(incumbent_lp, solution, basis);

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -1465,6 +1465,7 @@ HighsBasis HEkk::getHighsBasis(HighsLp& use_lp) const {
   }
   highs_basis.valid = true;
   highs_basis.alien = false;
+  highs_basis.useful = true;
   highs_basis.was_alien = false;
   highs_basis.debug_id =
       (HighsInt)(build_synthetic_tick_ + total_synthetic_tick_);


### PR DESCRIPTION
When columns and rows are deleted from the incumbent LP after a basic solution has been found, HiGHS no longer invalidates the basis. Now it maintains the basic and nonbasic status of the remaining variables and constraints. When the model is re-solved, this information is used to construct a starting basis. 