### PR TITLE
Minor change to constructor

### DIFF
--- a/src/lp_data/HighsOptions.h
+++ b/src/lp_data/HighsOptions.h
@@ -51,7 +51,6 @@ class OptionRecordBool : public OptionRecord {
   OptionRecordBool(std::string Xname, std::string Xdescription, bool Xadvanced,
                    bool* Xvalue_pointer, bool Xdefault_value)
       : OptionRecord(HighsOptionType::kBool, Xname, Xdescription, Xadvanced) {
-    advanced = Xadvanced;
     value = Xvalue_pointer;
     default_value = Xdefault_value;
     *value = default_value;


### PR DESCRIPTION
Remove initialization of boolean `advanced` in `OptionRecordBool` constructor since it is already set in parent class constructor `OptionRecord`.