### PR TITLE
Nuget Linux builds using Clang 11.0.1 for AWS compatibility

### DIFF
--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -101,7 +101,7 @@ jobs:
           path: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native/runtimes
 
   build_linux_arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -80,47 +80,49 @@ jobs:
 
   build_linux:
     runs-on: ubuntu-latest
+    container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
         run: |
-         cmake -E make_directory ${{runner.workspace}}/build
+         cmake -E make_directory /__w/HiGHS/HiGHS/build
 
       - name: Configure CMake
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON
 
       - name: Build
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake --build . --config Release --parallel
 
       - uses: actions/upload-artifact@v4
         with:
           name: linux-x64
-          path: ${{runner.workspace}}/build/dotnet/Highs.Native/runtimes
+          path: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native/runtimes
 
   build_linux_arm64:
     runs-on: ubuntu-latest
+    container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
         run: |
-         cmake -E make_directory ${{runner.workspace}}/build_linux_arm64
+         cmake -E make_directory /__w/HiGHS/HiGHS/build_linux_arm64
 
       - name: Configure CMake linux-arm-64
-        working-directory: ${{runner.workspace}}/build_linux_arm64
+        working-directory: /__w/HiGHS/HiGHS/build_linux_arm64
         shell: bash
         run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/nuget/arm-toolchain.cmake
 
       - name: Build linux-arm-64
-        working-directory: ${{runner.workspace}}/build_linux_arm64
+        working-directory: /__w/HiGHS/HiGHS/build_linux_arm64
         shell: bash
         run: cmake --build . --config Release --parallel
 
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64
-          path: ${{runner.workspace}}/build_linux_arm64/dotnet/Highs.Native/runtimes
+          path: /__w/HiGHS/HiGHS/build_linux_arm64/dotnet/Highs.Native/runtimes
 
   build_windows:
     runs-on: windows-latest

--- a/.github/workflows/test-nuget-package.yml
+++ b/.github/workflows/test-nuget-package.yml
@@ -102,20 +102,21 @@ jobs:
 
   build_linux:
     runs-on: ubuntu-latest
+    container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
         run: |
-         cmake -E make_directory ${{runner.workspace}}/build
-         cmake -E make_directory ${{runner.workspace}}/nugets
-         cmake -E make_directory ${{runner.workspace}}/test_nuget
+         cmake -E make_directory /__w/HiGHS/HiGHS/build
+         cmake -E make_directory /__w/HiGHS/HiGHS/nugets
+         cmake -E make_directory /__w/HiGHS/HiGHS/test_nuget
 
       - name: Configure CMake
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON
 
       - name: Build
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake --build . --config Release --parallel
 
       - uses: actions/setup-dotnet@v4
@@ -123,42 +124,43 @@ jobs:
           dotnet-version: '6.0.x'
 
       - name: Dotnet pack
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
         run: dotnet pack -c Release /p:Version=1.9.0
 
       - name: Add local feed 
-        run: dotnet nuget add source ${{runner.workspace}}/nugets
+        run: dotnet nuget add source /__w/HiGHS/HiGHS/nugets
 
       - name: Dotnet push to local feed
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
-        run: dotnet nuget push ./bin/Release/*.nupkg -s ${{runner.workspace}}/nugets
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
+        run: dotnet nuget push ./bin/Release/*.nupkg -s /__w/HiGHS/HiGHS/nugets
 
       - name: Create new project and test
         shell: bash
-        working-directory: ${{runner.workspace}}/test_nuget
+        working-directory: /__w/HiGHS/HiGHS/test_nuget
         run: |
           dotnet new console
           rm Program.cs 
           cp $GITHUB_WORKSPACE/examples/call_highs_from_csharp.cs . 
-          dotnet add package Highs.Native -s ${{runner.workspace}}/nugets 
+          dotnet add package Highs.Native -s /__w/HiGHS/HiGHS/nugets 
           dotnet run
 
   build_linux_8:
     runs-on: ubuntu-latest
+    container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
         run: |
-         cmake -E make_directory ${{runner.workspace}}/build
-         cmake -E make_directory ${{runner.workspace}}/nugets
-         cmake -E make_directory ${{runner.workspace}}/test_nuget
+         cmake -E make_directory /__w/HiGHS/HiGHS/build
+         cmake -E make_directory /__w/HiGHS/HiGHS/nugets
+         cmake -E make_directory /__w/HiGHS/HiGHS/test_nuget
 
       - name: Configure CMake
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON
 
       - name: Build
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake --build . --config Release --parallel
 
       - uses: actions/setup-dotnet@v4
@@ -166,24 +168,24 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Dotnet pack
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
         run: dotnet pack -c Release /p:Version=1.9.0
 
       - name: Add local feed 
-        run: dotnet nuget add source ${{runner.workspace}}/nugets
+        run: dotnet nuget add source /__w/HiGHS/HiGHS/nugets
 
       - name: Dotnet push to local feed
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
-        run: dotnet nuget push ./bin/Release/*.nupkg -s ${{runner.workspace}}/nugets
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
+        run: dotnet nuget push ./bin/Release/*.nupkg -s /__w/HiGHS/HiGHS/nugets
 
       - name: Create new project and test
         shell: bash
-        working-directory: ${{runner.workspace}}/test_nuget
+        working-directory: /__w/HiGHS/HiGHS/test_nuget
         run: |
           dotnet new console
           rm Program.cs 
           cp $GITHUB_WORKSPACE/examples/call_highs_from_csharp.cs . 
-          dotnet add package Highs.Native -s ${{runner.workspace}}/nugets 
+          dotnet add package Highs.Native -s /__w/HiGHS/HiGHS/nugets 
           dotnet run
 
   build_windows:

--- a/.github/workflows/test-nuget-ubuntu.yml
+++ b/.github/workflows/test-nuget-ubuntu.yml
@@ -9,20 +9,21 @@ concurrency:
 jobs:
   build_linux:
     runs-on: ubuntu-latest
+    container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
         run: |
-         cmake -E make_directory ${{runner.workspace}}/build
-         cmake -E make_directory ${{runner.workspace}}/nugets
-         cmake -E make_directory ${{runner.workspace}}/test_nuget
+         cmake -E make_directory /__w/HiGHS/HiGHS/build
+         cmake -E make_directory /__w/HiGHS/HiGHS/nugets
+         cmake -E make_directory /__w/HiGHS/HiGHS/test_nuget
 
       - name: Configure CMake
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON
 
       - name: Build
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake --build . --config Release --parallel
 
       - uses: actions/setup-dotnet@v4
@@ -30,42 +31,43 @@ jobs:
           dotnet-version: '6.0.x'
 
       - name: Dotnet pack
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
         run: dotnet pack -c Release /p:Version=1.9.0
 
       - name: Add local feed 
-        run: dotnet nuget add source ${{runner.workspace}}/nugets
+        run: dotnet nuget add source /__w/HiGHS/HiGHS/nugets
 
       - name: Dotnet push to local feed
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
-        run: dotnet nuget push ./bin/Release/*.nupkg -s ${{runner.workspace}}/nugets
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
+        run: dotnet nuget push ./bin/Release/*.nupkg -s /__w/HiGHS/HiGHS/nugets
 
       - name: Create new project and test
         shell: bash
-        working-directory: ${{runner.workspace}}/test_nuget
+        working-directory: /__w/HiGHS/HiGHS/test_nuget
         run: |
           dotnet new console
           rm Program.cs 
           cp $GITHUB_WORKSPACE/examples/call_highs_from_csharp.cs . 
-          dotnet add package Highs.Native -s ${{runner.workspace}}/nugets 
+          dotnet add package Highs.Native -s /__w/HiGHS/HiGHS/nugets 
           dotnet run
 
   build_linux_8:
     runs-on: ubuntu-latest
+    container: stabletec/build-core:debian-11
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
         run: |
-         cmake -E make_directory ${{runner.workspace}}/build
-         cmake -E make_directory ${{runner.workspace}}/nugets
-         cmake -E make_directory ${{runner.workspace}}/test_nuget
+         cmake -E make_directory /__w/HiGHS/HiGHS/build
+         cmake -E make_directory /__w/HiGHS/HiGHS/nugets
+         cmake -E make_directory /__w/HiGHS/HiGHS/test_nuget
 
       - name: Configure CMake
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON
 
       - name: Build
-        working-directory: ${{runner.workspace}}/build
+        working-directory: /__w/HiGHS/HiGHS/build
         run: cmake --build . --config Release --parallel
 
       - uses: actions/setup-dotnet@v4
@@ -73,24 +75,24 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Dotnet pack
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
         run: dotnet pack -c Release /p:Version=1.9.0
 
       - name: Add local feed 
-        run: dotnet nuget add source ${{runner.workspace}}/nugets
+        run: dotnet nuget add source /__w/HiGHS/HiGHS/nugets
 
       - name: Dotnet push to local feed
-        working-directory: ${{runner.workspace}}/build/dotnet/Highs.Native
-        run: dotnet nuget push ./bin/Release/*.nupkg -s ${{runner.workspace}}/nugets
+        working-directory: /__w/HiGHS/HiGHS/build/dotnet/Highs.Native
+        run: dotnet nuget push ./bin/Release/*.nupkg -s /__w/HiGHS/HiGHS/nugets
 
       - name: Create new project and test
         shell: bash
-        working-directory: ${{runner.workspace}}/test_nuget
+        working-directory: /__w/HiGHS/HiGHS/test_nuget
         run: |
           dotnet new console
           rm Program.cs 
           cp $GITHUB_WORKSPACE/examples/call_highs_from_csharp.cs . 
-          dotnet add package Highs.Native -s ${{runner.workspace}}/nugets 
+          dotnet add package Highs.Native -s /__w/HiGHS/HiGHS/nugets 
           dotnet run
 
  


### PR DESCRIPTION
These changes let the Github Runners use a container [(StableCoder/docker-build-core)](https://github.com/StableCoder/docker-build-core) based on Debian 11 to build Linux binaries using Clang 11.0.1. The binaries are linked against till GLIBCXX 3.4.26 instead of 3.4.30 which is not provided by the standard AWS EC2 image (Amazon Linux 2023).

Besides, the ARM64 build now uses the proper runner (ubuntu-24.04-arm). Till now, the produced binaries were actually build against x64.