### PR TITLE
Increase MPS precision when writing to file

### DIFF
--- a/highs/io/HMPSIO.cpp
+++ b/highs/io/HMPSIO.cpp
@@ -798,7 +798,7 @@ HighsStatus writeMps(
       num_no_cost_zero_columns++;
       if (write_no_cost_zero_columns) {
         // Give the column a presence by writing out a zero cost
-        fprintf(file, "    %-8s  %-8s  %.10g\n", col_names[c_n].c_str(),
+        fprintf(file, "    %-8s  %-8s  %.15g\n", col_names[c_n].c_str(),
                 objective_name.c_str(), 0.0);
       }
       continue;
@@ -822,13 +822,13 @@ HighsStatus writeMps(
     }
     if (col_cost[c_n] != 0) {
       double v = use_sense * col_cost[c_n];
-      fprintf(file, "    %-8s  %-8s  %.10g\n", col_names[c_n].c_str(),
+      fprintf(file, "    %-8s  %-8s  %.15g\n", col_names[c_n].c_str(),
               objective_name.c_str(), v);
     }
     for (HighsInt el_n = a_start[c_n]; el_n < a_start[c_n + 1]; el_n++) {
       double v = a_value[el_n];
       HighsInt r_n = a_index[el_n];
-      fprintf(file, "    %-8s  %-8s  %.10g\n", col_names[c_n].c_str(),
+      fprintf(file, "    %-8s  %-8s  %.15g\n", col_names[c_n].c_str(),
               row_names[r_n].c_str(), v);
     }
   }
@@ -844,12 +844,12 @@ HighsStatus writeMps(
     if (offset) {
       // Handle the objective offset as a RHS entry for the cost row
       double v = -use_sense * offset;
-      fprintf(file, "    RHS_V     %-8s  %.10g\n", objective_name.c_str(), v);
+      fprintf(file, "    RHS_V     %-8s  %.15g\n", objective_name.c_str(), v);
     }
     for (HighsInt r_n = 0; r_n < num_row; r_n++) {
       double v = rhs[r_n];
       if (v) {
-        fprintf(file, "    RHS_V     %-8s  %.10g\n", row_names[r_n].c_str(), v);
+        fprintf(file, "    RHS_V     %-8s  %.15g\n", row_names[r_n].c_str(), v);
       }
     }
   }
@@ -858,7 +858,7 @@ HighsStatus writeMps(
     for (HighsInt r_n = 0; r_n < num_row; r_n++) {
       double v = ranges[r_n];
       if (v) {
-        fprintf(file, "    RANGE     %-8s  %.10g\n", row_names[r_n].c_str(), v);
+        fprintf(file, "    RANGE     %-8s  %.15g\n", row_names[r_n].c_str(), v);
       }
     }
   }
@@ -884,7 +884,7 @@ HighsStatus writeMps(
       }
       if (lb == ub) {
         // Equal lower and upper bounds: Fixed
-        fprintf(file, " FX BOUND     %-8s  %.10g\n", col_names[c_n].c_str(),
+        fprintf(file, " FX BOUND     %-8s  %.15g\n", col_names[c_n].c_str(),
                 lb);
       } else if (highs_isInfinity(-lb) && highs_isInfinity(ub)) {
         // Infinite lower and upper bounds: Free
@@ -923,7 +923,7 @@ HighsStatus writeMps(
                 // Finite lower bound. No need to state this if LB is
                 // zero unless UB is infinite
                 if (lb || highs_isInfinity(ub))
-                  fprintf(file, " LI BOUND     %-8s  %.10g\n",
+                  fprintf(file, " LI BOUND     %-8s  %.15g\n",
                           col_names[c_n].c_str(), lb);
               } else {
                 // Infinite lower bound
@@ -931,7 +931,7 @@ HighsStatus writeMps(
               }
               if (!highs_isInfinity(ub)) {
                 // Finite upper bound
-                fprintf(file, " UI BOUND     %-8s  %.10g\n",
+                fprintf(file, " UI BOUND     %-8s  %.15g\n",
                         col_names[c_n].c_str(), ub);
               }
             }
@@ -959,14 +959,14 @@ HighsStatus writeMps(
                   log_options, HighsLogType::kWarning,
                   "Upper bound for semi-variable \"%s\" is %g but writing %g\n",
                   col_names[c_n].c_str(), ub, use_ub);
-            fprintf(file, " LO BOUND     %-8s  %.10g\n", col_names[c_n].c_str(),
+            fprintf(file, " LO BOUND     %-8s  %.15g\n", col_names[c_n].c_str(),
                     use_lb);
             if (integrality[c_n] == HighsVarType::kSemiInteger) {
-              fprintf(file, " SI BOUND     %-8s  %.10g\n",
+              fprintf(file, " SI BOUND     %-8s  %.15g\n",
                       col_names[c_n].c_str(), use_ub);
             } else {
               // Semi-continuous
-              fprintf(file, " SC BOUND     %-8s  %.10g\n",
+              fprintf(file, " SC BOUND     %-8s  %.15g\n",
                       col_names[c_n].c_str(), use_ub);
             }
           }
@@ -974,7 +974,7 @@ HighsStatus writeMps(
           if (!highs_isInfinity(-lb)) {
             // Lower bounded variable - default is 0
             if (lb) {
-              fprintf(file, " LO BOUND     %-8s  %.10g\n",
+              fprintf(file, " LO BOUND     %-8s  %.15g\n",
                       col_names[c_n].c_str(), lb);
             }
           } else {
@@ -983,7 +983,7 @@ HighsStatus writeMps(
           }
           if (!highs_isInfinity(ub)) {
             // Upper bounded variable
-            fprintf(file, " UP BOUND     %-8s  %.10g\n", col_names[c_n].c_str(),
+            fprintf(file, " UP BOUND     %-8s  %.15g\n", col_names[c_n].c_str(),
                     ub);
           }
         }
@@ -1004,7 +1004,7 @@ HighsStatus writeMps(
         assert(row >= col);
         // May have explicit zeroes on the diagonal
         if (q_value[el])
-          fprintf(file, "    %-8s  %-8s  %.10g\n", col_names[col].c_str(),
+          fprintf(file, "    %-8s  %-8s  %.15g\n", col_names[col].c_str(),
                   col_names[row].c_str(), use_sense * q_value[el]);
       }
     }


### PR DESCRIPTION
This increases the precision of coefficients and bounds written to an MPS file to what is currently written to LP files. This was requested by the Xpress team. 