### PR TITLE
Fix 2415

### DIFF
--- a/check/TestRays.cpp
+++ b/check/TestRays.cpp
@@ -4,7 +4,7 @@
 #include "catch.hpp"
 #include "lp_data/HConst.h"
 
-const bool dev_run = true;//false;
+const bool dev_run = true;  // false;
 const double zero_ray_value_tolerance = 1e-14;
 
 void reportRay(std::string message, HighsInt dim, double* computed,
@@ -979,28 +979,28 @@ TEST_CASE("Rays-2415-primal", "[highs_test_rays]") {
   Highs h;
   h.setOptionValue("output_flag", dev_run);
   if (dev_run) printf("For unbounded LP\n");
-  for (HighsInt k = 0; k< 2; k++) {
+  for (HighsInt k = 0; k < 2; k++) {
     bool is_mip = k == 1;
     HighsInt require_dual_solution_status = kSolutionStatusInfeasible;
-    if (is_mip) 
-      require_dual_solution_status = kSolutionStatusNone;
+    if (is_mip) require_dual_solution_status = kSolutionStatusNone;
     REQUIRE(h.passModel(lp) == HighsStatus::kOk);
     REQUIRE(h.run() == HighsStatus::kOk);
     if (dev_run)
       printf("Solution values are col_value[0] = %g; row_value[0] = %g\n",
-	     h.getSolution().col_value[0], h.getSolution().row_value[0]);
+             h.getSolution().col_value[0], h.getSolution().row_value[0]);
     if (dev_run)
       printf("Solution duals are col_dual[0] = %g; row_dual[0] = %g\n",
-	     h.getSolution().col_dual[0], h.getSolution().row_dual[0]);
+             h.getSolution().col_dual[0], h.getSolution().row_dual[0]);
     if (dev_run)
-      printf("Dual Solution status is %d\n", int(h.getInfo().dual_solution_status));
+      printf("Dual Solution status is %d\n",
+             int(h.getInfo().dual_solution_status));
     REQUIRE(h.getInfo().dual_solution_status != kSolutionStatusFeasible);
     REQUIRE(h.getInfo().dual_solution_status == require_dual_solution_status);
 
     bool has_primal_ray;
     std::vector<double> primal_ray_value(lp.num_col_);
     REQUIRE(h.getPrimalRay(has_primal_ray, primal_ray_value.data()) ==
-	    HighsStatus::kOk);
+            HighsStatus::kOk);
     REQUIRE(h.getInfo().dual_solution_status != kSolutionStatusFeasible);
     REQUIRE(h.getInfo().dual_solution_status == require_dual_solution_status);
     if (k == 1) break;

--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -2603,7 +2603,8 @@ HighsStatus Highs::lpKktCheck(const std::string& message) {
                    primal_dual_errors, get_residuals);
   //  highsLogUser(options.log_options, HighsLogType::kInfo,
   //               "Highs::lpKktCheck: %s\n", message.c_str());
-  reportLpKktFailures(model_.lp_, options, info, "LP");
+  if (this->model_status_ == HighsModelStatus::kOptimal)
+    reportLpKktFailures(model_.lp_, options, info, "LP");
   // get_residuals is false when there is a valid basis, since
   // residual errors are assumed to be small, so
   // info.num_primal_residual_errors = -1, since they aren't


### PR DESCRIPTION
 For an unbounded MIP, the relaxation is necessarily unbounded, so the status mis-match with an infeasible MIP that prompted #2415 can't occur when solving an LP to get a primal ray. However, the dual solution status in such cases was being returned as kInfeasible, rather than kNone, and this PR fixes this.