### PR TITLE
Fix bug in separateImpliedBounds

### DIFF
--- a/highs/mip/HighsImplications.cpp
+++ b/highs/mip/HighsImplications.cpp
@@ -635,7 +635,7 @@ void HighsImplications::separateImpliedBounds(
           vals[0] = -1.0;
           inds[0] = implics[i].column;
           vals[1] =
-              globaldomain.col_lower_[implics[i].column] - implics[i].boundval;
+              implics[i].boundval - globaldomain.col_lower_[implics[i].column];
           inds[1] = col;
           rhs = -globaldomain.col_lower_[implics[i].column];
         }


### PR DESCRIPTION
There is a bug when calculating a coefficient in one of the cuts in `separateImpliedBounds`. It only seems to affect implications of the form `x=1 => y >=M` and is fixed by rearranging the terms in one of the coefficients. 

Take the implication `x=1 => y >=3`, where `x in [0,1] && y in [0,4]`. The current code calculates the inequality `-y -3x <= 0`, which is true but is substantially weaker than it should be. The correct inequality should be `-y + 3x <= 0`.

This should hopefully improve performance by some minor amount. 