### PR TITLE
Fix 2331: Remove incorrect assert (and debug logging)

### DIFF
--- a/highs/mip/HighsFeasibilityJump.cpp
+++ b/highs/mip/HighsFeasibilityJump.cpp
@@ -112,16 +112,6 @@ HighsModelStatus HighsMipSolverData::feasibilityJump() {
                                       status.solution + status.numVars);
       objective_function_value =
           model->offset_ + sense_multiplier * status.solutionObjectiveValue;
-      if (verbosity > 0) {
-        printf("Feasibility Jump has found a solution");
-        if (model->num_col_ < 10) {
-          printf(" [");
-          for (HighsInt col = 0; col < std::min(10, model->num_col_); ++col)
-            printf(" %g", col_value[col]);
-          printf("]");
-        }
-        printf(" with objective %g\n", objective_function_value);
-      }
     }
     if (status.effortSinceLastImprovement > kMaxEffortSinceLastImprovement ||
         status.totalEffort > kMaxTotalEffort) {
@@ -131,11 +121,6 @@ HighsModelStatus HighsMipSolverData::feasibilityJump() {
     }
   };
 
-  if (verbosity > 0)
-    printf(
-        "Feasibility Jump: kMaxTotalEffort = %zd; "
-        "kMaxEffortSinceLastImprovement = %zd\n",
-        kMaxTotalEffort, kMaxEffortSinceLastImprovement);
   solver.solve(col_value.data(), fjControlCallback);
 
   if (found_integer_feasible_solution) {

--- a/highs/mip/HighsFeasibilityJump.cpp
+++ b/highs/mip/HighsFeasibilityJump.cpp
@@ -142,13 +142,7 @@ HighsModelStatus HighsMipSolverData::feasibilityJump() {
     // Initial assignments that violate integrality or column bounds can lead to
     // infeasible results. Even if those initial assignments should not occur,
     // use trySolution rather than addIncumbent for an explicit check.
-    bool is_really_feasible =
-        trySolution(col_value, kSolutionSourceFeasibilityJump);
-    if (!is_really_feasible) {
-      highsLogUser(log_options, HighsLogType::kInfo,
-                   "Discarding infeasible result from Feasibility Jump\n");
-    }
-    assert(is_really_feasible);
+    trySolution(col_value, kSolutionSourceFeasibilityJump);
   }
   return HighsModelStatus::kNotset;
 #endif


### PR DESCRIPTION
Because `trySolution` may return false even if the solution is feasible (but not improving), the assert on its return value is incorrect. ([My comment explaining this in more detail](https://github.com/ERGO-Code/HiGHS/issues/2331#issuecomment-2871716936))

We of course could also factor out the feasibility check and replace the assert if we think the effort is warranted.

I also noticed some leftover debug logging, so I removed that too.