### PR TITLE
fix new compiler warnings

### DIFF
--- a/highs/lp_data/HighsSolution.cpp
+++ b/highs/lp_data/HighsSolution.cpp
@@ -199,7 +199,7 @@ void getKktFailures(const HighsOptions& options, const bool is_qp,
   double primal_infeasibility;
   double relative_primal_infeasibility;
   double dual_infeasibility;
-  double cost;
+  double cost = 0.0;
   double lower;
   double upper;
   double value;

--- a/highs/mip/HighsPrimalHeuristics.cpp
+++ b/highs/mip/HighsPrimalHeuristics.cpp
@@ -1152,7 +1152,7 @@ void HighsPrimalHeuristics::shifting(const std::vector<double>& relaxationsol) {
         if (currentLp.col_lower_[j] == currentLp.col_upper_[j]) continue;
 
         // lambda for finding best shift
-        auto repair = [this, &findPairByIndex, &current_fractional_integers,
+        auto repair = [&findPairByIndex, &current_fractional_integers,
                        &findShiftsByIndex, &shift_iterations_set, &t,
                        &score_min, &j_min, &aij_min, &x_j_min,
                        &current_relax_solution, &moveValueUp](
@@ -1274,8 +1274,8 @@ void HighsPrimalHeuristics::shifting(const std::vector<double>& relaxationsol) {
         assert(col >= 0);
         assert(col < mipsolver.numCol());
 
-        auto isBetter = [this, &currentLp, &it, &xi_max, &delta_c_min,
-                         &pind_j_min, &j_min, &x_j_min, &sigma,
+        auto isBetter = [&currentLp, &it, &xi_max, &delta_c_min, &pind_j_min,
+                         &j_min, &x_j_min, &sigma,
                          &i](double col, double xi, double roundedval,
                              HighsInt direction) {
           double c_min = currentLp.col_cost_[col] * (roundedval - it.second);


### PR DESCRIPTION
There was a warning on a maybe uninitialized variable, which seems a false positive.

The other is about passing `this` to a lambda which does not need access to `this`. It raised an unused lambda capture warning from clang.