### PR TITLE
Now testing just the first three chatacters of upper_word for "MAX"/"MIN" in MPS read

### DIFF
--- a/src/io/HMpsFF.cpp
+++ b/src/io/HMpsFF.cpp
@@ -424,9 +424,9 @@ HMpsFF::Parsekey HMpsFF::checkFirstWord(std::string& strline, size_t& start,
     key = HMpsFF::Parsekey::kName;
   else if (upper_word == "OBJSENSE")
     key = HMpsFF::Parsekey::kObjsense;
-  else if (upper_word == "MAX")
+  else if (upper_word.substr(0, 3) == "MAX")
     key = HMpsFF::Parsekey::kMax;
-  else if (upper_word == "MIN")
+  else if (upper_word.substr(0, 3) == "MIN")
     key = HMpsFF::Parsekey::kMin;
   else if (upper_word == "ROWS")
     key = HMpsFF::Parsekey::kRows;


### PR DESCRIPTION
Allows the lines

> OBJSENSE
 MAXIMIZE

produced by (eg) Xpress to be read, not just

> OBJSENSE
 MAX
