### PR TITLE
Tests: fix bazel tests on Windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,7 @@
+build --enable_platform_specific_config
+
+build:windows --enable_runfiles
+
 build:asan --strip=never
 build:asan --copt -fsanitize=address
 build:asan --copt -O1


### PR DESCRIPTION
For some reason I did not think of this before. I was told the tests failed because of lack of access to the MPS files, and the reason is that, by default, bazel tests running on Windows do not have access to data files, and must be [enabled explicitly](https://bazel.build/configure/windows#symlink). It's a easy fix.