### PR TITLE
Minor correction to nqueens.py

### DIFF
--- a/examples/nqueens.py
+++ b/examples/nqueens.py
@@ -13,8 +13,8 @@ h.silent()
 
 x = h.addBinaries(N, N)
 
-h.addConstrs(x.sum(axis=0) == 1)    # each row has exactly one queen
-h.addConstrs(x.sum(axis=1) == 1)    # each col has exactly one queen
+h.addConstrs(x.sum(axis=1) == 1)    # each row has exactly one queen
+h.addConstrs(x.sum(axis=0) == 1)    # each col has exactly one queen
 
 y = np.fliplr(x)
 h.addConstrs(x.diagonal(k).sum() <= 1 for k in range(-N + 1, N))   # each diagonal has at most one queen


### PR DESCRIPTION
Preparing to use this for a demo, I noticed a minor inconsistency.

The `axis` kwarg specifies the axis over which to sum, with 0 being rows and 1 being columns. But to get row totals you have to sum over columns, and vice versa.

Although the symmetry in this problem means it makes no difference, I thought it'd be better to avoid confusion.

Tagging @mathgeekcoder since I can't add you as a reviewer!