### PR TITLE
MIP IPX default

### DIFF
--- a/highs/io/HighsIO.cpp
+++ b/highs/io/HighsIO.cpp
@@ -29,7 +29,8 @@ void highsLogHeader(const HighsLogOptions& log_options,
 
 #ifdef HIPO
 #ifdef BLAS_LIBRARIES
-  highsLogUser(log_options, HighsLogType::kInfo, "Using blas: %s\n", BLAS_LIBRARIES);
+  highsLogUser(log_options, HighsLogType::kInfo, "Using blas: %s\n",
+               BLAS_LIBRARIES);
 #else
   highsLogUser(log_options, HighsLogType::kInfo, "Using blas: unknown\n");
 #endif

--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -1098,6 +1098,8 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
     const std::string mip_lp_solver = mipsolver.options_mip_->mip_lp_solver;
     if (useIpm(mip_lp_solver)) {
       bool use_hipo = mip_lp_solver == kHipoString;
+      // Later still, pass mip_lp_solver and take action on failure in
+      // solveLp
 #ifndef HIPO
       // Shouldn't be possible to choose HiPO if it's not in the build
       assert(!use_hipo);
@@ -1318,10 +1320,15 @@ HighsLpRelaxation::Status HighsLpRelaxation::run(bool resolve_on_error) {
         // here. Later pass mip_ipm_solver and take action on failure in
         // solveLp
         bool use_hipo =
-#ifdef HIPO
+            /*
+      #ifdef HIPO
+            // Later use HiPO by default
             mip_ipm_solver == kHighsChooseString ||
-#endif
+      #endif
+            */
             mip_ipm_solver == kHipoString;
+        // Later still, pass mip_ipm_solver and take action on failure in
+        // solveLp
 #ifndef HIPO
         // Shouldn't be possible to choose HiPO if it's not in the build
         assert(!use_hipo);


### PR DESCRIPTION
Was using IPX by default in two main cases where IPM is/might be used in the MIP solver, but now using IPX by default in the other: when switching to IPM after simplex reaches iteration limit in `HighsLpRelaxation::run`