### PR TITLE
Fix 2432

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -974,9 +974,9 @@ TEST_CASE("issue-2432", "[highs_test_mip_solver]") {
   lp.col_upper_ = {120, 10, 0};
   lp.row_lower_ = {3994.5, -4878.3, -4930};
   lp.row_upper_ = {kHighsInf, kHighsInf, kHighsInf};
-  lp.a_matrix_.start_ = {0, 3, 7, 10};
-  lp.a_matrix_.index_ = {1, 2, 3, 1, 2, 3, 1, 2, 3};
-  lp.a_matrix_.value_ = {-89, -40.7, -12, -0.1, 77.2, -23.7, -8.6, -6.5, 72.78};
+  lp.a_matrix_.start_ = {0, 3, 6, 9};
+  lp.a_matrix_.index_ = {0, 1, 2, 0, 1, 2, 0, 1, 2};
+  lp.a_matrix_.value_ = {-89, -0.1, -8.6, -40.7, 77.2, -6.5, -12, -23.7, 72.78};
   lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kContinuous,
                      HighsVarType::kInteger};
   const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -985,8 +985,7 @@ TEST_CASE("issue-2432", "[highs_test_mip_solver]") {
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   if (dev_run) printf("Testing that presolve reduces the problem to empty\n");
   REQUIRE(highs.presolve() == HighsStatus::kOk);
-  REQUIRE(highs.getModelPresolveStatus() ==
-          HighsPresolveStatus::kReducedToEmpty);
+  REQUIRE(highs.getModelPresolveStatus() == HighsPresolveStatus::kReduced);
 
   if (dev_run)
     printf(

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -983,7 +983,7 @@ TEST_CASE("issue-2432", "[highs_test_mip_solver]") {
   const double optimal_objective = -3777.57124352;
   Highs highs;
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
-  if (dev_run) printf("Testing that presolve reduces the problem to empty\n");
+  if (dev_run) printf("Testing that presolve reduces the problem\n");
   REQUIRE(highs.presolve() == HighsStatus::kOk);
   REQUIRE(highs.getModelPresolveStatus() == HighsPresolveStatus::kReduced);
 

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -932,8 +932,6 @@ TEST_CASE("issue-2290", "[highs_test_mip_solver]") {
 
 TEST_CASE("issue-2409", "[highs_test_mip_solver]") {
   HighsLp lp;
-  HighsModelStatus require_model_status;
-  double optimal_objective;
   lp.num_col_ = 2;
   lp.num_row_ = 2;
   lp.col_cost_ = {-1, 1};
@@ -945,8 +943,8 @@ TEST_CASE("issue-2409", "[highs_test_mip_solver]") {
   lp.a_matrix_.index_ = {0, 1, 0, 1};
   lp.a_matrix_.value_ = {-1, 1, 1, 1};
   lp.integrality_ = {HighsVarType::kContinuous, HighsVarType::kInteger};
-  require_model_status = HighsModelStatus::kOptimal;
-  optimal_objective = 0.1;
+  const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;
+  const double optimal_objective = 0.1;
   Highs highs;
   REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
   if (dev_run) printf("Testing that presolve reduces the problem to empty\n");
@@ -956,12 +954,49 @@ TEST_CASE("issue-2409", "[highs_test_mip_solver]") {
 
   if (dev_run)
     printf(
-        "\nTesting that with presolve the correct optimal objecive is found\n");
+        "\nTesting that with presolve the correct optimal objective is "
+        "found\n");
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
   highs.clearSolver();
   if (dev_run)
     printf(
-        "\nTesting that without presolve the correct optimal objecive is "
+        "\nTesting that without presolve the correct optimal objective is "
+        "found\n");
+  solve(highs, kHighsOffString, require_model_status, optimal_objective);
+}
+
+TEST_CASE("issue-2432", "[highs_test_mip_solver]") {
+  HighsLp lp;
+  lp.num_col_ = 3;
+  lp.num_row_ = 3;
+  lp.col_cost_ = {-93, 25, 17};
+  lp.col_lower_ = {-100, -100, -100};
+  lp.col_upper_ = {120, 10, 0};
+  lp.row_lower_ = {3994.5, -4878.3, -4930};
+  lp.row_upper_ = {kHighsInf, kHighsInf, kHighsInf};
+  lp.a_matrix_.start_ = {0, 3, 7, 10};
+  lp.a_matrix_.index_ = {1, 2, 3, 1, 2, 3, 1, 2, 3};
+  lp.a_matrix_.value_ = {-89, -40.7, -12, -0.1, 77.2, -23.7, -8.6, -6.5, 72.78};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kContinuous,
+                     HighsVarType::kInteger};
+  const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;
+  const double optimal_objective = -3777.57124352;
+  Highs highs;
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  if (dev_run) printf("Testing that presolve reduces the problem to empty\n");
+  REQUIRE(highs.presolve() == HighsStatus::kOk);
+  REQUIRE(highs.getModelPresolveStatus() ==
+          HighsPresolveStatus::kReducedToEmpty);
+
+  if (dev_run)
+    printf(
+        "\nTesting that with presolve the correct optimal objective is "
+        "found\n");
+  solve(highs, kHighsOnString, require_model_status, optimal_objective);
+  highs.clearSolver();
+  if (dev_run)
+    printf(
+        "\nTesting that without presolve the correct optimal objective is "
         "found\n");
   solve(highs, kHighsOffString, require_model_status, optimal_objective);
 }

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -348,8 +348,7 @@ HPresolve::StatusResult HPresolve::isImpliedInteger(HighsInt col) const {
       runDualDetection = false;
       double scale = 1.0 / nz.value();
 
-      if (fractionality(model->row_lower_[nz.index()] * scale) > primal_feastol)
-        return StatusResult(Result::kPrimalInfeasible);
+      if (fractionality(rowLower * scale) > primal_feastol) continue;
 
       if (!rowCoefficientsIntegral(nz.index(), scale)) continue;
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -273,7 +273,7 @@ HPresolve::StatusResult HPresolve::isImpliedIntegral(HighsInt col) {
       double scale = 1.0 / nz.value();
       if (!rowCoefficientsIntegral(nz.index(), scale)) continue;
 
-      if (fractionality(model->row_lower_[nz.index()] * scale) > primal_feastol)
+      if (fractionality(rowLower * scale) > primal_feastol)
         return StatusResult(Result::kPrimalInfeasible);
 
       return StatusResult(true);

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -271,6 +271,7 @@ HPresolve::StatusResult HPresolve::isImpliedIntegral(HighsInt col) {
       // if there is an equation the dual detection does not need to be tried
       runDualDetection = false;
       double scale = 1.0 / nz.value();
+
       if (!rowCoefficientsIntegral(nz.index(), scale)) continue;
 
       if (fractionality(rowLower * scale) > primal_feastol)

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -221,7 +221,7 @@ void HPresolve::dualImpliedFreeGetRhsAndRowType(
 }
 
 bool HPresolve::isEquation(HighsInt row) const {
-  return (model->row_lower_[row] == model->row_lower_[row]);
+  return (model->row_lower_[row] == model->row_upper_[row]);
 }
 
 bool HPresolve::isImpliedEquationAtLower(HighsInt row) const {

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -196,6 +196,8 @@ class HPresolve {
                                        HighsPostsolveStack::RowType& rowType,
                                        bool relaxRowDualBounds = false);
 
+  bool isEquation(HighsInt row) const;
+
   bool isImpliedEquationAtLower(HighsInt row) const;
 
   bool isImpliedEquationAtUpper(HighsInt row) const;


### PR DESCRIPTION
Fix #2432 
- `HPresolve::isImpliedInteger` incorrectly declares the reproduction example infeasible.
- I added `HPresolve::isEquation` to simplify the presolve code and an automated test. 