### PR TITLE
Add max scale factor for generated inequalities

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -22,5 +22,5 @@ Corrected docstrings for `Highs_getReducedRow`, motivated by [#2312](https://git
 
 LP file reader no longer fails when there is no objective section. Fix is [#2316](https://github.com/ERGO-Code/HiGHS/pull/2316)), but this exposes code quality issue [#2318](https://github.com/ERGO-Code/HiGHS/issues/2318))
 
-
+Added a max scale factor (+1024) when scaling up coefficients in `preprocessBaseInequality` and `postprocessCut`. Fix is [#2337](https://github.com/ERGO-Code/HiGHS/pull/2337).
 

--- a/highs/mip/HighsCutGeneration.cpp
+++ b/highs/mip/HighsCutGeneration.cpp
@@ -781,6 +781,8 @@ bool HighsCutGeneration::postprocessCut() {
     }
   }
 
+  if (rowlen == 0) return false;
+
   if (integralSupport) {
     // integral support -> determine scale to make all coefficients integral
     double intscale =
@@ -861,6 +863,8 @@ bool HighsCutGeneration::postprocessCut() {
     int expshift;
     std::frexp(maxAbsValue - epsilon, &expshift);
     expshift = -expshift;
+    // Don't scale the coefficients by more than +1024 (violations can increase)
+    expshift = std::min(10, expshift);
     rhs = std::ldexp((double)rhs, expshift);
 
     for (HighsInt i = 0; i != rowlen; ++i)
@@ -895,6 +899,8 @@ bool HighsCutGeneration::preprocessBaseInequality(bool& hasUnboundedInts,
   int expshift = 0;
   std::frexp(maxAbsVal, &expshift);
   expshift = -expshift;
+  // Don't scale the coefficients by more than +1024 (violations can increase)
+  expshift = std::min(10, expshift);
   initialScale = std::ldexp(1.0, expshift);
   rhs *= initialScale;
   for (HighsInt i = 0; i < rowlen; ++i) vals[i] = std::ldexp(vals[i], expshift);

--- a/highs/mip/HighsCutGeneration.cpp
+++ b/highs/mip/HighsCutGeneration.cpp
@@ -900,7 +900,7 @@ bool HighsCutGeneration::preprocessBaseInequality(bool& hasUnboundedInts,
   for (HighsInt i = 0; i < rowlen; ++i)
     maxAbsVal = std::max(std::abs(vals[i]), maxAbsVal);
 
-  scale(maxAbsVal);
+  initialScale = scale(maxAbsVal);
 
   isintegral.resize(rowlen);
   for (HighsInt i = 0; i != rowlen; ++i) {

--- a/highs/mip/HighsCutGeneration.cpp
+++ b/highs/mip/HighsCutGeneration.cpp
@@ -717,6 +717,25 @@ bool HighsCutGeneration::cmirCutGenerationHeuristic(double minEfficacy,
   return true;
 }
 
+double HighsCutGeneration::scale(double val) {
+  int expshift = 0;
+  std::frexp(val, &expshift);
+  expshift = -expshift;
+
+  // Don't scale the coefficients by more than +1024 (violations can increase)
+  expshift = std::min(10, expshift);
+
+  // Scale rhs
+  rhs = std::ldexp(static_cast<double>(rhs), expshift);
+
+  // Scale row
+  for (HighsInt i = 0; i != rowlen; ++i)
+    vals[i] = std::ldexp(vals[i], expshift);
+
+  // Return scaling factor
+  return std::ldexp(1.0, expshift);
+}
+
 bool HighsCutGeneration::postprocessCut() {
   // right hand sides slightly below zero are likely due to numerical errors and
   // can cause numerical troubles with scaling, so set them to zero
@@ -848,27 +867,12 @@ bool HighsCutGeneration::postprocessCut() {
       for (HighsInt i = 0; i != rowlen; ++i)
         minAbsValue = std::min(std::abs(vals[i]), minAbsValue);
 
-      int expshift;
-      std::frexp(minAbsValue - epsilon, &expshift);
-      expshift = -expshift;
-
-      rhs = std::ldexp((double)rhs, expshift);
-
-      for (HighsInt i = 0; i != rowlen; ++i)
-        vals[i] = std::ldexp(vals[i], expshift);
+      scale(minAbsValue - epsilon);
     }
   } else {
     // the support is not integral, scale cut to have the largest coefficient
     // around 1.0
-    int expshift;
-    std::frexp(maxAbsValue - epsilon, &expshift);
-    expshift = -expshift;
-    // Don't scale the coefficients by more than +1024 (violations can increase)
-    expshift = std::min(10, expshift);
-    rhs = std::ldexp((double)rhs, expshift);
-
-    for (HighsInt i = 0; i != rowlen; ++i)
-      vals[i] = std::ldexp(vals[i], expshift);
+    scale(maxAbsValue - epsilon);
   }
 
   return true;
@@ -896,14 +900,7 @@ bool HighsCutGeneration::preprocessBaseInequality(bool& hasUnboundedInts,
   for (HighsInt i = 0; i < rowlen; ++i)
     maxAbsVal = std::max(std::abs(vals[i]), maxAbsVal);
 
-  int expshift = 0;
-  std::frexp(maxAbsVal, &expshift);
-  expshift = -expshift;
-  // Don't scale the coefficients by more than +1024 (violations can increase)
-  expshift = std::min(10, expshift);
-  initialScale = std::ldexp(1.0, expshift);
-  rhs *= initialScale;
-  for (HighsInt i = 0; i < rowlen; ++i) vals[i] = std::ldexp(vals[i], expshift);
+  scale(maxAbsVal);
 
   isintegral.resize(rowlen);
   for (HighsInt i = 0; i != rowlen; ++i) {

--- a/highs/mip/HighsCutGeneration.cpp
+++ b/highs/mip/HighsCutGeneration.cpp
@@ -726,7 +726,7 @@ double HighsCutGeneration::scale(double val) {
   expshift = std::min(10, expshift);
 
   // Scale rhs
-  rhs = std::ldexp(static_cast<double>(rhs), expshift);
+  rhs = ldexp(rhs, expshift);
 
   // Scale row
   for (HighsInt i = 0; i != rowlen; ++i)

--- a/highs/mip/HighsCutGeneration.h
+++ b/highs/mip/HighsCutGeneration.h
@@ -65,6 +65,8 @@ class HighsCutGeneration {
   bool cmirCutGenerationHeuristic(double minEfficacy,
                                   bool onlyInitialCMIRScale = false);
 
+  double scale(double val);
+
   bool postprocessCut();
 
   bool preprocessBaseInequality(bool& hasUnboundedInts, bool& hasGeneralInts,

--- a/highs/util/HighsCDouble.h
+++ b/highs/util/HighsCDouble.h
@@ -314,6 +314,10 @@ class HighsCDouble {
   }
 
   friend HighsCDouble round(const HighsCDouble& x) { return floor(x + 0.5); }
+
+  friend HighsCDouble ldexp(const HighsCDouble& v, int exp) {
+    return HighsCDouble(std::ldexp(v.hi, exp), std::ldexp(v.lo, exp));
+  }
 };
 
 #endif


### PR DESCRIPTION
This should fix #2322 

Explanation: HiGHS always scales a generated inequality so that the largest coefficient is approximately 1.0 before running a separator from `HighsCutGeneration`. This results in problems when all the coefficients are small, e.g. near `feastol = 1e-6`, and the inequality violates the optimal solution by some minor value, e.g., `1e-10`, because the violation grows substantially after scaling, and the resultant cut then removes the solution.

Solution: Add a max scaling factor (you can still scale from 1e+12 to 1.0, but not from 1e-6 to 1.0). Talked with Leona and some other developers on a sensible value (`2**10 = 1024`). 

Instances affected: Any instance where HiGHS generates an inequality with largest absolute coefficient less than `5e-4` and then calls a separator from `HighsCutGeneration`. I don't see these being frequent and it's not like we're stopping a cut from being generated (just scaling it by less), but I can imagine a tiny performance hit. 

TLDR: Puts up some additional guard rails for numerically instable cuts