### PR TITLE
Tolerance fixes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -50,3 +50,5 @@ Introduced the following KKT error measures to `HighsInfo`: `num_relative_primal
 
 Added a max scale factor (+1024) when scaling up coefficients in `preprocessBaseInequality` and `postprocessCut`. Fix is [#2337](https://github.com/ERGO-Code/HiGHS/pull/2337).
 
+Renamed `HighsOptions::pdlp_d_gap_tol` to `HighsOptions::pdlp_optimality_tolerance` for consistency with IPM
+

--- a/check/TestAlienBasis.cpp
+++ b/check/TestAlienBasis.cpp
@@ -434,7 +434,7 @@ void testAlienBasis(const bool avgas, const HighsInt seed) {
 
   HighsStatus read_status = highs.readModel(filename);
   assert(read_status == HighsStatus::kOk);
-  
+
   HighsLp lp = highs.getLp();
   HighsInt num_col = lp.num_col_;
   HighsInt num_row = lp.num_row_;

--- a/check/TestIpm.cpp
+++ b/check/TestIpm.cpp
@@ -1,9 +1,8 @@
 #include <cmath>
 
+#include "HCheckConfig.h"
 #include "Highs.h"
 #include "catch.hpp"
-
-#include "HCheckConfig.h"
 
 // I use dev_run to switch on/off printing and logging used for
 // development of the unit test

--- a/check/TestModelProperties.cpp
+++ b/check/TestModelProperties.cpp
@@ -1,9 +1,8 @@
 #include <cmath>
 
+#include "HCheckConfig.h"
 #include "Highs.h"
 #include "catch.hpp"
-
-#include "HCheckConfig.h"
 
 const bool dev_run = false;
 const double inf = kHighsInf;

--- a/check/TestUserScale.cpp
+++ b/check/TestUserScale.cpp
@@ -1,9 +1,8 @@
 #include <cmath>
 
+#include "HCheckConfig.h"
 #include "Highs.h"
 #include "catch.hpp"
-
-#include "HCheckConfig.h"
 
 const bool dev_run = false;
 const double inf = kHighsInf;

--- a/highs/interfaces/highs_c_api.cpp
+++ b/highs/interfaces/highs_c_api.cpp
@@ -1171,13 +1171,13 @@ HighsInt Highs_getPresolvedNumNz(const void* highs) {
 // Gets pointers to all the public data members of HighsLp: avoids
 // duplicate code in Highs_getModel, Highs_getPresolvedLp,
 static HighsInt Highs_getHighsLpData(const HighsLp& lp, const HighsInt a_format,
-                              HighsInt* num_col, HighsInt* num_row,
-                              HighsInt* num_nz, HighsInt* sense, double* offset,
-                              double* col_cost, double* col_lower,
-                              double* col_upper, double* row_lower,
-                              double* row_upper, HighsInt* a_start,
-                              HighsInt* a_index, double* a_value,
-                              HighsInt* integrality) {
+                                     HighsInt* num_col, HighsInt* num_row,
+                                     HighsInt* num_nz, HighsInt* sense,
+                                     double* offset, double* col_cost,
+                                     double* col_lower, double* col_upper,
+                                     double* row_lower, double* row_upper,
+                                     HighsInt* a_start, HighsInt* a_index,
+                                     double* a_value, HighsInt* integrality) {
   const MatrixFormat desired_a_format =
       a_format == HighsInt(MatrixFormat::kColwise) ? MatrixFormat::kColwise
                                                    : MatrixFormat::kRowwise;

--- a/highs/ipm/IpxWrapper.cpp
+++ b/highs/ipm/IpxWrapper.cpp
@@ -117,11 +117,6 @@ HighsStatus solveLpIpx(const HighsOptions& options, HighsTimer& timer,
     parameters.ipm_feasibility_tol = options.kkt_tolerance;
     parameters.ipm_optimality_tol = 1e-1 * options.kkt_tolerance;
     parameters.start_crossover_tol = 1e-1 * options.kkt_tolerance;
-    printf(
-        "IpxWrapper: ipm_feasibility_tol = %g; ipm_optimality_tol = %g; "
-        "start_crossover_tol = %g\n",
-        parameters.ipm_feasibility_tol, parameters.ipm_optimality_tol,
-        parameters.start_crossover_tol);
   }
 
   parameters.analyse_basis_data =

--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -280,6 +280,9 @@ enum IisStrategy {
 // Default KKT tolerance
 const double kDefaultKktTolerance = 1e-7;
 
+// Default QP Hessian regularization value
+const double kHessianRegularizationValue = 1e-7;
+
 // Default and max allowed power-of-two matrix scale factor
 const HighsInt kDefaultAllowedMatrixPow2Scale = 20;
 const HighsInt kMaxAllowedMatrixPow2Scale = 30;

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -1959,10 +1959,7 @@ HighsStatus Highs::getIis(HighsIis& iis) {
 
 HighsStatus Highs::getDualObjectiveValue(
     double& dual_objective_function_value) const {
-  bool have_dual_objective_value = false;
-  if (!this->model_.isQp())
-    have_dual_objective_value = computeDualObjectiveValue(
-        model_.lp_, solution_, dual_objective_function_value);
+  bool have_dual_objective_value = computeDualObjectiveValue(model_, solution_, dual_objective_function_value);
   return have_dual_objective_value ? HighsStatus::kOk : HighsStatus::kError;
 }
 
@@ -4673,7 +4670,7 @@ void Highs::reportSolvedLpQpStats() {
                  "Objective value     : %17.10e\n",
                  info_.objective_function_value);
   }
-  if (solution_.dual_valid && !this->model_.isQp())
+  if (solution_.dual_valid)
     highsLogUser(log_options, HighsLogType::kInfo,
                  "P-D objective error : %17.10e\n",
                  info_.primal_dual_objective_error);

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -3904,7 +3904,9 @@ HighsStatus Highs::callSolveQp() {
 
   settings.iteration_limit = options_.qp_iteration_limit;
   settings.nullspace_limit = options_.qp_nullspace_limit;
-
+  assert(settings.hessian_regularization_value == kHessianRegularizationValue);
+  settings.hessian_regularization_value = options_.qp_regularization_value;
+    
   // Define the QP model status logging function
   settings.qp_model_status_log.subscribe(
       [this](QpModelStatus& qp_model_status) {

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -1959,7 +1959,8 @@ HighsStatus Highs::getIis(HighsIis& iis) {
 
 HighsStatus Highs::getDualObjectiveValue(
     double& dual_objective_function_value) const {
-  bool have_dual_objective_value = computeDualObjectiveValue(model_, solution_, dual_objective_function_value);
+  bool have_dual_objective_value = computeDualObjectiveValue(
+      model_, solution_, dual_objective_function_value);
   return have_dual_objective_value ? HighsStatus::kOk : HighsStatus::kError;
 }
 
@@ -3906,7 +3907,7 @@ HighsStatus Highs::callSolveQp() {
   settings.nullspace_limit = options_.qp_nullspace_limit;
   assert(settings.hessian_regularization_value == kHessianRegularizationValue);
   settings.hessian_regularization_value = options_.qp_regularization_value;
-    
+
   // Define the QP model status logging function
   settings.qp_model_status_log.subscribe(
       [this](QpModelStatus& qp_model_status) {

--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -2658,7 +2658,7 @@ HighsStatus Highs::lpKktCheck(const std::string& message) {
     double local_dual_objective = 0;
     if (info.primal_dual_objective_error > complementarity_tolerance) {
       // Ignore primal-dual objective errors if both objectives are small
-      const bool ok_dual_objective = computeDualObjectiveValue(
+      const bool ok_dual_objective = computeDualObjectiveValue(nullptr,
           this->model_.lp_, this->solution_, local_dual_objective);
       assert(ok_dual_objective);
       if (info.objective_function_value * info.objective_function_value >

--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -2658,8 +2658,8 @@ HighsStatus Highs::lpKktCheck(const std::string& message) {
     double local_dual_objective = 0;
     if (info.primal_dual_objective_error > complementarity_tolerance) {
       // Ignore primal-dual objective errors if both objectives are small
-      const bool ok_dual_objective = computeDualObjectiveValue(nullptr,
-          this->model_.lp_, this->solution_, local_dual_objective);
+      const bool ok_dual_objective = computeDualObjectiveValue(
+          nullptr, this->model_.lp_, this->solution_, local_dual_objective);
       assert(ok_dual_objective);
       if (info.objective_function_value * info.objective_function_value >
               complementarity_tolerance &&

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -356,6 +356,7 @@ struct HighsOptionsStruct {
   // Options for QP solver
   HighsInt qp_iteration_limit;
   HighsInt qp_nullspace_limit;
+  double qp_regularization_value;
 
   // Options for IIS calculation
   HighsInt iis_strategy;
@@ -516,6 +517,7 @@ struct HighsOptionsStruct {
         pdlp_optimality_tolerance(0.0),
         qp_iteration_limit(0),
         qp_nullspace_limit(0),
+	qp_regularization_value(0),
         iis_strategy(0),
         blend_multi_objectives(false),
         log_dev_level(0),
@@ -1222,6 +1224,11 @@ class HighsOptions : public HighsOptionsStruct {
                                      "Nullspace limit for QP solver", advanced,
                                      &qp_nullspace_limit, 0, 4000, kHighsIInf);
     records.push_back(record_int);
+
+    record_double = new OptionRecordDouble(
+        "qp_regularization_value", "Regularization value added to the Hessian", advanced,
+        &qp_regularization_value, 0, kHessianRegularizationValue, kHighsInf);
+    records.push_back(record_double);
 
     record_int = new OptionRecordInt(
         "iis_strategy",

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -517,7 +517,7 @@ struct HighsOptionsStruct {
         pdlp_optimality_tolerance(0.0),
         qp_iteration_limit(0),
         qp_nullspace_limit(0),
-	qp_regularization_value(0),
+        qp_regularization_value(0),
         iis_strategy(0),
         blend_multi_objectives(false),
         log_dev_level(0),
@@ -1226,8 +1226,9 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_double = new OptionRecordDouble(
-        "qp_regularization_value", "Regularization value added to the Hessian", advanced,
-        &qp_regularization_value, 0, kHessianRegularizationValue, kHighsInf);
+        "qp_regularization_value", "Regularization value added to the Hessian",
+        advanced, &qp_regularization_value, 0, kHessianRegularizationValue,
+        kHighsInf);
     records.push_back(record_double);
 
     record_int = new OptionRecordInt(

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -351,7 +351,7 @@ struct HighsOptionsStruct {
   bool pdlp_scaling;
   HighsInt pdlp_iteration_limit;
   HighsInt pdlp_e_restart_method;
-  double pdlp_d_gap_tol;
+  double pdlp_optimality_tolerance;
 
   // Options for QP solver
   HighsInt qp_iteration_limit;
@@ -513,7 +513,7 @@ struct HighsOptionsStruct {
         pdlp_scaling(false),
         pdlp_iteration_limit(0),
         pdlp_e_restart_method(0),
-        pdlp_d_gap_tol(0.0),
+        pdlp_optimality_tolerance(0.0),
         qp_iteration_limit(0),
         qp_nullspace_limit(0),
         iis_strategy(0),
@@ -1209,8 +1209,8 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_double = new OptionRecordDouble(
-        "pdlp_d_gap_tol", "Duality gap tolerance for PDLP solver", advanced,
-        &pdlp_d_gap_tol, 1e-12, kDefaultKktTolerance, kHighsInf);
+        "pdlp_optimality_tolerance", "PDLP optimality tolerance", advanced,
+        &pdlp_optimality_tolerance, 1e-12, kDefaultKktTolerance, kHighsInf);
     records.push_back(record_double);
 
     record_int = new OptionRecordInt(

--- a/highs/lp_data/HighsSolution.cpp
+++ b/highs/lp_data/HighsSolution.cpp
@@ -1025,8 +1025,6 @@ bool computeDualObjectiveValue(const double* gradient,
     for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
       double quad_term = (lp.col_cost_[iCol]-gradient[iCol])*solution.col_value[iCol];
       quad_value += quad_term;
-      printf("computeDualObjectiveValue %d: c = %17.10g; g = %17.10g; quad_term = %17.10g; quad_value = %17.10g\n",
-	     int(iCol), lp.col_cost_[iCol], gradient[iCol], quad_term, quad_value);
     }	     
     quad_value *= 0.5;
   }
@@ -1049,8 +1047,6 @@ bool computeDualObjectiveValue(const double* gradient,
     }
     dual_objective_value += bound * dual;
   }
-  printf("computeDualObjectiveValue: offset + quad_value + dual_term = %17.10g + %17.10g + %17.10g = %17.10g\n",
-	 lp.offset_, quad_value, dual_objective_value, lp.offset_ + quad_value + dual_objective_value);
   dual_objective_value += (lp.offset_ + quad_value);
   return true;
 }

--- a/highs/lp_data/HighsSolution.cpp
+++ b/highs/lp_data/HighsSolution.cpp
@@ -464,8 +464,8 @@ void getKktFailures(const HighsOptions& options, const bool is_qp,
     // pass a pointer to the gradient data if this is necessary
     const double* gradient_p = is_qp ? gradient.data() : nullptr;
     double dual_objective_value;
-    bool dual_objective_status = 
-      computeDualObjectiveValue(gradient_p, lp, solution, dual_objective_value);
+    bool dual_objective_status = computeDualObjectiveValue(
+        gradient_p, lp, solution, dual_objective_value);
     assert(dual_objective_status);
     const double abs_objective_difference =
         std::fabs(highs_info.objective_function_value - dual_objective_value);
@@ -990,22 +990,23 @@ bool getComplementarityViolations(const HighsLp& lp,
 }
 
 bool computeDualObjectiveValue(const HighsModel& model,
-			       const HighsSolution& solution,
+                               const HighsSolution& solution,
                                double& dual_objective_value) {
   const HighsLp& lp = model.lp_;
   if (!model.isQp())
-    return computeDualObjectiveValue(nullptr, lp, solution, dual_objective_value);
+    return computeDualObjectiveValue(nullptr, lp, solution,
+                                     dual_objective_value);
   assert(solution.col_value.size() == static_cast<size_t>(lp.num_col_));
   // Model is QP, so compute gradient Qx + c so generic
   // computeDualObjectiveValue can be used
   std::vector<double> gradient;
   model.objectiveGradient(solution.col_value, gradient);
-  return computeDualObjectiveValue(gradient.data(), lp, solution, dual_objective_value);
+  return computeDualObjectiveValue(gradient.data(), lp, solution,
+                                   dual_objective_value);
 }
 
-bool computeDualObjectiveValue(const double* gradient,
-			       const HighsLp& lp,
-			       const HighsSolution& solution,
+bool computeDualObjectiveValue(const double* gradient, const HighsLp& lp,
+                               const HighsSolution& solution,
                                double& dual_objective_value) {
   dual_objective_value = 0;
   if (!solution.dual_valid) return false;
@@ -1023,9 +1024,10 @@ bool computeDualObjectiveValue(const double* gradient,
     // -(1/2)(g-c)^Tx = (1/2)(c-g)^Tx, a pointer to the gradient data
     // is passed if this is necessary
     for (HighsInt iCol = 0; iCol < lp.num_col_; iCol++) {
-      double quad_term = (lp.col_cost_[iCol]-gradient[iCol])*solution.col_value[iCol];
+      double quad_term =
+          (lp.col_cost_[iCol] - gradient[iCol]) * solution.col_value[iCol];
       quad_value += quad_term;
-    }	     
+    }
     quad_value *= 0.5;
   }
   double bound = 0;

--- a/highs/lp_data/HighsSolution.h
+++ b/highs/lp_data/HighsSolution.h
@@ -108,7 +108,13 @@ bool getComplementarityViolations(const HighsLp& lp,
                                   HighsInt& num_complementarity_violations,
                                   double& max_complementarity_violation);
 
-bool computeDualObjectiveValue(const HighsLp& lp, const HighsSolution& solution,
+bool computeDualObjectiveValue(const HighsModel& model,
+			       const HighsSolution& solution,
+			       double& dual_objective_value);
+
+bool computeDualObjectiveValue(const double* gradient,
+			       const HighsLp& lp,
+			       const HighsSolution& solution,
                                double& dual_objective_value);
 
 double computeObjectiveValue(const HighsLp& lp, const HighsSolution& solution);

--- a/highs/lp_data/HighsSolution.h
+++ b/highs/lp_data/HighsSolution.h
@@ -109,12 +109,11 @@ bool getComplementarityViolations(const HighsLp& lp,
                                   double& max_complementarity_violation);
 
 bool computeDualObjectiveValue(const HighsModel& model,
-			       const HighsSolution& solution,
-			       double& dual_objective_value);
+                               const HighsSolution& solution,
+                               double& dual_objective_value);
 
-bool computeDualObjectiveValue(const double* gradient,
-			       const HighsLp& lp,
-			       const HighsSolution& solution,
+bool computeDualObjectiveValue(const double* gradient, const HighsLp& lp,
+                               const HighsSolution& solution,
                                double& dual_objective_value);
 
 double computeObjectiveValue(const HighsLp& lp, const HighsSolution& solution);

--- a/highs/model/HighsHessian.cpp
+++ b/highs/model/HighsHessian.cpp
@@ -189,11 +189,14 @@ void HighsHessian::product(const std::vector<double>& solution,
                            std::vector<double>& product) const {
   if (this->dim_ <= 0) return;
   product.assign(this->dim_, 0);
+  const bool triangular = this->format_ == HessianFormat::kTriangular;
   for (HighsInt iCol = 0; iCol < this->dim_; iCol++) {
     for (HighsInt iEl = this->start_[iCol]; iEl < this->start_[iCol + 1];
          iEl++) {
       const HighsInt iRow = this->index_[iEl];
       product[iRow] += this->value_[iEl] * solution[iCol];
+      if (triangular && iRow != iCol)
+	product[iCol] += this->value_[iEl] * solution[iRow];
     }
   }
 }
@@ -202,6 +205,7 @@ double HighsHessian::objectiveValue(const std::vector<double>& solution) const {
   double objective_function_value = 0;
   for (HighsInt iCol = 0; iCol < this->dim_; iCol++) {
     HighsInt iEl = this->start_[iCol];
+    // Assumes Hessian format is triangular 
     assert(this->index_[iEl] == iCol);
     objective_function_value +=
         0.5 * solution[iCol] * this->value_[iEl] * solution[iCol];
@@ -218,6 +222,7 @@ HighsCDouble HighsHessian::objectiveCDoubleValue(
   HighsCDouble objective_function_value = HighsCDouble(0);
   for (HighsInt iCol = 0; iCol < this->dim_; iCol++) {
     HighsInt iEl = this->start_[iCol];
+    // Assumes Hessian format is triangular 
     assert(this->index_[iEl] == iCol);
     objective_function_value +=
         0.5 * solution[iCol] * this->value_[iEl] * solution[iCol];

--- a/highs/model/HighsHessian.cpp
+++ b/highs/model/HighsHessian.cpp
@@ -196,7 +196,7 @@ void HighsHessian::product(const std::vector<double>& solution,
       const HighsInt iRow = this->index_[iEl];
       product[iRow] += this->value_[iEl] * solution[iCol];
       if (triangular && iRow != iCol)
-	product[iCol] += this->value_[iEl] * solution[iRow];
+        product[iCol] += this->value_[iEl] * solution[iRow];
     }
   }
 }
@@ -205,7 +205,7 @@ double HighsHessian::objectiveValue(const std::vector<double>& solution) const {
   double objective_function_value = 0;
   for (HighsInt iCol = 0; iCol < this->dim_; iCol++) {
     HighsInt iEl = this->start_[iCol];
-    // Assumes Hessian format is triangular 
+    // Assumes Hessian format is triangular
     assert(this->index_[iEl] == iCol);
     objective_function_value +=
         0.5 * solution[iCol] * this->value_[iEl] * solution[iCol];
@@ -222,7 +222,7 @@ HighsCDouble HighsHessian::objectiveCDoubleValue(
   HighsCDouble objective_function_value = HighsCDouble(0);
   for (HighsInt iCol = 0; iCol < this->dim_; iCol++) {
     HighsInt iEl = this->start_[iCol];
-    // Assumes Hessian format is triangular 
+    // Assumes Hessian format is triangular
     assert(this->index_[iEl] == iCol);
     objective_function_value +=
         0.5 * solution[iCol] * this->value_[iEl] * solution[iCol];

--- a/highs/pdlp/CupdlpWrapper.cpp
+++ b/highs/pdlp/CupdlpWrapper.cpp
@@ -656,7 +656,7 @@ void getUserParamsFromOptions(const HighsOptions& options, HighsTimer& timer,
   floatParam[D_DUAL_TOL] = options.dual_feasibility_tolerance;
   //
   ifChangeFloatParam[D_GAP_TOL] = true;
-  floatParam[D_GAP_TOL] = options.pdlp_d_gap_tol;
+  floatParam[D_GAP_TOL] = options.pdlp_optimality_tolerance;
   // Possibly over-write with uniform KKT tolerance
   if (options.kkt_tolerance != kDefaultKktTolerance) {
     floatParam[D_PRIMAL_TOL] = options.kkt_tolerance;

--- a/highs/qpsolver/a_quass.cpp
+++ b/highs/qpsolver/a_quass.cpp
@@ -139,7 +139,7 @@ QpAsmStatus solveqp(Instance& instance, Settings& settings, Statistics& stats,
     for (HighsInt index = instance.Q.mat.start[i];
          index < instance.Q.mat.start[i + 1]; index++) {
       if (instance.Q.mat.index[index] == i) {
-        instance.Q.mat.value[index] += settings.hessianregularizationfactor;
+        instance.Q.mat.value[index] += settings.hessian_regularization_value;
       }
     }
   }

--- a/highs/qpsolver/feasibility_bounded.hpp
+++ b/highs/qpsolver/feasibility_bounded.hpp
@@ -62,12 +62,12 @@ static void computeStartingPointBounded(Instance& instance, Settings& settings,
   std::vector<BasisStatus> atlower;
 
   for (int i = 0; i < instance.num_var; i++) {
-    if (res.value[i] > 0.5 / settings.hessianregularizationfactor &&
+    if (res.value[i] > 0.5 / settings.hessian_regularization_value &&
         instance.var_up[i] == std::numeric_limits<double>::infinity() &&
         instance.c.value[i] < 0.0) {
       modelstatus = QpModelStatus::kUnbounded;
       return;
-    } else if (res.value[i] < 0.5 / settings.hessianregularizationfactor &&
+    } else if (res.value[i] < 0.5 / settings.hessian_regularization_value &&
                instance.var_lo[i] == std::numeric_limits<double>::infinity() &&
                instance.c.value[i] > 0.0) {
       modelstatus = QpModelStatus::kUnbounded;

--- a/highs/qpsolver/quass.cpp
+++ b/highs/qpsolver/quass.cpp
@@ -190,16 +190,20 @@ static std::unique_ptr<Pricing> getPricing(Runtime& runtime, Basis& basis,
 }
 
 static void regularize(Runtime& rt) {
-  if (!rt.settings.hessianregularization) {
+  assert(!rt.settings.hessian_regularization_on);
+  if (!rt.settings.hessian_regularization_on) {
     return;
   }
+  // This regularization is not called, since
+  // rt.settings.hessian_regularization_on is false
+  //
   // add small diagonal to hessian
   for (HighsInt i = 0; i < rt.instance.num_var; i++) {
     for (HighsInt index = rt.instance.Q.mat.start[i];
          index < rt.instance.Q.mat.start[i + 1]; index++) {
       if (rt.instance.Q.mat.index[index] == i) {
         rt.instance.Q.mat.value[index] +=
-            rt.settings.hessianregularizationfactor;
+            rt.settings.hessian_regularization_value;
       }
     }
   }

--- a/highs/qpsolver/settings.hpp
+++ b/highs/qpsolver/settings.hpp
@@ -32,11 +32,18 @@ struct Settings {
       1e-7;  // if p'Qp < this, p is determined to not have curvature, a
              // simplex-like iteration is performed.
 
-  bool hessianregularization =
+  bool hessian_regularization_on =
       false;  // if true, a small multiple of the identity matrix will be added
-              // to the Hessian
-  double hessianregularizationfactor =
-      1e-7;  // multiple of identity matrix added to hessian in case of
+              // to the Hessian.
+              //
+              // This is always false, so regularization in
+              // regularize(Runtime& rt) never happens, but
+              // regularization in solveqp is _always_ performed
+              //
+              // This explains the "perturbed" solutions of problems
+              // in TestQpSolver.cpp
+  double hessian_regularization_value =
+      1e-7;  // multiple of identity matrix added to Hessian in case of
              // regularization
 
   Phase1Strategy phase1strategy = Phase1Strategy::HIGHS;


### PR DESCRIPTION
Added `HighsOption::qp_regularization_value` so that QP regularization can be switched off in `TestQpSolver.cpp`. 

Hence exact solutions of simple QPs are now obtained, validating code to compute dual objective value for QPs (and primal-dual objective error), and tightening up QP unit tests; fixed error in `HighsHessian::product`.