### PR TITLE
Clean up compiler warnings (Mark unused variables with '[[maybe_unused]]')

### DIFF
--- a/src/presolve/HighsPostsolveStack.h
+++ b/src/presolve/HighsPostsolveStack.h
@@ -785,8 +785,9 @@ class HighsPostsolveStack {
 
   // Only used for debugging
   void undoUntil(const HighsOptions& options,
-                 const std::vector<HighsInt>& flagRow,
-                 const std::vector<HighsInt>& flagCol, HighsSolution& solution,
+                 [[maybe_unused]] const std::vector<HighsInt>& flagRow,
+                 [[maybe_unused]] const std::vector<HighsInt>& flagCol,
+                 HighsSolution& solution,
                  HighsBasis& basis, size_t numReductions) {
     reductionValues.resetPosition();
 


### PR DESCRIPTION
As part of #2006, warnings generated by -Wall and -Wextra will need to be fixed. The tallest nail gets the hammer, I see at least 90 'unused-parameter' warnings on MacOS with the default build options.

Here I make a minimal pull request fixing one file to make discussion easy:
```
src/presolve/HighsPostsolveStack.h:788:47: warning: unused parameter 'flagRow' [-Wunused-parameter]
src/presolve/HighsPostsolveStack.h:789:47: warning: unused parameter 'flagCol' [-Wunused-parameter]
```

I see the minimum C++ standard is C++11, I thought this would preclude some more modern features, but compilers seem to support some

I see two ways of fixing this warning (that don't change the inputs to the function):

Option 1: Use [[maybe_unused]]
--------------------------
```C++
int example_function([[maybe_unused]] int a)
{
    return 0;
}
```
This is a 'modern' feature, while officially a C++17 feature, my tests show most compilers seem to understand it (even when set to C++11)

https://godbolt.org/z/qdPvo6Mdc

Testing shows that the minimum compiler version (that build this test function in C++11)
gcc 7.1
clang 3.9.0
msvc v19.21 VS16.1*

*msvc throws a warning that `[[maybe_unused]]` is ignored

I am very interested to see if your CI actions are happy with this syntax.

Optional 2: Comment out the variable name
--------------------------
```C++
int example_function(int /* a */)
{
    return 0;
}
```

This is perhaps a more old fashioned fix, the major disadvantage is that `/* */` doesn't nest. So it becomes annoying to comment out an entire function.

I look forward to hearing your thoughts
