### PR TITLE
Minor parameter changes

### DIFF
--- a/highs/mip/HighsCutPool.cpp
+++ b/highs/mip/HighsCutPool.cpp
@@ -317,7 +317,7 @@ void HighsCutPool::separate(const std::vector<double>& sol, HighsDomain& domain,
 
   for (const std::pair<double, HighsInt>& p : efficacious_cuts) {
     bool discard = false;
-    double maxpar = 0.1;
+    double maxpar = 0.05;
     for (HighsInt k : cutset.cutindices) {
       if (getParallelism(k, p.second) > maxpar) {
         discard = true;

--- a/highs/mip/HighsCutPool.cpp
+++ b/highs/mip/HighsCutPool.cpp
@@ -317,7 +317,7 @@ void HighsCutPool::separate(const std::vector<double>& sol, HighsDomain& domain,
 
   for (const std::pair<double, HighsInt>& p : efficacious_cuts) {
     bool discard = false;
-    double maxpar = 0.05;
+    double maxpar = 0.1;
     for (HighsInt k : cutset.cutindices) {
       if (getParallelism(k, p.second) > maxpar) {
         discard = true;

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -62,7 +62,7 @@ static inline double boundRange(double upper_bound, double lower_bound,
                                 double tolerance, HighsVarType var_type) {
   double range = upper_bound - lower_bound;
   return range - (var_type == HighsVarType::kContinuous
-                      ? std::max(0.3 * range, 1000.0 * tolerance)
+                      ? std::max(0.15 * range, 1000.0 * tolerance)
                       : tolerance);
 }
 
@@ -1353,7 +1353,7 @@ double HighsDomain::adjustedUb(HighsInt col, HighsCDouble boundVal,
       else
         relativeImprove /=
             std::max(std::fabs(col_upper_[col]), std::fabs(bound));
-      accept = relativeImprove >= 0.3;
+      accept = relativeImprove >= 0.15;
     } else
       accept = false;
   }
@@ -1385,7 +1385,7 @@ double HighsDomain::adjustedLb(HighsInt col, HighsCDouble boundVal,
       else
         relativeImprove /=
             std::max(std::fabs(col_lower_[col]), std::fabs(bound));
-      accept = relativeImprove >= 0.3;
+      accept = relativeImprove >= 0.15;
     } else
       accept = false;
   }

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -62,7 +62,7 @@ static inline double boundRange(double upper_bound, double lower_bound,
                                 double tolerance, HighsVarType var_type) {
   double range = upper_bound - lower_bound;
   return range - (var_type == HighsVarType::kContinuous
-                      ? std::max(0.15 * range, 1000.0 * tolerance)
+                      ? std::max(0.2 * range, 1000.0 * tolerance)
                       : tolerance);
 }
 
@@ -1353,7 +1353,7 @@ double HighsDomain::adjustedUb(HighsInt col, HighsCDouble boundVal,
       else
         relativeImprove /=
             std::max(std::fabs(col_upper_[col]), std::fabs(bound));
-      accept = relativeImprove >= 0.15;
+      accept = relativeImprove >= 0.2;
     } else
       accept = false;
   }
@@ -1385,7 +1385,7 @@ double HighsDomain::adjustedLb(HighsInt col, HighsCDouble boundVal,
       else
         relativeImprove /=
             std::max(std::fabs(col_lower_[col]), std::fabs(bound));
-      accept = relativeImprove >= 0.15;
+      accept = relativeImprove >= 0.2;
     } else
       accept = false;
   }

--- a/highs/mip/HighsSearch.cpp
+++ b/highs/mip/HighsSearch.cpp
@@ -1208,7 +1208,7 @@ HighsSearch::NodeResult HighsSearch::branch() {
       }
     }
 
-    double degeneracyFac = lp->computeLPDegneracy(localdom);
+    double degeneracyFac = std::min(10.0, lp->computeLPDegneracy(localdom));
     pseudocost.setDegeneracyFactor(degeneracyFac);
     if (degeneracyFac >= 10.0) pseudocost.setMinReliable(0);
     // if (!mipsolver.submip)


### PR DESCRIPTION
This PR would change two minor things (I am seeing a very nice chunk of performance improvement for smaller instances):

1. Currently there is no upper limit on the weight of `degeneracyFactor` in the branching scores. Let's imagine a scenario where `degeneracyFactor` has meaningful impact in the code (when it's `>=10`). In that case, strong branching is disabled, so we don't gather any new observations. We don't do this as we predict that most strong branching decisions are not going to return any objective value improvements and thus just populate our pseudo-costs with 0. 
What about when `degeneracyFactor = 1000`? In that case we still wouldn't get any strong branching information, but now the score is essentially ignoring the pseudocosts that we have actually gathered just from regular branching. I'm just adding a cap on the factor during scoring so that the pseudo-costs in scoring are never ignored (if they're all 0 then who cares and if they're larger than 0 on some variables then we probably shouldn't be ignoring them). 

2. HiGHS has a huge threshold for allowing a bound change on a continuous variable (currently needs to reduce the domain by 30%). That is, currently if we could reduce the domain of a continuous variable from `100` to `80` we'd be ignoring it. I've changed this to 20% (which is still relatively large). I observed even better performance at 15%, but much worse at 10%, so I played it safe. If we have the time to test more values then we should be trying 15% on a wide amount of instances.