### PR TITLE
Check correct index for skipping cut propagation

### DIFF
--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -2455,9 +2455,9 @@ bool HighsDomain::propagate() {
               numproprows, std::make_pair(HighsInt{0}, HighsInt{0}));
 
           auto propagateIndex = [&](HighsInt k) {
-            // first check if cut is marked as deleted
-            if (cutpoolprop.propagatecutflags_[k] & 2) return;
             HighsInt i = propagateinds[k];
+            // first check if cut is marked as deleted
+            if (cutpoolprop.propagatecutflags_[i] & 2) return;
 
             HighsInt Rlen;
             const HighsInt* Rindex;


### PR DESCRIPTION
I noticed this while trying to debug something else. I believe we're simply using the wrong index in a check (luckily the index can never be out of range so it will never fail a test). Specifically, we're checking the `propagatecutflags_[k]`, where `k` is the index looping over a subset of cuts we want to propagate, while we should be checking `propagatecutflags[propagateinds[k]]`, i.e., the actual index of the cut being checked. Current behavior means we could be skipping propagation of some cut because a cut at another index has been deleted.

@fwesselm The propagation code is headache inducing, so I'd appreciate a second set of eyes checking this.