### PR TITLE
#2633 pass-by-ref to avoid expensive copying of matrix for every constraint…

### DIFF
--- a/highs/io/FilereaderLp.cpp
+++ b/highs/io/FilereaderLp.cpp
@@ -343,8 +343,8 @@ void FilereaderLp::writeToFileVar(FILE* file, const std::string var_name) {
 }
 
 void FilereaderLp::writeToFileMatrixRow(FILE* file, const HighsInt iRow,
-                                        const HighsSparseMatrix ar_matrix,
-                                        const std::vector<string> col_names) {
+                                        const HighsSparseMatrix& ar_matrix,
+                                        const std::vector<string>& col_names) {
   assert(ar_matrix.isRowwise());
 
   for (HighsInt iEl = ar_matrix.start_[iRow]; iEl < ar_matrix.start_[iRow + 1];

--- a/highs/io/FilereaderLp.h
+++ b/highs/io/FilereaderLp.h
@@ -42,8 +42,8 @@ class FilereaderLp : public Filereader {
                         const bool force_plus = true);
   void writeToFileVar(FILE* file, const std::string var_name);
   void writeToFileMatrixRow(FILE* file, const HighsInt iRow,
-                            const HighsSparseMatrix ar_matrix,
-                            const std::vector<string> col_names);
+                            const HighsSparseMatrix& ar_matrix,
+                            const std::vector<string>& col_names);
 };
 
 #endif


### PR DESCRIPTION
Fixes #2633 
… while writing LP Model - gives 10x faster LP model writes for large models (20M nz)