### PR TITLE
Fix code to match comments

### DIFF
--- a/highs/mip/HighsPrimalHeuristics.cpp
+++ b/highs/mip/HighsPrimalHeuristics.cpp
@@ -392,7 +392,7 @@ retry:
     // printf("after evaluating node current fixingrate is %g\n", fixingrate);
     if (fixingrate >= maxfixingrate) break;
     if (stop) break;
-    if (nbacktracks >= 10) break;
+    if (nbacktracks >= 15) break;
 
     HighsInt numBranched = 0;
     double stopFixingRate = std::min(
@@ -444,7 +444,7 @@ retry:
           fixval = std::ceil(fracval);
         else if (rootchange <= -0.4)
           fixval = std::floor(fracval);
-        if (mipsolver.model_->col_cost_[col] > 0.0)
+        else if (mipsolver.model_->col_cost_[col] > 0.0)
           fixval = std::ceil(fracval);
         else if (mipsolver.model_->col_cost_[col] < 0.0)
           fixval = std::floor(fracval);
@@ -673,7 +673,7 @@ retry:
           fixval = std::ceil(fracval);
         else if (rootchange <= -0.4)
           fixval = std::floor(fracval);
-        if (mipsolver.model_->col_cost_[col] > 0.0)
+        else if (mipsolver.model_->col_cost_[col] > 0.0)
           fixval = std::ceil(fracval);
         else if (mipsolver.model_->col_cost_[col] < 0.0)
           fixval = std::floor(fracval);

--- a/highs/mip/HighsPrimalHeuristics.cpp
+++ b/highs/mip/HighsPrimalHeuristics.cpp
@@ -392,7 +392,7 @@ retry:
     // printf("after evaluating node current fixingrate is %g\n", fixingrate);
     if (fixingrate >= maxfixingrate) break;
     if (stop) break;
-    if (nbacktracks >= 15) break;
+    if (nbacktracks >= 10) break;
 
     HighsInt numBranched = 0;
     double stopFixingRate = std::min(


### PR DESCRIPTION
This is a relatively minor code fix, but it affects which variables get fixed by RINS / RENS, so will have big changes on plenty of instances.

There's no guarantee that this improves performance, and if it doesn't then the complement of this should be done (remove the redundant logic and comment). Hopefully it does though as the original intention seems to sound decent.  