### PR TITLE
Fix: Add missing include needed for gcc v15 and clang v19

### DIFF
--- a/extern/zstr/zstr.hpp
+++ b/extern/zstr/zstr.hpp
@@ -11,6 +11,7 @@
 #include <zlib.h>
 
 #include <cassert>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
There is a missing include for cstdint. Without it, the build fails on gcc v15 and clang v19 (see below).

Gcc v15 has already been shipped in some distros (Fedora, Arch, maybe others), so it would be great if you could tag a new release ASAP. I'm using HiGHS indirectly via the Rust crate and currently can't build it on my machine.

Build log:

```
In file included from /home/alex/code/HiGHS/extern/filereaderlp/reader.cpp:20:
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:58:24: error: use of undeclared identifier 'uintptr_t'; did you mean 'intptr_t'?
   58 |         std::to_string(uintptr_t(zstrm_p->next_in)) +
      |                        ^
/usr/include/unistd.h:267:20: note: 'intptr_t' declared here
  267 | typedef __intptr_t intptr_t;
      |                    ^
In file included from /home/alex/code/HiGHS/extern/filereaderlp/reader.cpp:20:
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:59:41: error: use of undeclared identifier 'uintptr_t'; did you mean 'intptr_t'?
   59 |         ", avail_in: " + std::to_string(uintptr_t(zstrm_p->avail_in)) +
      |                                         ^
/usr/include/unistd.h:267:20: note: 'intptr_t' declared here
  267 | typedef __intptr_t intptr_t;
      |                    ^
In file included from /home/alex/code/HiGHS/extern/filereaderlp/reader.cpp:20:
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:60:41: error: use of undeclared identifier 'uintptr_t'; did you mean 'intptr_t'?
   60 |         ", next_out: " + std::to_string(uintptr_t(zstrm_p->next_out)) +
      |                                         ^
/usr/include/unistd.h:267:20: note: 'intptr_t' declared here
  267 | typedef __intptr_t intptr_t;
      |                    ^
In file included from /home/alex/code/HiGHS/extern/filereaderlp/reader.cpp:20:
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:61:42: error: use of undeclared identifier 'uintptr_t'; did you mean 'intptr_t'?
   61 |         ", avail_out: " + std::to_string(uintptr_t(zstrm_p->avail_out)) + ")";
      |                                          ^
/usr/include/unistd.h:267:20: note: 'intptr_t' declared here
  267 | typedef __intptr_t intptr_t;
      |                    ^
In file included from /home/alex/code/HiGHS/extern/filereaderlp/reader.cpp:20:
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:194:31: error: use of undeclared identifier 'uint32_t'
  194 |           zstrm_p->avail_in = uint32_t(in_buff_end - in_buff_start);
      |                               ^
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:198:15: error: use of undeclared identifier 'uint32_t'
  198 |               uint32_t((out_buff.get() + buff_size) - out_buff_free_start);
      |               ^
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:266:28: error: use of undeclared identifier 'uint32_t'
  266 |       zstrm_p->avail_out = uint32_t(buff_size);
      |                            ^
/home/alex/code/HiGHS/src/../extern/zstr/zstr.hpp:305:25: error: use of undeclared identifier 'uint32_t'
  305 |     zstrm_p->avail_in = uint32_t(pptr() - pbase());
      |                         ^
8 errors generated.
```