### PR TITLE
Clean up Feasibility Jump logging

### DIFF
--- a/highs/mip/HighsFeasibilityJump.cpp
+++ b/highs/mip/HighsFeasibilityJump.cpp
@@ -30,6 +30,7 @@ HighsModelStatus HighsMipSolverData::feasibilityJump() {
   // Configure Feasibility Jump and pass it the problem
   int verbosity = mipsolver.submip ? 0 : mipsolver.options_mip_->log_dev_level;
   auto solver = external_feasibilityjump::FeasibilityJumpSolver(
+      log_options,
       /* seed = */ mipsolver.options_mip_->random_seed,
       /* verbosity = */ verbosity,
       /* equalityTolerance = */ epsilon,

--- a/highs/mip/HighsFeasibilityJump.cpp
+++ b/highs/mip/HighsFeasibilityJump.cpp
@@ -28,11 +28,9 @@ HighsModelStatus HighsMipSolverData::feasibilityJump() {
   double objective_function_value;
 
   // Configure Feasibility Jump and pass it the problem
-  int verbosity = mipsolver.submip ? 0 : mipsolver.options_mip_->log_dev_level;
   auto solver = external_feasibilityjump::FeasibilityJumpSolver(
       log_options,
       /* seed = */ mipsolver.options_mip_->random_seed,
-      /* verbosity = */ verbosity,
       /* equalityTolerance = */ epsilon,
       /* violationTolerance = */ feastol);
 

--- a/highs/mip/feasibilityjump.hh
+++ b/highs/mip/feasibilityjump.hh
@@ -550,7 +550,7 @@ class FeasibilityJumpSolver {
 
  private:
   void logging(const int step, const bool header = false) {
-    const HighsLogType logType = HighsLogType::kInfo;
+    const HighsLogType logType = HighsLogType::kDetailed;
     if (header) {
       highsLogDev(logOptions, logType,
                   FJ_LOG_PREFIX

--- a/highs/mip/feasibilityjump.hh
+++ b/highs/mip/feasibilityjump.hh
@@ -495,10 +495,10 @@ class FeasibilityJumpSolver {
   int solve(double* initialValues,
             std::function<CallbackControlFlow(FJStatus)> callback) {
     assert(callback);
-    highsLogUser(logOptions, HighsLogType::kInfo,
-                 FJ_LOG_PREFIX
-                 "starting solve. weightUpdateDecay=%g, relaxContinuous=%d  \n",
-                 weightUpdateDecay, problem.usedRelaxContinuous);
+    highsLogDev(logOptions, HighsLogType::kInfo,
+                FJ_LOG_PREFIX
+                "starting solve. weightUpdateDecay=%g, relaxContinuous=%d  \n",
+                weightUpdateDecay, problem.usedRelaxContinuous);
 
     init(initialValues);
 
@@ -552,17 +552,16 @@ class FeasibilityJumpSolver {
   void logging(const int step, const bool header = false) {
     const HighsLogType logType = HighsLogType::kInfo;
     if (header) {
-      highsLogUser(
-          logOptions, logType,
-          FJ_LOG_PREFIX
-          "       step  violations     good    bumps       effort (per "
-          "step)          Objective\n");
+      highsLogDev(logOptions, logType,
+                  FJ_LOG_PREFIX
+                  "       step  violations     good    bumps       effort (per "
+                  "step)          Objective\n");
     } else {
-      highsLogUser(logOptions, logType,
-                   " %10d    %8zd   %6zd %8zd %12zd    %6zd          %10.4g\n",
-                   step, problem.violatedConstraints.size(), goodVarsSet.size(),
-                   nBumps, totalEffort, step > 0 ? totalEffort / step : 0,
-                   problem.incumbentObjective);
+      highsLogDev(logOptions, logType,
+                  " %10d    %8zd   %6zd %8zd %12zd    %6zd          %10.4g\n",
+                  step, problem.violatedConstraints.size(), goodVarsSet.size(),
+                  nBumps, totalEffort, step > 0 ? totalEffort / step : 0,
+                  problem.incumbentObjective);
       effortAtLastLogging = totalEffort;
     }
   }

--- a/highs/mip/feasibilityjump.hh
+++ b/highs/mip/feasibilityjump.hh
@@ -1,6 +1,3 @@
-#include <HConst.h>
-#include <io/HighsIO.h>
-
 #include <algorithm>
 #include <cassert>
 #include <climits>
@@ -9,6 +6,9 @@
 #include <numeric>
 #include <random>
 #include <vector>
+
+#include "io/HighsIO.h"
+#include "lp_data/HConst.h"
 
 #define FJ_LOG_PREFIX "Feasibility Jump: "
 


### PR DESCRIPTION
Minor change making Feasibility Jump (FJ) use the HiGHS logging calls rather than `printf`. Because HiGHS sets `log_options` correctly for submips, we no longer need FJ's internal `verbosity` parameter.

I also adjusted the logging levels for the different messages to make them more sensible.