### PR TITLE
Fix 1517

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3789,10 +3789,8 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
           double val = direction * Avalue[rowiter];
 
           // get lower and upper bounds
-          double col_lower =
-              std::max(implColLower[col], model->col_lower_[col]);
-          double col_upper =
-              std::min(implColUpper[col], model->col_upper_[col]);
+          double col_lower = impliedRowBounds.getImplVarLower(row, col);
+          double col_upper = impliedRowBounds.getImplVarUpper(row, col);
 
           // skip continuous variables
           if (model->integrality_[col] == HighsVarType::kContinuous) continue;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3788,23 +3788,29 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
           HighsInt col = Acol[rowiter];
           double val = direction * Avalue[rowiter];
 
+          // get lower and upper bounds
+          double col_lower =
+              std::max(implColLower[col], model->col_lower_[col]);
+          double col_upper =
+              std::min(implColUpper[col], model->col_upper_[col]);
+
           // skip continuous variables
           if (model->integrality_[col] == HighsVarType::kContinuous) continue;
 
           if (val > maxAbsCoefValue + primal_feastol) {
-            assert(model->col_upper_[col] != kHighsInf);
+            assert(col_upper != kHighsInf);
             // new matrix coefficient is direction * maxAbsCoefValue; subtract
             // existing matrix coefficient to get delta
             HighsCDouble delta = direction * (maxAbsCoefValue - val);
             addToMatrix(row, col, static_cast<double>(delta));
-            rhs += delta * model->col_upper_[col];
+            rhs += delta * col_upper;
           } else if (val < -maxAbsCoefValue - primal_feastol) {
-            assert(model->col_lower_[col] != -kHighsInf);
+            assert(col_lower != -kHighsInf);
             // new matrix coefficient is (-direction) * maxAbsCoefValue;
             // subtract existing matrix coefficient to get delta
             HighsCDouble delta = -direction * (maxAbsCoefValue + val);
             addToMatrix(row, col, static_cast<double>(delta));
-            rhs += delta * model->col_lower_[col];
+            rhs += delta * col_lower;
           }
         }
       };

--- a/highs/util/HighsLinearSumBounds.cpp
+++ b/highs/util/HighsLinearSumBounds.cpp
@@ -10,139 +10,18 @@
 #include <algorithm>
 
 void HighsLinearSumBounds::add(HighsInt sum, HighsInt var, double coefficient) {
-  double vLower = implVarLowerSource[var] == sum
-                      ? varLower[var]
-                      : std::max(implVarLower[var], varLower[var]);
-  double vUpper = implVarUpperSource[var] == sum
-                      ? varUpper[var]
-                      : std::min(implVarUpper[var], varUpper[var]);
-
-  if (coefficient > 0) {
-    // coefficient is positive, therefore variable lower contributes to sum
-    // lower bound
-    if (vLower == -kHighsInf)
-      numInfSumLower[sum] += 1;
-    else
-      sumLower[sum] += vLower * coefficient;
-
-    if (vUpper == kHighsInf)
-      numInfSumUpper[sum] += 1;
-    else
-      sumUpper[sum] += vUpper * coefficient;
-
-    if (varLower[var] == -kHighsInf)
-      numInfSumLowerOrig[sum] += 1;
-    else
-      sumLowerOrig[sum] += varLower[var] * coefficient;
-
-    if (varUpper[var] == kHighsInf)
-      numInfSumUpperOrig[sum] += 1;
-    else
-      sumUpperOrig[sum] += varUpper[var] * coefficient;
-  } else {
-    // coefficient is negative, therefore variable upper contributes to sum
-    // lower bound
-    if (vUpper == kHighsInf)
-      numInfSumLower[sum] += 1;
-    else
-      sumLower[sum] += vUpper * coefficient;
-
-    if (vLower == -kHighsInf)
-      numInfSumUpper[sum] += 1;
-    else
-      sumUpper[sum] += vLower * coefficient;
-
-    if (varUpper[var] == kHighsInf)
-      numInfSumLowerOrig[sum] += 1;
-    else
-      sumLowerOrig[sum] += varUpper[var] * coefficient;
-
-    if (varLower[var] == -kHighsInf)
-      numInfSumUpperOrig[sum] += 1;
-    else
-      sumUpperOrig[sum] += varLower[var] * coefficient;
-  }
+  addOrRemove(sum, var, coefficient, HighsInt{1});
 }
 
 void HighsLinearSumBounds::remove(HighsInt sum, HighsInt var,
                                   double coefficient) {
-  double vLower = implVarLowerSource[var] == sum
-                      ? varLower[var]
-                      : std::max(implVarLower[var], varLower[var]);
-  double vUpper = implVarUpperSource[var] == sum
-                      ? varUpper[var]
-                      : std::min(implVarUpper[var], varUpper[var]);
-
-  if (coefficient > 0) {
-    // coefficient is positive, therefore variable lower contributes to sum
-    // lower bound
-    if (vLower == -kHighsInf)
-      numInfSumLower[sum] -= 1;
-    else
-      sumLower[sum] -= vLower * coefficient;
-
-    if (vUpper == kHighsInf)
-      numInfSumUpper[sum] -= 1;
-    else
-      sumUpper[sum] -= vUpper * coefficient;
-
-    if (varLower[var] == -kHighsInf)
-      numInfSumLowerOrig[sum] -= 1;
-    else
-      sumLowerOrig[sum] -= varLower[var] * coefficient;
-
-    if (varUpper[var] == kHighsInf)
-      numInfSumUpperOrig[sum] -= 1;
-    else
-      sumUpperOrig[sum] -= varUpper[var] * coefficient;
-  } else {
-    // coefficient is negative, therefore variable upper contributes to sum
-    // lower bound
-    if (vUpper == kHighsInf)
-      numInfSumLower[sum] -= 1;
-    else
-      sumLower[sum] -= vUpper * coefficient;
-
-    if (vLower == -kHighsInf)
-      numInfSumUpper[sum] -= 1;
-    else
-      sumUpper[sum] -= vLower * coefficient;
-
-    if (varUpper[var] == kHighsInf)
-      numInfSumLowerOrig[sum] -= 1;
-    else
-      sumLowerOrig[sum] -= varUpper[var] * coefficient;
-
-    if (varLower[var] == -kHighsInf)
-      numInfSumUpperOrig[sum] -= 1;
-    else
-      sumUpperOrig[sum] -= varLower[var] * coefficient;
-  }
+  addOrRemove(sum, var, coefficient, HighsInt{-1});
 }
 
 void HighsLinearSumBounds::updatedVarUpper(HighsInt sum, HighsInt var,
                                            double coefficient,
                                            double oldVarUpper) {
-  double oldVUpper = implVarUpperSource[var] == sum
-                         ? oldVarUpper
-                         : std::min(implVarUpper[var], oldVarUpper);
-
-  double vUpper = implVarUpperSource[var] == sum
-                      ? varUpper[var]
-                      : std::min(implVarUpper[var], varUpper[var]);
-
   if (coefficient > 0) {
-    if (vUpper != oldVUpper) {
-      if (oldVUpper == kHighsInf)
-        numInfSumUpper[sum] -= 1;
-      else
-        sumUpper[sum] -= oldVUpper * coefficient;
-
-      if (vUpper == kHighsInf)
-        numInfSumUpper[sum] += 1;
-      else
-        sumUpper[sum] += vUpper * coefficient;
-    }
     if (oldVarUpper == kHighsInf)
       numInfSumUpperOrig[sum] -= 1;
     else
@@ -153,17 +32,6 @@ void HighsLinearSumBounds::updatedVarUpper(HighsInt sum, HighsInt var,
     else
       sumUpperOrig[sum] += varUpper[var] * coefficient;
   } else {
-    if (vUpper != oldVUpper) {
-      if (oldVUpper == kHighsInf)
-        numInfSumLower[sum] -= 1;
-      else
-        sumLower[sum] -= oldVUpper * coefficient;
-
-      if (vUpper == kHighsInf)
-        numInfSumLower[sum] += 1;
-      else
-        sumLower[sum] += vUpper * coefficient;
-    }
     if (oldVarUpper == kHighsInf)
       numInfSumLowerOrig[sum] -= 1;
     else
@@ -174,32 +42,14 @@ void HighsLinearSumBounds::updatedVarUpper(HighsInt sum, HighsInt var,
     else
       sumLowerOrig[sum] += varUpper[var] * coefficient;
   }
+  updatedImplVarUpper(sum, var, coefficient, oldVarUpper, implVarUpper[var],
+                      implVarUpperSource[var]);
 }
 
 void HighsLinearSumBounds::updatedVarLower(HighsInt sum, HighsInt var,
                                            double coefficient,
                                            double oldVarLower) {
-  double oldVLower = implVarLowerSource[var] == sum
-                         ? oldVarLower
-                         : std::max(implVarLower[var], oldVarLower);
-
-  double vLower = implVarLowerSource[var] == sum
-                      ? varLower[var]
-                      : std::max(implVarLower[var], varLower[var]);
-
   if (coefficient > 0) {
-    if (vLower != oldVLower) {
-      if (oldVLower == -kHighsInf)
-        numInfSumLower[sum] -= 1;
-      else
-        sumLower[sum] -= oldVLower * coefficient;
-
-      if (vLower == -kHighsInf)
-        numInfSumLower[sum] += 1;
-      else
-        sumLower[sum] += vLower * coefficient;
-    }
-
     if (oldVarLower == -kHighsInf)
       numInfSumLowerOrig[sum] -= 1;
     else
@@ -211,17 +61,6 @@ void HighsLinearSumBounds::updatedVarLower(HighsInt sum, HighsInt var,
       sumLowerOrig[sum] += varLower[var] * coefficient;
 
   } else {
-    if (vLower != oldVLower) {
-      if (oldVLower == -kHighsInf)
-        numInfSumUpper[sum] -= 1;
-      else
-        sumUpper[sum] -= oldVLower * coefficient;
-
-      if (vLower == -kHighsInf)
-        numInfSumUpper[sum] += 1;
-      else
-        sumUpper[sum] += vLower * coefficient;
-    }
     if (oldVarLower == -kHighsInf)
       numInfSumUpperOrig[sum] -= 1;
     else
@@ -232,81 +71,24 @@ void HighsLinearSumBounds::updatedVarLower(HighsInt sum, HighsInt var,
     else
       sumUpperOrig[sum] += varLower[var] * coefficient;
   }
+  updatedImplVarLower(sum, var, coefficient, oldVarLower, implVarLower[var],
+                      implVarLowerSource[var]);
 }
 
 void HighsLinearSumBounds::updatedImplVarUpper(HighsInt sum, HighsInt var,
                                                double coefficient,
                                                double oldImplVarUpper,
                                                HighsInt oldImplVarUpperSource) {
-  double oldVUpper = oldImplVarUpperSource == sum
-                         ? varUpper[var]
-                         : std::min(oldImplVarUpper, varUpper[var]);
-
-  double vUpper = implVarUpperSource[var] == sum
-                      ? varUpper[var]
-                      : std::min(implVarUpper[var], varUpper[var]);
-
-  if (vUpper == oldVUpper) return;
-
-  if (coefficient > 0) {
-    if (oldVUpper == kHighsInf)
-      numInfSumUpper[sum] -= 1;
-    else
-      sumUpper[sum] -= oldVUpper * coefficient;
-
-    if (vUpper == kHighsInf)
-      numInfSumUpper[sum] += 1;
-    else
-      sumUpper[sum] += vUpper * coefficient;
-  } else {
-    if (oldVUpper == kHighsInf)
-      numInfSumLower[sum] -= 1;
-    else
-      sumLower[sum] -= oldVUpper * coefficient;
-
-    if (vUpper == kHighsInf)
-      numInfSumLower[sum] += 1;
-    else
-      sumLower[sum] += vUpper * coefficient;
-  }
+  updatedImplVarUpper(sum, var, coefficient, varUpper[var], oldImplVarUpper,
+                      oldImplVarUpperSource);
 }
 
 void HighsLinearSumBounds::updatedImplVarLower(HighsInt sum, HighsInt var,
                                                double coefficient,
                                                double oldImplVarLower,
                                                HighsInt oldImplVarLowerSource) {
-  double oldVLower = oldImplVarLowerSource == sum
-                         ? varLower[var]
-                         : std::max(oldImplVarLower, varLower[var]);
-
-  double vLower = implVarLowerSource[var] == sum
-                      ? varLower[var]
-                      : std::max(implVarLower[var], varLower[var]);
-
-  if (vLower == oldVLower) return;
-
-  if (coefficient > 0) {
-    if (oldVLower == -kHighsInf)
-      numInfSumLower[sum] -= 1;
-    else
-      sumLower[sum] -= oldVLower * coefficient;
-
-    if (vLower == -kHighsInf)
-      numInfSumLower[sum] += 1;
-    else
-      sumLower[sum] += vLower * coefficient;
-
-  } else {
-    if (oldVLower == -kHighsInf)
-      numInfSumUpper[sum] -= 1;
-    else
-      sumUpper[sum] -= oldVLower * coefficient;
-
-    if (vLower == -kHighsInf)
-      numInfSumUpper[sum] += 1;
-    else
-      sumUpper[sum] += vLower * coefficient;
-  }
+  updatedImplVarLower(sum, var, coefficient, varLower[var], oldImplVarLower,
+                      oldImplVarLowerSource);
 }
 
 double HighsLinearSumBounds::getResidualSumLower(HighsInt sum, HighsInt var,
@@ -314,28 +96,18 @@ double HighsLinearSumBounds::getResidualSumLower(HighsInt sum, HighsInt var,
   switch (numInfSumLower[sum]) {
     case 0:
       if (coefficient > 0) {
-        double vLower = implVarLowerSource[var] == sum
-                            ? varLower[var]
-                            : std::max(implVarLower[var], varLower[var]);
-        return double(sumLower[sum] - vLower * coefficient);
+        return double(sumLower[sum] - getImplVarLower(sum, var) * coefficient);
       } else {
-        double vUpper = implVarUpperSource[var] == sum
-                            ? varUpper[var]
-                            : std::min(implVarUpper[var], varUpper[var]);
-        return double(sumLower[sum] - vUpper * coefficient);
+        return double(sumLower[sum] - getImplVarUpper(sum, var) * coefficient);
       }
       break;
     case 1:
       if (coefficient > 0) {
-        double vLower = implVarLowerSource[var] == sum
-                            ? varLower[var]
-                            : std::max(implVarLower[var], varLower[var]);
-        return vLower == -kHighsInf ? double(sumLower[sum]) : -kHighsInf;
+        return getImplVarLower(sum, var) == -kHighsInf ? double(sumLower[sum])
+                                                       : -kHighsInf;
       } else {
-        double vUpper = implVarUpperSource[var] == sum
-                            ? varUpper[var]
-                            : std::min(implVarUpper[var], varUpper[var]);
-        return vUpper == kHighsInf ? double(sumLower[sum]) : -kHighsInf;
+        return getImplVarUpper(sum, var) == kHighsInf ? double(sumLower[sum])
+                                                      : -kHighsInf;
       }
       break;
     default:
@@ -348,28 +120,18 @@ double HighsLinearSumBounds::getResidualSumUpper(HighsInt sum, HighsInt var,
   switch (numInfSumUpper[sum]) {
     case 0:
       if (coefficient > 0) {
-        double vUpper = implVarUpperSource[var] == sum
-                            ? varUpper[var]
-                            : std::min(implVarUpper[var], varUpper[var]);
-        return double(sumUpper[sum] - vUpper * coefficient);
+        return double(sumUpper[sum] - getImplVarUpper(sum, var) * coefficient);
       } else {
-        double vLower = implVarLowerSource[var] == sum
-                            ? varLower[var]
-                            : std::max(implVarLower[var], varLower[var]);
-        return double(sumUpper[sum] - vLower * coefficient);
+        return double(sumUpper[sum] - getImplVarLower(sum, var) * coefficient);
       }
       break;
     case 1:
       if (coefficient > 0) {
-        double vUpper = implVarUpperSource[var] == sum
-                            ? varUpper[var]
-                            : std::min(implVarUpper[var], varUpper[var]);
-        return vUpper == kHighsInf ? double(sumUpper[sum]) : kHighsInf;
+        return getImplVarUpper(sum, var) == kHighsInf ? double(sumUpper[sum])
+                                                      : kHighsInf;
       } else {
-        double vLower = implVarLowerSource[var] == sum
-                            ? varLower[var]
-                            : std::max(implVarLower[var], varLower[var]);
-        return vLower == -kHighsInf ? double(sumUpper[sum]) : kHighsInf;
+        return getImplVarLower(sum, var) == -kHighsInf ? double(sumUpper[sum])
+                                                       : kHighsInf;
       }
       break;
     default:
@@ -445,4 +207,149 @@ void HighsLinearSumBounds::shrink(const std::vector<HighsInt>& newIndices,
   sumUpperOrig.resize(newSize);
   numInfSumLowerOrig.resize(newSize);
   numInfSumUpperOrig.resize(newSize);
+}
+
+double HighsLinearSumBounds::getImplVarUpper(HighsInt sum, HighsInt var) const {
+  return getImplVarUpper(sum, varUpper[var], implVarUpper[var],
+                         implVarUpperSource[var]);
+}
+
+double HighsLinearSumBounds::getImplVarLower(HighsInt sum, HighsInt var) const {
+  return getImplVarLower(sum, varLower[var], implVarLower[var],
+                         implVarLowerSource[var]);
+}
+
+double HighsLinearSumBounds::getImplVarUpper(
+    HighsInt sum, double myVarUpper, double myImplVarUpper,
+    HighsInt myImplVarUpperSource) const {
+  return (myImplVarUpperSource == sum ? myVarUpper
+                                      : std::min(myImplVarUpper, myVarUpper));
+}
+
+double HighsLinearSumBounds::getImplVarLower(
+    HighsInt sum, double myVarLower, double myImplVarLower,
+    HighsInt myImplVarLowerSource) const {
+  return (myImplVarLowerSource == sum ? myVarLower
+                                      : std::min(myImplVarLower, myVarLower));
+}
+
+void HighsLinearSumBounds::addOrRemove(HighsInt sum, HighsInt var,
+                                       double coefficient, HighsInt direction) {
+  double vLower = getImplVarLower(sum, var);
+  double vUpper = getImplVarUpper(sum, var);
+
+  if (coefficient > 0) {
+    // coefficient is positive, therefore variable lower contributes to sum
+    // lower bound
+    if (vLower == -kHighsInf)
+      numInfSumLower[sum] += direction;
+    else
+      sumLower[sum] += direction * vLower * coefficient;
+
+    if (vUpper == kHighsInf)
+      numInfSumUpper[sum] += direction;
+    else
+      sumUpper[sum] += direction * vUpper * coefficient;
+
+    if (varLower[var] == -kHighsInf)
+      numInfSumLowerOrig[sum] += direction;
+    else
+      sumLowerOrig[sum] += direction * varLower[var] * coefficient;
+
+    if (varUpper[var] == kHighsInf)
+      numInfSumUpperOrig[sum] += direction;
+    else
+      sumUpperOrig[sum] += direction * varUpper[var] * coefficient;
+  } else {
+    // coefficient is negative, therefore variable upper contributes to sum
+    // lower bound
+    if (vUpper == kHighsInf)
+      numInfSumLower[sum] += direction;
+    else
+      sumLower[sum] += direction * vUpper * coefficient;
+
+    if (vLower == -kHighsInf)
+      numInfSumUpper[sum] += direction;
+    else
+      sumUpper[sum] += direction * vLower * coefficient;
+
+    if (varUpper[var] == kHighsInf)
+      numInfSumLowerOrig[sum] += direction;
+    else
+      sumLowerOrig[sum] += direction * varUpper[var] * coefficient;
+
+    if (varLower[var] == -kHighsInf)
+      numInfSumUpperOrig[sum] += direction;
+    else
+      sumUpperOrig[sum] += direction * varLower[var] * coefficient;
+  }
+}
+
+void HighsLinearSumBounds::updatedImplVarUpper(HighsInt sum, HighsInt var,
+                                               double coefficient,
+                                               double oldVarUpper,
+                                               double oldImplVarUpper,
+                                               HighsInt oldImplVarUpperSource) {
+  double oldVUpper =
+      getImplVarUpper(sum, oldVarUpper, oldImplVarUpper, oldImplVarUpperSource);
+  double vUpper = getImplVarUpper(sum, var);
+
+  if (vUpper == oldVUpper) return;
+
+  if (coefficient > 0) {
+    if (oldVUpper == kHighsInf)
+      numInfSumUpper[sum] -= 1;
+    else
+      sumUpper[sum] -= oldVUpper * coefficient;
+
+    if (vUpper == kHighsInf)
+      numInfSumUpper[sum] += 1;
+    else
+      sumUpper[sum] += vUpper * coefficient;
+  } else {
+    if (oldVUpper == kHighsInf)
+      numInfSumLower[sum] -= 1;
+    else
+      sumLower[sum] -= oldVUpper * coefficient;
+
+    if (vUpper == kHighsInf)
+      numInfSumLower[sum] += 1;
+    else
+      sumLower[sum] += vUpper * coefficient;
+  }
+}
+
+void HighsLinearSumBounds::updatedImplVarLower(HighsInt sum, HighsInt var,
+                                               double coefficient,
+                                               double oldVarLower,
+                                               double oldImplVarLower,
+                                               HighsInt oldImplVarLowerSource) {
+  double oldVLower =
+      getImplVarLower(sum, oldVarLower, oldImplVarLower, oldImplVarLowerSource);
+  double vLower = getImplVarLower(sum, var);
+
+  if (vLower == oldVLower) return;
+
+  if (coefficient > 0) {
+    if (oldVLower == -kHighsInf)
+      numInfSumLower[sum] -= 1;
+    else
+      sumLower[sum] -= oldVLower * coefficient;
+
+    if (vLower == -kHighsInf)
+      numInfSumLower[sum] += 1;
+    else
+      sumLower[sum] += vLower * coefficient;
+
+  } else {
+    if (oldVLower == -kHighsInf)
+      numInfSumUpper[sum] -= 1;
+    else
+      sumUpper[sum] -= oldVLower * coefficient;
+
+    if (vLower == -kHighsInf)
+      numInfSumUpper[sum] += 1;
+    else
+      sumUpper[sum] += vLower * coefficient;
+  }
 }

--- a/highs/util/HighsLinearSumBounds.cpp
+++ b/highs/util/HighsLinearSumBounds.cpp
@@ -230,7 +230,7 @@ double HighsLinearSumBounds::getImplVarLower(
     HighsInt sum, double myVarLower, double myImplVarLower,
     HighsInt myImplVarLowerSource) const {
   return (myImplVarLowerSource == sum ? myVarLower
-                                      : std::min(myImplVarLower, myVarLower));
+                                      : std::max(myImplVarLower, myVarLower));
 }
 
 void HighsLinearSumBounds::addOrRemove(HighsInt sum, HighsInt var,

--- a/highs/util/HighsLinearSumBounds.cpp
+++ b/highs/util/HighsLinearSumBounds.cpp
@@ -67,18 +67,24 @@ double HighsLinearSumBounds::getResidualSumLower(HighsInt sum, HighsInt var,
   switch (numInfSumLower[sum]) {
     case 0:
       if (coefficient > 0) {
-        return double(sumLower[sum] - getImplVarLower(sum, var) * coefficient);
+        return static_cast<double>(
+            sumLower[sum] -
+            static_cast<HighsCDouble>(getImplVarLower(sum, var)) * coefficient);
       } else {
-        return double(sumLower[sum] - getImplVarUpper(sum, var) * coefficient);
+        return static_cast<double>(
+            sumLower[sum] -
+            static_cast<HighsCDouble>(getImplVarUpper(sum, var)) * coefficient);
       }
       break;
     case 1:
       if (coefficient > 0) {
-        return getImplVarLower(sum, var) == -kHighsInf ? double(sumLower[sum])
-                                                       : -kHighsInf;
+        return getImplVarLower(sum, var) == -kHighsInf
+                   ? static_cast<double>(sumLower[sum])
+                   : -kHighsInf;
       } else {
-        return getImplVarUpper(sum, var) == kHighsInf ? double(sumLower[sum])
-                                                      : -kHighsInf;
+        return getImplVarUpper(sum, var) == kHighsInf
+                   ? static_cast<double>(sumLower[sum])
+                   : -kHighsInf;
       }
       break;
     default:
@@ -91,18 +97,24 @@ double HighsLinearSumBounds::getResidualSumUpper(HighsInt sum, HighsInt var,
   switch (numInfSumUpper[sum]) {
     case 0:
       if (coefficient > 0) {
-        return double(sumUpper[sum] - getImplVarUpper(sum, var) * coefficient);
+        return static_cast<double>(
+            sumUpper[sum] -
+            static_cast<HighsCDouble>(getImplVarUpper(sum, var)) * coefficient);
       } else {
-        return double(sumUpper[sum] - getImplVarLower(sum, var) * coefficient);
+        return static_cast<double>(
+            sumUpper[sum] -
+            static_cast<HighsCDouble>(getImplVarLower(sum, var)) * coefficient);
       }
       break;
     case 1:
       if (coefficient > 0) {
-        return getImplVarUpper(sum, var) == kHighsInf ? double(sumUpper[sum])
-                                                      : kHighsInf;
+        return getImplVarUpper(sum, var) == kHighsInf
+                   ? static_cast<double>(sumUpper[sum])
+                   : kHighsInf;
       } else {
-        return getImplVarLower(sum, var) == -kHighsInf ? double(sumUpper[sum])
-                                                       : kHighsInf;
+        return getImplVarLower(sum, var) == -kHighsInf
+                   ? static_cast<double>(sumUpper[sum])
+                   : kHighsInf;
       }
       break;
     default:
@@ -115,17 +127,23 @@ double HighsLinearSumBounds::getResidualSumLowerOrig(HighsInt sum, HighsInt var,
   switch (numInfSumLowerOrig[sum]) {
     case 0:
       if (coefficient > 0)
-        return double(sumLowerOrig[sum] - varLower[var] * coefficient);
+        return static_cast<double>(sumLowerOrig[sum] -
+                                   static_cast<HighsCDouble>(varLower[var]) *
+                                       coefficient);
       else
-        return double(sumLowerOrig[sum] - varUpper[var] * coefficient);
+        return static_cast<double>(sumLowerOrig[sum] -
+                                   static_cast<HighsCDouble>(varUpper[var]) *
+                                       coefficient);
       break;
     case 1:
       if (coefficient > 0)
-        return varLower[var] == -kHighsInf ? double(sumLowerOrig[sum])
-                                           : -kHighsInf;
+        return varLower[var] == -kHighsInf
+                   ? static_cast<double>(sumLowerOrig[sum])
+                   : -kHighsInf;
       else
-        return varUpper[var] == kHighsInf ? double(sumLowerOrig[sum])
-                                          : -kHighsInf;
+        return varUpper[var] == kHighsInf
+                   ? static_cast<double>(sumLowerOrig[sum])
+                   : -kHighsInf;
       break;
     default:
       return -kHighsInf;
@@ -137,17 +155,23 @@ double HighsLinearSumBounds::getResidualSumUpperOrig(HighsInt sum, HighsInt var,
   switch (numInfSumUpperOrig[sum]) {
     case 0:
       if (coefficient > 0)
-        return double(sumUpperOrig[sum] - varUpper[var] * coefficient);
+        return static_cast<double>(sumUpperOrig[sum] -
+                                   static_cast<HighsCDouble>(varUpper[var]) *
+                                       coefficient);
       else
-        return double(sumUpperOrig[sum] - varLower[var] * coefficient);
+        return static_cast<double>(sumUpperOrig[sum] -
+                                   static_cast<HighsCDouble>(varLower[var]) *
+                                       coefficient);
       break;
     case 1:
       if (coefficient > 0)
-        return varUpper[var] == kHighsInf ? double(sumUpperOrig[sum])
-                                          : kHighsInf;
+        return varUpper[var] == kHighsInf
+                   ? static_cast<double>(sumUpperOrig[sum])
+                   : kHighsInf;
       else
-        return varLower[var] == -kHighsInf ? double(sumUpperOrig[sum])
-                                           : kHighsInf;
+        return varLower[var] == -kHighsInf
+                   ? static_cast<double>(sumUpperOrig[sum])
+                   : kHighsInf;
       break;
     default:
       return kHighsInf;
@@ -214,14 +238,16 @@ void HighsLinearSumBounds::addOrRemoveVarUpper(HighsInt sum, HighsInt var,
     if (myVarUpper == kHighsInf)
       numInfSumUpperOrig[sum] += direction;
     else
-      sumUpperOrig[sum] += direction * myVarUpper * coefficient;
+      sumUpperOrig[sum] +=
+          direction * static_cast<HighsCDouble>(myVarUpper) * coefficient;
   } else {
     // coefficient is negative, therefore variable upper bound contributes to
     // sum lower bound
     if (myVarUpper == kHighsInf)
       numInfSumLowerOrig[sum] += direction;
     else
-      sumLowerOrig[sum] += direction * myVarUpper * coefficient;
+      sumLowerOrig[sum] +=
+          direction * static_cast<HighsCDouble>(myVarUpper) * coefficient;
   }
 }
 
@@ -235,14 +261,16 @@ void HighsLinearSumBounds::addOrRemoveVarLower(HighsInt sum, HighsInt var,
     if (myVarLower == -kHighsInf)
       numInfSumLowerOrig[sum] += direction;
     else
-      sumLowerOrig[sum] += direction * myVarLower * coefficient;
+      sumLowerOrig[sum] +=
+          direction * static_cast<HighsCDouble>(myVarLower) * coefficient;
   } else {
     // coefficient is negative, therefore variable lower bound contributes to
     // sum upper bound
     if (myVarLower == -kHighsInf)
       numInfSumUpperOrig[sum] += direction;
     else
-      sumUpperOrig[sum] += direction * myVarLower * coefficient;
+      sumUpperOrig[sum] +=
+          direction * static_cast<HighsCDouble>(myVarLower) * coefficient;
   }
 }
 
@@ -256,14 +284,16 @@ void HighsLinearSumBounds::addOrRemoveImplVarUpper(HighsInt sum, HighsInt var,
     if (myImplVarUpper == kHighsInf)
       numInfSumUpper[sum] += direction;
     else
-      sumUpper[sum] += direction * myImplVarUpper * coefficient;
+      sumUpper[sum] +=
+          direction * static_cast<HighsCDouble>(myImplVarUpper) * coefficient;
   } else {
     // coefficient is negative, therefore variable upper bound contributes to
     // sum lower bound
     if (myImplVarUpper == kHighsInf)
       numInfSumLower[sum] += direction;
     else
-      sumLower[sum] += direction * myImplVarUpper * coefficient;
+      sumLower[sum] +=
+          direction * static_cast<HighsCDouble>(myImplVarUpper) * coefficient;
   }
 }
 
@@ -277,14 +307,16 @@ void HighsLinearSumBounds::addOrRemoveImplVarLower(HighsInt sum, HighsInt var,
     if (myImplVarLower == -kHighsInf)
       numInfSumLower[sum] += direction;
     else
-      sumLower[sum] += direction * myImplVarLower * coefficient;
+      sumLower[sum] +=
+          direction * static_cast<HighsCDouble>(myImplVarLower) * coefficient;
   } else {
     // coefficient is negative, therefore variable lower bound contributes to
     // sum upper bound
     if (myImplVarLower == -kHighsInf)
       numInfSumUpper[sum] += direction;
     else
-      sumUpper[sum] += direction * myImplVarLower * coefficient;
+      sumUpper[sum] +=
+          direction * static_cast<HighsCDouble>(myImplVarLower) * coefficient;
   }
 }
 

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -164,8 +164,17 @@ class HighsLinearSumBounds {
   double getImplVarLower(HighsInt sum, double myVarLower, double myImplVarLower,
                          HighsInt myImplVarLowerSource) const;
 
-  void addOrRemove(HighsInt sum, HighsInt var, double coefficient,
-                   HighsInt direction);
+  void addOrRemoveVarUpper(HighsInt sum, HighsInt var, double coefficient,
+                           double myVarUpper, HighsInt direction);
+
+  void addOrRemoveVarLower(HighsInt sum, HighsInt var, double coefficient,
+                           double myVarLower, HighsInt direction);
+
+  void addOrRemoveImplVarUpper(HighsInt sum, HighsInt var, double coefficient,
+                               double myImplVarUpper, HighsInt direction);
+
+  void addOrRemoveImplVarLower(HighsInt sum, HighsInt var, double coefficient,
+                               double myImplVarLower, HighsInt direction);
 
   void updatedImplVarUpper(HighsInt sum, HighsInt var, double coefficient,
                            double oldVarUpper, double oldImplVarUpper,

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -164,17 +164,20 @@ class HighsLinearSumBounds {
   double getImplVarLower(HighsInt sum, double myVarLower, double myImplVarLower,
                          HighsInt myImplVarLowerSource) const;
 
-  void addOrRemoveVarUpper(HighsInt sum, HighsInt var, double coefficient,
-                           double myVarUpper, HighsInt direction);
+  void update(HighsInt& numInf, HighsCDouble& sum, bool isBoundFinite,
+              HighsInt direction, double bound, double coefficient);
 
-  void addOrRemoveVarLower(HighsInt sum, HighsInt var, double coefficient,
-                           double myVarLower, HighsInt direction);
+  void handleVarUpper(HighsInt sum, double coefficient, double myVarUpper,
+                      HighsInt direction);
 
-  void addOrRemoveImplVarUpper(HighsInt sum, HighsInt var, double coefficient,
-                               double myImplVarUpper, HighsInt direction);
+  void handleVarLower(HighsInt sum, double coefficient, double myVarLower,
+                      HighsInt direction);
 
-  void addOrRemoveImplVarLower(HighsInt sum, HighsInt var, double coefficient,
-                               double myImplVarLower, HighsInt direction);
+  void handleImplVarUpper(HighsInt sum, double coefficient,
+                          double myImplVarUpper, HighsInt direction);
+
+  void handleImplVarLower(HighsInt sum, double coefficient,
+                          double myImplVarLower, HighsInt direction);
 
   void updatedImplVarUpper(HighsInt sum, HighsInt var, double coefficient,
                            double oldVarUpper, double oldImplVarUpper,

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -152,6 +152,28 @@ class HighsLinearSumBounds {
   }
 
   void shrink(const std::vector<HighsInt>& newIndices, HighsInt newSize);
+
+  double getImplVarUpper(HighsInt sum, HighsInt var) const;
+
+  double getImplVarLower(HighsInt sum, HighsInt var) const;
+
+ private:
+  double getImplVarUpper(HighsInt sum, double myVarUpper, double myImplVarUpper,
+                         HighsInt myImplVarUpperSource) const;
+
+  double getImplVarLower(HighsInt sum, double myVarLower, double myImplVarLower,
+                         HighsInt myImplVarLowerSource) const;
+
+  void addOrRemove(HighsInt sum, HighsInt var, double coefficient,
+                   HighsInt direction);
+
+  void updatedImplVarUpper(HighsInt sum, HighsInt var, double coefficient,
+                           double oldVarUpper, double oldImplVarUpper,
+                           HighsInt oldImplVarUpperSource);
+
+  void updatedImplVarLower(HighsInt sum, HighsInt var, double coefficient,
+                           double oldVarLower, double oldImplVarLower,
+                           HighsInt oldImplVarLowerSource);
 };
 
 #endif


### PR DESCRIPTION
Fix #1517 
- Use correct bounds when strengthening coefficients in `HPresolve::rowPresolve`
- Remove duplicate code from `highs/util/HighsLinearSumBounds.cpp`
- Testing on 850+ MIPs did not show any regressions. The reproduction example runs for a very long time, but it is not declared infeasible anymore with these changes:

```
        Nodes      |    B&B Tree     |            Objective Bounds              |  Dynamic Constraints |       Work
Src  Proc. InQueue |  Leaves   Expl. | BestBound       BestSol              Gap |   Cuts   InLp Confl. | LpIters     Time
     .....
     36278   16919      4140  46.57%   12407311.05012  12462663.59113     0.44%    10675   1790   9998    12343k 12826.4s 
```