### PR TITLE
Decrease probing budget after some limit

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1557,7 +1557,7 @@ HPresolve::Result HPresolve::runProbing(HighsPostsolveStack& postsolve_stack) {
             std::max(HighsInt{1000}, (model->num_row_ + model->num_col_) / 20);
       } else {
         probingEarlyAbort =
-            numDel > std::min(HighsInt{500}, model->num_col_ / 20);
+            numDel > std::min(HighsInt{1000}, (model->num_row_ + model->num_col_) / 40);
       }
       if (probingEarlyAbort) break;
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1556,7 +1556,8 @@ HPresolve::Result HPresolve::runProbing(HighsPostsolveStack& postsolve_stack) {
             std::max(HighsInt{1000}, (model->num_row_ + model->num_col_) / 20);
       } else {
         probingEarlyAbort =
-            numDel > std::min(HighsInt{1000}, (model->num_row_ + model->num_col_) / 20);
+            numDel >
+            std::min(HighsInt{1000}, (model->num_row_ + model->num_col_) / 20);
       }
       if (probingEarlyAbort) break;
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1545,8 +1545,7 @@ HPresolve::Result HPresolve::runProbing(HighsPostsolveStack& postsolve_stack) {
       if (cliquetable.getSubstitution(i) != nullptr || !domain.isBinary(i))
         continue;
 
-      bool tightenLimits = (numProbed - oldNumProbed) >= 1000;
-      if (numProbed - oldNumProbed == 1000) splayContingent /= 2;
+      bool tightenLimits = (numProbed - oldNumProbed) >= 2500;
 
       // when a large percentage of columns have been deleted, stop this round
       // of probing
@@ -1557,7 +1556,7 @@ HPresolve::Result HPresolve::runProbing(HighsPostsolveStack& postsolve_stack) {
             std::max(HighsInt{1000}, (model->num_row_ + model->num_col_) / 20);
       } else {
         probingEarlyAbort =
-            numDel > std::min(HighsInt{1000}, (model->num_row_ + model->num_col_) / 40);
+            numDel > std::min(HighsInt{1000}, (model->num_row_ + model->num_col_) / 20);
       }
       if (probingEarlyAbort) break;
 
@@ -1599,17 +1598,16 @@ HPresolve::Result HPresolve::runProbing(HighsPostsolveStack& postsolve_stack) {
       if (newNumDel > numDel) {
         probingContingent += numDel;
         if (!mipsolver->submip) {
-          splayContingent +=
-              (tightenLimits ? 50 : 100) * (newNumDel + numDelStart);
-          splayContingent += (tightenLimits ? 500 : 1000) * numNewCliques;
+          splayContingent += 100 * (newNumDel + numDelStart);
+          splayContingent += 1000 * numNewCliques;
         }
         numDel = newNumDel;
         numFail = 0;
       } else if (mipsolver->submip || numNewCliques == 0) {
-        splayContingent -= (tightenLimits ? 200 : 100) * numFail;
+        splayContingent -= (tightenLimits ? 250 : 100) * numFail;
         ++numFail;
       } else {
-        splayContingent += (tightenLimits ? 500 : 1000) * numNewCliques;
+        splayContingent += 1000 * numNewCliques;
         numFail = 0;
       }
 


### PR DESCRIPTION
This PR adds stricter limits on probing after 2500 columns have been probed on. Specifically, it decreases the amount of deleted columns used as a stopping criteria, and changes the weights used to calculate the dynamic probing budget. 
This fixes worst-case performance for #2478 where HiGHS was probing on everything for a huge amount of cliques / some deletions, despite the instance being easy to solve regardless. 
I've run some experiments on 60 or so instances, with most being unaffected, and some minor improvements that I'd say are noise. This change is only likely to affect large instances. The PR needs to go through more rigorous computational experiments before being merged.
I decided on the numbers from playing around a bit on some instances. They're unlikely to be perfect (as the original ones aren't), so am open to any changes / new approaches. I tried to be conservative because I don't want to ruin probings effectiveness on other instances just to avoid these fringe cases. 