### PR TITLE
Describe supported model file formats in the documentation

### DIFF
--- a/docs/src/executable.md
+++ b/docs/src/executable.md
@@ -1,9 +1,13 @@
 # [Executable](@id executable)
 
-For convenience, the executable is assumed to be `bin/highs`.
+HiGHS can run as a standalone program with a command-line interface. It solves an optimization problem provided by a model file. HiGHS supports the following model file formats:
+
+- [MPS file format](https://en.wikipedia.org/wiki/MPS_(format))
+- (CPLEX) [LP file format](https://docs.mosek.com/latest/capi/lp-format.html)
 
 ### Running the executable
 
+For convenience, the executable is assumed to be `bin/highs`.
 The model given by the MPS file `model.mps` is solved by the command:
 
 ```shell


### PR DESCRIPTION
Hello,
While reading the documentation about the HiGHS executable (https://ergo-code.github.io/HiGHS/dev/executable/), I noticed that the supported file format are not described there.

I found in the [README](https://github.com/ERGO-Code/HiGHS/blob/master/README.md#running-highs) that MPS and CPLEX LP file formats are supported. I've added this to the doc.

To make the document a bit more easy for newcomers, I've added links to the file format description. I've used the same as used by [JuMP](https://jump.dev/JuMP.jl/stable/manual/models/#Write-a-model-to-file):
- MPS: Wikipedia https://en.wikipedia.org/wiki/MPS_(format)
- LP: MOSEK API doc https://docs.mosek.com/latest/capi/lp-format.html

Finally, while reviewing the entire doc, I noticed the following sentence:

> When HiGHS is run from the command line, some fundamental option values may be specified directly. **Many more may be specified via a file**.

and I'm not sure I understand what it means. Does this refer to the `--options_file file` option? Is that's correct, I can add an extra commit for this, but then I'd like to describe the option file format (or put a link if it's elsewhere in the doc).