### PR TITLE
Update free-threading option in pyproject.toml

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -47,6 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v3.0.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,7 @@ build = "*"
 skip = "cp3{6,7}-*"
 
 # Enable free-threaded support
-free-threaded-support = true
+enable = ["cpython-freethreading"]
 
 test-command = "pytest {project}/tests"
 test-extras = ["test", "numpy"]


### PR DESCRIPTION
This is an attempt to stop the failing tests.

The issue:
- `cibuildwheel` just pushed a new major version. The jobs are automatically downloading the new version (3.0.0) and our pyproject.toml is now longer valid.

The fix:
- They've deprecated one of the parameters we were using. I've just replaced it with what the documentation said was now the equivalent (not sure if there are broader consequences as it's likely not a perfect 1-1 swap)

The easier temporary potential fix:
- Add a version requirement of `<3` when `pip` installing `cibuildwheel` in the GitHub actions for now,

As a disclaimer: I have never used this option, so am far from an expert.