### PR TITLE
Fixed error in analyseVectorValues MIP profiling, and now analysing spectrum of times for node search and dive.

### DIFF
--- a/src/mip/HighsMipAnalysis.cpp
+++ b/src/mip/HighsMipAnalysis.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 
 #include "mip/MipTimer.h"
+#include "util/HighsUtils.h"
 
 const HighsInt check_mip_clock = -4;
 
@@ -153,4 +154,8 @@ void HighsMipAnalysis::reportMipTimer() {
   reportMipSolveLpClock(true);
   mip_timer.csvMipClock(this->model_name, mip_clocks, false, false);
   reportMipSolveLpClock(false);
+  analyseVectorValues(nullptr, "Node search time",
+                      HighsInt(node_search_time.size()), node_search_time);
+  analyseVectorValues(nullptr, "Dive time", HighsInt(dive_time.size()),
+                      dive_time);
 }

--- a/src/mip/HighsMipAnalysis.h
+++ b/src/mip/HighsMipAnalysis.h
@@ -42,6 +42,8 @@ class HighsMipAnalysis {
   std::string model_name;
   HighsTimerClock mip_clocks;
   bool analyse_mip_time;
+  std::vector<double> dive_time;
+  std::vector<double> node_search_time;
 };
 
 #endif /* MIP_HIGHSMIPANALYSIS_H_ */

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -304,10 +304,14 @@ restart:
       if (mipdata_->domain.infeasible()) break;
 
       if (!search.currentNodePruned()) {
+        double this_dive_time = -analysis_.mipTimerRead(kMipClockTheDive);
         analysis_.mipTimerStart(kMipClockTheDive);
         const HighsSearch::NodeResult search_dive_result = search.dive();
         analysis_.mipTimerStop(kMipClockTheDive);
-
+        if (analysis_.analyse_mip_time) {
+          this_dive_time += analysis_.mipTimerRead(kMipClockNodeSearch);
+          analysis_.dive_time.push_back(this_dive_time);
+        }
         if (search_dive_result == HighsSearch::NodeResult::kSubOptimal) break;
 
         ++mipdata_->num_leaves;
@@ -507,6 +511,7 @@ restart:
     // mipdata_->lp.setIterationLimit();
 
     // loop to install the next node for the search
+    double this_node_search_time = -analysis_.mipTimerRead(kMipClockNodeSearch);
     analysis_.mipTimerStart(kMipClockNodeSearch);
 
     while (!mipdata_->nodequeue.empty()) {
@@ -651,7 +656,10 @@ restart:
       break;
     }  // while(!mipdata_->nodequeue.empty())
     analysis_.mipTimerStop(kMipClockNodeSearch);
-
+    if (analysis_.analyse_mip_time) {
+      this_node_search_time += analysis_.mipTimerRead(kMipClockNodeSearch);
+      analysis_.node_search_time.push_back(this_node_search_time);
+    }
     if (limit_reached) break;
   }  // while(search.hasNode())
   analysis_.mipTimerStop(kMipClockSearch);

--- a/src/mip/MipTimer.h
+++ b/src/mip/MipTimer.h
@@ -334,7 +334,7 @@ class MipTimer {
                    const bool end_line) {
     const std::vector<HighsInt> mip_clock_list{
         kMipClockRunPresolve, kMipClockEvaluateRootNode,
-        kMipClockPrimalHeuristics, kMipClockTheDive};
+        kMipClockPrimalHeuristics, kMipClockTheDive, kMipClockNodeSearch};
     csvMipClockList(model_name, mip_clock_list, mip_timer_clock, kMipClockTotal,
                     header, end_line);
   };

--- a/src/util/HighsUtils.cpp
+++ b/src/util/HighsUtils.cpp
@@ -435,7 +435,7 @@ void analyseVectorValues(const HighsLogOptions* log_options,
           highsFormatToString("%12" HIGHSINT_FORMAT
                               " values satisfy 10^(%3" HIGHSINT_FORMAT
                               ") <= v < 10^(%3" HIGHSINT_FORMAT ")\n",
-                              vK, k, k + 1));
+                              vK, k - 1, k));
   }
   for (HighsInt k = 1; k <= nVK; k++) {
     HighsInt vK = negVK[k];
@@ -445,7 +445,7 @@ void analyseVectorValues(const HighsLogOptions* log_options,
           highsFormatToString("%12" HIGHSINT_FORMAT
                               " values satisfy 10^(%3" HIGHSINT_FORMAT
                               ") <= v < 10^(%3" HIGHSINT_FORMAT ")\n",
-                              vK, -k, 1 - k));
+                              vK, -k - 1, -k));
   }
   vK = vecDim - nNz;
   if (vK > 0)


### PR DESCRIPTION
Good to have the fix in latest, and analysis is an extension of MIP ananlysis that it off by default.

MIP profiling error was omission of node search time