### PR TITLE
Avoided false claim of optimality when presolve is terminated by `presolve_reduction_limit` when reduced model has no columns but zero row activity is infeasible.

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -27,8 +27,8 @@ TEST_CASE("MIP-distillation", "[highs_test_mip_solver]") {
   highs.resetGlobalScheduler(true);
 }
 
-// Fails but the cases work separately in 
-// MIP-rowless-1 and 
+// Fails but the cases work separately in
+// MIP-rowless-1 and
 // MIP-rowless-2 below
 // TEST_CASE("MIP-rowless", "[highs_test_mip_solver]") {
 //   Highs highs;
@@ -843,7 +843,6 @@ void rowlessMIP1(Highs& highs) {
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
   // solve(highs, kHighsOffString, require_model_status, optimal_objective);
 }
-
 
 void rowlessMIP2(Highs& highs) {
   HighsLp lp;

--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -262,7 +262,8 @@ enum PresolveRuleType : int {
   kPresolveRuleDependentFreeCols,
   kPresolveRuleAggregator,
   kPresolveRuleParallelRowsAndCols,
-  kPresolveRuleMax = kPresolveRuleParallelRowsAndCols,
+  kPresolveRuleProbing,
+  kPresolveRuleMax = kPresolveRuleProbing,
   kPresolveRuleLastAllowOff = kPresolveRuleMax,
   kPresolveRuleCount,
 };

--- a/highs/lp_data/HighsModelUtils.cpp
+++ b/highs/lp_data/HighsModelUtils.cpp
@@ -1421,6 +1421,8 @@ std::string utilPresolveRuleTypeToString(const HighsInt rule_type) {
     return "Aggregator";
   } else if (rule_type == kPresolveRuleParallelRowsAndCols) {
     return "Parallel rows and columns";
+  } else if (rule_type == kPresolveRuleProbing) {
+    return "Probing";
   }
   assert(1 == 0);
   return "????";

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -6898,8 +6898,8 @@ bool HPresolve::zeroRowActivityFeasible() const {
   // has no columns to assess whether the HighsModelStatus returned is
   // kOptimal or kInfeasible (as was required for 2326)
   for (HighsInt iRow = 0; iRow < model->num_row_; iRow++)
-    if (model->row_lower_[row] > primal_feastol ||
-        model->row_upper_[row] < -primal_feastol)
+    if (model->row_lower_[iRow] > primal_feastol ||
+        model->row_upper_[iRow] < -primal_feastol)
       return false;
   return true;
 }

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4757,8 +4757,9 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
     presolve_status_ = HighsPresolveStatus::kReducedToEmpty;
     // Make sure that zero row activity from the column-less model is
     // consistent with the bounds
-    return zeroRowActivityFeasible() ? HighsModelStatus::kOptimal
-                                     : HighsModelStatus::kInfeasible;
+    return model->num_row_ == 0 || zeroRowActivityFeasible()
+               ? HighsModelStatus::kOptimal
+               : HighsModelStatus::kInfeasible;
   } else if (postsolve_stack.numReductions() > 0) {
     // Reductions performed
     presolve_status_ = HighsPresolveStatus::kReduced;
@@ -6897,7 +6898,8 @@ bool HPresolve::zeroRowActivityFeasible() const {
   // has no columns to assess whether the HighsModelStatus returned is
   // kOptimal or kInfeasible (as was required for 2326)
   for (HighsInt iRow = 0; iRow < model->num_row_; iRow++)
-    if (model->row_lower_[iRow] > 0 || model->row_upper_[iRow] < 0)
+    if (model->row_lower_[row] > primal_feastol ||
+        model->row_upper_[row] < -primal_feastol)
       return false;
   return true;
 }

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4365,7 +4365,8 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
     bool trySparsify =
         mipsolver != nullptr || !options->lp_presolve_requires_basis_postsolve;
 #endif
-    bool tryProbing = mipsolver != nullptr;
+    bool tryProbing =
+        mipsolver != nullptr && analysis_.allow_rule_[kPresolveRuleProbing];
     HighsInt numCliquesBeforeProbing = -1;
     bool domcolAfterProbingCalled = false;
     bool dependentEquationsCalled = mipsolver != nullptr;

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -394,6 +394,8 @@ class HPresolve {
 
   HighsPresolveStatus getPresolveStatus() const { return presolve_status_; }
 
+  bool zeroRowActivityFeasible() const;
+
   HighsInt debugGetCheckCol() const;
   HighsInt debugGetCheckRow() const;
 


### PR DESCRIPTION
This addresses the (separate) issue raised within #1578, and adds the "probing off" bit to `presolve_rule_off` option that allowed probing to be identified as the reason for the excessive time and memory requirement of #2326 