### PR TITLE
Logging clean-up

### DIFF
--- a/check/TestPresolve.cpp
+++ b/check/TestPresolve.cpp
@@ -838,4 +838,3 @@ TEST_CASE("presolve-egout-ac", "[highs_test_presolve]") {
 
   h.resetGlobalScheduler(true);
 }
-

--- a/check/TestPresolve.cpp
+++ b/check/TestPresolve.cpp
@@ -838,3 +838,4 @@ TEST_CASE("presolve-egout-ac", "[highs_test_presolve]") {
 
   h.resetGlobalScheduler(true);
 }
+

--- a/check/TestSemiVariables.cpp
+++ b/check/TestSemiVariables.cpp
@@ -17,7 +17,7 @@ TEST_CASE("semi-variable-model", "[highs_test_semi_variables]") {
   const HighsInfo& info = highs.getInfo();
   HighsStatus return_status;
   double optimal_objective_function_value;
-  if (!dev_run) highs.setOptionValue("output_flag", false);
+  highs.setOptionValue("output_flag", dev_run);
   HighsModel model;
   HighsLp& lp = model.lp_;
   semiModel0(lp);

--- a/highs/Highs.h
+++ b/highs/Highs.h
@@ -1700,7 +1700,7 @@ class Highs {
   bool qFormatOk(const HighsInt num_nz, const HighsInt format);
   void clearZeroHessian();
   HighsStatus checkOptimality(const std::string& solver_type);
-  HighsStatus lpKktCheck(const std::string& message);
+  HighsStatus lpKktCheck(const HighsLp& lp, const std::string& message = "");
   HighsStatus invertRequirementError(std::string method_name) const;
 
   HighsStatus handleInfCost();

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -1627,7 +1627,7 @@ HighsStatus Highs::optimizeModel() {
       presolve_.data_.recovered_basis_ = basis_;
 
       if (model_presolve_status_ == HighsPresolveStatus::kReduced)
-      	this->lpKktCheck(presolve_.getReducedProblem(), "Before postsolve");
+        this->lpKktCheck(presolve_.getReducedProblem(), "Before postsolve");
 
       this_postsolve_time = -timer_.read(timer_.postsolve_clock);
       timer_.start(timer_.postsolve_clock);
@@ -1637,11 +1637,11 @@ HighsStatus Highs::optimizeModel() {
       presolve_.info_.postsolve_time = this_postsolve_time;
 
       if (postsolve_status == HighsPostsolveStatus::kSolutionRecovered) {
-	// Indicate that nontrivial postsolve has been performed
+        // Indicate that nontrivial postsolve has been performed
         if (model_presolve_status_ == HighsPresolveStatus::kReduced ||
-	    model_presolve_status_ == HighsPresolveStatus::kReducedToEmpty)
-	  highsLogUser(log_options, HighsLogType::kInfo,
-		       "Performed postsolve\n");
+            model_presolve_status_ == HighsPresolveStatus::kReducedToEmpty)
+          highsLogUser(log_options, HighsLogType::kInfo,
+                       "Performed postsolve\n");
         // Set solution and its status
         solution_.clear();
         solution_ = presolve_.data_.recovered_solution_;
@@ -2314,7 +2314,7 @@ HighsStatus Highs::setSolution(const HighsInt num_entries,
     highsLogUser(options_.log_options, HighsLogType::kWarning,
                  "setSolution: User set of indices has %d duplicate%s: last "
                  "value used\n",
-                 int(num_duplicates), num_duplicates > 1 ? "s" : "");
+                 int(num_duplicates), num_duplicates == 1 ? "" : "s");
     return_status = HighsStatus::kWarning;
   }
 

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -874,7 +874,8 @@ HighsStatus Highs::presolve() {
   }
 
   bool using_reduced_lp = false;
-  reportPresolveReductions(log_options, model_presolve_status_, model_.lp_, presolve_.getReducedProblem());
+  reportPresolveReductions(log_options, model_presolve_status_, model_.lp_,
+                           presolve_.getReducedProblem());
   switch (model_presolve_status_) {
     case HighsPresolveStatus::kNotPresolved: {
       // Shouldn't happen
@@ -929,8 +930,7 @@ HighsStatus Highs::presolve() {
     presolved_model_.lp_.setMatrixDimensions();
   }
 
-  highsLogUser(log_options, HighsLogType::kInfo,
-               "Presolve status: %s\n",
+  highsLogUser(log_options, HighsLogType::kInfo, "Presolve status: %s\n",
                presolveStatusToString(model_presolve_status_).c_str());
   return returnFromHighs(return_status);
 }
@@ -1403,8 +1403,8 @@ HighsStatus Highs::optimizeModel() {
     // if PDLP is used to clean up after postsolve
     HighsInt presolved_lp_pdlp_iteration_count = 0;
     // Log the presolve reductions
-    reportPresolveReductions(log_options, model_presolve_status_,
-			     incumbent_lp, presolve_.getReducedProblem());
+    reportPresolveReductions(log_options, model_presolve_status_, incumbent_lp,
+                             presolve_.getReducedProblem());
     switch (model_presolve_status_) {
       case HighsPresolveStatus::kNotPresolved: {
         ekk_instance_.lp_name_ = "Original LP";

--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -66,11 +66,11 @@ void Highs::reportModelStats() const {
     highsLogDev(log_options, HighsLogType::kInfo, "%4s      : %s\n",
                 problem_type.c_str(), lp.model_name_.c_str());
     highsLogDev(log_options, HighsLogType::kInfo,
-                "Row%s      : %" HIGHSINT_FORMAT "\n",
-		lp.num_row_, lp.num_row_ > 1 ? "s" : "");
+                "Row%s      : %" HIGHSINT_FORMAT "\n", lp.num_row_,
+                lp.num_row_ == 1 ? "" : "s");
     highsLogDev(log_options, HighsLogType::kInfo,
-                "Col%s      : %" HIGHSINT_FORMAT "\n",
-		lp.num_col_, lp.num_col_ > 1 ? "s" : "");
+                "Col%s      : %" HIGHSINT_FORMAT "\n", lp.num_col_,
+                lp.num_col_ == 1 ? "" : "s");
     if (q_num_nz) {
       highsLogDev(log_options, HighsLogType::kInfo,
                   "Matrix Nz : %" HIGHSINT_FORMAT "\n", a_num_nz);
@@ -78,8 +78,8 @@ void Highs::reportModelStats() const {
                   "Hessian Nz: %" HIGHSINT_FORMAT "\n", q_num_nz);
     } else {
       highsLogDev(log_options, HighsLogType::kInfo,
-                  "Nonzero%s  : %" HIGHSINT_FORMAT "\n",
-		  a_num_nz, a_num_nz > 1 ? "s" : "");
+                  "Nonzero%s  : %" HIGHSINT_FORMAT "\n", a_num_nz,
+                  a_num_nz == 1 ? "" : "s");
     }
     if (num_integer)
       highsLogDev(log_options, HighsLogType::kInfo,
@@ -96,19 +96,22 @@ void Highs::reportModelStats() const {
     std::stringstream stats_line;
     stats_line << problem_type;
     if (lp.model_name_.length()) stats_line << " " << lp.model_name_;
-    stats_line << " has "
-	       << lp.num_row_ << " row" << (lp.num_row_ > 1 ? "s" : "") << "; "
-	       << lp.num_col_ << " col" << (lp.num_col_ > 1 ? "s" : "");
+    stats_line << " has " << lp.num_row_ << " row"
+               << (lp.num_row_ == 1 ? "" : "s") << "; " << lp.num_col_ << " col"
+               << (lp.num_col_ == 1 ? "" : "s");
     if (q_num_nz) {
-      stats_line << "; " << a_num_nz << " matrix nonzero" << (a_num_nz > 1 ? "s" : "");
-      stats_line << "; " << q_num_nz << " Hessian nonzero" << (q_num_nz > 1 ? "s" : "");
+      stats_line << "; " << a_num_nz << " matrix nonzero"
+                 << (a_num_nz == 1 ? "" : "s");
+      stats_line << "; " << q_num_nz << " Hessian nonzero"
+                 << (q_num_nz == 1 ? "" : "s");
     } else {
-      stats_line << "; " << a_num_nz << " nonzero" << (a_num_nz > 1 ? "s" : "");
+      stats_line << "; " << a_num_nz << " nonzero"
+                 << (a_num_nz == 1 ? "" : "s");
     }
     if (num_integer)
-      stats_line << "; "
-		 << num_integer << " integer variable" << (a_num_nz > 1 ? "s" : "") << " ("
-		 << num_binary << " binary)";
+      stats_line << "; " << num_integer << " integer variable"
+                 << (a_num_nz == 1 ? "" : "s") << " (" << num_binary
+                 << " binary)";
     if (num_semi_continuous)
       stats_line << "; " << num_semi_continuous << " semi-continuous variables";
     if (num_semi_integer)
@@ -2662,12 +2665,11 @@ HighsStatus Highs::lpKktCheck(const HighsLp& lp, const std::string& message) {
     dual_residual_tolerance = options.kkt_tolerance;
     optimality_tolerance = options.kkt_tolerance;
   }
-  info.objective_function_value =
-      lp.objectiveValue(solution_.col_value);
+  info.objective_function_value = lp.objectiveValue(solution_.col_value);
   HighsPrimalDualErrors primal_dual_errors;
   const bool get_residuals = !basis_.valid;
-  getLpKktFailures(options, lp, solution, basis_, info,
-                   primal_dual_errors, get_residuals);
+  getLpKktFailures(options, lp, solution, basis_, info, primal_dual_errors,
+                   get_residuals);
   if (this->model_status_ == HighsModelStatus::kOptimal)
     reportLpKktFailures(lp, options, info, message);
   // get_residuals is false when there is a valid basis, since

--- a/highs/lp_data/HighsLpUtils.cpp
+++ b/highs/lp_data/HighsLpUtils.cpp
@@ -1808,20 +1808,21 @@ void reportLpDimensions(const HighsLogOptions& log_options, const HighsLp& lp) {
   else
     lp_num_nz = lp.a_matrix_.start_[lp.num_col_];
   highsLogUser(log_options, HighsLogType::kInfo,
-               "LP has %" HIGHSINT_FORMAT " row%s, %" HIGHSINT_FORMAT " column%s",
-               lp.num_row_, lp.num_row_ > 1 ? "s" : "",
-	       lp.num_col_, lp.num_col_ > 1 ? "s" : "");
+               "LP has %" HIGHSINT_FORMAT " row%s, %" HIGHSINT_FORMAT
+               " column%s",
+               lp.num_row_, lp.num_row_ == 1 ? "" : "s", lp.num_col_,
+               lp.num_col_ == 1 ? "" : "s");
   HighsInt num_int = getNumInt(lp);
   if (num_int) {
     highsLogUser(log_options, HighsLogType::kInfo,
                  ", %" HIGHSINT_FORMAT " nonzeros and %" HIGHSINT_FORMAT
                  " integer column%s\n",
-                 lp_num_nz, lp_num_nz > 1 ? "s" : "",
-		 num_int, num_int > 1 ? "s" : "");
+                 lp_num_nz, lp_num_nz == 1 ? "" : "s", num_int,
+                 num_int == 1 ? "" : "s");
   } else {
     highsLogUser(log_options, HighsLogType::kInfo,
-                 " and %" HIGHSINT_FORMAT " nonzero%s\n",
-		 lp_num_nz, lp_num_nz > 1 ? "s" : "");
+                 " and %" HIGHSINT_FORMAT " nonzero%s\n", lp_num_nz,
+                 lp_num_nz == 1 ? "" : "s");
   }
 }
 

--- a/highs/lp_data/HighsLpUtils.cpp
+++ b/highs/lp_data/HighsLpUtils.cpp
@@ -2959,21 +2959,52 @@ bool isMatrixDataNull(const HighsLogOptions& log_options,
 }
 
 void reportPresolveReductions(const HighsLogOptions& log_options,
-                              const HighsLp& lp, const HighsLp& presolve_lp) {
-  HighsInt num_col_from = lp.num_col_;
-  HighsInt num_row_from = lp.num_row_;
-  HighsInt num_nz_from = lp.a_matrix_.start_[num_col_from];
-  HighsInt num_col_to = presolve_lp.num_col_;
-  HighsInt num_row_to = presolve_lp.num_row_;
-  HighsInt num_nz_to;
-  if (num_col_to) {
-    num_nz_to = presolve_lp.a_matrix_.start_[num_col_to];
-  } else {
-    num_nz_to = 0;
+			      HighsPresolveStatus presolve_status,
+                              const HighsLp& lp,
+			      const HighsLp& presolved_lp) {
+  const HighsInt num_col_from = lp.num_col_;
+  const HighsInt num_row_from = lp.num_row_;
+  const HighsInt num_nz_from = lp.a_matrix_.numNz();
+  HighsInt num_col_to = 0;
+  HighsInt num_row_to = 0;
+  HighsInt num_nz_to = 0;
+  std::string message = "";
+  
+  switch (presolve_status) {
+    case HighsPresolveStatus::kNotPresolved: 
+    case HighsPresolveStatus::kInfeasible:
+    case HighsPresolveStatus::kUnboundedOrInfeasible: return;
+    case HighsPresolveStatus::kNotReduced: {
+      num_col_to = num_col_from;
+      num_row_to = num_row_from;
+      num_nz_to = num_nz_from;
+      message = "- Not reduced";
+      break;
+    }
+    case HighsPresolveStatus::kReduced:
+    case HighsPresolveStatus::kTimeout: {
+      num_col_to = presolved_lp.num_col_;
+      num_row_to = presolved_lp.num_row_;
+      num_nz_to = presolved_lp.a_matrix_.numNz();
+      message = presolve_status == HighsPresolveStatus::kTimeout ? "- Timeout" : "";
+      break;
+    }
+    case HighsPresolveStatus::kReducedToEmpty: {
+      num_col_to = 0;
+      num_row_to = 0;
+      num_nz_to = 0;
+      message = "- Reduced to empty";
+      break;
+    }
+    default: {
+      // case HighsPresolveStatus::kOutOfMemory
+      assert(presolve_status == HighsPresolveStatus::kOutOfMemory);
+      return;
+    }
   }
   char nz_sign_char = '-';
   HighsInt delta_nz = num_nz_from - num_nz_to;
-  if (num_nz_from < num_nz_to) {
+  if (num_nz_to > num_nz_from) {
     delta_nz = -delta_nz;
     nz_sign_char = '+';
   }
@@ -2982,40 +3013,9 @@ void reportPresolveReductions(const HighsLogOptions& log_options,
       "Presolve reductions: rows %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
       "); columns %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
       "); "
-      "nonzeros %" HIGHSINT_FORMAT "(%c%" HIGHSINT_FORMAT ")\n",
+      "nonzeros %" HIGHSINT_FORMAT "(%c%" HIGHSINT_FORMAT ") %s\n",
       num_row_to, (num_row_from - num_row_to), num_col_to,
-      (num_col_from - num_col_to), num_nz_to, nz_sign_char, delta_nz);
-}
-
-void reportPresolveReductions(const HighsLogOptions& log_options,
-                              const HighsLp& lp, const bool presolve_to_empty) {
-  HighsInt num_col_from = lp.num_col_;
-  HighsInt num_row_from = lp.num_row_;
-  HighsInt num_nz_from = lp.a_matrix_.start_[num_col_from];
-  HighsInt num_col_to;
-  HighsInt num_row_to;
-  HighsInt num_nz_to;
-  std::string message;
-  if (presolve_to_empty) {
-    num_col_to = 0;
-    num_row_to = 0;
-    num_nz_to = 0;
-    message = "- Reduced to empty";
-  } else {
-    num_col_to = num_col_from;
-    num_row_to = num_row_from;
-    num_nz_to = num_nz_from;
-    message = "- Not reduced";
-  }
-  highsLogUser(log_options, HighsLogType::kInfo,
-               "Presolve reductions: rows %" HIGHSINT_FORMAT
-               "(-%" HIGHSINT_FORMAT "); columns %" HIGHSINT_FORMAT
-               "(-%" HIGHSINT_FORMAT
-               "); "
-               "nonzeros %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT ") %s\n",
-               num_row_to, (num_row_from - num_row_to), num_col_to,
-               (num_col_from - num_col_to), num_nz_to,
-               (num_nz_from - num_nz_to), message.c_str());
+      (num_col_from - num_col_to), num_nz_to, nz_sign_char, delta_nz, message.c_str());
 }
 
 bool isLessInfeasibleDSECandidate(const HighsLogOptions& log_options,
@@ -3212,6 +3212,10 @@ HighsLp withoutSemiVariables(const HighsLp& lp_, HighsSolution& solution,
   lp.num_col_ += num_semi_variables;
   lp.num_row_ += 2 * num_semi_variables;
   assert((HighsInt)index.size() == new_num_nz);
+  // Ensure that the matrix dimensions are consistent with the LP
+  // dimensions
+  lp.a_matrix_.num_col_ = lp.num_col_;
+  lp.a_matrix_.num_row_ = lp.num_row_;
   // Clear any modifications inherited from lp_
   lp.mods_.clear();
   return lp;

--- a/highs/lp_data/HighsLpUtils.cpp
+++ b/highs/lp_data/HighsLpUtils.cpp
@@ -1808,17 +1808,20 @@ void reportLpDimensions(const HighsLogOptions& log_options, const HighsLp& lp) {
   else
     lp_num_nz = lp.a_matrix_.start_[lp.num_col_];
   highsLogUser(log_options, HighsLogType::kInfo,
-               "LP has %" HIGHSINT_FORMAT " rows, %" HIGHSINT_FORMAT " columns",
-               lp.num_row_, lp.num_col_);
+               "LP has %" HIGHSINT_FORMAT " row%s, %" HIGHSINT_FORMAT " column%s",
+               lp.num_row_, lp.num_row_ > 1 ? "s" : "",
+	       lp.num_col_, lp.num_col_ > 1 ? "s" : "");
   HighsInt num_int = getNumInt(lp);
   if (num_int) {
     highsLogUser(log_options, HighsLogType::kInfo,
                  ", %" HIGHSINT_FORMAT " nonzeros and %" HIGHSINT_FORMAT
-                 " integer columns\n",
-                 lp_num_nz, num_int);
+                 " integer column%s\n",
+                 lp_num_nz, lp_num_nz > 1 ? "s" : "",
+		 num_int, num_int > 1 ? "s" : "");
   } else {
     highsLogUser(log_options, HighsLogType::kInfo,
-                 " and %" HIGHSINT_FORMAT " nonzeros\n", lp_num_nz, num_int);
+                 " and %" HIGHSINT_FORMAT " nonzero%s\n",
+		 lp_num_nz, lp_num_nz > 1 ? "s" : "");
   }
 }
 

--- a/highs/lp_data/HighsLpUtils.cpp
+++ b/highs/lp_data/HighsLpUtils.cpp
@@ -2959,9 +2959,8 @@ bool isMatrixDataNull(const HighsLogOptions& log_options,
 }
 
 void reportPresolveReductions(const HighsLogOptions& log_options,
-			      HighsPresolveStatus presolve_status,
-                              const HighsLp& lp,
-			      const HighsLp& presolved_lp) {
+                              HighsPresolveStatus presolve_status,
+                              const HighsLp& lp, const HighsLp& presolved_lp) {
   const HighsInt num_col_from = lp.num_col_;
   const HighsInt num_row_from = lp.num_row_;
   const HighsInt num_nz_from = lp.a_matrix_.numNz();
@@ -2969,11 +2968,12 @@ void reportPresolveReductions(const HighsLogOptions& log_options,
   HighsInt num_row_to = 0;
   HighsInt num_nz_to = 0;
   std::string message = "";
-  
+
   switch (presolve_status) {
-    case HighsPresolveStatus::kNotPresolved: 
+    case HighsPresolveStatus::kNotPresolved:
     case HighsPresolveStatus::kInfeasible:
-    case HighsPresolveStatus::kUnboundedOrInfeasible: return;
+    case HighsPresolveStatus::kUnboundedOrInfeasible:
+      return;
     case HighsPresolveStatus::kNotReduced: {
       num_col_to = num_col_from;
       num_row_to = num_row_from;
@@ -2986,7 +2986,8 @@ void reportPresolveReductions(const HighsLogOptions& log_options,
       num_col_to = presolved_lp.num_col_;
       num_row_to = presolved_lp.num_row_;
       num_nz_to = presolved_lp.a_matrix_.numNz();
-      message = presolve_status == HighsPresolveStatus::kTimeout ? "- Timeout" : "";
+      message =
+          presolve_status == HighsPresolveStatus::kTimeout ? "- Timeout" : "";
       break;
     }
     case HighsPresolveStatus::kReducedToEmpty: {
@@ -3008,14 +3009,15 @@ void reportPresolveReductions(const HighsLogOptions& log_options,
     delta_nz = -delta_nz;
     nz_sign_char = '+';
   }
-  highsLogUser(
-      log_options, HighsLogType::kInfo,
-      "Presolve reductions: rows %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
-      "); columns %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
-      "); "
-      "nonzeros %" HIGHSINT_FORMAT "(%c%" HIGHSINT_FORMAT ") %s\n",
-      num_row_to, (num_row_from - num_row_to), num_col_to,
-      (num_col_from - num_col_to), num_nz_to, nz_sign_char, delta_nz, message.c_str());
+  highsLogUser(log_options, HighsLogType::kInfo,
+               "Presolve reductions: rows %" HIGHSINT_FORMAT
+               "(-%" HIGHSINT_FORMAT "); columns %" HIGHSINT_FORMAT
+               "(-%" HIGHSINT_FORMAT
+               "); "
+               "nonzeros %" HIGHSINT_FORMAT "(%c%" HIGHSINT_FORMAT ") %s\n",
+               num_row_to, (num_row_from - num_row_to), num_col_to,
+               (num_col_from - num_col_to), num_nz_to, nz_sign_char, delta_nz,
+               message.c_str());
 }
 
 bool isLessInfeasibleDSECandidate(const HighsLogOptions& log_options,

--- a/highs/lp_data/HighsLpUtils.cpp
+++ b/highs/lp_data/HighsLpUtils.cpp
@@ -1808,8 +1808,8 @@ void reportLpDimensions(const HighsLogOptions& log_options, const HighsLp& lp) {
   else
     lp_num_nz = lp.a_matrix_.start_[lp.num_col_];
   highsLogUser(log_options, HighsLogType::kInfo,
-               "LP has %" HIGHSINT_FORMAT " columns, %" HIGHSINT_FORMAT " rows",
-               lp.num_col_, lp.num_row_);
+               "LP has %" HIGHSINT_FORMAT " rows, %" HIGHSINT_FORMAT " columns",
+               lp.num_row_, lp.num_col_);
   HighsInt num_int = getNumInt(lp);
   if (num_int) {
     highsLogUser(log_options, HighsLogType::kInfo,
@@ -2962,60 +2962,60 @@ void reportPresolveReductions(const HighsLogOptions& log_options,
                               const HighsLp& lp, const HighsLp& presolve_lp) {
   HighsInt num_col_from = lp.num_col_;
   HighsInt num_row_from = lp.num_row_;
-  HighsInt num_els_from = lp.a_matrix_.start_[num_col_from];
+  HighsInt num_nz_from = lp.a_matrix_.start_[num_col_from];
   HighsInt num_col_to = presolve_lp.num_col_;
   HighsInt num_row_to = presolve_lp.num_row_;
-  HighsInt num_els_to;
+  HighsInt num_nz_to;
   if (num_col_to) {
-    num_els_to = presolve_lp.a_matrix_.start_[num_col_to];
+    num_nz_to = presolve_lp.a_matrix_.start_[num_col_to];
   } else {
-    num_els_to = 0;
+    num_nz_to = 0;
   }
-  char elemsignchar = '-';
-  HighsInt elemdelta = num_els_from - num_els_to;
-  if (num_els_from < num_els_to) {
-    elemdelta = -elemdelta;
-    elemsignchar = '+';
+  char nz_sign_char = '-';
+  HighsInt delta_nz = num_nz_from - num_nz_to;
+  if (num_nz_from < num_nz_to) {
+    delta_nz = -delta_nz;
+    nz_sign_char = '+';
   }
   highsLogUser(
       log_options, HighsLogType::kInfo,
-      "Presolve : Reductions: rows %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
+      "Presolve reductions: rows %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
       "); columns %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT
       "); "
-      "elements %" HIGHSINT_FORMAT "(%c%" HIGHSINT_FORMAT ")\n",
+      "nonzeros %" HIGHSINT_FORMAT "(%c%" HIGHSINT_FORMAT ")\n",
       num_row_to, (num_row_from - num_row_to), num_col_to,
-      (num_col_from - num_col_to), num_els_to, elemsignchar, elemdelta);
+      (num_col_from - num_col_to), num_nz_to, nz_sign_char, delta_nz);
 }
 
 void reportPresolveReductions(const HighsLogOptions& log_options,
                               const HighsLp& lp, const bool presolve_to_empty) {
   HighsInt num_col_from = lp.num_col_;
   HighsInt num_row_from = lp.num_row_;
-  HighsInt num_els_from = lp.a_matrix_.start_[num_col_from];
+  HighsInt num_nz_from = lp.a_matrix_.start_[num_col_from];
   HighsInt num_col_to;
   HighsInt num_row_to;
-  HighsInt num_els_to;
+  HighsInt num_nz_to;
   std::string message;
   if (presolve_to_empty) {
     num_col_to = 0;
     num_row_to = 0;
-    num_els_to = 0;
+    num_nz_to = 0;
     message = "- Reduced to empty";
   } else {
     num_col_to = num_col_from;
     num_row_to = num_row_from;
-    num_els_to = num_els_from;
+    num_nz_to = num_nz_from;
     message = "- Not reduced";
   }
   highsLogUser(log_options, HighsLogType::kInfo,
-               "Presolve : Reductions: rows %" HIGHSINT_FORMAT
+               "Presolve reductions: rows %" HIGHSINT_FORMAT
                "(-%" HIGHSINT_FORMAT "); columns %" HIGHSINT_FORMAT
                "(-%" HIGHSINT_FORMAT
                "); "
-               "elements %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT ") %s\n",
+               "nonzeros %" HIGHSINT_FORMAT "(-%" HIGHSINT_FORMAT ") %s\n",
                num_row_to, (num_row_from - num_row_to), num_col_to,
-               (num_col_from - num_col_to), num_els_to,
-               (num_els_from - num_els_to), message.c_str());
+               (num_col_from - num_col_to), num_nz_to,
+               (num_nz_from - num_nz_to), message.c_str());
 }
 
 bool isLessInfeasibleDSECandidate(const HighsLogOptions& log_options,

--- a/highs/lp_data/HighsLpUtils.h
+++ b/highs/lp_data/HighsLpUtils.h
@@ -260,9 +260,8 @@ bool isMatrixDataNull(const HighsLogOptions& log_options,
                       const double* usr_matrix_value);
 
 void reportPresolveReductions(const HighsLogOptions& log_options,
-			      HighsPresolveStatus presolve_status,
-                              const HighsLp& lp,
-			      const HighsLp& presolved_lp);
+                              HighsPresolveStatus presolve_status,
+                              const HighsLp& lp, const HighsLp& presolved_lp);
 
 bool isLessInfeasibleDSECandidate(const HighsLogOptions& log_options,
                                   const HighsLp& lp);

--- a/highs/lp_data/HighsLpUtils.h
+++ b/highs/lp_data/HighsLpUtils.h
@@ -260,10 +260,9 @@ bool isMatrixDataNull(const HighsLogOptions& log_options,
                       const double* usr_matrix_value);
 
 void reportPresolveReductions(const HighsLogOptions& log_options,
-                              const HighsLp& lp, const HighsLp& presolve_lp);
-
-void reportPresolveReductions(const HighsLogOptions& log_options,
-                              const HighsLp& lp, const bool presolve_to_empty);
+			      HighsPresolveStatus presolve_status,
+                              const HighsLp& lp,
+			      const HighsLp& presolved_lp);
 
 bool isLessInfeasibleDSECandidate(const HighsLogOptions& log_options,
                                   const HighsLp& lp);

--- a/highs/lp_data/HighsModelUtils.cpp
+++ b/highs/lp_data/HighsModelUtils.cpp
@@ -428,7 +428,7 @@ HighsStatus normaliseNames(const HighsLogOptions& log_options, bool column,
                  "Replaced %d blank %6s name%s by name%s with prefix \"%s\", "
                  "beginning with suffix %d\n",
                  int(num_blank), column ? "column" : "row",
-                 num_blank > 1 ? "s" : "", num_blank > 1 ? "s" : "",
+                 num_blank == 1 ? "" : "s", num_blank == 1 ? "" : "s",
                  name_prefix.c_str(), int(from_name_suffix));
     return HighsStatus::kWarning;
   }

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -96,7 +96,7 @@ void HighsMipSolver::run() {
   mipdata_->runMipPresolve(options_mip_->presolve_reduction_limit);
   analysis_.mipTimerStop(kMipClockRunPresolve);
   analysis_.mipTimerStop(kMipClockPresolve);
-  
+
   if (analysis_.analyse_mip_time && !submip)
     highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                  "MIP-Timing: %11.2g - completed presolve\n", timer_.read());
@@ -832,27 +832,37 @@ void HighsMipSolver::cleanupSolve() {
                  "                    %.12g (row viol.)\n",
                  solution_objective_, bound_violation_, integrality_violation_,
                  row_violation_);
-  if (!timeless_log)
+  if (!timeless_log) {
     highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
-                 "  Timing            %.2f (total)\n"
-                 "                    %.2f (presolve)\n"
-                 "                    %.2f (solve)\n"
-                 "                    %.2f (postsolve)\n",
-                 timer_.read(), analysis_.mipTimerRead(kMipClockPresolve),
-                 analysis_.mipTimerRead(kMipClockSolve),
-                 analysis_.mipTimerRead(kMipClockPostsolve));
+                 "  Timing            %.2f\n", timer_.read());
+    if (analysis_.analyse_mip_time)
+      highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                   "                    %.2f (presolve)\n"
+                   "                    %.2f (solve)\n"
+                   "                    %.2f (postsolve)\n",
+                   analysis_.mipTimerRead(kMipClockPresolve),
+                   analysis_.mipTimerRead(kMipClockSolve),
+                   analysis_.mipTimerRead(kMipClockPostsolve));
+  }
   highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                "  Max sub-MIP depth %d\n"
-               "  Nodes             %llu\n"
-               "  Repair LPs        %llu (%llu feasible; %llu iterations)\n"
-               "  LP iterations     %llu (total)\n"
+               "  Nodes             %llu\n",
+               int(max_submip_level), (long long unsigned)mipdata_->num_nodes);
+  if (mipdata_->total_repair_lp) {
+    highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                 "  Repair LPs        %llu (%llu feasible; %llu iterations)\n",
+                 (long long unsigned)mipdata_->total_repair_lp,
+                 (long long unsigned)mipdata_->total_repair_lp_feasible,
+                 (long long unsigned)mipdata_->total_repair_lp_iterations);
+  } else {
+    highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+                 "  Repair LPs        0\n");
+  }
+  highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
+               "  LP iterations     %llu\n"
                "                    %llu (strong br.)\n"
                "                    %llu (separation)\n"
                "                    %llu (heuristics)\n",
-               int(max_submip_level), (long long unsigned)mipdata_->num_nodes,
-               (long long unsigned)mipdata_->total_repair_lp,
-               (long long unsigned)mipdata_->total_repair_lp_feasible,
-               (long long unsigned)mipdata_->total_repair_lp_iterations,
                (long long unsigned)mipdata_->total_lp_iterations,
                (long long unsigned)mipdata_->sb_lp_iterations,
                (long long unsigned)mipdata_->sepa_lp_iterations,

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -93,9 +93,10 @@ void HighsMipSolver::run() {
   std::swap(mipdata_->debugSolution.debugSolActive, debugSolActive);
 #endif
   analysis_.mipTimerStart(kMipClockRunPresolve);
-  mipdata_->runPresolve(options_mip_->presolve_reduction_limit);
+  mipdata_->runMipPresolve(options_mip_->presolve_reduction_limit);
   analysis_.mipTimerStop(kMipClockRunPresolve);
   analysis_.mipTimerStop(kMipClockPresolve);
+  
   if (analysis_.analyse_mip_time && !submip)
     highsLogUser(options_mip_->log_options, HighsLogType::kInfo,
                  "MIP-Timing: %11.2g - completed presolve\n", timer_.read());
@@ -865,10 +866,10 @@ void HighsMipSolver::cleanupSolve() {
 }
 
 // Only called in Highs::runPresolve
-void HighsMipSolver::runPresolve(const HighsInt presolve_reduction_limit) {
+void HighsMipSolver::runMipPresolve(const HighsInt presolve_reduction_limit) {
   mipdata_ = decltype(mipdata_)(new HighsMipSolverData(*this));
   mipdata_->init();
-  mipdata_->runPresolve(presolve_reduction_limit);
+  mipdata_->runMipPresolve(presolve_reduction_limit);
 }
 
 const HighsLp& HighsMipSolver::getPresolvedModel() const {

--- a/highs/mip/HighsMipSolver.h
+++ b/highs/mip/HighsMipSolver.h
@@ -97,7 +97,7 @@ class HighsMipSolver {
   mutable HighsTimer timer_;
   void cleanupSolve();
 
-  void runPresolve(const HighsInt presolve_reduction_limit);
+  void runMipPresolve(const HighsInt presolve_reduction_limit);
   const HighsLp& getPresolvedModel() const;
   HighsPresolveStatus getPresolveStatus() const;
   presolve::HighsPostsolveStack getPostsolveStack() const;

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -692,7 +692,8 @@ void HighsMipSolverData::init() {
     dispfreq = 100;
 }
 
-void HighsMipSolverData::runMipPresolve(const HighsInt presolve_reduction_limit) {
+void HighsMipSolverData::runMipPresolve(
+    const HighsInt presolve_reduction_limit) {
   mipsolver.timer_.start(mipsolver.timer_.presolve_clock);
   presolve::HPresolve presolve;
   if (!presolve.okSetInput(mipsolver, presolve_reduction_limit)) {
@@ -704,10 +705,8 @@ void HighsMipSolverData::runMipPresolve(const HighsInt presolve_reduction_limit)
   }
   mipsolver.timer_.stop(mipsolver.timer_.presolve_clock);
 
-  reportPresolveReductions(mipsolver.options_mip_->log_options,
-			   presolve_status,
-			   *mipsolver.orig_model_,
-			   *mipsolver.model_);
+  reportPresolveReductions(mipsolver.options_mip_->log_options, presolve_status,
+                           *mipsolver.orig_model_, *mipsolver.model_);
 }
 
 void HighsMipSolverData::runSetup() {

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -705,8 +705,10 @@ void HighsMipSolverData::runMipPresolve(
   }
   mipsolver.timer_.stop(mipsolver.timer_.presolve_clock);
 
-  reportPresolveReductions(mipsolver.options_mip_->log_options, presolve_status,
-                           *mipsolver.orig_model_, *mipsolver.model_);
+  if (numRestarts == 0)
+    reportPresolveReductions(mipsolver.options_mip_->log_options,
+                             presolve_status, *mipsolver.orig_model_,
+                             *mipsolver.model_);
 }
 
 void HighsMipSolverData::runSetup() {
@@ -980,34 +982,38 @@ void HighsMipSolverData::runSetup() {
     highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
                  // clang-format off
 		 "\nSolving MIP model with:\n"
-		 "   %" HIGHSINT_FORMAT " rows\n"
-		 "   %" HIGHSINT_FORMAT " cols ("
+		 "   %" HIGHSINT_FORMAT " row%s\n"
+		 "   %" HIGHSINT_FORMAT " col%s ("
 		 "%" HIGHSINT_FORMAT" binary, "
 		 "%" HIGHSINT_FORMAT " integer, "
 		 "%" HIGHSINT_FORMAT" implied int., "
 		 "%" HIGHSINT_FORMAT " continuous, "
 		 "%" HIGHSINT_FORMAT " domain fixed)\n"
-		 "   %" HIGHSINT_FORMAT " nonzeros\n",
+		 "   %" HIGHSINT_FORMAT " nonzero%s\n",
                  // clang-format on
-                 mipsolver.numRow(), num_col, num_binary, num_general_integer,
-                 num_implied_integer, num_continuous, num_domain_fixed,
-                 mipsolver.numNonzero());
+                 mipsolver.numRow(), mipsolver.numRow() == 1 ? "" : "s",
+                 num_col, num_col == 1 ? "" : "s", num_binary,
+                 num_general_integer, num_implied_integer, num_continuous,
+                 num_domain_fixed, mipsolver.numNonzero(),
+                 mipsolver.numNonzero() == 1 ? "" : "s");
   } else {
     highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kInfo,
                  "Model after restart has "
                  // clang-format off
-		 "%" HIGHSINT_FORMAT " rows, "
-		 "%" HIGHSINT_FORMAT " cols ("
+		 "%" HIGHSINT_FORMAT " row%s, "
+		 "%" HIGHSINT_FORMAT " col%s ("
 		 "%" HIGHSINT_FORMAT " bin., "
 		 "%" HIGHSINT_FORMAT " int., "
 		 "%" HIGHSINT_FORMAT " impl., "
 		 "%" HIGHSINT_FORMAT " cont., "
 		 "%" HIGHSINT_FORMAT " dom.fix.), and "
-		 "%" HIGHSINT_FORMAT " nonzeros\n",
+		 "%" HIGHSINT_FORMAT " nonzero%s\n",
                  // clang-format on
-                 mipsolver.numRow(), num_col, num_binary, num_general_integer,
-                 num_implied_integer, num_continuous, num_domain_fixed,
-                 mipsolver.numNonzero());
+                 mipsolver.numRow(), mipsolver.numRow() == 1 ? "" : "s",
+                 num_col, num_col == 1 ? "" : "s", num_binary,
+                 num_general_integer, num_implied_integer, num_continuous,
+                 num_domain_fixed, mipsolver.numNonzero(),
+                 mipsolver.numNonzero() == 1 ? "" : "s");
   }
 
   heuristics.setupIntCols();

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -703,30 +703,11 @@ void HighsMipSolverData::runMipPresolve(const HighsInt presolve_reduction_limit)
     presolve_status = presolve.getPresolveStatus();
   }
   mipsolver.timer_.stop(mipsolver.timer_.presolve_clock);
-  const HighsLogOptions& log_options = mipsolver.options_mip_->log_options;
-  const HighsLp& incumbent_lp = *mipsolver.model_;
-  switch (presolve_status) {
-    case HighsPresolveStatus::kNotPresolved: {
-      // Shouldn't happen
-      assert(presolve_status != HighsPresolveStatus::kNotPresolved);
-      break;
-    }
-    case HighsPresolveStatus::kNotReduced:
-      reportPresolveReductions(log_options, incumbent_lp, false);
-    case HighsPresolveStatus::kInfeasible:
-    case HighsPresolveStatus::kReduced:
-      reportPresolveReductions(log_options, incumbent_lp, *mipsolver.model_);
-    case HighsPresolveStatus::kReducedToEmpty:
-      reportPresolveReductions(log_options, incumbent_lp, true);
-    case HighsPresolveStatus::kUnboundedOrInfeasible: 
-    case HighsPresolveStatus::kTimeout: {
-      break;
-    }
-    default: {
-      // case HighsPresolveStatus::kOutOfMemory
-      assert(presolve_status == HighsPresolveStatus::kOutOfMemory);
-    }
-  } 
+
+  reportPresolveReductions(mipsolver.options_mip_->log_options,
+			   presolve_status,
+			   *mipsolver.orig_model_,
+			   *mipsolver.model_);
 }
 
 void HighsMipSolverData::runSetup() {

--- a/highs/mip/HighsMipSolverData.h
+++ b/highs/mip/HighsMipSolverData.h
@@ -251,7 +251,7 @@ struct HighsMipSolverData {
   void init();
   void basisTransfer();
   void checkObjIntegrality();
-  void runPresolve(const HighsInt presolve_reduction_limit);
+  void runMipPresolve(const HighsInt presolve_reduction_limit);
   void setupDomainPropagation();
   void saveReportMipSolution(const double new_upper_limit = -kHighsInf);
   void runSetup();

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4879,20 +4879,19 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
       mipsolver->mipdata_->lower_bound = 0;
     } else {
       // An LP with no columns must have no rows, unless the reduction
-      // limit has been reached
-      assert(model->num_row_ == 0 ||
-             postsolve_stack.numReductions() >= reductionLimit);
-      if (model->num_row_ != 0) {
+      // limit has been reached. As exposed when studying 2326
+      const bool num_row_ok = model->num_row_ == 0 ||
+	postsolve_stack.numReductions() >= reductionLimit;
+      assert(num_row_ok);
+      if (!num_row_ok) {
         presolve_status_ = HighsPresolveStatus::kNotPresolved;
         return HighsModelStatus::kNotset;
       }
     }
     presolve_status_ = HighsPresolveStatus::kReducedToEmpty;
-    // Make sure that zero row activity from the column-less model is
+    // Make sure that zero row activity from the columnless model is
     // consistent with the bounds
-    return model->num_row_ == 0 || zeroRowActivityFeasible()
-               ? HighsModelStatus::kOptimal
-               : HighsModelStatus::kInfeasible;
+    return zeroRowActivityFeasible() ? HighsModelStatus::kOptimal : HighsModelStatus::kInfeasible;
   } else if (postsolve_stack.numReductions() > 0) {
     // Reductions performed
     presolve_status_ = HighsPresolveStatus::kReduced;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4881,7 +4881,7 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
       // An LP with no columns must have no rows, unless the reduction
       // limit has been reached. As exposed when studying 2326
       const bool num_row_ok = model->num_row_ == 0 ||
-	postsolve_stack.numReductions() >= reductionLimit;
+                              postsolve_stack.numReductions() >= reductionLimit;
       assert(num_row_ok);
       if (!num_row_ok) {
         presolve_status_ = HighsPresolveStatus::kNotPresolved;
@@ -4891,7 +4891,8 @@ HighsModelStatus HPresolve::run(HighsPostsolveStack& postsolve_stack) {
     presolve_status_ = HighsPresolveStatus::kReducedToEmpty;
     // Make sure that zero row activity from the columnless model is
     // consistent with the bounds
-    return zeroRowActivityFeasible() ? HighsModelStatus::kOptimal : HighsModelStatus::kInfeasible;
+    return zeroRowActivityFeasible() ? HighsModelStatus::kOptimal
+                                     : HighsModelStatus::kInfeasible;
   } else if (postsolve_stack.numReductions() > 0) {
     // Reductions performed
     presolve_status_ = HighsPresolveStatus::kReduced;


### PR DESCRIPTION
All problem dimensions now reported as rows, cols and nonzeros - with correct grammar if singular!

Eliminated duplicate code for reporting presolve reductions: all cases handled in one, and called in minimal number of locations

KKT errors reported before (nontrivial) postsolve as well as after

Renamed `HighsMipSolver::runPresolve` to `HighsMipSolver::runMipPresolve` to distinguish it from `Highs::runPresolve`

Cleaned up "Solving report" in MIP solver. Sub-solution (presolve/solve/postsolve) times only reported when known; "repair LP" data only printed when at least one repair LP has been solved.

Closes #2515 