### PR TITLE
Replaces deprecated macos-13 runner with macos-15-intel runner

### DIFF
--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -7,9 +7,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # macos 13 is Intel
-  build_macos_13:
-    runs-on: macos-13
+  # Build macos intel
+  build_macos_intel:
+    runs-on: macos-15-intel
     # strategy:
       # matrix:
       #   python: [3.11]
@@ -32,9 +32,9 @@ jobs:
           name: macos-x64
           path: ${{runner.workspace}}/build/dotnet/Highs.Native/runtimes
             
-  # macos 14 is M1
-  build_macos_14:
-    runs-on: macos-14 
+  # Build macos arm64
+  build_macos_arm:
+    runs-on: macos-14  # macos-14 is arm64
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS
@@ -126,7 +126,7 @@ jobs:
 
   build_windows:
     runs-on: windows-latest
-    needs: [build_macos_13, build_macos_14, build_windows_32, build_linux, build_linux_arm64]
+    needs: [build_macos_intel, build_macos_arm, build_windows_32, build_linux, build_linux_arm64]
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS Windows native

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -132,9 +132,8 @@ jobs:
           python3 -m pip install pytest
           python3 -m pytest $GITHUB_WORKSPACE
 
-  # macos 13 is Intel
-  build_wheel_macos_13:
-    runs-on: macos-13
+  build_wheel_macos_intel:
+    runs-on: macos-15-intel
     strategy:
       matrix:
         python: [3.11]    
@@ -163,9 +162,8 @@ jobs:
           python3 -m pip install pytest
           python3 -m pytest $GITHUB_WORKSPACE
             
-  # macos 14 is M1
-  build_wheel_macos_14:
-    runs-on: macos-14 
+  build_wheel_macos_arm:
+    runs-on: macos-14  # macos-14 is arm64
     strategy:
       matrix:
         python: [3.11]    

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -49,7 +49,7 @@ jobs:
           - [ubuntu-24.04, musllinux_x86_64] # No OpenBlas, no test
           - [ubuntu-24.04, musllinux_i686]
           - [ubuntu-24.04-arm, musllinux_aarch64]
-          - [macos-13, macosx_x86_64]
+          - [macos-15-intel, macosx_x86_64]
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -38,7 +38,7 @@ jobs:
           - [ubuntu-24.04, musllinux_x86_64] # No OpenBlas, no test
           - [ubuntu-24.04, musllinux_i686]
           - [ubuntu-24.04-arm, musllinux_aarch64]
-          - [macos-13, macosx_x86_64]
+          - [macos-15-intel, macosx_x86_64]
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]

--- a/.github/workflows/test-fortran-macos.yml
+++ b/.github/workflows/test-fortran-macos.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   fast_build_release:
-    runs-on: [macos-13]
+    runs-on: [macos-15-intel]
     
 
     steps:

--- a/.github/workflows/test-nuget-macos.yml
+++ b/.github/workflows/test-nuget-macos.yml
@@ -7,9 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # macos 13 is Intel
-  build_macos_13:
-    runs-on: macos-13
+  build_macos_intel:
+    runs-on: macos-15-intel
     # strategy:
       # matrix:
       #   python: [3.11]
@@ -55,9 +54,8 @@ jobs:
           dotnet run
 
             
-  # macos 14 is M1
-  build_macos_14:
-    runs-on: macos-14 
+  build_macos_arm:
+    runs-on: macos-14  # macos-14 is arm64
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS

--- a/.github/workflows/test-nuget-package.yml
+++ b/.github/workflows/test-nuget-package.yml
@@ -7,9 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # macos 13 is Intel
-  build_macos_13:
-    runs-on: macos-13
+  build_macos_intel:
+    runs-on: macos-15-intel
     # strategy:
       # matrix:
       #   python: [3.11]
@@ -56,9 +55,8 @@ jobs:
 
 
             
-  # macos 14 is M1
-  build_macos_14:
-    runs-on: macos-14 
+  build_macos_arm:
+    runs-on: macos-14  # macos-14 is arm64
     steps:
       - uses: actions/checkout@v4
       - name: Build HiGHS


### PR DESCRIPTION
# Description

Github announced that they will be retiring the `macos-13` runner soon (see [here](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)). The runner seems to be mainly used to get a darwin/x64 environment. A sensible replacement should be the new `macos-15-intel` runner.

I hope this makes sense as a replacement runner. See above link as well for other recommendations. Happy to further assist if helpful. :relaxed: 

## Changes

- Replaces deprecated `macos-13` runner with new `macos-15-intel` runner.