### PR TITLE
Fix #2320

### DIFF
--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1105,6 +1105,10 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
     }
   }
 
+  if (rhs - minact < 0.0) {
+    return;
+  }
+
   for (HighsInt i = 0; i != len; ++i) {
     if (mipsolver.variableType(inds[i]) == HighsVarType::kContinuous) continue;
 

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1105,14 +1105,15 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
     }
   }
 
-  if (rhs - minact < 0.0) {
-    return;
+  HighsCDouble rhsminactdiff = rhs - minact;
+  if (rhsminactdiff < 0.0) {
+    rhsminactdiff = 0.0;
   }
 
   for (HighsInt i = 0; i != len; ++i) {
     if (mipsolver.variableType(inds[i]) == HighsVarType::kContinuous) continue;
 
-    double boundVal = double((rhs - minact) / vals[i]);
+    double boundVal = double(rhsminactdiff / vals[i]);
     if (vals[i] > 0) {
       boundVal = std::floor(boundVal + globaldom.col_lower_[inds[i]] +
                             globaldom.feastol());
@@ -1146,7 +1147,7 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
   if (nbin < len) {
     for (HighsInt i = 0; i != nbin; ++i) {
       HighsInt bincol = inds[perm[i]];
-      HighsCDouble impliedActivity = rhs - minact - std::abs(vals[perm[i]]);
+      HighsCDouble impliedActivity = rhsminactdiff - std::abs(vals[perm[i]]);
       for (HighsInt j = nbin; j != len; ++j) {
         HighsInt col = inds[perm[j]];
         if (globaldom.isFixed(col)) continue;
@@ -1220,7 +1221,7 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
   });
   // check if any cliques exists
   if (std::abs(vals[perm[0]]) + std::abs(vals[perm[1]]) <=
-      double(rhs - minact + feastol))
+      double(rhsminactdiff + feastol))
     return;
 
   HighsInt maxNewEntries =
@@ -1230,7 +1231,7 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
 
   for (HighsInt k = nbin - 1; k != 0 && numEntries < maxNewEntries; --k) {
     double mincliqueval =
-        double(rhs - minact - std::abs(vals[perm[k]]) + feastol);
+        double(rhsminactdiff - std::abs(vals[perm[k]]) + feastol);
     auto cliqueend = std::partition_point(
         perm.begin(), perm.begin() + k,
         [&](HighsInt p) { return std::abs(vals[p]) > mincliqueval; });


### PR DESCRIPTION
Walked through this fix with @BenChampion for issue #2320 

Summary: Seems to be a numerical error. The min activity ends up being some epsilon value larger than the RHS (one is calculated using `double` and one with `HighsCDouble`), and therefore the difference (assumed to be positive) is negative. That later leads to floor calculations used for rounding having stuff like `floor(398.999999999999998)`. 

Fix: We check for the case where `rhs - minact < 0.0` and set them cancel out to 0 properly.