### PR TITLE
Add check for local domain during clique substitution

### DIFF
--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -1301,6 +1301,19 @@ HighsLpRelaxation::Status HighsLpRelaxation::resolveLp(HighsDomain* domain) {
                   break;
               }
 
+              // Spot cases where a global domain change during the search has
+              // led to a clique and the local domain has branched into a state
+              // where the clique subst. would be invalid for the local domain.
+              // TODO: Turn into assert when search becomes parallel
+              if (domain) {
+                double replace_val = subst->replace.val == 0 ? 1.0 - val : val;
+                double replace_lb = domain->col_lower_[subst->replace.col];
+                double replace_ub = domain->col_upper_[subst->replace.col];
+                double feastol = mipsolver.mipdata_->feastol;
+                if ((replace_val < replace_lb - feastol) ||
+                    (replace_val > replace_ub + feastol)) break;
+              }
+
               col = subst->replace.col;
               if (subst->replace.val == 0) val = 1.0 - val;
 


### PR DESCRIPTION
This fixes #2205 and I suspect #1862 

Explanation:
In a sub-milp HiGHS is managing to tighten the global bounds of x4 from a dual proof. That is, given `x4 + x6 <= 1`, where `0 <= x6 <= 1` & `0 <= x4 <= 2` it can conclude that `x4 <= 1`. It also stores a clique (let's assume equality to make it easier) and manages to derive that `x4 = 1 - x6`. The problem is that this bound update (`x4 <= 1`) is only given to the global domain and NOT to the domain attached to the HighsSearch object!
This leads to a problem later when HiGHS during its search has branched upwards on `x4`, i.e., `1 <= x4 <= 2`. HiGHS is going to use the clique substitution (that is supposed to be globally valid) and replace some valid LP value of `x4` by `1 - x6`. Let's say `x6 = 0.05` and therefore `x4 = 1 - x6 = 0.95`  (violates the local domain `1 <= x4 <= 2`)!!

The fundamental problem is simply that the search is using some global information that has not yet been passed to it. I've added a band-aid if statement to catch these rare cases that should have no practical overhead and cannot imagine many instances at all get affected by this change.

I removed the more robust fix because that would essentially be adding more sync points of the global domain and the domain attached to the search object. This may not be worth it because of the overhead, and would have to be removed if we ever want to parallelise the search. (For parallel search: This clique is a great example of something we're going to have to disable to make parallelism valid or we would have to create an entirely new clique buffer data structure)