### PR TITLE
FindCUDAConf on windows

### DIFF
--- a/cmake/FindCUDAConf.cmake
+++ b/cmake/FindCUDAConf.cmake
@@ -2,7 +2,17 @@ set(CUDA_LIBRARY-NOTFOUND, OFF)
 message(NOTICE "Finding CUDA environment")
 message(NOTICE "    - CUDA Home detected at $ENV{CUDA_HOME}")
 set(CMAKE_CUDA_ARCHITECTURES "all")
-set(CMAKE_CUDA_PATH "$ENV{CUDA_HOME}")
+
+# On Windows users should set -DCMAKE_CUDA_PATH="..." when configuring CMake. 
+# For all test setups CUPDLP_FIND_CUDA was not required on Windows.
+if (NOT WIN32)
+        set(CMAKE_CUDA_PATH "$ENV{CUDA_HOME}")
+endif()
+# For local testing.
+# set(CMAKE_CUDA_PATH "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.9")
+
+# message(STATUS "CMAKE_CUDA_PATH  ${CMAKE_CUDA_PATH}")
+
 set(CMAKE_CUDA_COMPILER "${CMAKE_CUDA_PATH}/bin/nvcc")
 
 enable_language(CUDA)
@@ -10,16 +20,19 @@ enable_language(CUDA)
 find_library(CUDA_LIBRARY_ART
         NAMES cudart
         HINTS "${CMAKE_CUDA_PATH}/lib64/"
+        HINTS "${CMAKE_CUDA_PATH}/lib/x64"
         REQUIRED
 )
 find_library(CUDA_LIBRARY_SPS
         NAMES cusparse
         HINTS "${CMAKE_CUDA_PATH}/lib64/"
+        HINTS "${CMAKE_CUDA_PATH}/lib/x64/"
         REQUIRED
 )
 find_library(CUDA_LIBRARY_BLS
         NAMES cublas
         HINTS "${CMAKE_CUDA_PATH}/lib64/"
+        HINTS "${CMAKE_CUDA_PATH}/lib/x64/"
         REQUIRED
 )
 if (${CUDA_LIBRARY-NOTFOUND})


### PR DESCRIPTION
This only affects -DCUPDLP_FIND_CUDA=ON. 
For all of our test setups CUPDLP_FIND_CUDA was not required at all on Windows.
I modified it anyway, just in case there are problems with the default CMake find CUDA on Windows, possibly Windows server since CUPDLP_FIND_CUDA was required for linux servers. 
Users should set -DCMAKE_CUDA_PATH="..." when configuring CMake if they use -DCUPDLP_FIND_CUDA=ON