### PR TITLE
Fix 2185

### DIFF
--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -256,19 +256,16 @@ restart:
             analysis_.mipTimerStop(kMipClockRandomizedRounding0);
           }
 
-          // previous heuristic may have detected infeasibility
-          if (!mipdata_->domain.infeasible()) {
-            if (mipdata_->incumbent.empty()) {
-              analysis_.mipTimerStart(kMipClockRens);
-              mipdata_->heuristics.RENS(
-                  mipdata_->lp.getLpSolver().getSolution().col_value);
-              analysis_.mipTimerStop(kMipClockRens);
-            } else {
-              analysis_.mipTimerStart(kMipClockRins);
-              mipdata_->heuristics.RINS(
-                  mipdata_->lp.getLpSolver().getSolution().col_value);
-              analysis_.mipTimerStop(kMipClockRins);
-            }
+          if (mipdata_->incumbent.empty()) {
+            analysis_.mipTimerStart(kMipClockRens);
+            mipdata_->heuristics.RENS(
+                mipdata_->lp.getLpSolver().getSolution().col_value);
+            analysis_.mipTimerStop(kMipClockRens);
+          } else {
+            analysis_.mipTimerStart(kMipClockRins);
+            mipdata_->heuristics.RINS(
+                mipdata_->lp.getLpSolver().getSolution().col_value);
+            analysis_.mipTimerStop(kMipClockRins);
           }
 
           mipdata_->heuristics.flushStatistics();

--- a/src/mip/HighsMipSolver.cpp
+++ b/src/mip/HighsMipSolver.cpp
@@ -256,16 +256,19 @@ restart:
             analysis_.mipTimerStop(kMipClockRandomizedRounding0);
           }
 
-          if (mipdata_->incumbent.empty()) {
-            analysis_.mipTimerStart(kMipClockRens);
-            mipdata_->heuristics.RENS(
-                mipdata_->lp.getLpSolver().getSolution().col_value);
-            analysis_.mipTimerStop(kMipClockRens);
-          } else {
-            analysis_.mipTimerStart(kMipClockRins);
-            mipdata_->heuristics.RINS(
-                mipdata_->lp.getLpSolver().getSolution().col_value);
-            analysis_.mipTimerStop(kMipClockRins);
+          // previous heuristic may have detected infeasibility
+          if (!mipdata_->domain.infeasible()) {
+            if (mipdata_->incumbent.empty()) {
+              analysis_.mipTimerStart(kMipClockRens);
+              mipdata_->heuristics.RENS(
+                  mipdata_->lp.getLpSolver().getSolution().col_value);
+              analysis_.mipTimerStop(kMipClockRens);
+            } else {
+              analysis_.mipTimerStart(kMipClockRins);
+              mipdata_->heuristics.RINS(
+                  mipdata_->lp.getLpSolver().getSolution().col_value);
+              analysis_.mipTimerStop(kMipClockRins);
+            }
           }
 
           mipdata_->heuristics.flushStatistics();

--- a/src/mip/HighsPrimalHeuristics.cpp
+++ b/src/mip/HighsPrimalHeuristics.cpp
@@ -319,6 +319,9 @@ void HighsPrimalHeuristics::rootReducedCost() {
 }
 
 void HighsPrimalHeuristics::RENS(const std::vector<double>& tmp) {
+  // return if domain is infeasible
+  if (mipsolver.mipdata_->domain.infeasible()) return;
+
   HighsPseudocost pscost(mipsolver.mipdata_->pseudocost);
   HighsSearch heur(mipsolver, pscost);
   HighsDomain& localdom = heur.getLocalDomain();
@@ -567,7 +570,10 @@ retry:
 }
 
 void HighsPrimalHeuristics::RINS(const std::vector<double>& relaxationsol) {
-  if (int(relaxationsol.size()) != mipsolver.numCol()) return;
+  // return if domain is infeasible
+  if (mipsolver.mipdata_->domain.infeasible()) return;
+
+  if (relaxationsol.size() != static_cast<size_t>(mipsolver.numCol())) return;
 
   intcols.erase(std::remove_if(intcols.begin(), intcols.end(),
                                [&](HighsInt i) {
@@ -979,7 +985,7 @@ bool HighsPrimalHeuristics::linesearchRounding(
 
 void HighsPrimalHeuristics::randomizedRounding(
     const std::vector<double>& relaxationsol) {
-  if (int(relaxationsol.size()) != mipsolver.numCol()) return;
+  if (relaxationsol.size() != static_cast<size_t>(mipsolver.numCol())) return;
 
   auto localdom = mipsolver.mipdata_->domain;
 
@@ -1158,7 +1164,8 @@ void HighsPrimalHeuristics::feasibilityPump() {
 }
 
 void HighsPrimalHeuristics::centralRounding() {
-  if (HighsInt(mipsolver.mipdata_->analyticCenter.size()) != mipsolver.numCol())
+  if (mipsolver.mipdata_->analyticCenter.size() !=
+      static_cast<size_t>(mipsolver.numCol()))
     return;
 
   if (!mipsolver.mipdata_->firstlpsol.empty())

--- a/src/mip/HighsSearch.cpp
+++ b/src/mip/HighsSearch.cpp
@@ -32,7 +32,7 @@ HighsSearch::HighsSearch(HighsMipSolver& mipsolver, HighsPseudocost& pseudocost)
   childselrule = mipsolver.submip ? ChildSelectionRule::kHybridInferenceCost
                                   : ChildSelectionRule::kRootSol;
   // the infeasibility flag is overwritten and lost when setDomainChangeStack is
-  // called. therefore, assume that localdom is not infeasible here.
+  // called. therefore, assert that localdom is not infeasible here.
   assert(!this->localdom.infeasible());
   this->localdom.setDomainChangeStack(std::vector<HighsDomainChange>());
 }

--- a/src/mip/HighsSearch.cpp
+++ b/src/mip/HighsSearch.cpp
@@ -31,6 +31,9 @@ HighsSearch::HighsSearch(HighsMipSolver& mipsolver, HighsPseudocost& pseudocost)
   countTreeWeight = true;
   childselrule = mipsolver.submip ? ChildSelectionRule::kHybridInferenceCost
                                   : ChildSelectionRule::kRootSol;
+  // the infeasibility flag is overwritten and lost when setDomainChangeStack is
+  // called. therefore, assume that localdom is not infeasible here.
+  assert(!this->localdom.infeasible());
   this->localdom.setDomainChangeStack(std::vector<HighsDomainChange>());
 }
 


### PR DESCRIPTION
Fix issue #2185 
- Do not call `RENS` or `RINS` heuristics when the domain they operate on is infeasible (i.e. `mipdata_->domain.infeasible()`) since this creates inconsistencies in the bounds on constraint activities.
- Unfortunately, the reproduction example takes relatively long to solve, so I did not use it as an automated test.
- Testing is ongoing.