### PR TITLE
Chvátal-Gomory strengthening

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3998,7 +3998,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
             }
           };
 
-          // try different scalars and return an improving one
+          // try different scalars and return if an improving one was found
           auto rowCanBeTightened = [&](const HighsCDouble& rhs,
                                        HighsCDouble& roundedRhs) {
             for (double s : scalars) {

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4030,7 +4030,8 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
             }
           };
 
-          // direction = 1: <= constraint, direction = -1: >= constraint
+          // convert to >= inequality
+          // direction = -1: <= constraint, direction = 1: >= constraint
           HighsInt direction =
               model->row_upper_[row] != kHighsInf ? HighsInt{-1} : HighsInt{1};
           // get rhs

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3957,10 +3957,10 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
                 roundedRhs += roundedRowCoefs[i] *
                               static_cast<HighsCDouble>(model->col_lower_[col]);
               }
-              // flip coefficient sign for >= inequality
+              // flip coefficient sign for <= inequality
               roundedRowCoefs[i] *= direction;
             }
-            // flip rhs sign for >= inequality
+            // flip rhs sign for <= inequality
             roundedRhs *= direction;
           };
 
@@ -3969,15 +3969,18 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
                               HighsCDouble& roundedRhs) {
             bool accept = false;
             // round rhs (using feasibility tolerance)
-            roundedRhs = ceil(rhs * s - primal_feastol);
-            assert(roundedRhs != 0.0);
+            HighsCDouble scalar = static_cast<HighsCDouble>(s);
+            roundedRhs = ceil(rhs * scalar - primal_feastol);
+            assert(roundedRhs > 0.0);
             HighsCDouble rhsRatio = rhs / roundedRhs;
+
             for (size_t i = 0; i < rowCoefs.size(); ++i) {
               // coefficient sign has not been flipped for complemented
               // variables; take absolute value of coefficient.
               double absCoef = std::abs(rowCoefs[i]);
               // round coefficient
-              roundedRowCoefs[i] = std::ceil(absCoef * s - kHighsTiny);
+              roundedRowCoefs[i] =
+                  static_cast<double>(ceil(absCoef * scalar - kHighsTiny));
               // compare "normalised" coefficients, i.e. coefficients divided by
               // corresponding rhs.
               double threshold =

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3907,25 +3907,32 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
           // try Chvatal-Gomory strengthening
           std::vector<HighsInt> complementedOrShifted;
           complementedOrShifted.resize(rowCoefs.size());
+
           HighsInt direction =
               model->row_upper_[row] != kHighsInf ? HighsInt{1} : HighsInt{-1};
-          double rhs =
+          HighsCDouble rhs =
               direction > 0 ? model->row_upper_[row] : -model->row_lower_[row];
-          for (size_t i = 0; i < rowCoefs.size(); ++i) {
-            HighsInt col = rowIndex[i];
-            double val = rowCoefs[i];
-            if (direction * val < 0.0 && model->col_upper_[col] != kHighsInf) {
-              rhs -= direction * val * model->col_upper_[col];
-              rowCoefs[i] = -rowCoefs[i];
-              complementedOrShifted[i] = -1;
-            } else if (direction * val > 0.0 &&
-                       model->col_lower_[col] != -kHighsInf) {
-              rhs -= direction * val * model->col_lower_[col];
-              complementedOrShifted[i] = 1;
-            } else {
-              // no bounds
-              break;
+
+          auto complementOrShift = [&]() {
+            for (size_t i = 0; i < rowCoefs.size(); ++i) {
+              HighsInt col = rowIndex[i];
+              double val = direction * rowCoefs[i];
+              if (val < 0.0 && model->col_upper_[col] != kHighsInf) {
+                rhs -= val * static_cast<HighsCDouble>(model->col_upper_[col]);
+                rowCoefs[i] = -rowCoefs[i];
+                complementedOrShifted[i] = -1;
+              } else if (val > 0.0 && model->col_lower_[col] != -kHighsInf) {
+                rhs -= val * static_cast<HighsCDouble>(model->col_lower_[col]);
+                complementedOrShifted[i] = 1;
+              } else {
+                // unbounded variable; cannot shift or complement!
+                return false;
+              }
             }
+            return true;
+          };
+
+          if (complementOrShift()) {
           }
         }
       }

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3902,12 +3902,15 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
         } else if (model->row_lower_[row] == -kHighsInf ||
                    model->row_upper_[row] == kHighsInf) {
           // Chvatal-Gomory strengthening
+          // See section 3.4 "Chvatal-Gomory strengthening of inequalities",
+          // Achterberg et al., Presolve Reductions in Mixed Integer
+          // Programming, INFORMS Journal on Computing 32(2):473-506.
           std::vector<double> roundedRowCoefs;
           roundedRowCoefs.resize(rowsize[row]);
           std::set<double> scalars;
 
-          // lambda for reformulating row to only contain variables with a lower
-          // bound of zero (if possible)
+          // lambda for reformulating row to only contain variables with lower
+          // bounds of zero (if possible)
           auto complementOrShift = [&](HighsInt direction, HighsCDouble& rhs,
                                        double& minAbsCoef, double& maxAbsCoef) {
             minAbsCoef = kHighsInf;
@@ -3942,7 +3945,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
               HighsInt col = rowIndex[i];
               double val = direction * rowCoefs[i];
               if (val < 0.0 && model->col_upper_[col] != kHighsInf) {
-                // un-complement
+                // uncomplement
                 roundedRowCoefs[i] = -roundedRowCoefs[i];
                 roundedRhs += roundedRowCoefs[i] *
                               static_cast<HighsCDouble>(model->col_upper_[col]);

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3996,12 +3996,12 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
           };
 
           // try different scalars and return an improving one
-          auto scalarToTightenRow = [&](const HighsCDouble& rhs,
-                                        HighsCDouble& roundedRhs) {
+          auto rowCanBeTightened = [&](const HighsCDouble& rhs,
+                                       HighsCDouble& roundedRhs) {
             for (double s : scalars) {
-              if (roundRow(s, rhs, roundedRhs)) return s;
+              if (roundRow(s, rhs, roundedRhs)) return true;
             }
-            return 0.0;
+            return false;
           };
 
           // replace the model row by the rounded one
@@ -4036,8 +4036,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
             // identify scalars for row
             setScalars(minAbsCoef, maxAbsCoef);
             // find a scalar that produces improved coefficients
-            double s = scalarToTightenRow(rhs, roundedRhs);
-            if (s != 0.0) {
+            if (rowCanBeTightened(rhs, roundedRhs)) {
               // undo complementation and shifting
               undoComplementOrShift(direction, roundedRhs);
               // replace row by rounded one

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4017,7 +4017,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
 
           // replace the model row by the rounded one
           auto updateRow = [&](HighsInt row, HighsInt direction,
-                               HighsCDouble roundedRhs) {
+                               const HighsCDouble& roundedRhs) {
             if (direction < 0)
               model->row_upper_[row] = static_cast<double>(roundedRhs);
             else

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -209,6 +209,8 @@ class HPresolve {
 
   bool isEquation(HighsInt row) const;
 
+  bool isRanged(HighsInt row) const;
+
   bool isImpliedEquationAtLower(HighsInt row) const;
 
   bool isImpliedEquationAtUpper(HighsInt row) const;


### PR DESCRIPTION
- I am proposing to add Chvátal-Gomory strengthening for inequality constraints to `HPresolve::rowPresolve` (as described by Achterberg et al., Presolve Reductions in Mixed Integer Programming). 
- I tested on more than 800 MIPs and, unfortunately, the impact on performance is small. Only 97 instances are affected in terms of numbers of branching nodes, and the ratios between the shifted geometric means of running times and numbers of branching nodes are very close to 1.0.
- These results are in line with what Achterberg et al. report. But, the reduction still is turned on by default in Gurobi. Therefore, it may be good to have it in HiGHS as well.