### PR TITLE
Standardised factorization logging for IPX, and added time stamp

### DIFF
--- a/highs/ipm/IpxWrapper.cpp
+++ b/highs/ipm/IpxWrapper.cpp
@@ -86,6 +86,10 @@ HighsStatus solveLpIpx(const HighsOptions& options, HighsTimer& timer,
   }
   parameters.highs_logging = true;
   parameters.timeless_log = options.timeless_log;
+  // Use this to change print_interval from default value (5s) to
+  // other value for debugging
+  //
+  //  parameters.print_interval = 1e-4;
   parameters.log_options = &options.log_options;
   // Just test feasibility and optimality tolerances for now
   // ToDo Set more parameters

--- a/highs/ipm/ipx/basis.cc
+++ b/highs/ipm/ipx/basis.cc
@@ -130,8 +130,9 @@ Int Basis::Factorize() {
     std::stringstream h_logging_stream;
     h_logging_stream.str(std::string());
     h_logging_stream <<
-      " Start  factorization " << num_factorizations_+1 <<
-      ": nonzeros in basis = " << basis_num_nz << "\n";
+      "    Start  factorization " << Format(num_factorizations_+1, 3) <<
+      ": nonzeros in basis = " << Format(basis_num_nz, 9) <<
+      Format("", 14) << Fixed(control_.Elapsed(), 6, 0) << "s\n";
     control_.hIntervalLog(h_logging_stream);
 
     Int err = 0;                // return code
@@ -162,8 +163,9 @@ Int Basis::Factorize() {
     factorization_is_fresh_ = true;
     h_logging_stream.str(std::string());
     h_logging_stream <<
-      " Finish factorization " << num_factorizations_ <<
-      ": fill factor = " << lu_->fill_factor() << "\n";
+      "    Finish factorization " << Format(num_factorizations_, 3) <<
+      ": fill factor = " << Fixed(lu_->fill_factor(), 6, 2) <<
+      Format("", 23) << Fixed(control_.Elapsed(), 6, 0) << "s\n";
     control_.hIntervalLog(h_logging_stream);
     return err;
 }
@@ -929,9 +931,10 @@ void Basis::PivotFixedVariablesOutOfBasis(const double* colweights, Info* info){
         }
 	std::stringstream h_logging_stream;
 	h_logging_stream.str(std::string());
-	h_logging_stream << " " << remaining.size() << " fixed variables remaining\n";
+	h_logging_stream << Format(remaining.size(), 9) <<
+	  " fixed variables remaining" << Format("", 38) <<
+	  Fixed(control_.Elapsed(), 6, 0) << "s\n";
 	control_.hIntervalLog(h_logging_stream);
-
     }
     control_.Debug()
         << Textline("Number of fixed variables swapped for stability:")


### PR DESCRIPTION
IPX now gives logging between main logging lines if factorization takes too long, but it's better than being silent for a _long_ time. Perhaps more logging could be added - such as after each system solve