### PR TITLE
Take into account discreteness for no cost zero variables in bounds section

### DIFF
--- a/highs/io/HMPSIO.cpp
+++ b/highs/io/HMPSIO.cpp
@@ -876,7 +876,7 @@ HighsStatus writeMps(
           !col_cost[c_n] && a_start[c_n] == a_start[c_n + 1];
       if (no_cost_zero_column) {
         // Possibly skip this column if it's zero and has no cost
-        if (!highs_isInfinity(ub) || lb) {
+        if (!highs_isInfinity(ub) || lb || discrete) {
           // Column would have a bound to report
           num_no_cost_zero_columns_in_bounds_section++;
         }
@@ -1014,7 +1014,7 @@ HighsStatus writeMps(
     highsLogUser(log_options, HighsLogType::kInfo,
                  "Model has %" HIGHSINT_FORMAT
                  " zero columns with no costs: %" HIGHSINT_FORMAT
-                 " have finite upper bounds "
+                 " are discrete or have finite upper bounds "
                  "or nonzero lower bounds and are %swritten in MPS file\n",
                  num_no_cost_zero_columns,
                  num_no_cost_zero_columns_in_bounds_section,


### PR DESCRIPTION
It seems that there was inconsistency in https://github.com/ERGO-Code/HiGHS/blob/master/src/io/HMPSIO.cpp#L879 with https://github.com/ERGO-Code/HiGHS/blob/master/src/io/HMPSIO.cpp#L724-L728

As I understand, for example, https://github.com/ERGO-Code/HiGHS/blob/master/src/io/HMPSIO.cpp#L925-L927 - for no cost zero integer variable with `lb = 0` and `ub = +inf` `LI BOUND` will be written (unless `write_no_cost_zero_columns = false`) and then maybe it is worth taking this into account in `num_no_cost_zero_columns_in_bounds_section` variable and corresponding log