### PR TITLE
Suppress call to `reportSolvedLpQpStats()` if model is MIP and not solving relaxation

### DIFF
--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -4764,8 +4764,7 @@ HighsStatus Highs::returnFromOptimizeModel(const HighsStatus run_return_status,
   }
 
   // Unless solved as a MIP, report on the solution
-  const bool solved_as_mip = !options_.solver.compare(kHighsChooseString) &&
-                             model_.isMip() && !options_.solve_relaxation;
+  const bool solved_as_mip = model_.isMip() && !options_.solve_relaxation;
   if (!solved_as_mip) reportSolvedLpQpStats();
   return returnFromHighs(return_status);
 }


### PR DESCRIPTION
#2650 exposed the fact that  `reportSolvedLpQpStats()` is called if `solver` is not "choose" - which reflects the previous policy of solving a MIP as an LP if `solver` is not "choose", leading to excess (and spurious) logging.

This closes #2650