### PR TITLE
Name callback data structs

### DIFF
--- a/highs/lp_data/HighsCallbackStruct.h
+++ b/highs/lp_data/HighsCallbackStruct.h
@@ -21,7 +21,7 @@ extern "C" {
  * Struct to handle callback output data
  *
  */
-typedef struct _HighsCallbackDataOut {
+typedef struct HighsCallbackDataOut {
   void* cbdata;  // cast of HighsCallbackOutput
   int log_type;  // cast of HighsLogType
   double running_time;
@@ -50,7 +50,7 @@ typedef struct _HighsCallbackDataOut {
 // Some external packages (e.g., jump) currently assume that the first 2 fields
 // of this struct are interrupt and solution. Rearranging the struct may be a
 // breaking change.
-typedef struct _HighsCallbackDataIn {
+typedef struct HighsCallbackDataIn {
   int user_interrupt;
   double* user_solution;
   void* cbdata;  // cast of HighsCallbackInput (for internal use)


### PR DESCRIPTION
Rationale: this allows to forward-declare callback data types in case a callback needs to be declared in a public header:

struct _HighsCallbackDataOut;
struct _HighsCallbackDataIn;
typedef _HighsCallbackDataOut HighsCallbackDataOut; typedef _HighsCallbackDataIn HighsCallbackDataIn;