### PR TITLE
Fix reading MPS with CSECTION

### DIFF
--- a/highs/io/HMpsFF.cpp
+++ b/highs/io/HMpsFF.cpp
@@ -475,9 +475,10 @@ HMpsFF::Parsekey HMpsFF::checkFirstWord(std::string& strline, size_t& start,
   // Can have keywords used as column names or names of RHS, BOUND,
   // RANGES etc, so assume this if there are non-blanks after the
   // apparent keyword. Only cases that don't work are NAME, OBJSENSE,
-  // QCMATRIX and QSECTION, since they can be followed by text
+  // QCMATRIX, QSECTION, and CSECTION since they can be followed by text
   if (key == HMpsFF::Parsekey::kName || key == HMpsFF::Parsekey::kObjsense ||
-      key == HMpsFF::Parsekey::kQcmatrix || key == HMpsFF::Parsekey::kQsection)
+      key == HMpsFF::Parsekey::kQcmatrix || key == HMpsFF::Parsekey::kQsection ||
+      key == HMpsFF::Parsekey::kCsection)
     return key;
   assert(key != HMpsFF::Parsekey::kNone);
 


### PR DESCRIPTION
9acbd2ad8a broke parsing MPS files with CSECTION, e.g.,
```
NAME          CQO1 EXAMPLE
OBJSENSE
    MIN
ROWS
 N  obj
 E  c1      
COLUMNS
    x1        obj       0.0
    x1        c1        1.0
    x2        obj       0.0
    x2        c1        1.0
    x3        obj       0.0
    x3        c1        2.0
    x4        obj       1.0
    x5        obj       1.0
    x6        obj       1.0
RHS
    rhs       c1        1.0
BOUNDS
 FR bound     x4      
 FR bound     x5      
 FR bound     x6      
CSECTION      k1        0.0            QUAD
    x4      
    x1      
    x2      
CSECTION      k2        0.0            RQUAD
    x5      
    x6      
    x3      
ENDATA
```
With HiGHS 1.10.0, this gives the error
```
ERROR:   Entry in BOUNDS section of MPS file is of type "CSECTION"
```

This PR fixes this by adding CSECTION to the exceptions for keywords that are followed by text, and thus cannot be used as other names.