### PR TITLE
Stronger CMIR cuts and correct efficacy calculation

### DIFF
--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -589,14 +589,15 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
     double oneoveroneminusf0 = 1.0 / (1.0 - f0);
     if (oneoveroneminusf0 > maxCMirScale) continue;
 
-    double sqrnorm = scale * scale * continuoussqrnorm;
-    double viol = scale * continuouscontribution * oneoveroneminusf0 - downrhs;
+    double contscale = scale * oneoveroneminusf0;
+    double sqrnorm = contscale * contscale * continuoussqrnorm;
+    double viol = contscale * continuouscontribution - downrhs;
 
     for (HighsInt j : integerinds) {
       double scalaj = vals[j] * scale;
       double downaj = fast_floor(scalaj + kHighsTiny);
       double fj = scalaj - downaj;
-      double aj = downaj + std::max(0.0, fj - f0);
+      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0);
       updateViolationAndNorm(j, aj, viol, sqrnorm);
     }
 
@@ -621,14 +622,15 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
     double oneoveroneminusf0 = 1.0 / (1.0 - f0);
     if (oneoveroneminusf0 > maxCMirScale) continue;
 
-    double sqrnorm = scale * scale * continuoussqrnorm;
-    double viol = scale * continuouscontribution * oneoveroneminusf0 - downrhs;
+    double contscale = scale * oneoveroneminusf0;
+    double sqrnorm = contscale * contscale * continuoussqrnorm;
+    double viol = contscale * continuouscontribution - downrhs;
 
     for (HighsInt j : integerinds) {
       double scalaj = vals[j] * scale;
       double downaj = fast_floor(scalaj + kHighsTiny);
       double fj = scalaj - downaj;
-      double aj = downaj + std::max(0.0, fj - f0);
+      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0 );
       updateViolationAndNorm(j, aj, viol, sqrnorm);
     }
 
@@ -665,14 +667,15 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
       continue;
     }
 
-    double sqrnorm = scale * scale * continuoussqrnorm;
-    double viol = scale * continuouscontribution * oneoveroneminusf0 - downrhs;
+    double contscale = scale * oneoveroneminusf0;
+    double sqrnorm = contscale * contscale * continuoussqrnorm;
+    double viol = contscale * continuouscontribution - downrhs;
 
     for (HighsInt j : integerinds) {
       double scalaj = vals[j] * scale;
       double downaj = fast_floor(scalaj + kHighsTiny);
       double fj = scalaj - downaj;
-      double aj = downaj + std::max(0.0, fj - f0);
+      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0 );
       updateViolationAndNorm(j, aj, viol, sqrnorm);
     }
 
@@ -708,11 +711,25 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
       double downaj = floor(double(scalaj + kHighsTiny));
       HighsCDouble fj = scalaj - downaj;
       HighsCDouble aj = downaj;
-      if (fj > f0) aj += fj - f0;
+      if (fj > f0) aj += (fj - f0) * oneoveroneminusf0;
 
       vals[j] = double(aj * bestdelta);
     }
   }
+
+#ifndef NDEBUG
+  //Check if the computed cut has the correct efficacy
+  {
+    double checkviol = -downrhs * bestdelta;
+    double checknorm = 0.0;
+    for (HighsInt j = 0; j != rowlen; ++j) {
+      if (vals[j] == 0.0) continue;
+      updateViolationAndNorm(j, vals[j], checkviol, checknorm);
+    }
+    double checkefficacy = checkviol / sqrt(checknorm);
+    assert(fabs(checkefficacy - bestefficacy) < 0.001);
+  }
+#endif
 
   return true;
 }

--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -727,7 +727,8 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
       updateViolationAndNorm(j, vals[j], checkviol, checknorm);
     }
     double checkefficacy = checkviol / sqrt(checknorm);
-    assert(fabs(checkefficacy - bestefficacy) < 0.001);
+    // the efficacy can become infinite if the cut 0 <= -1 is derived
+    assert(fabs(checkefficacy - bestefficacy) < 0.001 || fabs(checkefficacy) >= 1e30);
   }
 #endif
 

--- a/src/mip/HighsCutGeneration.cpp
+++ b/src/mip/HighsCutGeneration.cpp
@@ -630,7 +630,7 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
       double scalaj = vals[j] * scale;
       double downaj = fast_floor(scalaj + kHighsTiny);
       double fj = scalaj - downaj;
-      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0 );
+      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0);
       updateViolationAndNorm(j, aj, viol, sqrnorm);
     }
 
@@ -675,7 +675,7 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
       double scalaj = vals[j] * scale;
       double downaj = fast_floor(scalaj + kHighsTiny);
       double fj = scalaj - downaj;
-      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0 );
+      double aj = downaj + std::max(0.0, (fj - f0) * oneoveroneminusf0);
       updateViolationAndNorm(j, aj, viol, sqrnorm);
     }
 
@@ -718,7 +718,7 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
   }
 
 #ifndef NDEBUG
-  //Check if the computed cut has the correct efficacy
+  // Check if the computed cut has the correct efficacy
   {
     double checkviol = -downrhs * bestdelta;
     double checknorm = 0.0;


### PR DESCRIPTION
This PR fixes some details in the calculation of the MIR cuts in HiGHS. Fixes #2334.

For the j'th integer variable, HiGHS is using the formula:
floor(a_j) +  max(0, (fj-f0)) 
where a_j is the coefficient in the original row, fj is the fractionality of variable j and f0 is the fractionality of the right hand side.

Other solvers are using the following formula, which computes strictly better coefficients:

floor(a_j) +  max(0, (fj-f0) / (1 - f0) ) 

This PR also contains some fixes for the efficacy calculation in the CMIR code, which was also incorrect because of a similar error where the scaling factor 1/(1-f0) was left out.
The changes here should be tested for performance before they are merged. Likely, the stronger cuts and the corrected efficacy calculation should give better performance.