### PR TITLE
Understand why presolve cannot be used for AC calculation

### DIFF
--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -1300,9 +1300,12 @@ HighsStatus Highs::optimizeModel() {
     // return HighsStatus::kOk;
   }
 
-  if (!basis_.valid && solution_.value_valid) {
-    // There is no valid basis, but there is a valid solution, so use
-    // it to construct a basis
+  const bool can_use_basis =
+      !this->model_.lp_.isMip() || options_.solve_relaxation;
+  if (can_use_basis && !basis_.valid && solution_.value_valid) {
+    // Solver may be able to make use of basis, and there is no valid
+    // basis, but there is a valid solution, so use it to construct a
+    // basis
     return_status =
         interpretCallStatus(options_.log_options, basisForSolution(),
                             return_status, "basisForSolution");


### PR DESCRIPTION
So, if the LP for the AC calculation is presolved, the solution obtained may well have integer variables at bounds. 

This is not just a "bad" interior point, it can lead to incorrect deductions about the feasible values of integer variables, and incorrect optimal solutions of the MIP being claimed. This was behind the errors observed with `egout`.

All that's come out of this is that when no basis exists, a basis is only constructed from an existing solution when it might be useful - ie when the problem is not a MIP, or a MIP relaxation is being solved.