### PR TITLE
Update model_status when checkOptimality fails

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -1967,6 +1967,25 @@ void test_multiObjective() {
   free(col_value);
 }
 
+void test_qp_indefinite_failure() {
+    void* highs = Highs_create();
+    HighsInt ret;
+    const double inf = Highs_getInfinity(highs);
+    ret = Highs_addCol(highs, 0.0, 1.0, inf, 0, NULL, NULL);
+    assert(ret == 0);
+    ret = Highs_addCol(highs, 0.0, 1.0, 1.0, 0, NULL, NULL);
+    HighsInt start[2] = {0, 1};
+    HighsInt index[1] = {1};
+    double value[1] = {1.0};
+    ret = Highs_passHessian(highs, 2, 1, kHighsHessianFormatTriangular, start, index, value);
+    assert(ret == 0);
+    HighsInt run_status = Highs_run(highs);
+    HighsInt model_status = Highs_getModelStatus(highs);
+    assert(run_status == kHighsStatusError);
+    assert(model_status == kHighsModelStatusSolveError);
+    Highs_destroy(highs);
+}
+
 /*
 The horrible C in this causes problems in some of the CI tests,
 so suppress thius test until the C has been improved
@@ -2032,6 +2051,7 @@ int main() {
   test_feasibilityRelaxation();
   test_getModel();
   test_multiObjective();
+  test_qp_indefinite_failure();
   return 0;
 }
 //  test_setSolution();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3783,8 +3783,13 @@ HighsStatus Highs::callSolveLp(HighsLp& lp, const string message) {
   return_status = solveLp(solver_object, message);
   // Extract the model status
   model_status_ = solver_object.model_status_;
-  if (model_status_ == HighsModelStatus::kOptimal)
-    checkOptimality("LP", return_status);
+  if (model_status_ == HighsModelStatus::kOptimal) {
+    HighsStatus check_status = checkOptimality("LP", return_status);
+    if (check_status == HighsStatus::kError) {
+      return_status = check_status;
+      solver_object.model_status_ = HighsModelStatus::kSolveError;
+    }
+  }
   return return_status;
 }
 
@@ -3929,8 +3934,13 @@ HighsStatus Highs::callSolveQp() {
   info_.simplex_iteration_count += stats.phase1_iterations;
   info_.qp_iteration_count += stats.num_iterations;
   info_.valid = true;
-  if (model_status_ == HighsModelStatus::kOptimal)
-    checkOptimality("QP", return_status);
+  if (model_status_ == HighsModelStatus::kOptimal) {
+    HighsStatus check_status = checkOptimality("QP", return_status);
+    if (check_status == HighsStatus::kError) {
+      return_status = check_status;
+      model_status_ = HighsModelStatus::kSolveError;
+    }
+  }
   return return_status;
 }
 
@@ -4024,8 +4034,13 @@ HighsStatus Highs::callSolveMip() {
                                       ? -1
                                       : HighsInt(mip_total_lp_iterations);
   info_.valid = true;
-  if (model_status_ == HighsModelStatus::kOptimal)
-    checkOptimality("MIP", return_status);
+  if (model_status_ == HighsModelStatus::kOptimal) {
+    HighsStatus check_status = checkOptimality("QP", return_status);
+    if (check_status == HighsStatus::kError) {
+      return_status = check_status;
+      model_status_ = HighsModelStatus::kSolveError;
+    }
+  }
   if (use_mip_feasibility_tolerance) {
     // Overwrite max infeasibility to include integrality if there is a solution
     if (solver.solution_objective_ != kHighsInf) {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -4035,7 +4035,7 @@ HighsStatus Highs::callSolveMip() {
                                       : HighsInt(mip_total_lp_iterations);
   info_.valid = true;
   if (model_status_ == HighsModelStatus::kOptimal) {
-    HighsStatus check_status = checkOptimality("QP", return_status);
+    HighsStatus check_status = checkOptimality("MIP", return_status);
     if (check_status == HighsStatus::kError) {
       return_status = check_status;
       model_status_ = HighsModelStatus::kSolveError;


### PR DESCRIPTION
I'm not sure if this is the correct fix, but see https://github.com/jump-dev/JuMP.jl/issues/3947

Without this PR, I get `Model status        : Optimal`:
```raw
Running HiGHS 1.9.0 (git hash: 05db5c231): Copyright (c) 2025 HiGHS under MIT licence terms
Coefficient ranges:
  Cost   [0e+00, 0e+00]
  Bound  [1e+00, 1e+00]
  Iteration        Objective     NullspaceDim
ERROR:   QP solver claims optimality, but with num/max/sum primal(2/1/2) infeasibilities
Model status        : Optimal
Objective value     :  0.0000000000e+00
HiGHS run time      :          0.00
```
which is very confusing for users.