### PR TITLE
Fix #2310: Fix FeasibilityJumpSolver arguments

### DIFF
--- a/highs/mip/HighsFeasibilityJump.cpp
+++ b/highs/mip/HighsFeasibilityJump.cpp
@@ -30,7 +30,8 @@ HighsModelStatus HighsMipSolverData::feasibilityJump() {
   // Configure Feasibility Jump and pass it the problem
   int verbosity = mipsolver.submip ? 0 : mipsolver.options_mip_->log_dev_level;
   auto solver = external_feasibilityjump::FeasibilityJumpSolver(
-      /* seed = */ 0, /* verbosity = */ verbosity,
+      /* seed = */ mipsolver.options_mip_->random_seed,
+      /* verbosity = */ verbosity,
       /* equalityTolerance = */ epsilon,
       /* violationTolerance = */ feastol);
 

--- a/highs/mip/feasibilityjump.hh
+++ b/highs/mip/feasibilityjump.hh
@@ -467,9 +467,9 @@ class FeasibilityJumpSolver {
 
  public:
   FeasibilityJumpSolver(int seed = 0, int _verbosity = 0,
-                        double _weightUpdateDecay = 1.0,
                         double equalityTolerance = 1e-5,
-                        double violationTolerance = 1e-5)
+                        double violationTolerance = 1e-5,
+                        double _weightUpdateDecay = 1.0)
       : problem(equalityTolerance, violationTolerance),
         jumpMove(equalityTolerance) {
     verbosity = _verbosity;


### PR DESCRIPTION
This fixes #2310.

The order of the FeasibilityJumpSolver constructor arguments meant that the code was calling it with the wrong arguments.

This moves the unused argument to the end of the argument list.

Also, I noticed it's probably better if we use the overall `random_seed` for FeasibilityJump, rather than just 0.