### PR TITLE
Fix 2129

### DIFF
--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -215,6 +215,10 @@ void HighsCutGeneration::separateLiftedKnapsackCover() {
 }
 
 bool HighsCutGeneration::separateLiftedMixedBinaryCover() {
+  // initialize indicators
+  integralSupport = false;
+  integralCoefficients = false;
+
   HighsInt coversize = cover.size();
   std::vector<double> S;
   S.resize(coversize);
@@ -275,6 +279,10 @@ bool HighsCutGeneration::separateLiftedMixedBinaryCover() {
 }
 
 bool HighsCutGeneration::separateLiftedMixedIntegerCover() {
+  // initialize indicators
+  integralSupport = false;
+  integralCoefficients = false;
+
   HighsInt coversize = cover.size();
 
   HighsInt l = -1;
@@ -500,6 +508,10 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
   using std::floor;
   using std::max;
   using std::sqrt;
+
+  // initialize indicators
+  integralSupport = false;
+  integralCoefficients = false;
 
   double continuouscontribution = 0.0;
   double continuoussqrnorm = 0.0;

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -4421,12 +4421,14 @@ void HEkk::unitBtranResidual(const HighsInt row_out, const HVector& row_ep,
 void HighsSimplexStats::report(FILE* file, std::string message) const {
   fprintf(file, "\nSimplex stats: %s\n", message.c_str());
   fprintf(file, "   valid                      = %d\n", this->valid);
-  fprintf(file, "   iteration_count            = %d\n", this->iteration_count);
-  fprintf(file, "   num_invert                 = %d\n", this->num_invert);
+  fprintf(file, "   iteration_count            = %d\n",
+          static_cast<int>(this->iteration_count));
+  fprintf(file, "   num_invert                 = %d\n",
+          static_cast<int>(this->num_invert));
   fprintf(file, "   last_invert_num_el         = %d\n",
-          this->last_invert_num_el);
+          static_cast<int>(this->last_invert_num_el));
   fprintf(file, "   last_factored_basis_num_el = %d\n",
-          this->last_factored_basis_num_el);
+          static_cast<int>(this->last_factored_basis_num_el));
   fprintf(file, "   col_aq_density             = %g\n", this->col_aq_density);
   fprintf(file, "   row_ep_density             = %g\n", this->row_ep_density);
   fprintf(file, "   row_ap_density             = %g\n", this->row_ap_density);


### PR DESCRIPTION
Fix #2129 
- Initialize `integralSupport` and `integralCoefficients` in `HighsCutGeneration::separateLiftedMixedBinaryCover`, `HighsCutGeneration::separateLiftedMixedIntegerCover` and `HighsCutGeneration::cmirCutGenerationHeuristic`.
- These change will not affect HiGHS' behavior since these variables were only uninitialized when the respective cut generation method failed (and hence `integralSupport` and `integralCoefficients` were not used).