### PR TITLE
Expand MIP debug solution capabilities

### DIFF
--- a/highs/mip/HighsDebugSol.cpp
+++ b/highs/mip/HighsDebugSol.cpp
@@ -35,30 +35,45 @@ void HighsDebugSol::activate() {
     if (file) {
       std::string varname;
       double varval;
+      std::string line;
+      bool incolsection;
       std::map<std::string, int> nametoidx;
 
-      for (HighsInt i = 0; i != mipsolver->model_->num_col_; ++i)
-        nametoidx["c" + std::to_string(i)] = i;
+      for (HighsInt i = 0; i != mipsolver->orig_model_->num_col_; ++i)
+        nametoidx[mipsolver->orig_model_->col_names_[i]] = i;
 
-      debugSolution.resize(mipsolver->model_->num_col_, 0.0);
-      while (!file.eof()) {
-        file >> varname;
+      debugOrigSolution.resize(mipsolver->orig_model_->num_col_, 0.0);
+      while (std::getline(file, line)) {
+        // Check for start and stop markers
+        if (line.find("# Columns") != std::string::npos) {
+          incolsection = true;
+          continue;
+        }
+        if (line.find("# Rows") != std::string::npos) {
+          break;
+        }
+        if (!incolsection)
+          continue;
+
+        std::istringstream linestream(line);
+        linestream >> varname;
         auto it = nametoidx.find(varname);
         if (it != nametoidx.end()) {
-          file >> varval;
+          linestream >> varval;
+          debugOrigSolution[it->second] = varval;
           highsLogDev(mipsolver->options_mip_->log_options, HighsLogType::kInfo,
                       "%s = %g\n", varname.c_str(), varval);
-          debugSolution[it->second] = varval;
+          debugOrigSolution[it->second] = varval;
         }
-
-        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
       }
+      debugSolution = debugOrigSolution;
 
       HighsCDouble debugsolobj = 0.0;
-      for (HighsInt i = 0; i != mipsolver->model_->num_col_; ++i)
-        debugsolobj += mipsolver->model_->col_cost_[i] * debugSolution[i];
+      for (HighsInt i = 0; i != mipsolver->orig_model_->num_col_; ++i)
+        debugsolobj +=
+            mipsolver->orig_model_->col_cost_[i] * debugOrigSolution[i];
 
-      debugSolObjective = double(debugsolobj);
+      debugSolObjective = double(debugsolobj + mipsolver->orig_model_->offset_);
       debugSolActive = true;
       printf("debug sol active\n");
       registerDomain(mipsolver->mipdata_->domain);

--- a/highs/mip/HighsDebugSol.cpp
+++ b/highs/mip/HighsDebugSol.cpp
@@ -52,8 +52,7 @@ void HighsDebugSol::activate() {
         if (line.find("# Rows") != std::string::npos) {
           break;
         }
-        if (!incolsection)
-          continue;
+        if (!incolsection) continue;
 
         std::istringstream linestream(line);
         linestream >> varname;
@@ -70,8 +69,8 @@ void HighsDebugSol::activate() {
 
       HighsCDouble debugsolobj = 0.0;
       for (HighsInt i = 0; i != mipsolver->orig_model_->num_col_; ++i)
-        debugsolobj +=
-            mipsolver->orig_model_->col_cost_[i] * debugOrigSolution[i];
+        debugsolobj += mipsolver->orig_model_->col_cost_[i] *
+                       HighsCDouble(debugOrigSolution[i]);
 
       debugSolObjective = double(debugsolobj + mipsolver->orig_model_->offset_);
       debugSolActive = true;

--- a/highs/mip/HighsDebugSol.h
+++ b/highs/mip/HighsDebugSol.h
@@ -29,6 +29,7 @@ class HighsLp;
 struct HighsDebugSol {
   const HighsMipSolver* mipsolver;
   double debugSolObjective;
+  std::vector<double> debugOrigSolution;
   std::vector<double> debugSolution;
   bool debugSolActive;
   std::unordered_map<const HighsDomain*, std::multiset<HighsDomainChange>>

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -89,6 +89,8 @@ void HighsMipSolver::run() {
   analysis_.mipTimerStop(kMipClockInit);
 #ifdef HIGHS_DEBUGSOL
   mipdata_->debugSolution.activate();
+  bool debugSolActive = false;
+  std::swap(mipdata_->debugSolution.debugSolActive, debugSolActive);
 #endif
   analysis_.mipTimerStart(kMipClockRunPresolve);
   mipdata_->runPresolve(options_mip_->presolve_reduction_limit);
@@ -122,6 +124,9 @@ void HighsMipSolver::run() {
     highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                  "MIP-Timing: %11.2g - starting  setup\n", timer_.read());
   analysis_.mipTimerStart(kMipClockRunSetup);
+#ifdef HIGHS_DEBUGSOL
+  mipdata_->debugSolution.debugSolActive = debugSolActive;
+#endif
   mipdata_->runSetup();
   analysis_.mipTimerStop(kMipClockRunSetup);
   if (analysis_.analyse_mip_time && !submip)

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -87,6 +87,9 @@ void HighsMipSolver::run() {
   analysis_.mipTimerStart(kMipClockInit);
   mipdata_->init();
   analysis_.mipTimerStop(kMipClockInit);
+#ifdef HIGHS_DEBUGSOL
+  mipdata_->debugSolution.activate();
+#endif
   analysis_.mipTimerStart(kMipClockRunPresolve);
   mipdata_->runPresolve(options_mip_->presolve_reduction_limit);
   analysis_.mipTimerStop(kMipClockRunPresolve);

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -694,7 +694,6 @@ void HighsMipSolverData::init() {
 }
 
 void HighsMipSolverData::runPresolve(const HighsInt presolve_reduction_limit) {
-
   mipsolver.timer_.start(mipsolver.timer_.presolve_clock);
   presolve::HPresolve presolve;
   if (!presolve.okSetInput(mipsolver, presolve_reduction_limit)) {
@@ -1018,7 +1017,8 @@ void HighsMipSolverData::runSetup() {
     debugSolution.debugSolObjective = 0;
     HighsCDouble debugsolobj = 0.0;
     for (HighsInt i = 0; i != mipsolver.model_->num_col_; ++i)
-      debugsolobj += mipsolver.colCost(i) * debugSolution.debugSolution[i];
+      debugsolobj +=
+          mipsolver.colCost(i) * HighsCDouble(debugSolution.debugSolution[i]);
     debugSolution.debugSolObjective = static_cast<double>(debugsolobj);
     debugSolution.registerDomain(domain);
     assert(checkSolution(debugSolution.debugSolution));

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1015,12 +1015,11 @@ void HighsMipSolverData::runSetup() {
     debugSolution.debugSolution.clear();
     debugSolution.debugSolution = postSolveStack.getReducedPrimalSolution(
         debugSolution.debugOrigSolution);
-    // Do we even need to recalculate the objective?
     debugSolution.debugSolObjective = 0;
-    for (HighsInt i = 0; i != mipsolver.model_->num_col_; ++i) {
-      debugSolution.debugSolObjective +=
-          mipsolver.colCost(i) * debugSolution.debugSolution[i];
-    }
+    HighsCDouble debugsolobj = 0.0;
+    for (HighsInt i = 0; i != mipsolver.model_->num_col_; ++i)
+      debugsolobj += mipsolver.colCost(i) * debugSolution.debugSolution[i];
+    debugSolution.debugSolObjective = static_cast<double>(debugsolobj);
     debugSolution.registerDomain(domain);
     assert(checkSolution(debugSolution.debugSolution));
   }


### PR DESCRIPTION
This expands how the MIP debug solution can be used. 

Previously: Presolve had to be disabled and the solution was removed if a restart occurred. The expected solution format was also SCIP's .sol format with anaonymised variable names. 

Now: The expected solution format is a .sol file produced by HiGHS (of the original problem). The solution is then saved both in the original and transformed space when loaded in, and transformed appropriately at each restart and after presolve. 

I guess this feature is not used by many people? It's not meant to public facing, and the code is hidden by a compiler flag. This makes is substantially easier to use, and has already been helpful. 

I'm still not too sure on C++ that isn't doing MIP stuff. Opinions on how the `.sol` file is parsed are welcome. 