### PR TITLE
fix compiler warnings from HiGHS 1.10.0

### DIFF
--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -674,10 +674,10 @@ HighsStatus Highs::addRowsInterface(HighsInt ext_num_new_row,
   return return_status;
 }
 
-void deleteBasisEntries(std::vector<HighsBasisStatus>& status,
-                        bool& deleted_basic, bool& deleted_nonbasic,
-                        const HighsIndexCollection& index_collection,
-                        const HighsInt entry_dim) {
+static void deleteBasisEntries(std::vector<HighsBasisStatus>& status,
+                               bool& deleted_basic, bool& deleted_nonbasic,
+                               const HighsIndexCollection& index_collection,
+                               const HighsInt entry_dim) {
   assert(ok(index_collection));
   assert(static_cast<size_t>(entry_dim) == status.size());
   HighsInt from_k;
@@ -717,9 +717,9 @@ void deleteBasisEntries(std::vector<HighsBasisStatus>& status,
   status.resize(new_num_entry);
 }
 
-void deleteBasisCols(HighsBasis& basis,
-                     const HighsIndexCollection& index_collection,
-                     const HighsInt original_num_col) {
+static void deleteBasisCols(HighsBasis& basis,
+                            const HighsIndexCollection& index_collection,
+                            const HighsInt original_num_col) {
   bool deleted_basic;
   bool deleted_nonbasic;
   deleteBasisEntries(basis.col_status, deleted_basic, deleted_nonbasic,
@@ -727,9 +727,9 @@ void deleteBasisCols(HighsBasis& basis,
   if (deleted_basic) basis.valid = false;
 }
 
-void deleteBasisRows(HighsBasis& basis,
-                     const HighsIndexCollection& index_collection,
-                     const HighsInt original_num_row) {
+static void deleteBasisRows(HighsBasis& basis,
+                            const HighsIndexCollection& index_collection,
+                            const HighsInt original_num_row) {
   bool deleted_basic;
   bool deleted_nonbasic;
   deleteBasisEntries(basis.row_status, deleted_basic, deleted_nonbasic,

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1806,7 +1806,7 @@ HighsLpRelaxation::Status HighsMipSolverData::evaluateRootLp() {
   } while (true);
 }
 
-void clockOff(HighsMipAnalysis& analysis) {
+static void clockOff(HighsMipAnalysis& analysis) {
   if (!analysis.analyse_mip_time) return;
   // Make sure that exactly one of the following clocks is running
   const int clock0_running =

--- a/highs/pdlp/CupdlpWrapper.h
+++ b/highs/pdlp/CupdlpWrapper.h
@@ -79,6 +79,12 @@ cupdlp_retcode data_alloc(CUPDLPdata* data, cupdlp_int nRows, cupdlp_int nCols,
 
 double infNorm(double* x, cupdlp_int n);
 
+void cupdlp_hasLower(cupdlp_float *haslb, const cupdlp_float *lb,
+                     const cupdlp_float bound, const cupdlp_int len);
+
+void cupdlp_hasUpper(cupdlp_float *hasub, const cupdlp_float *ub,
+                     const cupdlp_float bound, const cupdlp_int len);
+
 void cupdlp_haslb(cupdlp_float* haslb, const cupdlp_float* lb,
                   const cupdlp_float bound, const cupdlp_int len);
 

--- a/highs/util/HighsTimer.h
+++ b/highs/util/HighsTimer.h
@@ -45,6 +45,7 @@ class HighsTimer {
     num_clock = 0;
     HighsInt i_clock = clock_def("Run HiGHS");
     assert(i_clock == 0);
+    (void)i_clock;
 
     presolve_clock = clock_def("Presolve");
     solve_clock = clock_def("Solve");
@@ -102,6 +103,7 @@ class HighsTimer {
     this->clock_names.clear();
     HighsInt i_clock = clock_def("Run HiGHS");
     assert(i_clock == 0);
+    (void)i_clock;
     this->presolve_clock = clock_def("Presolve");
     this->solve_clock = clock_def("Solve");
     this->postsolve_clock = clock_def("Postsolve");


### PR DESCRIPTION
This fixes again compiler warnings
- on defining public functions without declaring them first, by either making them static or adding the declaration, and
- on unused variables (`i_clock` is assigned by not used if `NDEBUG` is defined)