### PR TITLE
Fix compiler warning

### DIFF
--- a/highs/lp_data/HighsIis.cpp
+++ b/highs/lp_data/HighsIis.cpp
@@ -864,15 +864,15 @@ bool HighsIis::indexStatusOk(const HighsLp& lp) const {
   const HighsInt illegal_status = -99;
   for (HighsInt iX = 0; iX < num_iis_col; iX++) {
     HighsInt iCol = this->col_index_[iX];
-    if (col_status_[iCol] != true_iis ? kIisStatusInConflict
-                                      : kIisStatusMaybeInConflict)
+    if (col_status_[iCol] !=
+        (true_iis ? kIisStatusInConflict : kIisStatusMaybeInConflict))
       return indexStatusOkReturn(false);
     col_status[iCol] = illegal_status;
   }
   for (HighsInt iX = 0; iX < num_iis_row; iX++) {
     HighsInt iRow = this->row_index_[iX];
-    if (row_status_[iRow] != true_iis ? kIisStatusInConflict
-                                      : kIisStatusMaybeInConflict)
+    if (row_status_[iRow] !=
+        (true_iis ? kIisStatusInConflict : kIisStatusMaybeInConflict))
       return indexStatusOkReturn(false);
     row_status[iRow] = illegal_status;
   }


### PR DESCRIPTION
Fix compiler warning in `HighsIis::indexStatusOk` issued by `VS 2022` on `win64`:

```
1>HighsIis.cpp
1>L:\HiGHS\myHiGHS\highs\lp_data\HighsIis.cpp(867,30): warning C4805: '!=': unsafe mix of type 'const _Ty' and type 'bool' in operation
1>        with
1>        [
1>            _Ty=HighsInt
1>        ]
1>L:\HiGHS\myHiGHS\highs\lp_data\HighsIis.cpp(874,30): warning C4805: '!=': unsafe mix of type 'const _Ty' and type 'bool' in operation
1>        with
1>        [
1>            _Ty=HighsInt
1>        ]
```