### PR TITLE
Minor fix for HPresolve::sparsify

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -6657,11 +6657,11 @@ HPresolve::Result HPresolve::sparsify(HighsPostsolveStack& postsolve_stack) {
       if (colsize[col] < sparsestColLen) {
         secondSparsestCol = sparsestCol;
         secondSparsestColLen = sparsestColLen;
-        sparsestColLen = colsize[col];
         sparsestCol = col;
+        sparsestColLen = colsize[col];
       } else if (colsize[col] < secondSparsestColLen) {
-        secondSparsestColLen = colsize[col];
         secondSparsestCol = col;
+        secondSparsestColLen = colsize[col];
       }
     }
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -6715,7 +6715,7 @@ HPresolve::Result HPresolve::sparsify(HighsPostsolveStack& postsolve_stack) {
         auto it = possibleScales.lower_bound(scale - scaleTolerance);
         if (it != possibleScales.end() &&
             std::abs(it->first - scale) <= scaleTolerance) {
-          // there already is a scale that is very close and could produces
+          // there already is a scale that is very close and could produce
           // a matrix value for this nonzero that is below the allowed
           // threshold. Therefore we check if the matrix value is small enough
           // for this nonzero to be deleted, in which case the number of
@@ -6799,7 +6799,7 @@ HPresolve::Result HPresolve::sparsify(HighsPostsolveStack& postsolve_stack) {
           auto it = possibleScales.lower_bound(scale - scaleTolerance);
           if (it != possibleScales.end() &&
               std::abs(it->first - scale) <= scaleTolerance) {
-            // there already is a scale that is very close and could produces
+            // there already is a scale that is very close and could produce
             // a matrix value for this nonzero that is below the allowed
             // threshold. Therefore we check if the matrix value is small enough
             // for this nonzero to be deleted, in which case the number of

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -6666,7 +6666,6 @@ HPresolve::Result HPresolve::sparsify(HighsPostsolveStack& postsolve_stack) {
     }
 
     assert(sparsestCol != -1 && secondSparsestCol != -1);
-
     assert(colsize[sparsestCol] <= colsize[secondSparsestCol]);
 
     std::map<double, HighsInt> possibleScales;


### PR DESCRIPTION
This PR fixes the loop identifying the sparsest and second sparsest columns in `HPresolve::sparsify(...)`.