### PR TITLE
Fix min and max for compilation on Windows

### DIFF
--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -20,9 +20,9 @@
 const std::string kHighsCopyrightStatement =
     "Copyright (c) 2025 HiGHS under MIT licence terms";
 
-const size_t kHighsSize_tInf = std::numeric_limits<size_t>::max();
-const HighsInt kHighsIInf = std::numeric_limits<HighsInt>::max();
-const HighsInt kHighsIInf32 = std::numeric_limits<int>::max();
+const size_t kHighsSize_tInf = (std::numeric_limits<size_t>::max)();
+const HighsInt kHighsIInf = (std::numeric_limits<HighsInt>::max)();
+const HighsInt kHighsIInf32 = (std::numeric_limits<int>::max)();
 const double kHighsInf = std::numeric_limits<double>::infinity();
 const double kHighsUndefined = kHighsInf;
 const double kHighsTiny = 1e-14;

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -1125,7 +1125,7 @@ class HighsOptions : public HighsOptionsStruct {
         "Maximal age of dynamic LP rows before "
         "they are removed from the LP relaxation in the MIP solver",
         advanced, &mip_lp_age_limit, 0, 10,
-        std::numeric_limits<int16_t>::max());
+        (std::numeric_limits<int16_t>::max)());
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(

--- a/highs/util/HighsSparseVectorSum.h
+++ b/highs/util/HighsSparseVectorSum.h
@@ -39,7 +39,7 @@ class HighsSparseVectorSum {
     }
 
     if (values[index] == 0.0)
-      values[index] = std::numeric_limits<double>::min();
+      values[index] = (std::numeric_limits<double>::min)();
   }
 
   void add(HighsInt index, HighsCDouble value) {
@@ -51,7 +51,7 @@ class HighsSparseVectorSum {
     }
 
     if (values[index] == 0.0)
-      values[index] = std::numeric_limits<double>::min();
+      values[index] = (std::numeric_limits<double>::min)();
   }
 
   const std::vector<HighsInt>& getNonzeros() const { return nonzeroinds; }

--- a/highs/util/HighsTimer.h
+++ b/highs/util/HighsTimer.h
@@ -294,7 +294,7 @@ class HighsTimer {
       HighsInt iClock = clock_list[i];
       percent_sum_clock_times[i] = 100.0 * clock_time[iClock] / sum_clock_times;
       max_percent_sum_clock_times =
-          std::max(percent_sum_clock_times[i], max_percent_sum_clock_times);
+          (std::max)(percent_sum_clock_times[i], max_percent_sum_clock_times);
     }
     if (max_percent_sum_clock_times < tolerance_percent_report)
       return non_null_report;


### PR DESCRIPTION
When compiling on Windows with icl, I also had issues with the min/max macros from `windows.h`.

I tried to define `NOMINMAX` but that didn't change anything.

The only way I managed to make the compilation work is by adding parentheses

Feel free to keep these changes or not.