### PR TITLE
Fix 2290

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -916,3 +916,16 @@ TEST_CASE("ZI Round and Shifting Heuristics", "[highs_test_mip_solver]") {
   const double optimal_objective = 82.19999924;
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
 }
+
+TEST_CASE("issue-2290", "[highs_test_mip_solver]") {
+  std::string filename =
+      std::string(HIGHS_DIR) + "/check/instances/issue-2290.mps";
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.setOptionValue("mip_rel_gap", 0);
+  highs.setOptionValue("mip_abs_gap", 0);
+  highs.readModel(filename);
+  const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;
+  const double optimal_objective = -1.6666666666;
+  solve(highs, kHighsOnString, require_model_status, optimal_objective);
+}

--- a/check/instances/issue-2290.mps
+++ b/check/instances/issue-2290.mps
@@ -1,0 +1,158 @@
+NAME        
+ROWS
+ N  Obj     
+ E  r0      
+ E  r1      
+ L  r2      
+ L  r3      
+ L  r4      
+ L  r5      
+ L  r6      
+ L  r7      
+ E  r8      
+ E  r9      
+ E  r10     
+ G  r11     
+ E  r12     
+ E  r13     
+ E  r14     
+ L  r15     
+ L  r16     
+ L  r17     
+ L  r18     
+ L  r19     
+ L  r20     
+ L  r21     
+ E  r22     
+ E  r23     
+ E  r24     
+ G  r25     
+ E  r26     
+ E  r27     
+ E  r28     
+ L  r29     
+ L  r30     
+ L  r31     
+ L  r32     
+ L  r33     
+ L  r34     
+COLUMNS
+    c0        r11       1
+    c0        r13       -0.08
+    c0        r14       -1
+    c0        r15       1
+    c0        r18       1
+    c1        r25       1
+    c1        r27       -0.08
+    c1        r28       -1
+    c1        r29       1
+    c1        r32       1
+    MARK0000  'MARKER'                 'INTORG'
+    c2        r17       3
+    c2        r18       -3
+    c3        r31       3
+    c3        r32       -3
+    MARK0001  'MARKER'                 'INTEND'
+    c4        r10       1
+    c5        r24       1
+    c6        r8        1
+    c6        r13       -0.08333333333
+    c7        r22       1
+    c7        r27       -0.08333333333
+    c8        r9        1
+    c8        r11       1
+    c8        r14       1
+    c9        r23       1
+    c9        r25       1
+    c9        r28       1
+    c10       r2        0.08680555556
+    c10       r11       1
+    c10       r13       0.08680555556
+    c10       r14       1
+    c10       r16       1
+    c10       r17       1
+    c11       r3        0.08680555556
+    c11       r25       1
+    c11       r27       0.08680555556
+    c11       r28       1
+    c11       r30       1
+    c11       r31       1
+    c12       r12       1
+    c12       r13       0.08333333333
+    c13       r26       1
+    c13       r27       0.08333333333
+    c14       Obj       -0.8333333333
+    c14       r14       -1
+    c14       r20       1
+    c15       Obj       -0.8333333333
+    c15       r28       -1
+    c15       r34       1
+    c16       r15       1
+    c16       r19       1
+    c17       r25       0.01
+    c17       r27       -0.0008
+    c17       r29       1
+    c17       r33       1
+    c18       Obj       2.5
+    c18       r14       1
+    c18       r19       1
+    c19       Obj       2.5
+    c19       r28       1
+    c19       r33       1
+    c20       r2        0.5208333333
+    c20       r16       1
+    c20       r20       1
+    c21       r3        0.5208333333
+    c21       r25       0.011
+    c21       r27       0.0009548611111
+    c21       r30       1
+    c21       r34       1
+    c22       r11       1
+    c23       r25       1
+    c24       r0        1
+    c24       r2        -1
+    c24       r4        1
+    c24       r13       -1
+    c25       r3        -1
+    c25       r5        1
+    c25       r13       1
+    c25       r27       -1
+    c26       r6        1
+    c26       r27       1
+    c27       r7        1
+    c27       r14       -1
+    c28       r21       1
+    c28       r28       -1
+    c29       r1        1
+RHS
+    RHS_V     r0        4.5
+    RHS_V     r1        21
+    RHS_V     r2        -0.45
+    RHS_V     r3        -0.45
+    RHS_V     r4        4.5
+    RHS_V     r5        4.5
+    RHS_V     r6        4.5
+    RHS_V     r7        0.1
+    RHS_V     r11       1
+    RHS_V     r14       -1.1
+    RHS_V     r15       3
+    RHS_V     r16       3
+    RHS_V     r17       3
+    RHS_V     r19       1000
+    RHS_V     r20       1
+    RHS_V     r21       0.1
+    RHS_V     r25       1
+    RHS_V     r28       -1.1
+    RHS_V     r29       3
+    RHS_V     r30       3
+    RHS_V     r31       3
+    RHS_V     r33       1000
+    RHS_V     r34       1
+BOUNDS
+ BV BOUND     c2      
+ BV BOUND     c3      
+ FR BOUND     c24     
+ FR BOUND     c25     
+ FR BOUND     c26     
+ FR BOUND     c29     
+ENDATA

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3827,9 +3827,19 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
   //        baseiRUpper);
 
   auto checkForcingRow = [&](HighsInt row, HighsInt direction, double rowSide,
+                             double impliedRowBound, double minAbsCoef,
                              HighsPostsolveStack::RowType rowType) {
-    // store row
-    storeRow(row);
+    // 1. direction =  1 (>=): forcing row if upper bound on constraint activity
+    //                         is equal to row's lower bound
+    // 2. direction = -1 (<=): forcing row if lower bound on constraint activity
+    //                         is equal to row's upper bound
+    // scale tolerance (equivalent to scaling row to have minimum absolute
+    // coefficient of 1)
+    if (direction * impliedRowBound >
+        direction * rowSide + primal_feastol * std::min(1.0, minAbsCoef))
+      return Result::kOk;
+
+    // get stored row
     auto rowVector = getStoredRow();
 
     HighsInt nfixings = 0;
@@ -3905,29 +3915,25 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
 
   if (analysis_.allow_rule_[kPresolveRuleForcingRow]) {
     // Allow rule to consider forcing rows
-    if (impliedRowUpper <=  // check for forcing row on the row lower bound
-        model->row_lower_[row] + primal_feastol) {
-      // the row upper bound that is implied by the column bounds is equal to
-      // the row lower bound there for we can fix all columns at their bound
-      // as this is the only feasible assignment for this row and then find a
-      // suitable dual multiplier in postsolve. First we store the row on the
-      // postsolve stack (forcingRow() call) afterwards we store each column
-      // fixing on the postsolve stack. As the postsolve goes over the stack
-      // in reverse, it will first restore the column primal and dual values
-      // as the dual values are required to find the proper dual multiplier for
-      // the row and the column that we put in the basis.
-      HPRESOLVE_CHECKED_CALL(
-          checkForcingRow(row, HighsInt{1}, model->row_lower_[row],
-                          HighsPostsolveStack::RowType::kGeq));
-      if (rowDeleted[row]) return Result::kOk;
 
-    } else if (impliedRowLower >= model->row_upper_[row] - primal_feastol) {
-      // forcing row in the other direction
-      HPRESOLVE_CHECKED_CALL(
-          checkForcingRow(row, HighsInt{-1}, model->row_upper_[row],
-                          HighsPostsolveStack::RowType::kLeq));
-      if (rowDeleted[row]) return Result::kOk;
+    // store row and compute minimum absolute coefficient
+    storeRow(row);
+    double minAbsCoef = kHighsInf;
+    for (const HighsSliceNonzero& nonzero : getStoredRow()) {
+      minAbsCoef = std::min(minAbsCoef, std::abs(nonzero.value()));
     }
+
+    // >= inequality
+    HPRESOLVE_CHECKED_CALL(checkForcingRow(
+        row, HighsInt{1}, model->row_lower_[row], impliedRowUpper, minAbsCoef,
+        HighsPostsolveStack::RowType::kGeq));
+    if (rowDeleted[row]) return Result::kOk;
+
+    // <= inequality
+    HPRESOLVE_CHECKED_CALL(checkForcingRow(
+        row, HighsInt{-1}, model->row_upper_[row], impliedRowLower, minAbsCoef,
+        HighsPostsolveStack::RowType::kLeq));
+    if (rowDeleted[row]) return Result::kOk;
   }
 
   // implied bounds can only be computed when row bounds are available and


### PR DESCRIPTION
Fix #2290 
- Scale tolerance in forcing row reduction (`HPresolve::rowPresolve`)
- Testing on 850+ MIPs did not reveal any regressions
- Added a test