### PR TITLE
Fix 2159

### DIFF
--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -1989,6 +1989,7 @@ void testQpIndefiniteFailure() {
 
 void testDualRayTwice() {
     void* highs = Highs_create();
+    Highs_setBoolOptionValue(highs, "output_flag", dev_run);
     int ret;
     double INF = Highs_getInfinity(highs);
     ret = Highs_changeObjectiveOffset(highs, 0.0);

--- a/check/TestCAPI.c
+++ b/check/TestCAPI.c
@@ -2004,7 +2004,7 @@ void testDualRayTwice() {
     assert(ret == 0);
     ret = Highs_addCol(highs, -1.0, 0.0, INF, 0, NULL, NULL);
     assert(ret == 0);
-    int index[2] = {2, 3};
+    HighsInt index[2] = {2, 3};
     double value[2] = {1.0, -1.0};
     ret = Highs_addRow(highs, 0.0, 0.0, 2, index, value);
     assert(ret == 0);
@@ -2022,7 +2022,7 @@ void testDualRayTwice() {
     assert(ret == 0);
     ret = Highs_run(highs);
     assert(ret == 0);
-    int has_dual_ray = 0;
+    HighsInt has_dual_ray = 0;
     double dual_ray_value[4] = {0.0, 0.0, 0.0, 0.0};
     ret = Highs_getDualRay(highs, &has_dual_ray, dual_ray_value);
     assert(ret == 0);

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1528,8 +1528,8 @@ class Highs {
   // Clears the standard form LP
   void clearStandardFormLp();
 
-  // Clears the ray properties
-  void clearRayProperties() { this->ekk_instance_.clearRayProperties(); }
+  // Clears the ray records
+  void clearRayRecords() { this->ekk_instance_.clearRayRecords(); }
   //
   // Methods to clear solver data for users in Highs class members
   // before (possibly) updating them with data from trying to solve

--- a/src/Highs.h
+++ b/src/Highs.h
@@ -1516,11 +1516,20 @@ class Highs {
   // and basis data
   void setHighsModelStatusAndClearSolutionAndBasis(
       const HighsModelStatus model_status);
+
+  // Clears derived model properties (like any presolved model,
+  // standard form LP, and ray information) that (unlike solution and
+  // basis) cannot be updated
+  void clearDerivedModelProperties();
+
   // Clears the presolved model and its status
   void clearPresolve();
-  //
+
   // Clears the standard form LP
   void clearStandardFormLp();
+
+  // Clears the ray properties
+  void clearRayProperties() { this->ekk_instance_.clearRayProperties(); }
   //
   // Methods to clear solver data for users in Highs class members
   // before (possibly) updating them with data from trying to solve
@@ -1528,8 +1537,9 @@ class Highs {
   //
   // Invalidates all solver data in Highs class members by calling
   // invalidateModelStatus(), invalidateSolution(), invalidateBasis(),
-  // invalidateInfo() and invalidateEkk()
-  void invalidateUserSolverData();
+  // invalidateRanging(), invalidateInfo(), invalidateEkk() and
+  // invalidateIis()
+  void invalidateSolverData();
   //
   // Invalidates the model status, solution_ and info_
   void invalidateModelStatusSolutionAndInfo();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1754,7 +1754,7 @@ HighsStatus Highs::getDualRay(bool& has_dual_ray, double* dual_ray_value) {
 
 HighsStatus Highs::getDualRaySparse(bool& has_dual_ray,
                                     HVector& row_ep_buffer) {
-  has_dual_ray = ekk_instance_.dual_ray_record_.exists;
+  has_dual_ray = ekk_instance_.dual_ray_record_.index != kNoRayIndex;
   if (has_dual_ray) {
     ekk_instance_.setNlaPointersForLpAndScale(model_.lp_);
     row_ep_buffer.clear();

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -1754,15 +1754,15 @@ HighsStatus Highs::getDualRay(bool& has_dual_ray, double* dual_ray_value) {
 
 HighsStatus Highs::getDualRaySparse(bool& has_dual_ray,
                                     HVector& row_ep_buffer) {
-  has_dual_ray = ekk_instance_.status_.has_dual_ray;
+  has_dual_ray = ekk_instance_.dual_ray_record_.exists;
   if (has_dual_ray) {
     ekk_instance_.setNlaPointersForLpAndScale(model_.lp_);
     row_ep_buffer.clear();
     row_ep_buffer.count = 1;
     row_ep_buffer.packFlag = true;
-    HighsInt iRow = ekk_instance_.info_.dual_ray_row_;
+    HighsInt iRow = ekk_instance_.dual_ray_record_.index;
     row_ep_buffer.index[0] = iRow;
-    row_ep_buffer.array[iRow] = ekk_instance_.info_.dual_ray_sign_;
+    row_ep_buffer.array[iRow] = ekk_instance_.dual_ray_record_.sign;
 
     ekk_instance_.btran(row_ep_buffer, ekk_instance_.info_.row_ep_density);
   }
@@ -3513,11 +3513,10 @@ HighsPostsolveStatus Highs::runPostsolve() {
   return postsolve_status;
 }
 
-
 void Highs::clearDerivedModelProperties() {
   this->clearPresolve();
   this->clearStandardFormLp();
-  this->clearRayProperties();  
+  this->clearRayProperties();
 }
 
 void Highs::clearPresolve() {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -62,8 +62,7 @@ HighsStatus Highs::clearModel() {
 
 HighsStatus Highs::clearSolver() {
   HighsStatus return_status = HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   invalidateSolverData();
   return returnFromHighs(return_status);
 }
@@ -2430,8 +2429,7 @@ HighsStatus Highs::addCols(const HighsInt num_new_col, const double* costs,
                            const HighsInt* indices, const double* values) {
   this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   return_status = interpretCallStatus(
       options_.log_options,
       addColsInterface(num_new_col, costs, lower_bounds, upper_bounds,
@@ -2469,8 +2467,7 @@ HighsStatus Highs::addRows(const HighsInt num_new_row,
                            const HighsInt* indices, const double* values) {
   this->logHeader();
   HighsStatus return_status = HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   return_status = interpretCallStatus(
       options_.log_options,
       addRowsInterface(num_new_row, lower_bounds, upper_bounds, num_new_nz,
@@ -2485,8 +2482,7 @@ HighsStatus Highs::changeObjectiveSense(const ObjSense sense) {
       (model_.lp_.sense_ == ObjSense::kMinimize)) {
     model_.lp_.sense_ = sense;
     // Nontrivial change
-    clearPresolve();
-    clearStandardFormLp();
+    clearDerivedModelProperties();
     invalidateModelStatusSolutionAndInfo();
   }
   return returnFromHighs(HighsStatus::kOk);
@@ -2615,8 +2611,7 @@ HighsStatus Highs::changeColCost(const HighsInt col, const double cost) {
 
 HighsStatus Highs::changeColsCost(const HighsInt from_col,
                                   const HighsInt to_col, const double* cost) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, from_col, to_col, model_.lp_.num_col_);
@@ -2642,8 +2637,7 @@ HighsStatus Highs::changeColsCost(const HighsInt num_set_entries,
   // values are sorted with set
   if (doubleUserDataNotNull(options_.log_options, cost, "column costs"))
     return HighsStatus::kError;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   // Ensure that the set and data are in ascending order
   std::vector<double> local_cost{cost, cost + num_set_entries};
   std::vector<HighsInt> local_set{set, set + num_set_entries};
@@ -2666,8 +2660,7 @@ HighsStatus Highs::changeColsCost(const HighsInt num_set_entries,
 }
 
 HighsStatus Highs::changeColsCost(const HighsInt* mask, const double* cost) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const bool create_error = create(index_collection, mask, model_.lp_.num_col_);
   assert(!create_error);
@@ -2688,8 +2681,7 @@ HighsStatus Highs::changeColBounds(const HighsInt col, const double lower,
 HighsStatus Highs::changeColsBounds(const HighsInt from_col,
                                     const HighsInt to_col, const double* lower,
                                     const double* upper) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, from_col, to_col, model_.lp_.num_col_);
@@ -2723,8 +2715,7 @@ HighsStatus Highs::changeColsBounds(const HighsInt num_set_entries,
                                     "column upper bounds") ||
               null_data;
   if (null_data) return HighsStatus::kError;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   // Ensure that the set and data are in ascending order
   std::vector<double> local_lower{lower, lower + num_set_entries};
   std::vector<double> local_upper{upper, upper + num_set_entries};
@@ -2749,8 +2740,7 @@ HighsStatus Highs::changeColsBounds(const HighsInt num_set_entries,
 
 HighsStatus Highs::changeColsBounds(const HighsInt* mask, const double* lower,
                                     const double* upper) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const bool create_error = create(index_collection, mask, model_.lp_.num_col_);
   assert(!create_error);
@@ -2772,8 +2762,7 @@ HighsStatus Highs::changeRowBounds(const HighsInt row, const double lower,
 HighsStatus Highs::changeRowsBounds(const HighsInt from_row,
                                     const HighsInt to_row, const double* lower,
                                     const double* upper) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, from_row, to_row, model_.lp_.num_row_);
@@ -2807,8 +2796,7 @@ HighsStatus Highs::changeRowsBounds(const HighsInt num_set_entries,
       doubleUserDataNotNull(options_.log_options, upper, "row upper bounds") ||
       null_data;
   if (null_data) return HighsStatus::kError;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   // Ensure that the set and data are in ascending order
   std::vector<double> local_lower{lower, lower + num_set_entries};
   std::vector<double> local_upper{upper, upper + num_set_entries};
@@ -2833,8 +2821,7 @@ HighsStatus Highs::changeRowsBounds(const HighsInt num_set_entries,
 
 HighsStatus Highs::changeRowsBounds(const HighsInt* mask, const double* lower,
                                     const double* upper) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const bool create_error = create(index_collection, mask, model_.lp_.num_row_);
   assert(!create_error);
@@ -3133,8 +3120,7 @@ HighsStatus Highs::getCoeff(const HighsInt row, const HighsInt col,
 }
 
 HighsStatus Highs::deleteCols(const HighsInt from_col, const HighsInt to_col) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, from_col, to_col, model_.lp_.num_col_);
@@ -3152,8 +3138,7 @@ HighsStatus Highs::deleteCols(const HighsInt from_col, const HighsInt to_col) {
 HighsStatus Highs::deleteCols(const HighsInt num_set_entries,
                               const HighsInt* set) {
   if (num_set_entries == 0) return HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, num_set_entries, set, model_.lp_.num_col_);
@@ -3166,8 +3151,7 @@ HighsStatus Highs::deleteCols(const HighsInt num_set_entries,
 }
 
 HighsStatus Highs::deleteCols(HighsInt* mask) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   const HighsInt original_num_col = model_.lp_.num_col_;
   HighsIndexCollection index_collection;
   const bool create_error = create(index_collection, mask, original_num_col);
@@ -3180,8 +3164,7 @@ HighsStatus Highs::deleteCols(HighsInt* mask) {
 }
 
 HighsStatus Highs::deleteRows(const HighsInt from_row, const HighsInt to_row) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, from_row, to_row, model_.lp_.num_row_);
@@ -3199,8 +3182,7 @@ HighsStatus Highs::deleteRows(const HighsInt from_row, const HighsInt to_row) {
 HighsStatus Highs::deleteRows(const HighsInt num_set_entries,
                               const HighsInt* set) {
   if (num_set_entries == 0) return HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsIndexCollection index_collection;
   const HighsInt create_error =
       create(index_collection, num_set_entries, set, model_.lp_.num_row_);
@@ -3213,8 +3195,7 @@ HighsStatus Highs::deleteRows(const HighsInt num_set_entries,
 }
 
 HighsStatus Highs::deleteRows(HighsInt* mask) {
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   const HighsInt original_num_row = model_.lp_.num_row_;
   HighsIndexCollection index_collection;
   const bool create_error = create(index_collection, mask, original_num_row);
@@ -3228,8 +3209,7 @@ HighsStatus Highs::deleteRows(HighsInt* mask) {
 
 HighsStatus Highs::scaleCol(const HighsInt col, const double scale_value) {
   HighsStatus return_status = HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsStatus call_status = scaleColInterface(col, scale_value);
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "scaleCol");
@@ -3239,8 +3219,7 @@ HighsStatus Highs::scaleCol(const HighsInt col, const double scale_value) {
 
 HighsStatus Highs::scaleRow(const HighsInt row, const double scale_value) {
   HighsStatus return_status = HighsStatus::kOk;
-  clearPresolve();
-  clearStandardFormLp();
+  clearDerivedModelProperties();
   HighsStatus call_status = scaleRowInterface(row, scale_value);
   return_status = interpretCallStatus(options_.log_options, call_status,
                                       return_status, "scaleRow");

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -3516,7 +3516,7 @@ HighsPostsolveStatus Highs::runPostsolve() {
 void Highs::clearDerivedModelProperties() {
   this->clearPresolve();
   this->clearStandardFormLp();
-  this->clearRayProperties();
+  this->clearRayRecords();
 }
 
 void Highs::clearPresolve() {

--- a/src/lp_data/Highs.cpp
+++ b/src/lp_data/Highs.cpp
@@ -64,7 +64,7 @@ HighsStatus Highs::clearSolver() {
   HighsStatus return_status = HighsStatus::kOk;
   clearPresolve();
   clearStandardFormLp();
-  invalidateUserSolverData();
+  invalidateSolverData();
   return returnFromHighs(return_status);
 }
 
@@ -2115,7 +2115,7 @@ HighsStatus Highs::setSolution(const HighsSolution& solution) {
   const bool new_solution = new_primal_solution || new_dual_solution;
 
   if (new_solution) {
-    invalidateUserSolverData();
+    invalidateSolverData();
   } else {
     // Solution is rejected, so give a logging message and error
     // return
@@ -3534,6 +3534,13 @@ HighsPostsolveStatus Highs::runPostsolve() {
   return postsolve_status;
 }
 
+
+void Highs::clearDerivedModelProperties() {
+  this->clearPresolve();
+  this->clearStandardFormLp();
+  this->clearRayProperties();  
+}
+
 void Highs::clearPresolve() {
   model_presolve_status_ = HighsPresolveStatus::kNotPresolved;
   presolved_model_.clear();
@@ -3548,7 +3555,7 @@ void Highs::clearStandardFormLp() {
   standard_form_matrix_.clear();
 }
 
-void Highs::invalidateUserSolverData() {
+void Highs::invalidateSolverData() {
   invalidateModelStatus();
   invalidateSolution();
   invalidateBasis();
@@ -3907,7 +3914,7 @@ HighsStatus Highs::callSolveMip() {
   }
   // Ensure that any solver data for users in Highs class members are
   // cleared
-  invalidateUserSolverData();
+  invalidateSolverData();
   if (user_solution) {
     // Recover the col and row values
     solution_.col_value = std::move(user_solution_col_value);
@@ -4328,7 +4335,7 @@ HighsStatus Highs::returnFromRun(const HighsStatus run_return_status,
     case HighsModelStatus::kPostsolveError:
     case HighsModelStatus::kMemoryLimit:
       // Don't clear the model status!
-      //      invalidateUserSolverData();
+      //      invalidateSolverData();
       invalidateInfo();
       invalidateSolution();
       invalidateBasis();

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -1824,7 +1824,7 @@ HighsStatus Highs::getIisInterface() {
     // Full LP option chosen or no dual ray to use
     //
     // Working on the whole model so clear all solver data
-    this->invalidateUserSolverData();
+    this->invalidateSolverData();
     // 1789 Remove this check!
     HighsLp check_lp_before = this->model_.lp_;
     // Apply the elasticity filter to the whole model in order to

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -1514,7 +1514,7 @@ HighsStatus Highs::getDualRayInterface(bool& has_dual_ray,
   if (num_row == 0) return return_status;
   bool has_invert = ekk_instance_.status_.has_invert;
   assert(!lp.is_moved_);
-  has_dual_ray = ekk_instance_.dual_ray_record_.exists;
+  has_dual_ray = ekk_instance_.dual_ray_record_.index != kNoRayIndex;
 
   // Declare identifiers to save column costs, integrality, any Hessian and the
   // presolve setting, and a flag to know when they should be
@@ -1567,7 +1567,7 @@ HighsStatus Highs::getDualRayInterface(bool& has_dual_ray,
       this->setOptionValue("solve_relaxation", true);
       HighsStatus call_status = this->run();
       if (call_status != HighsStatus::kOk) return_status = call_status;
-      has_dual_ray = ekk_instance_.dual_ray_record_.exists;
+      has_dual_ray = ekk_instance_.dual_ray_record_.index != kNoRayIndex;
       has_invert = ekk_instance_.status_.has_invert;
       assert(has_invert);
     }
@@ -1651,7 +1651,7 @@ HighsStatus Highs::getPrimalRayInterface(bool& has_primal_ray,
   }
   bool has_invert = ekk_instance_.status_.has_invert;
   assert(!lp.is_moved_);
-  has_primal_ray = ekk_instance_.primal_ray_record_.exists;
+  has_primal_ray = ekk_instance_.primal_ray_record_.index != kNoRayIndex;
 
   std::string presolve;
   bool solve_relaxation;
@@ -1684,7 +1684,7 @@ HighsStatus Highs::getPrimalRayInterface(bool& has_primal_ray,
       this->setOptionValue("allow_unbounded_or_infeasible", false);
       HighsStatus call_status = this->run();
       if (call_status != HighsStatus::kOk) return_status = call_status;
-      has_primal_ray = ekk_instance_.primal_ray_record_.exists;
+      has_primal_ray = ekk_instance_.primal_ray_record_.index != kNoRayIndex;
       has_invert = ekk_instance_.status_.has_invert;
       assert(has_invert);
     }
@@ -1806,7 +1806,7 @@ HighsStatus Highs::getIisInterface() {
       return HighsStatus::kError;
     }
   }
-  const bool has_dual_ray = ekk_instance_.dual_ray_record_.exists;
+  const bool has_dual_ray = ekk_instance_.dual_ray_record_.index != kNoRayIndex;
   if (ray_option && !has_dual_ray)
     highsLogUser(
         options_.log_options, HighsLogType::kWarning,

--- a/src/lp_data/HighsInterface.cpp
+++ b/src/lp_data/HighsInterface.cpp
@@ -1550,8 +1550,10 @@ HighsStatus Highs::getDualRayInterface(bool& has_dual_ray,
       // Zero the costs, integrality and Hessian
       std::vector<double> zero_costs;
       zero_costs.assign(lp.num_col_, 0);
+      const bool has_primal_ray = this->ekk_instance_.status_.has_primal_ray;
       HighsStatus status =
           this->changeColsCost(0, lp.num_col_ - 1, zero_costs.data());
+      this->ekk_instance_.status_.has_primal_ray = has_primal_ray;
       assert(status == HighsStatus::kOk);
       if (is_qp) {
         HighsHessian zero_hessian;

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -335,11 +335,11 @@ inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
     // LP, see whether the proof still holds for the unscaled LP. If
     // it does, then there's no need to solve the unscaled LP
     solve_unscaled_lp = true;
-    // ToDo: ekk_instance.status_.has_dual_ray should now be true if
+    // ToDo: ekk_instance.dual_ray_record_.exists should now be true if
     // scaled_model_status == HighsModelStatus::kInfeasible since this
     // model status depends on the infeasibility proof being true
     if (scaled_model_status == HighsModelStatus::kInfeasible &&
-        ekk_instance.status_.has_dual_ray) {
+        ekk_instance.dual_ray_record_.exists) {
       ekk_instance.setNlaPointersForLpAndScale(ekk_lp);
       if (ekk_instance.proofOfPrimalInfeasibility()) solve_unscaled_lp = false;
     }

--- a/src/simplex/HApp.h
+++ b/src/simplex/HApp.h
@@ -335,11 +335,14 @@ inline HighsStatus solveLpSimplex(HighsLpSolverObject& solver_object) {
     // LP, see whether the proof still holds for the unscaled LP. If
     // it does, then there's no need to solve the unscaled LP
     solve_unscaled_lp = true;
-    // ToDo: ekk_instance.dual_ray_record_.exists should now be true if
-    // scaled_model_status == HighsModelStatus::kInfeasible since this
-    // model status depends on the infeasibility proof being true
+    // ToDo: ekk_instance.dual_ray_record_.index != kNoRayIndex should
+    // now be true if scaled_model_status ==
+    // HighsModelStatus::kInfeasible since this model status depends
+    // on the infeasibility proof being true
+    if (scaled_model_status == HighsModelStatus::kInfeasible)
+      assert(ekk_instance.dual_ray_record_.index != kNoRayIndex);
     if (scaled_model_status == HighsModelStatus::kInfeasible &&
-        ekk_instance.dual_ray_record_.exists) {
+        ekk_instance.dual_ray_record_.index != kNoRayIndex) {
       ekk_instance.setNlaPointersForLpAndScale(ekk_lp);
       if (ekk_instance.proofOfPrimalInfeasibility()) solve_unscaled_lp = false;
     }

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -80,6 +80,18 @@ void HEkk::clearNlaInvertStatus() {
   this->status_.has_fresh_invert = false;
 }
 
+void HEkk::clearRayProperties() {
+  // Invalidate dual and primal ray data
+  this->status_.has_dual_ray = false;
+  this->status_.has_primal_ray = false;
+  this->info_.dual_ray_row_ = -1;
+  this->info_.dual_ray_sign_ = -1;
+  this->dual_ray_.clear();
+  this->info_.primal_ray_col_ = -1;
+  this->info_.primal_ray_sign_ = -1;
+  this->primal_ray_.clear();
+}
+
 void HEkk::clearEkkPointers() {
   this->callback_ = nullptr;
   this->options_ = nullptr;
@@ -306,15 +318,7 @@ void HEkk::invalidateBasisArtifacts() {
   this->status_.has_fresh_rebuild = false;
   this->status_.has_dual_objective_value = false;
   this->status_.has_primal_objective_value = false;
-  // Invalidate dual and primal ray data
-  this->status_.has_dual_ray = false;
-  this->status_.has_primal_ray = false;
-  this->info_.dual_ray_row_ = -1;
-  this->info_.dual_ray_sign_ = -1;
-  this->dual_ray_.clear();
-  this->info_.primal_ray_col_ = -1;
-  this->info_.primal_ray_sign_ = -1;
-  this->primal_ray_.clear();
+  this->clearRayProperties();
 }
 
 void HEkk::updateStatus(LpAction action) {

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -39,8 +39,7 @@ void HEkk::clear() {
   this->basis_.clear();
   this->simplex_nla_.clear();
   this->clearEkkAllStatus();
-  this->primal_ray_record_.clear();
-  this->dual_ray_record_.clear();
+  this->clearRayRecords();
 }
 
 void HEkk::clearEkkAllStatus() {
@@ -64,8 +63,6 @@ void HEkk::clearEkkDataStatus() {
   status.has_fresh_rebuild = false;
   status.has_dual_objective_value = false;
   status.has_primal_objective_value = false;
-  dual_ray_record_.clear();
-  primal_ray_record_.clear();
 }
 
 void HEkk::clearNlaStatus() {
@@ -82,8 +79,7 @@ void HEkk::clearNlaInvertStatus() {
   this->status_.has_fresh_invert = false;
 }
 
-void HEkk::clearRayProperties() {
-  // Invalidate dual and primal ray data
+void HEkk::clearRayRecords() {
   this->dual_ray_record_.clear();
   this->primal_ray_record_.clear();
 }
@@ -148,8 +144,7 @@ void HEkk::clearEkkData() {
   this->proof_index_.clear();
   this->proof_value_.clear();
 
-  this->primal_ray_record_.clear();
-  this->dual_ray_record_.clear();
+  this->clearRayRecords();
 
   this->build_synthetic_tick_ = 0.0;
   this->total_synthetic_tick_ = 0.0;
@@ -310,7 +305,7 @@ void HEkk::invalidateBasisArtifacts() {
   this->status_.has_fresh_rebuild = false;
   this->status_.has_dual_objective_value = false;
   this->status_.has_primal_objective_value = false;
-  this->clearRayProperties();
+  this->clearRayRecords();
 }
 
 void HEkk::updateStatus(LpAction action) {
@@ -1041,8 +1036,7 @@ HighsStatus HEkk::solve(const bool force_phase2) {
   std::string algorithm_name;
 
   // Indicate that dual and primal rays are not known
-  dual_ray_record_.exists = false;
-  primal_ray_record_.exists = false;
+  this->clearRayRecords();
 
   // Allow primal and dual perturbations in case a block on them is
   // hanging over from a previous call

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -4017,7 +4017,7 @@ bool HEkk::logicalBasis() const {
 
 bool HEkk::proofOfPrimalInfeasibility() {
   // To be called from outside HEkk when row_ep is not known
-  assert(dual_ray_record_.exists);
+  assert(dual_ray_record_.index >= 0);
   HighsLp& lp = this->lp_;
   HighsInt move_out = dual_ray_record_.sign;
   HighsInt row_out = dual_ray_record_.index;
@@ -4353,7 +4353,6 @@ void HighsSimplexStats::initialise(const HighsInt iteration_count_) {
 
 HighsRayRecord HighsRayRecord::getRayRecord() const {
   HighsRayRecord record;
-  record.exists = this->exists;
   record.index = this->index;
   record.sign = this->sign;
   record.value = this->value;
@@ -4361,15 +4360,13 @@ HighsRayRecord HighsRayRecord::getRayRecord() const {
 }
 
 void HighsRayRecord::setRayRecord(const HighsRayRecord& from_record) {
-  this->exists = from_record.exists;
   this->index = from_record.index;
   this->sign = from_record.sign;
   this->value = from_record.value;
 }
 
 void HighsRayRecord::clear() {
-  this->exists = false;
-  this->index = -1;
-  this->sign = 0;
+  this->index = kNoRayIndex;
+  this->sign = kNoRaySign;
   this->value.clear();
 }

--- a/src/simplex/HEkk.cpp
+++ b/src/simplex/HEkk.cpp
@@ -39,6 +39,8 @@ void HEkk::clear() {
   this->basis_.clear();
   this->simplex_nla_.clear();
   this->clearEkkAllStatus();
+  this->primal_ray_record_.clear();
+  this->dual_ray_record_.clear();
 }
 
 void HEkk::clearEkkAllStatus() {
@@ -4364,3 +4366,27 @@ void HighsSimplexStats::initialise(const HighsInt iteration_count_) {
   row_ap_density = 0;
   row_DSE_density = 0;
 }
+
+HighsRayRecord HighsRayRecord::getRayRecord() const {
+  HighsRayRecord record;
+  record.has_ray = this->has_ray;
+  record.index = this->index;
+  record.sign = this->sign;
+  record.value = this->value;
+  return record;
+}
+
+void HighsRayRecord::setRayRecord(const HighsRayRecord& from_record) {
+  this->has_ray = from_record.has_ray;
+  this->index = from_record.index;
+  this->sign = from_record.sign;
+  this->value = from_record.value;
+}
+
+void HighsRayRecord::clear() {
+  this->has_ray = false;
+  this->index = -1;
+  this->sign = 0;
+  this->value.clear();
+}
+

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -73,7 +73,7 @@ class HEkk {
   void clearEkkDataStatus();
   void clearNlaStatus();
   void clearNlaInvertStatus();
-  void clearRayProperties();
+  void clearRayRecords();
 
   void invalidate();
   void invalidateBasisMatrix();

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -219,6 +219,9 @@ class HEkk {
   vector<double> primal_ray_;
   vector<double> dual_ray_;
 
+  HighsRayRecord dual_ray_record_;
+  HighsRayRecord primal_ray_record_;
+
   // Data to be retained when dualizing
   HighsInt original_num_col_;
   HighsInt original_num_row_;

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -73,6 +73,7 @@ class HEkk {
   void clearEkkDataStatus();
   void clearNlaStatus();
   void clearNlaInvertStatus();
+  void clearRayProperties();
 
   void invalidate();
   void invalidateBasisMatrix();

--- a/src/simplex/HEkk.h
+++ b/src/simplex/HEkk.h
@@ -216,9 +216,6 @@ class HEkk {
   vector<double> proof_value_;
 
   // Data to be retained after computing primal or dual ray
-  vector<double> primal_ray_;
-  vector<double> dual_ray_;
-
   HighsRayRecord dual_ray_record_;
   HighsRayRecord primal_ray_record_;
 

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -2543,8 +2543,9 @@ bool HEkkDual::proofOfPrimalInfeasibility() {
 }
 
 void HEkkDual::saveDualRay() {
-  ekk_instance_.dual_ray_record_.exists = true;
   assert(row_out >= 0);
+  assert(move_out != kNoRaySign);
+  ekk_instance_.dual_ray_record_.clear();
   ekk_instance_.dual_ray_record_.index = row_out;
   ekk_instance_.dual_ray_record_.sign = move_out;
 }

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -2544,6 +2544,7 @@ bool HEkkDual::proofOfPrimalInfeasibility() {
 
 void HEkkDual::saveDualRay() {
   ekk_instance_.dual_ray_record_.exists = true;
+  assert(row_out >= 0);
   ekk_instance_.dual_ray_record_.index = row_out;
   ekk_instance_.dual_ray_record_.sign = move_out;
 }

--- a/src/simplex/HEkkDual.cpp
+++ b/src/simplex/HEkkDual.cpp
@@ -2543,9 +2543,9 @@ bool HEkkDual::proofOfPrimalInfeasibility() {
 }
 
 void HEkkDual::saveDualRay() {
-  ekk_instance_.status_.has_dual_ray = true;
-  ekk_instance_.info_.dual_ray_row_ = row_out;
-  ekk_instance_.info_.dual_ray_sign_ = move_out;
+  ekk_instance_.dual_ray_record_.exists = true;
+  ekk_instance_.dual_ray_record_.index = row_out;
+  ekk_instance_.dual_ray_record_.sign = move_out;
 }
 
 void HEkkDual::assessPhase1Optimality() {

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -2848,9 +2848,9 @@ void HEkkPrimal::shiftBound(const bool lower, const HighsInt iVar,
 }
 
 void HEkkPrimal::savePrimalRay() {
-  ekk_instance_.status_.has_primal_ray = true;
-  ekk_instance_.info_.primal_ray_col_ = variable_in;
-  ekk_instance_.info_.primal_ray_sign_ = -move_in;
+  ekk_instance_.primal_ray_record_.exists = true;
+  ekk_instance_.primal_ray_record_.index = variable_in;
+  ekk_instance_.primal_ray_record_.sign = -move_in;
 }
 
 HighsDebugStatus HEkkPrimal::debugPrimalSimplex(const std::string message,

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -2849,6 +2849,7 @@ void HEkkPrimal::shiftBound(const bool lower, const HighsInt iVar,
 
 void HEkkPrimal::savePrimalRay() {
   ekk_instance_.primal_ray_record_.exists = true;
+  assert(variable_in >= 0);
   ekk_instance_.primal_ray_record_.index = variable_in;
   ekk_instance_.primal_ray_record_.sign = -move_in;
 }

--- a/src/simplex/HEkkPrimal.cpp
+++ b/src/simplex/HEkkPrimal.cpp
@@ -2848,8 +2848,9 @@ void HEkkPrimal::shiftBound(const bool lower, const HighsInt iVar,
 }
 
 void HEkkPrimal::savePrimalRay() {
-  ekk_instance_.primal_ray_record_.exists = true;
   assert(variable_in >= 0);
+  assert(move_in != kNoRaySign);
+  ekk_instance_.primal_ray_record_.clear();
   ekk_instance_.primal_ray_record_.index = variable_in;
   ekk_instance_.primal_ray_record_.sign = -move_in;
 }

--- a/src/simplex/SimplexConst.h
+++ b/src/simplex/SimplexConst.h
@@ -164,6 +164,9 @@ const double kMinDualSteepestEdgeWeight = 1e-4;
 const HighsInt kNoRowSought = -2;
 const HighsInt kNoRowChosen = -1;
 
+const HighsInt kNoRayIndex = -1;
+const HighsInt kNoRaySign = 0;
+
 // Switch to use code to check that, unless the basis supplied by the
 // MIP solver was alien, the simplex solver starts from dual
 // feasibility.

--- a/src/simplex/SimplexStruct.h
+++ b/src/simplex/SimplexStruct.h
@@ -251,7 +251,6 @@ struct HighsSimplexBadBasisChangeRecord {
 };
 
 struct HighsRayRecord {
-  bool exists;
   HighsInt index;
   HighsInt sign;
   std::vector<double> value;

--- a/src/simplex/SimplexStruct.h
+++ b/src/simplex/SimplexStruct.h
@@ -54,9 +54,7 @@ struct HighsSimplexStatus {
   bool has_dual_objective_value =
       false;  // The dual objective function value is known
   bool has_primal_objective_value =
-      false;                    // The dual objective function value is known
-  bool has_dual_ray = false;    // A dual unbounded ray is known
-  bool has_primal_ray = false;  // A primal unbounded ray is known
+      false;  // The dual objective function value is known
 };
 
 struct HighsSimplexInfo {
@@ -133,12 +131,6 @@ struct HighsSimplexInfo {
   std::vector<double> backtracking_basis_workLowerShift_;
   std::vector<double> backtracking_basis_workUpperShift_;
   std::vector<double> backtracking_basis_edge_weight_;
-
-  // Dual and primal ray vectors
-  HighsInt dual_ray_row_;
-  HighsInt dual_ray_sign_;
-  HighsInt primal_ray_col_;
-  HighsInt primal_ray_sign_;
 
   // Options from HighsOptions for the simplex solver
   HighsInt simplex_strategy;
@@ -259,7 +251,7 @@ struct HighsSimplexBadBasisChangeRecord {
 };
 
 struct HighsRayRecord {
-  bool has_ray;
+  bool exists;
   HighsInt index;
   HighsInt sign;
   std::vector<double> value;

--- a/src/simplex/SimplexStruct.h
+++ b/src/simplex/SimplexStruct.h
@@ -258,4 +258,13 @@ struct HighsSimplexBadBasisChangeRecord {
   double save_value;
 };
 
+struct HighsRayRecord {
+  bool has_ray;
+  HighsInt index;
+  HighsInt sign;
+  std::vector<double> value;
+  HighsRayRecord getRayRecord() const;
+  void setRayRecord(const HighsRayRecord& from_record);
+  void clear();
+};
 #endif /* SIMPLEX_SIMPLEXSTRUCT_H_ */


### PR DESCRIPTION
Created `HighsRayRecord` to accumulate primal/dual ray records previously stored in three different places. Rays records are now discarded whenever the model is changed. Slight cludge required when using changeColsCost to zero the objective to compute dual ray when not known due to infeasibility being detected in presolve. 