### PR TITLE
fix format of log message

### DIFF
--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -2009,6 +2009,7 @@ HighsStatus Highs::getIisInterface() {
       max_iterations = std::max(iterations, max_iterations);
     }
     highsLogUser(options_.log_options, HighsLogType::kInfo,
+                 " %d cols, %d rows, %d LPs solved"
                  " (min / average / max) iteration count (%6d / %6.2g / % 6d)"
                  " and time (%6.2f / %6.2f / % 6.2f) \n",
                  int(this->iis_.col_index_.size()),


### PR DESCRIPTION
`highsLogUser()` is given `int(this->iis_.col_index_.size()),  int(this->iis_.row_index_.size()), int(num_lp_solved)`, but the format string of the message seems to miss the corresponding `%d`'s.
