### PR TITLE
Similar code in dual fixing and dominated columns reductions

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4626,14 +4626,14 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
         double residual = 0.0;
         if (direction * triplet.jval < 0) {
           rhs = model->row_upper_[triplet.row];
-          residual = impliedRowBounds.getResidualSumLowerOrig(triplet.row, col,
-                                                              triplet.jval) +
-                     std::max(triplet.kval, 0.0);
+          residual = impliedRowBounds.getResidualSumLowerOrig(
+              triplet.row, col, triplet.jval, rowNz.index(), triplet.kval,
+              true);
         } else {
           rhs = model->row_lower_[triplet.row];
-          residual = impliedRowBounds.getResidualSumUpperOrig(triplet.row, col,
-                                                              triplet.jval) +
-                     std::min(triplet.kval, 0.0);
+          residual = impliedRowBounds.getResidualSumUpperOrig(
+              triplet.row, col, triplet.jval, rowNz.index(), triplet.kval,
+              true);
         }
         // direction =  1: compute implied lower bound
         // direction = -1: compute implied upper bound

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1259,15 +1259,15 @@ HPresolve::Result HPresolve::dominatedColumns(
         return Result::kOk;
       };
 
-      // see Gamrath, G., Koch, T., Martin, A. et al. Progress in presolving for
-      // mixed integer programming. Math. Prog. Comp. 7, 367–398 (2015).
+      // the worst-case lower bound provides an upper bound on the binary (see
+      // dual fixing method)
       if (model->col_cost_[j] >= 0.0 &&
           computeWorstCaseLowerBound(j) <= 1 + primal_feastol) {
-        // cost is positive and 1 + primal_feastol >= worstCaseLb >= 0, i.e.
-        // worstCaseLb agrees with the bounds: try to find dominated variable
-        // that allows for fixing binary variable to zero
+        // upper bound on binary is implied (due to worst-case lower bound)
         upperImplied = true;
         if (!lowerImplied && bestRowMinus != -1) {
+          // since the binary's objective coefficient is non-negative, try to
+          // fix it to zero
           HPRESOLVE_CHECKED_CALL(checkFixBinary(bestRowMinus, j, HighsInt{-1},
                                                 bestRowMinusScale,
                                                 ajBestRowMinus));
@@ -1275,13 +1275,15 @@ HPresolve::Result HPresolve::dominatedColumns(
         }
       }
 
+      // the worst-case upper bound provides a lower bound on the binary (see
+      // dual fixing method)
       if (model->col_cost_[j] <= 0.0 &&
           computeWorstCaseUpperBound(j) >= -primal_feastol) {
-        // cost is negative and 0 >= worstCaseUb >= -primal_feastol, i.e.
-        // worstCaseUb agrees with the bounds: try to find dominated variable
-        // that allows for fixing binary variable to one
+        // lower bound on binary is implied (due to worst-case upper bound)
         lowerImplied = true;
         if (!upperImplied && bestRowPlus != -1) {
+          // since the binary's objective coefficient is non-positive, try to
+          // fix it to one
           HPRESOLVE_CHECKED_CALL(checkFixBinary(
               bestRowPlus, j, HighsInt{1}, bestRowPlusScale, ajBestRowPlus));
           if (colDeleted[j]) continue;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1046,6 +1046,8 @@ HPresolve::Result HPresolve::dominatedColumns(
     HighsPostsolveStack& postsolve_stack) {
   // See section 6.4 "Dominated columns", Achterberg et al., Presolve Reductions
   // in Mixed Integer Programming, INFORMS Journal on Computing 32(2):473-506.
+  // See also Gamrath, G., Koch, T., Martin, A. et al., Progress in presolving
+  // for mixed integer programming, Math. Prog. Comp. 7, 367–398 (2015).
 
   std::vector<std::pair<uint32_t, uint32_t>> signatures(model->num_col_);
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4535,11 +4535,11 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
 
       // skip binary variable if setting it to its lower bound does not make the
       // row redundant
-      if ((rhsFinite && impliedRowBounds.getResidualSumUpper(row, rowNz.index(),
-                                                             rowNz.value()) >
+      if ((rhsFinite && impliedRowBounds.getResidualSumUpperOrig(
+                            row, rowNz.index(), rowNz.value()) >
                             model->row_upper_[row] + primal_feastol) ||
-          (lhsFinite && impliedRowBounds.getResidualSumLower(row, rowNz.index(),
-                                                             rowNz.value()) <
+          (lhsFinite && impliedRowBounds.getResidualSumLowerOrig(
+                            row, rowNz.index(), rowNz.value()) <
                             model->row_lower_[row] - primal_feastol))
         continue;
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4470,15 +4470,6 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
   // return if variable is already fixed
   if (model->col_lower_[col] == model->col_upper_[col]) return Result::kOk;
 
-  // struct for storing non-zeros while searching for substitutions
-  struct nonZeros {
-    HighsInt row;
-    double jval;
-    double kval;
-  };
-  std::vector<nonZeros> nzs;
-  nzs.reserve(colsize[col]);
-
   // lambda for checking whether a row provides an implied lower bound
   // (direction = 1) or implied upper bound (direction = -1)
   auto hasImpliedBound = [&](HighsInt row, HighsInt direction, double val) {

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4588,11 +4588,8 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
     newBound = direction > 0 ? computeWorstCaseLowerBound(col)
                              : -computeWorstCaseUpperBound(col);
 
-    // return if no bound was found
-    if (newBound == -kHighsInf) return false;
-
-    // stop if bound is too large
-    if (newBound >= currentBound - primal_feastol ||
+    // return if no bound was found or bound is too large
+    if (newBound == -kHighsInf || newBound >= currentBound - primal_feastol ||
         std::abs(newBound) > hugeBound)
       return false;
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1159,57 +1159,12 @@ HPresolve::Result HPresolve::dominatedColumns(
     HighsInt bestRowMinusScale = 0;
     double ajBestRowMinus = 0.0;
 
-    double worstCaseLb = -kHighsInf;
-    double worstCaseUb = kHighsInf;
-
     bool checkPosRow = upperImplied || colIsBinary;
     bool checkNegRow = lowerImplied || colIsBinary;
 
     for (const HighsSliceNonzero& nonz : getColumnVector(j)) {
       HighsInt row = nonz.index();
       HighsInt scale = model->row_upper_[row] != kHighsInf ? 1 : -1;
-
-      if (colIsBinary) {
-        // lambda for calculating residual minimum / maximum row activity
-        auto getResidual = [&](HighsInt row, HighsInt col, double val,
-                               HighsInt direction) {
-          if (direction > 0)
-            return impliedRowBounds.getResidualSumUpper(row, col, val);
-          else
-            return impliedRowBounds.getResidualSumLower(row, col, val);
-        };
-
-        // lambda for updating worst-case bound on binary variables
-        auto updateWorstCaseBounds = [&](HighsInt row, HighsInt col, double val,
-                                         HighsInt direction, double rhs) {
-          // direction =  1 (<= row): use upper bound on row's activity to
-          // compute worst-case implied column bounds.
-          // direction = -1 (>= row): use lower bound on row's activity to
-          // compute worst-case implied column bounds.
-          if (direction * rhs == kHighsInf) return;
-          if (model->col_cost_[col] >= 0.0 && direction * val < 0.0) {
-            // worst-case lower bound is non-negative:
-            // direction =  1 (<= row): rhs - getResidual(...) <= 0 and val < 0.
-            // direction = -1 (>= row): rhs - getResidual(...) >= 0 and val > 0.
-            worstCaseLb =
-                std::max((rhs - getResidual(row, col, val, direction)) / val,
-                         worstCaseLb);
-          } else if (model->col_cost_[col] <= 0.0 && direction * val > 0.0) {
-            // worst-case upper bound is non-positive:
-            // direction =  1 (<= row): rhs - getResidual(...) <= 0 and val > 0.
-            // direction = -1 (>= row): rhs - getResidual(...) >= 0 and val < 0.
-            worstCaseUb =
-                std::min((rhs - getResidual(row, col, val, direction)) / val,
-                         worstCaseUb);
-          }
-        };
-
-        // compute worst-case bounds for binary variables
-        updateWorstCaseBounds(row, j, nonz.value(), HighsInt{1},
-                              model->row_upper_[row]);
-        updateWorstCaseBounds(row, j, nonz.value(), HighsInt{-1},
-                              model->row_lower_[row]);
-      }
 
       double val = scale * nonz.value();
       if (checkPosRow && val > 0.0 && rowsize[row] < bestRowPlusLen) {
@@ -1293,28 +1248,38 @@ HPresolve::Result HPresolve::dominatedColumns(
 
       // see Gamrath, G., Koch, T., Martin, A. et al. Progress in presolving for
       // mixed integer programming. Math. Prog. Comp. 7, 367–398 (2015).
-      if (model->col_cost_[j] >= 0.0 && worstCaseLb <= 1 + primal_feastol) {
-        // cost is positive and 1 + primal_feastol >= worstCaseLb >= 0, i.e.
-        // worstCaseLb agrees with the bounds: try to find dominated variable
-        // that allows for fixing binary variable to zero
-        upperImplied = true;
-        if (!lowerImplied && bestRowMinus != -1) {
-          HPRESOLVE_CHECKED_CALL(checkFixBinary(bestRowMinus, j, HighsInt{-1},
-                                                bestRowMinusScale,
-                                                ajBestRowMinus));
-          if (colDeleted[j]) continue;
+      if (model->col_cost_[j] >= 0.0) {
+        double worstCaseLowerBound;
+        computeColBounds(j, -1, kHighsInf, nullptr, nullptr,
+                         &worstCaseLowerBound);
+        if (worstCaseLowerBound <= 1 + primal_feastol) {
+          // cost is positive and 1 + primal_feastol >= worstCaseLb >= 0, i.e.
+          // worstCaseLb agrees with the bounds: try to find dominated variable
+          // that allows for fixing binary variable to zero
+          upperImplied = true;
+          if (!lowerImplied && bestRowMinus != -1) {
+            HPRESOLVE_CHECKED_CALL(checkFixBinary(bestRowMinus, j, HighsInt{-1},
+                                                  bestRowMinusScale,
+                                                  ajBestRowMinus));
+            if (colDeleted[j]) continue;
+          }
         }
       }
 
-      if (model->col_cost_[j] <= 0.0 && worstCaseUb >= -primal_feastol) {
-        // cost is negative and 0 >= worstCaseUb >= -primal_feastol, i.e.
-        // worstCaseUb agrees with the bounds: try to find dominated variable
-        // that allows for fixing binary variable to one
-        lowerImplied = true;
-        if (!upperImplied && bestRowPlus != -1) {
-          HPRESOLVE_CHECKED_CALL(checkFixBinary(
-              bestRowPlus, j, HighsInt{1}, bestRowPlusScale, ajBestRowPlus));
-          if (colDeleted[j]) continue;
+      if (model->col_cost_[j] <= 0.0) {
+        double worstCaseUpperBound;
+        computeColBounds(j, -1, kHighsInf, nullptr, nullptr, nullptr,
+                         &worstCaseUpperBound);
+        if (worstCaseUpperBound >= -primal_feastol) {
+          // cost is negative and 0 >= worstCaseUb >= -primal_feastol, i.e.
+          // worstCaseUb agrees with the bounds: try to find dominated variable
+          // that allows for fixing binary variable to one
+          lowerImplied = true;
+          if (!upperImplied && bestRowPlus != -1) {
+            HPRESOLVE_CHECKED_CALL(checkFixBinary(
+                bestRowPlus, j, HighsInt{1}, bestRowPlusScale, ajBestRowPlus));
+            if (colDeleted[j]) continue;
+          }
         }
       }
     }
@@ -4584,62 +4549,25 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
 
       // skip binary variable if setting it to its lower bound does not make the
       // row redundant
-      if ((rhsFinite && impliedRowBounds.getResidualSumUpperOrig(
-                            row, rowNz.index(), rowNz.value()) >
+      if ((rhsFinite && impliedRowBounds.getResidualSumUpper(row, rowNz.index(),
+                                                             rowNz.value()) >
                             model->row_upper_[row] + primal_feastol) ||
-          (lhsFinite && impliedRowBounds.getResidualSumLowerOrig(
-                            row, rowNz.index(), rowNz.value()) <
+          (lhsFinite && impliedRowBounds.getResidualSumLower(row, rowNz.index(),
+                                                             rowNz.value()) <
                             model->row_lower_[row] - primal_feastol))
         continue;
 
       // now compute the implied lower bound (direction = 1) or implied upper
       // bound (direction = -1) provided that the binary variable is set to its
-      // upper bound. store triplets (row, nonzero, nonzero) in a vector to
-      // speed up search
-      nzs.clear();
-      if (colsize[col] < colsize[rowNz.index()]) {
-        for (const auto& colNz : getColumnVector(col)) {
-          // skip non-zeros that do not yield an implied bound
-          if (!hasImpliedBound(colNz.index(), direction, colNz.value()))
-            continue;
-          HighsInt nzPos = findNonzero(colNz.index(), rowNz.index());
-          if (nzPos == -1) continue;
-          nzs.push_back({colNz.index(), colNz.value(), Avalue[nzPos]});
-        }
+      // upper bound.
+      double bestBound;
+      if (direction > 0) {
+        computeColBounds(col, rowNz.index(), model->col_upper_[rowNz.index()],
+                         &bestBound);
       } else {
-        for (const auto& colNz : getColumnVector(rowNz.index())) {
-          HighsInt nzPos = findNonzero(colNz.index(), col);
-          if (nzPos == -1) continue;
-          // skip non-zeros that do not yield an implied bound
-          if (!hasImpliedBound(colNz.index(), direction, Avalue[nzPos]))
-            continue;
-          nzs.push_back({colNz.index(), Avalue[nzPos], colNz.value()});
-        }
-      }
-
-      // find best bound
-      double bestBound = -kHighsInf;
-      for (const auto& triplet : nzs) {
-        // compute implied bound from row given that the binary variable is at
-        // its upper bound
-        double rhs = 0.0;
-        double residual = 0.0;
-        if (direction * triplet.jval < 0) {
-          rhs = model->row_upper_[triplet.row];
-          residual = impliedRowBounds.getResidualSumLowerOrig(
-              triplet.row, col, triplet.jval, rowNz.index(), triplet.kval,
-              true);
-        } else {
-          rhs = model->row_lower_[triplet.row];
-          residual = impliedRowBounds.getResidualSumUpperOrig(
-              triplet.row, col, triplet.jval, rowNz.index(), triplet.kval,
-              true);
-        }
-        // direction =  1: compute implied lower bound
-        // direction = -1: compute implied upper bound
-        double candidateBound = direction * (rhs - residual) / triplet.jval;
-        // remember best bound (note the sign switch for direction < 0 above)
-        bestBound = std::max(bestBound, candidateBound);
+        computeColBounds(col, rowNz.index(), model->col_upper_[rowNz.index()],
+                         nullptr, &bestBound);
+        bestBound *= (-1);
       }
 
       // round bound
@@ -4786,6 +4714,131 @@ HPresolve::Result HPresolve::dualFixing(HighsPostsolveStack& postsolve_stack,
     }
   }
   return Result::kOk;
+}
+
+void HPresolve::computeColBounds(HighsInt col, HighsInt boundCol,
+                                 double boundColValue, double* lowerBound,
+                                 double* upperBound,
+                                 double* worstCaseLowerBound,
+                                 double* worstCaseUpperBound) {
+  assert(!colDeleted[col]);
+  assert(boundCol == -1 || !colDeleted[boundCol]);
+
+  // return if nothing to do
+  if (lowerBound == nullptr && upperBound == nullptr &&
+      worstCaseLowerBound == nullptr && worstCaseUpperBound == nullptr)
+    return;
+
+  // lambda for checking whether a row provides an lower bound
+  // (direction = 1) or upper bound (direction = -1)
+  auto hasImpliedBound = [&](HighsInt row, HighsInt direction, double val) {
+    return ((direction * val < 0 && model->row_upper_[row] != kHighsInf) ||
+            (direction * val > 0 && model->row_lower_[row] != -kHighsInf));
+  };
+
+  // lambda for skipping non-zeros
+  auto skipNonZero = [&](HighsInt row, double val) {
+    return ((lowerBound == nullptr && worstCaseLowerBound == nullptr &&
+             !hasImpliedBound(row, HighsInt{-1}, val)) ||
+            (upperBound == nullptr && worstCaseUpperBound == nullptr &&
+             !hasImpliedBound(row, HighsInt{1}, val)));
+  };
+
+  // struct for storing non-zeros
+  struct nonZeros {
+    HighsInt row;
+    double jval;
+    double kval;
+  };
+
+  std::vector<nonZeros> nzs;
+  nzs.reserve(colsize[col]);
+
+  // store triplets (row, nonzero, nonzero) in a vector to speed up bound
+  // computation
+  if (boundCol != -1) {
+    if (colsize[col] < colsize[boundCol]) {
+      for (const auto& colNz : getColumnVector(col)) {
+        // skip non-zero if it does not yield requested bounds
+        if (skipNonZero(colNz.index(), colNz.value())) continue;
+        HighsInt nzPos = findNonzero(colNz.index(), boundCol);
+        if (nzPos == -1) continue;
+        nzs.push_back({colNz.index(), colNz.value(), Avalue[nzPos]});
+      }
+    } else {
+      for (const auto& colNz : getColumnVector(boundCol)) {
+        HighsInt nzPos = findNonzero(colNz.index(), col);
+        if (nzPos == -1) continue;
+        // skip non-zero if it does not yield requested bounds
+        if (skipNonZero(colNz.index(), Avalue[nzPos])) continue;
+        nzs.push_back({colNz.index(), Avalue[nzPos], colNz.value()});
+      }
+    }
+  } else {
+    for (const auto& colNz : getColumnVector(col)) {
+      // skip non-zero if it does not yield requested bounds
+      if (skipNonZero(colNz.index(), colNz.value())) continue;
+      nzs.push_back({colNz.index(), colNz.value(), -kHighsInf});
+    }
+  }
+
+  // initialise bounds
+  if (lowerBound != nullptr) *lowerBound = -kHighsInf;
+  if (upperBound != nullptr) *upperBound = kHighsInf;
+  if (worstCaseLowerBound != nullptr) *worstCaseLowerBound = -kHighsInf;
+  if (worstCaseUpperBound != nullptr) *worstCaseUpperBound = kHighsInf;
+
+  // compute bounds
+  for (const auto& triplet : nzs) {
+    // lambda for actual bound computation
+    auto computeBound = [&](double rhs, double val, HighsInt direction,
+                            bool isWorstCaseBound) {
+      HighsCDouble residual;
+      if ((direction > 0 && !isWorstCaseBound) ||
+          (direction < 0 && isWorstCaseBound)) {
+        residual = impliedRowBounds.getResidualSumLower(
+            triplet.row, col, triplet.jval, boundCol, triplet.kval,
+            boundColValue);
+        if (residual == -kHighsInf) return std::copysign(kHighsInf, val);
+      } else {
+        residual = impliedRowBounds.getResidualSumUpper(
+            triplet.row, col, triplet.jval, boundCol, triplet.kval,
+            boundColValue);
+        if (residual == kHighsInf) return -std::copysign(kHighsInf, val);
+      }
+      return static_cast<double>((static_cast<HighsCDouble>(rhs) - residual) /
+                                 val);
+    };
+
+    // lambda for updating tightest bounds
+    auto updateBounds = [&](double rhs, HighsInt direction) {
+      if (direction * rhs == kHighsInf) return;
+      if (direction * triplet.jval < 0) {
+        // lower bounds
+        if (lowerBound != nullptr)
+          *lowerBound = std::max(
+              *lowerBound, computeBound(rhs, triplet.jval, direction, false));
+        if (worstCaseLowerBound != nullptr)
+          *worstCaseLowerBound =
+              std::max(*worstCaseLowerBound,
+                       computeBound(rhs, triplet.jval, direction, true));
+      } else {
+        // upper bounds
+        if (upperBound != nullptr)
+          *upperBound = std::min(
+              *upperBound, computeBound(rhs, triplet.jval, direction, false));
+        if (worstCaseUpperBound != nullptr)
+          *worstCaseUpperBound =
+              std::min(*worstCaseUpperBound,
+                       computeBound(rhs, triplet.jval, direction, true));
+      }
+    };
+
+    // compute bounds using right-hand side (direction = 1) and left-hand side
+    // (direction = -1)
+    updateBounds(model->row_upper_[triplet.row], HighsInt{1});
+    updateBounds(model->row_lower_[triplet.row], HighsInt{-1});
+  }
 }
 
 HPresolve::Result HPresolve::initialRowAndColPresolve(

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -381,6 +381,13 @@ class HPresolve {
 
   Result dualFixing(HighsPostsolveStack& postsolve_stack, HighsInt col);
 
+  void computeColBounds(HighsInt col, HighsInt boundCol = -1,
+                        double boundColValue = -kHighsInf,
+                        double* lowerBound = nullptr,
+                        double* upperBound = nullptr,
+                        double* worstCaseLowerBound = nullptr,
+                        double* worstCaseUpperBound = nullptr);
+
   Result initialRowAndColPresolve(HighsPostsolveStack& postsolve_stack);
 
   HighsModelStatus run(HighsPostsolveStack& postsolve_stack);

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -213,6 +213,10 @@ class HPresolve {
 
   bool isRedundant(HighsInt row) const;
 
+  bool yieldsImpliedLowerBound(HighsInt row, double val) const;
+
+  bool yieldsImpliedUpperBound(HighsInt row, double val) const;
+
   bool isImpliedEquationAtLower(HighsInt row) const;
 
   bool isImpliedEquationAtUpper(HighsInt row) const;

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -334,6 +334,13 @@ class HPresolve {
 
   double problemSizeReduction() const;
 
+  void computeColBounds(HighsInt col, HighsInt boundCol = -1,
+                        double boundColValue = -kHighsInf,
+                        double* lowerBound = nullptr,
+                        double* upperBound = nullptr,
+                        double* worstCaseLowerBound = nullptr,
+                        double* worstCaseUpperBound = nullptr);
+
  public:
   // for LP presolve
   bool okSetInput(HighsLp& model_, const HighsOptions& options_,
@@ -381,12 +388,17 @@ class HPresolve {
 
   Result dualFixing(HighsPostsolveStack& postsolve_stack, HighsInt col);
 
-  void computeColBounds(HighsInt col, HighsInt boundCol = -1,
-                        double boundColValue = -kHighsInf,
-                        double* lowerBound = nullptr,
-                        double* upperBound = nullptr,
-                        double* worstCaseLowerBound = nullptr,
-                        double* worstCaseUpperBound = nullptr);
+  double computeImpliedLowerBound(HighsInt col, HighsInt boundCol = -1,
+                                  double boundColValue = kHighsInf);
+
+  double computeImpliedUpperBound(HighsInt col, HighsInt boundCol = -1,
+                                  double boundColValue = kHighsInf);
+
+  double computeWorstCaseLowerBound(HighsInt col, HighsInt boundCol = -1,
+                                    double boundColValue = kHighsInf);
+
+  double computeWorstCaseUpperBound(HighsInt col, HighsInt boundCol = -1,
+                                    double boundColValue = kHighsInf);
 
   Result initialRowAndColPresolve(HighsPostsolveStack& postsolve_stack);
 

--- a/highs/util/HighsLinearSumBounds.cpp
+++ b/highs/util/HighsLinearSumBounds.cpp
@@ -59,32 +59,50 @@ void HighsLinearSumBounds::updatedImplVarLower(HighsInt sum, HighsInt var,
 }
 
 double HighsLinearSumBounds::getResidualSumLower(HighsInt sum, HighsInt var,
-                                                 double coefficient) const {
+                                                 double coefficient,
+                                                 HighsInt boundVar,
+                                                 double boundVarCoefficient,
+                                                 double boundVarValue) const {
   HighsCDouble activity = sumLower[sum];
   HighsInt numInfs = numInfSumLower[sum];
+  // remove contribution of 'var'
   update(
       numInfs, activity, HighsInt{-1},
       (coefficient > 0 ? getImplVarLower(sum, var) : getImplVarUpper(sum, var)),
       coefficient);
+  // update contribution of 'boundVar'
+  if (boundVar != -1)
+    update(numInfs, activity,
+           (boundVarCoefficient > 0 ? getImplVarLower(sum, boundVar)
+                                    : getImplVarUpper(sum, boundVar)),
+           boundVarValue, boundVarCoefficient);
   return (numInfs == 0 ? static_cast<double>(activity) : -kHighsInf);
 }
 
 double HighsLinearSumBounds::getResidualSumUpper(HighsInt sum, HighsInt var,
-                                                 double coefficient) const {
+                                                 double coefficient,
+                                                 HighsInt boundVar,
+                                                 double boundVarCoefficient,
+                                                 double boundVarValue) const {
   HighsCDouble activity = sumUpper[sum];
   HighsInt numInfs = numInfSumUpper[sum];
+  // remove contribution of 'var'
   update(
       numInfs, activity, HighsInt{-1},
       (coefficient < 0 ? getImplVarLower(sum, var) : getImplVarUpper(sum, var)),
       coefficient);
+  // update contribution of 'boundVar'
+  if (boundVar != -1)
+    update(numInfs, activity,
+           (boundVarCoefficient < 0 ? getImplVarLower(sum, boundVar)
+                                    : getImplVarUpper(sum, boundVar)),
+           boundVarValue, boundVarCoefficient);
   return (numInfs == 0 ? static_cast<double>(activity) : kHighsInf);
 }
 
-double HighsLinearSumBounds::getResidualSumLowerOrig(HighsInt sum, HighsInt var,
-                                                     double coefficient,
-                                                     HighsInt boundVar,
-                                                     double boundVarCoefficient,
-                                                     bool setToUpper) const {
+double HighsLinearSumBounds::getResidualSumLowerOrig(
+    HighsInt sum, HighsInt var, double coefficient, HighsInt boundVar,
+    double boundVarCoefficient, double boundVarValue) const {
   HighsCDouble activity = sumLowerOrig[sum];
   HighsInt numInfs = numInfSumLowerOrig[sum];
   // remove contribution of 'var'
@@ -94,16 +112,13 @@ double HighsLinearSumBounds::getResidualSumLowerOrig(HighsInt sum, HighsInt var,
   if (boundVar != -1)
     update(numInfs, activity,
            (boundVarCoefficient > 0 ? varLower[boundVar] : varUpper[boundVar]),
-           (setToUpper ? varUpper[boundVar] : varLower[boundVar]),
-           boundVarCoefficient);
+           boundVarValue, boundVarCoefficient);
   return (numInfs == 0 ? static_cast<double>(activity) : -kHighsInf);
 }
 
-double HighsLinearSumBounds::getResidualSumUpperOrig(HighsInt sum, HighsInt var,
-                                                     double coefficient,
-                                                     HighsInt boundVar,
-                                                     double boundVarCoefficient,
-                                                     bool setToUpper) const {
+double HighsLinearSumBounds::getResidualSumUpperOrig(
+    HighsInt sum, HighsInt var, double coefficient, HighsInt boundVar,
+    double boundVarCoefficient, double boundVarValue) const {
   HighsCDouble activity = sumUpperOrig[sum];
   HighsInt numInfs = numInfSumUpperOrig[sum];
   // remove contribution of 'var'
@@ -113,8 +128,7 @@ double HighsLinearSumBounds::getResidualSumUpperOrig(HighsInt sum, HighsInt var,
   if (boundVar != -1)
     update(numInfs, activity,
            (boundVarCoefficient < 0 ? varLower[boundVar] : varUpper[boundVar]),
-           (setToUpper ? varUpper[boundVar] : varLower[boundVar]),
-           boundVarCoefficient);
+           boundVarValue, boundVarCoefficient);
   return (numInfs == 0 ? static_cast<double>(activity) : kHighsInf);
 }
 

--- a/highs/util/HighsLinearSumBounds.cpp
+++ b/highs/util/HighsLinearSumBounds.cpp
@@ -81,15 +81,6 @@ double HighsLinearSumBounds::getResidualSumUpper(HighsInt sum, HighsInt var,
 }
 
 double HighsLinearSumBounds::getResidualSumLowerOrig(HighsInt sum, HighsInt var,
-                                                     double coefficient) const {
-  HighsCDouble activity = sumLowerOrig[sum];
-  HighsInt numInfs = numInfSumLowerOrig[sum];
-  update(numInfs, activity, HighsInt{-1},
-         (coefficient > 0 ? varLower[var] : varUpper[var]), coefficient);
-  return (numInfs == 0 ? static_cast<double>(activity) : -kHighsInf);
-}
-
-double HighsLinearSumBounds::getResidualSumLowerOrig(HighsInt sum, HighsInt var,
                                                      double coefficient,
                                                      HighsInt boundVar,
                                                      double boundVarCoefficient,
@@ -100,20 +91,12 @@ double HighsLinearSumBounds::getResidualSumLowerOrig(HighsInt sum, HighsInt var,
   update(numInfs, activity, HighsInt{-1},
          (coefficient > 0 ? varLower[var] : varUpper[var]), coefficient);
   // update contribution of 'boundVar'
-  update(numInfs, activity,
-         (boundVarCoefficient > 0 ? varLower[boundVar] : varUpper[boundVar]),
-         (setToUpper ? varUpper[boundVar] : varLower[boundVar]),
-         boundVarCoefficient);
+  if (boundVar != -1)
+    update(numInfs, activity,
+           (boundVarCoefficient > 0 ? varLower[boundVar] : varUpper[boundVar]),
+           (setToUpper ? varUpper[boundVar] : varLower[boundVar]),
+           boundVarCoefficient);
   return (numInfs == 0 ? static_cast<double>(activity) : -kHighsInf);
-}
-
-double HighsLinearSumBounds::getResidualSumUpperOrig(HighsInt sum, HighsInt var,
-                                                     double coefficient) const {
-  HighsCDouble activity = sumUpperOrig[sum];
-  HighsInt numInfs = numInfSumUpperOrig[sum];
-  update(numInfs, activity, HighsInt{-1},
-         (coefficient < 0 ? varLower[var] : varUpper[var]), coefficient);
-  return (numInfs == 0 ? static_cast<double>(activity) : kHighsInf);
 }
 
 double HighsLinearSumBounds::getResidualSumUpperOrig(HighsInt sum, HighsInt var,
@@ -127,10 +110,11 @@ double HighsLinearSumBounds::getResidualSumUpperOrig(HighsInt sum, HighsInt var,
   update(numInfs, activity, HighsInt{-1},
          (coefficient < 0 ? varLower[var] : varUpper[var]), coefficient);
   // update contribution of 'boundVar'
-  update(numInfs, activity,
-         (boundVarCoefficient < 0 ? varLower[boundVar] : varUpper[boundVar]),
-         (setToUpper ? varUpper[boundVar] : varLower[boundVar]),
-         boundVarCoefficient);
+  if (boundVar != -1)
+    update(numInfs, activity,
+           (boundVarCoefficient < 0 ? varLower[boundVar] : varUpper[boundVar]),
+           (setToUpper ? varUpper[boundVar] : varLower[boundVar]),
+           boundVarCoefficient);
   return (numInfs == 0 ? static_cast<double>(activity) : kHighsInf);
 }
 

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -173,6 +173,12 @@ class HighsLinearSumBounds {
   void update(HighsInt& numInfs, HighsCDouble& activity, double oldBound,
               double newBound, double coefficient) const;
 
+  void residual(HighsInt& numInfs, HighsCDouble& activity, double oldVarBound,
+                double coefficient, HighsInt boundVar = -1,
+                double boundVarCoefficient = kHighsInf,
+                double oldBoundVarBound = kHighsInf,
+                double newBoundVarBound = kHighsInf) const;
+
   void handleVarUpper(HighsInt sum, double coefficient, double myVarUpper,
                       HighsInt direction);
 

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -96,19 +96,15 @@ class HighsLinearSumBounds {
   double getResidualSumUpper(HighsInt sum, HighsInt var,
                              double coefficient) const;
 
-  double getResidualSumLowerOrig(HighsInt sum, HighsInt var,
-                                 double coefficient) const;
-
   double getResidualSumLowerOrig(HighsInt sum, HighsInt var, double coefficient,
-                                 HighsInt boundVar, double boundVarCoefficient,
-                                 bool setToUpper) const;
-
-  double getResidualSumUpperOrig(HighsInt sum, HighsInt var,
-                                 double coefficient) const;
+                                 HighsInt boundVar = -1,
+                                 double boundVarCoefficient = -kHighsInf,
+                                 bool setToUpper = false) const;
 
   double getResidualSumUpperOrig(HighsInt sum, HighsInt var, double coefficient,
-                                 HighsInt boundVar, double boundVarCoefficient,
-                                 bool setToUpper) const;
+                                 HighsInt boundVar = -1,
+                                 double boundVarCoefficient = -kHighsInf,
+                                 bool setToUpper = false) const;
 
   template <typename T = double>
   double getSumLowerOrig(HighsInt sum, T offset = T()) const {

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -167,7 +167,7 @@ class HighsLinearSumBounds {
   double getImplVarLower(HighsInt sum, double myVarLower, double myImplVarLower,
                          HighsInt myImplVarLowerSource) const;
 
-  void update(HighsInt& numInf, HighsCDouble& sum, HighsInt direction,
+  void update(HighsInt& numInf, HighsCDouble& activity, HighsInt direction,
               double bound, double coefficient) const;
 
   void update(HighsInt& numInfs, HighsCDouble& activity, double oldBound,

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -90,21 +90,25 @@ class HighsLinearSumBounds {
                            double oldImplVarLower,
                            HighsInt oldImplVarLowerSource);
 
-  double getResidualSumLower(HighsInt sum, HighsInt var,
-                             double coefficient) const;
+  double getResidualSumLower(HighsInt sum, HighsInt var, double coefficient,
+                             HighsInt boundVar = -1,
+                             double boundVarCoefficient = -kHighsInf,
+                             double boundVarValue = -kHighsInf) const;
 
-  double getResidualSumUpper(HighsInt sum, HighsInt var,
-                             double coefficient) const;
+  double getResidualSumUpper(HighsInt sum, HighsInt var, double coefficient,
+                             HighsInt boundVar = -1,
+                             double boundVarCoefficient = -kHighsInf,
+                             double boundVarValue = -kHighsInf) const;
 
   double getResidualSumLowerOrig(HighsInt sum, HighsInt var, double coefficient,
                                  HighsInt boundVar = -1,
                                  double boundVarCoefficient = -kHighsInf,
-                                 bool setToUpper = false) const;
+                                 double boundVarValue = -kHighsInf) const;
 
   double getResidualSumUpperOrig(HighsInt sum, HighsInt var, double coefficient,
                                  HighsInt boundVar = -1,
                                  double boundVarCoefficient = -kHighsInf,
-                                 bool setToUpper = false) const;
+                                 double boundVarValue = -kHighsInf) const;
 
   template <typename T = double>
   double getSumLowerOrig(HighsInt sum, T offset = T()) const {

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -153,6 +153,10 @@ class HighsLinearSumBounds {
   double getImplVarLower(HighsInt sum, HighsInt var) const;
 
  private:
+  void computeResidual(double coefficient, double lowerBound, double upperBound,
+                       HighsCDouble& activity, HighsInt& numInf,
+                       HighsInt direction) const;
+
   double getImplVarUpper(HighsInt sum, double myVarUpper, double myImplVarUpper,
                          HighsInt myImplVarUpperSource) const;
 

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -163,7 +163,7 @@ class HighsLinearSumBounds {
  private:
   void computeResidual(HighsInt& numInfs, HighsCDouble& activity,
                        double lowerBound, double upperBound, double coefficient,
-                       bool useLowerBound) const;
+                       HighsInt direction) const;
 
   void computeResidual(HighsInt& numInfs, HighsCDouble& activity, HighsInt var,
                        double coefficient, HighsInt direction,

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -99,8 +99,16 @@ class HighsLinearSumBounds {
   double getResidualSumLowerOrig(HighsInt sum, HighsInt var,
                                  double coefficient) const;
 
+  double getResidualSumLowerOrig(HighsInt sum, HighsInt var, double coefficient,
+                                 HighsInt boundVar, double boundVarCoefficient,
+                                 bool setToUpper) const;
+
   double getResidualSumUpperOrig(HighsInt sum, HighsInt var,
                                  double coefficient) const;
+
+  double getResidualSumUpperOrig(HighsInt sum, HighsInt var, double coefficient,
+                                 HighsInt boundVar, double boundVarCoefficient,
+                                 bool setToUpper) const;
 
   template <typename T = double>
   double getSumLowerOrig(HighsInt sum, T offset = T()) const {
@@ -153,9 +161,14 @@ class HighsLinearSumBounds {
   double getImplVarLower(HighsInt sum, HighsInt var) const;
 
  private:
-  void computeResidual(double coefficient, double lowerBound, double upperBound,
-                       HighsCDouble& activity, HighsInt& numInf,
-                       HighsInt direction) const;
+  void computeResidual(HighsInt& numInfs, HighsCDouble& activity,
+                       double lowerBound, double upperBound, double coefficient,
+                       bool useLowerBound) const;
+
+  void computeResidual(HighsInt& numInfs, HighsCDouble& activity, HighsInt var,
+                       double coefficient, HighsInt direction,
+                       HighsInt boundVar, double boundVarCoefficient,
+                       bool setToUpper) const;
 
   double getImplVarUpper(HighsInt sum, double myVarUpper, double myImplVarUpper,
                          HighsInt myImplVarUpperSource) const;
@@ -164,7 +177,7 @@ class HighsLinearSumBounds {
                          HighsInt myImplVarLowerSource) const;
 
   void update(HighsInt& numInf, HighsCDouble& sum, bool isBoundFinite,
-              HighsInt direction, double bound, double coefficient);
+              HighsInt direction, double bound, double coefficient) const;
 
   void handleVarUpper(HighsInt sum, double coefficient, double myVarUpper,
                       HighsInt direction);

--- a/highs/util/HighsLinearSumBounds.h
+++ b/highs/util/HighsLinearSumBounds.h
@@ -161,23 +161,17 @@ class HighsLinearSumBounds {
   double getImplVarLower(HighsInt sum, HighsInt var) const;
 
  private:
-  void computeResidual(HighsInt& numInfs, HighsCDouble& activity,
-                       double lowerBound, double upperBound, double coefficient,
-                       HighsInt direction) const;
-
-  void computeResidual(HighsInt& numInfs, HighsCDouble& activity, HighsInt var,
-                       double coefficient, HighsInt direction,
-                       HighsInt boundVar, double boundVarCoefficient,
-                       bool setToUpper) const;
-
   double getImplVarUpper(HighsInt sum, double myVarUpper, double myImplVarUpper,
                          HighsInt myImplVarUpperSource) const;
 
   double getImplVarLower(HighsInt sum, double myVarLower, double myImplVarLower,
                          HighsInt myImplVarLowerSource) const;
 
-  void update(HighsInt& numInf, HighsCDouble& sum, bool isBoundFinite,
-              HighsInt direction, double bound, double coefficient) const;
+  void update(HighsInt& numInf, HighsCDouble& sum, HighsInt direction,
+              double bound, double coefficient) const;
+
+  void update(HighsInt& numInfs, HighsCDouble& activity, double oldBound,
+              double newBound, double coefficient) const;
 
   void handleVarUpper(HighsInt sum, double coefficient, double myVarUpper,
                       HighsInt direction);


### PR DESCRIPTION
- This PR adds some utilities to the presolve code to remove similar / duplicate code from `HPresolve::dominatedColumns` and `HPresolve::dualFixing`.
- These changes are needed to make additional improvements to `HPresolve::dominatedColumns`.
- I ran 850 MIPs and the results look reasonable: the ratios of shifted geometric means are 0.99 for solution times and 0.97 for numbers of branching nodes.