### PR TITLE
Fix 2439 and 2455

### DIFF
--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -3215,6 +3215,8 @@ bool HighsDomain::ConflictSet::explainInfeasibility() {
       HighsInt ninfmin;
       HighsCDouble minAct;
       globaldom.computeMinActivity(0, len, inds, vals, ninfmin, minAct);
+      // This case should only happen when a globally unbounded column is bounded
+      // in the local domain, e.g., by a branching choice in some heuristic.
       if (ninfmin > 0) return false;
 
       return explainInfeasibilityLeq(inds, vals, len, rhs, double(minAct));

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -3215,8 +3215,9 @@ bool HighsDomain::ConflictSet::explainInfeasibility() {
       HighsInt ninfmin;
       HighsCDouble minAct;
       globaldom.computeMinActivity(0, len, inds, vals, ninfmin, minAct);
-      // This case should only happen when a globally unbounded column is bounded
-      // in the local domain, e.g., by a branching choice in some heuristic.
+      // This case should only happen when a globally unbounded column is
+      // bounded in the local domain, e.g., by a branching choice in some
+      // heuristic.
       if (ninfmin > 0) return false;
 
       return explainInfeasibilityLeq(inds, vals, len, rhs, double(minAct));

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -3215,7 +3215,7 @@ bool HighsDomain::ConflictSet::explainInfeasibility() {
       HighsInt ninfmin;
       HighsCDouble minAct;
       globaldom.computeMinActivity(0, len, inds, vals, ninfmin, minAct);
-      assert(ninfmin == 0);
+      if (ninfmin > 0) return false;
 
       return explainInfeasibilityLeq(inds, vals, len, rhs, double(minAct));
     }

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1120,8 +1120,10 @@ try_again:
     }
   }
 
-  const double transformed_solobj = static_cast<double>(static_cast<HighsInt>(mipsolver.orig_model_->sense_) *
-    mipsolver_quad_objective_value - mipsolver.model_->offset_);
+  const double transformed_solobj =
+      static_cast<double>(static_cast<HighsInt>(mipsolver.orig_model_->sense_) *
+                              mipsolver_quad_objective_value -
+                          mipsolver.model_->offset_);
 
   // Possible MIP solution callback
   if (!mipsolver.submip && feasible && mipsolver.callback_->user_callback &&

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1120,6 +1120,15 @@ try_again:
     }
   }
 
+  double transformed_solobj;
+  if (mipsolver.orig_model_->sense_ == ObjSense::kMaximize) {
+    transformed_solobj = -static_cast<double>(mipsolver_quad_objective_value +
+                                              mipsolver.model_->offset_);
+  } else {
+    transformed_solobj = static_cast<double>(mipsolver_quad_objective_value -
+                                             mipsolver.model_->offset_);
+  }
+
   // Possible MIP solution callback
   if (!mipsolver.submip && feasible && mipsolver.callback_->user_callback &&
       mipsolver.callback_->active[kCallbackMipSolution]) {
@@ -1128,6 +1137,12 @@ try_again:
     const bool interrupt = interruptFromCallbackWithData(
         kCallbackMipSolution, mipsolver_objective_value, "Feasible solution");
     assert(!interrupt);
+  }
+
+  // Catch the case where the repaired solution now has worse objective
+  // than the current stored solution
+  if (transformed_solobj >= upper_bound && !sol.empty()) {
+    return transformed_solobj;
   }
 
   if (possibly_store_as_new_incumbent) {
@@ -1171,11 +1186,9 @@ try_again:
       return kHighsInf;
     }
   }
-  // return the objective value in the transformed space
-  if (mipsolver.orig_model_->sense_ == ObjSense::kMaximize)
-    return -double(mipsolver_quad_objective_value + mipsolver.model_->offset_);
 
-  return double(mipsolver_quad_objective_value - mipsolver.model_->offset_);
+  // return the objective value in the transformed space
+  return transformed_solobj;
 }
 
 double HighsMipSolverData::percentageInactiveIntegers() const {

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1120,14 +1120,8 @@ try_again:
     }
   }
 
-  double transformed_solobj;
-  if (mipsolver.orig_model_->sense_ == ObjSense::kMaximize) {
-    transformed_solobj = -static_cast<double>(mipsolver_quad_objective_value +
-                                              mipsolver.model_->offset_);
-  } else {
-    transformed_solobj = static_cast<double>(mipsolver_quad_objective_value -
-                                             mipsolver.model_->offset_);
-  }
+  const double transformed_solobj = static_cast<double>(static_cast<HighsInt>(mipsolver.orig_model_->sense_) *
+    mipsolver_quad_objective_value - mipsolver.model_->offset_);
 
   // Possible MIP solution callback
   if (!mipsolver.submip && feasible && mipsolver.callback_->user_callback &&


### PR DESCRIPTION
This contains two changes:

1. It adds an additional check that the solution is actually improving on the current upper bound. In #2439 HiGHS was given a solution to try that was not feasible in the original space. After some repair LP the solution does become feasible, however the objective value becomes worse. Importantly, this objective change places it above the current best bound. As there is no objective value based check within the function though, it ends up overrides some global data (as seen in the output of the log). This is completely incorrect, and if it were to have happened in the middle of the solve process would have potentially terminated the solve with a fake optimal solution. All I've done is throw an additional sanity check inside of the function.
2. There is an assert that there are no infinite terms in the objective when propagating objective based infeasibility reasons. The logic is clear: If there is a `-inf` term in the objective how are you arguing that `-inf >= b` when b is finite?
The logic break when you are handling two different domains. Let's say the reason was found on the local domain, where a bound for `x1 <= inf` has potentially been changed to `x1 <= 1` in something like a fix-and-propagate heuristic. This means that after enough fixes and propagation rounds you can already see that the best possible remaining solution is worse than the current incumbent. The issue is that when you try and make a globally valid conflict out of this, you're going to use the global bounds `x1 <= inf`, for which the objective is unbounded, and this will hit the current assert. I think this is a simple error and should be replaced by a `return false`. This happens on both #2439 without presolve and on #2455  