### PR TITLE
Add a dynamic redcost budget

### DIFF
--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -213,7 +213,7 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
     }
   }
   HighsInt maxNumStepsExp = 10;
-  HighsInt expshift = 0;
+  int expshift = 0;
   std::frexp(numRedcostLargeDomainCols / 10, &expshift);
   if (expshift > 5) {
     expshift = std::min(expshift, maxNumStepsExp);

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -216,7 +216,7 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
   int expshift = 0;
   std::frexp(numRedcostLargeDomainCols / 10, &expshift);
   if (expshift > 5) {
-    expshift = std::min(expshift, maxNumStepsExp);
+    expshift = std::min(expshift, static_cast<int>(maxNumStepsExp));
     maxNumStepsExp = maxNumStepsExp - expshift + 5;
   }
   auto maxNumSteps = static_cast<HighsInt>(1ULL << maxNumStepsExp);

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -206,14 +206,10 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
   // This is to avoid doing 2**10 steps when there's many unbounded columns
   HighsInt numRedcostLargeDomainCols = 0;
   for (HighsInt col : mipsolver.mipdata_->integral_cols) {
-    if (mipsolver.mipdata_->domain.col_upper_[col] -
-            mipsolver.mipdata_->domain.col_lower_[col] >=
-        512) {
-      if (lpredcost[col] > mipsolver.mipdata_->feastol) {
-        numRedcostLargeDomainCols++;
-      } else if (lpredcost[col] < -mipsolver.mipdata_->feastol) {
-        numRedcostLargeDomainCols++;
-      }
+    if ((mipsolver.mipdata_->domain.col_upper_[col] -
+         mipsolver.mipdata_->domain.col_lower_[col]) >= 512 &&
+        std::abs(lpredcost[col]) > mipsolver.mipdata_->feastol) {
+      numRedcostLargeDomainCols++;
     }
   }
   HighsInt maxNumStepsExp = 10;
@@ -223,7 +219,7 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
     expshift = std::min(expshift, static_cast<int>(maxNumStepsExp));
     maxNumStepsExp = maxNumStepsExp - expshift + 5;
   }
-  auto maxNumSteps = static_cast<HighsInt>(1ULL << maxNumStepsExp);
+  HighsInt maxNumSteps = static_cast<HighsInt>(1ULL << maxNumStepsExp);
 
   for (HighsInt col : mipsolver.mipdata_->integral_cols) {
     if (lpredcost[col] > mipsolver.mipdata_->feastol) {

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -200,6 +200,10 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
   mipsolver.mipdata_->lp.computeBasicDegenerateDuals(
       mipsolver.mipdata_->feastol);
 
+  // Compute maximum number of steps per column with large domain
+  // max_steps = 2 ** k, k = max(5, min(10 ,round(log(|D| / 10)))),
+  // D = {col : integral_cols | (ub - lb) >= 512}
+  // This is to avoid doing 2**10 steps when there's many unbounded columns
   HighsInt numRedcostLargeDomainCols = 0;
   for (HighsInt col : mipsolver.mipdata_->integral_cols) {
     if (mipsolver.mipdata_->domain.col_upper_[col] -


### PR DESCRIPTION
Currently for each integral column with `ub - lb >= 1024`, HiGHS adds 1024 lurking bounds using reduced cost logic. In general this isn't an issue because most models don't have many integer columns with large domains. Additionally, if they do, presolve usually finds that most domains can be substantially tightened, and even if it doesn't, then it's unlikely for many of the integer columns to feature in the objective function. 
What happened in #2508 is that a huge amount of continuous columns got upgraded to implied integer, with most of them being unbounded and featuring in the objective. This led to a ridiculous amount of time being spent in adding lurking bounds derived from reduced cost, which is not that important for the solve process. 
The change: I've added a quick check to scale the max amount of values to query (instead of 1024 it's now some power of 2 in the range `[32, 1024]`). This is decided based on the amount of columns with non-zero reduced cost and domains wider than `ub - lb >= 512`.
The only downside: This adds a linear time check that is redundant for nearly all instances. I don't see it being a problem.

I've tested this on 60 or so instances, and as expected, there's no change in any of them. This should still be tested on a wider set of instances, just to see if the safety check does actually have an overhead, and if the change affect the solve path of any instance.