### PR TITLE
Remove cu headers pdlp etc and make it opt in

### DIFF
--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -13,8 +13,6 @@ set(include_dirs
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/mip>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/model>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/parallel>
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/pdlp>
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/pdlp/cupdlp>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/presolve>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/qpsolver>
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/simplex>
@@ -22,26 +20,39 @@ set(include_dirs
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/util>
   $<BUILD_INTERFACE:${HIGHS_BINARY_DIR}>)
 
-set(cupdlp_sources
-  pdlp/cupdlp/cupdlp_cs.c
-  pdlp/cupdlp/cupdlp_linalg.c
-  pdlp/cupdlp/cupdlp_proj.c
-  pdlp/cupdlp/cupdlp_restart.c
-  pdlp/cupdlp/cupdlp_scaling.c
-  pdlp/cupdlp/cupdlp_solver.c
-  pdlp/cupdlp/cupdlp_step.c
-  pdlp/cupdlp/cupdlp_utils.c)
+if(NOT DISABLE_PDLP)
+  list(APPEND include_dirs
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/pdlp>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/highs/pdlp/cupdlp>)
+endif()
 
-set(cupdlp_headers
-  pdlp/cupdlp/cupdlp_cs.h
-  pdlp/cupdlp/cupdlp_defs.h
-  pdlp/cupdlp/cupdlp_linalg.h
-  pdlp/cupdlp/cupdlp_proj.h
-  pdlp/cupdlp/cupdlp_restart.h
-  pdlp/cupdlp/cupdlp_scaling.h
-  pdlp/cupdlp/cupdlp_solver.h
-  pdlp/cupdlp/cupdlp_step.h
-  pdlp/cupdlp/cupdlp_utils.c)
+if(NOT DISABLE_PDLP)
+  set(cupdlp_sources
+    pdlp/CupdlpWrapper.cpp
+    pdlp/cupdlp/cupdlp_cs.c
+    pdlp/cupdlp/cupdlp_linalg.c
+    pdlp/cupdlp/cupdlp_proj.c
+    pdlp/cupdlp/cupdlp_restart.c
+    pdlp/cupdlp/cupdlp_scaling.c
+    pdlp/cupdlp/cupdlp_solver.c
+    pdlp/cupdlp/cupdlp_step.c
+    pdlp/cupdlp/cupdlp_utils.c)
+
+  set(cupdlp_headers
+    pdlp/CupdlpWrapper.h
+    pdlp/cupdlp/cupdlp_cs.h
+    pdlp/cupdlp/cupdlp_defs.h
+    pdlp/cupdlp/cupdlp_linalg.h
+    pdlp/cupdlp/cupdlp_proj.h
+    pdlp/cupdlp/cupdlp_restart.h
+    pdlp/cupdlp/cupdlp_scaling.h
+    pdlp/cupdlp/cupdlp_solver.h
+    pdlp/cupdlp/cupdlp_step.h
+    pdlp/cupdlp/cupdlp_utils.c)
+else()
+  set(cupdlp_sources "")
+  set(cupdlp_headers "")
+endif()
 
 set(cuda_sources
   pdlp/cupdlp/cuda/cupdlp_cuda_kernels.cu
@@ -236,7 +247,6 @@ set(highs_sources
     model/HighsHessianUtils.cpp
     model/HighsModel.cpp
     parallel/HighsTaskExecutor.cpp
-    pdlp/CupdlpWrapper.cpp
     presolve/HighsPostsolveStack.cpp
     presolve/HighsSymmetry.cpp
     presolve/HPresolve.cpp

--- a/highs/HConfig.h
+++ b/highs/HConfig.h
@@ -1,0 +1,21 @@
+#ifndef HCONFIG_H_
+#define HCONFIG_H_
+
+// Minimal configuration for testing
+#define FAST_BUILD
+/* #undef ZLIB_FOUND */
+/* #undef CUPDLP_CPU */
+/* #undef CUPDLP_GPU */
+#define CMAKE_BUILD_TYPE "Debug"
+/* #undef HIGHSINT64 */
+/* #undef HIGHS_NO_DEFAULT_THREADS */
+/* #undef HIGHS_HAVE_MM_PAUSE */
+/* #undef HIGHS_HAVE_BUILTIN_CLZ */
+/* #undef HIGHS_HAVE_BITSCAN_REVERSE */
+
+#define HIGHS_GITHASH "test-integration"
+#define HIGHS_VERSION_MAJOR 1
+#define HIGHS_VERSION_MINOR 7
+#define HIGHS_VERSION_PATCH 2
+
+#endif /* HCONFIG_H_ */

--- a/highs/lp_data/HighsSolve.cpp
+++ b/highs/lp_data/HighsSolve.cpp
@@ -11,7 +11,9 @@
 
 #include "ipm/IpxWrapper.h"
 #include "lp_data/HighsSolutionDebug.h"
+#ifndef DISABLE_PDLP
 #include "pdlp/CupdlpWrapper.h"
+#endif
 #include "simplex/HApp.h"
 
 // The method below runs simplex, ipx or pdlp solver on the lp.
@@ -57,6 +59,7 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
       return_status = interpretCallStatus(options.log_options, call_status,
                                           return_status, "solveLpIpx");
     } else {
+#ifndef DISABLE_PDLP
       // Use cuPDLP-C to solve the LP
       try {
         call_status = solveLpCupdlp(solver_object);
@@ -67,6 +70,12 @@ HighsStatus solveLp(HighsLpSolverObject& solver_object, const string message) {
       }
       return_status = interpretCallStatus(options.log_options, call_status,
                                           return_status, "solveLpCupdlp");
+#else
+      // PDLP is disabled
+      highsLogUser(options.log_options, HighsLogType::kError,
+                   "PDLP solver is disabled in this build\n");
+      return_status = HighsStatus::kError;
+#endif
     }
     // Check for error return
     if (return_status == HighsStatus::kError) return return_status;


### PR DESCRIPTION
This is more of the start of a discussion.

Would it be possible to enable the build without the cu dependencies?

This code was generated by Claude and I adjusted it to make it build so its probably not ideal.

If there is alternative guidance that would also be helpful.