### PR TITLE
Minor change to dual fixing

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4539,12 +4539,16 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
 
     // check coefficients
     for (const auto& nz : getColumnVector(col)) {
+      // skip redundant rows
+      if (isRedundant(nz.index())) continue;
+
       // update number of locks
       if (hasImpliedBound(nz.index(), HighsInt{1}, nz.value())) {
         // implied lower bound -> downlock
         numDownLocks++;
         downLockRow = nz.index();
       }
+
       if (hasImpliedBound(nz.index(), HighsInt{-1}, nz.value())) {
         // implied upper bound -> uplock
         numUpLocks++;


### PR DESCRIPTION
- Skip redundant rows when computing locks in `HPresolve::dualFixing`.
- Unfortunately, this change was lost during a last-minute cleanup of the dual fixing code. My test runs included this piece of code, so the change is fully qualified.