### PR TITLE
Zero out vectors with uplocks and downlocks

### DIFF
--- a/src/mip/HighsMipSolverData.cpp
+++ b/src/mip/HighsMipSolverData.cpp
@@ -758,8 +758,9 @@ void HighsMipSolverData::runSetup() {
     highsSparseTranspose(model.num_row_, model.num_col_, model.a_matrix_.start_,
                          model.a_matrix_.index_, model.a_matrix_.value_,
                          ARstart_, ARindex_, ARvalue_);
-    uplocks.resize(model.num_col_);
-    downlocks.resize(model.num_col_);
+    // (re-)initialize number of uplocks and downlocks
+    uplocks.assign(model.num_col_, 0);
+    downlocks.assign(model.num_col_, 0);
     for (HighsInt i = 0; i != model.num_col_; ++i) {
       HighsInt start = model.a_matrix_.start_[i];
       HighsInt end = model.a_matrix_.start_[i + 1];


### PR DESCRIPTION
Vectors `uplocks` and `downlocks` are not initialized with zeros before iterating over the matrix elements and computing the locks. Therefore, the number of locks may be incorrect after a restart, for example.