### PR TITLE
Changed >= to > in definition of comparison for Highs::multiobjectiveSolve()

### DIFF
--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -3952,7 +3952,7 @@ bool Highs::hasRepeatedLinearObjectivePriorities(
 
 static bool comparison(std::pair<HighsInt, HighsInt> x1,
                        std::pair<HighsInt, HighsInt> x2) {
-  return x1.first >= x2.first;
+  return x1.first > x2.first;
 }
 
 HighsStatus Highs::returnFromLexicographicOptimization(


### PR DESCRIPTION
This closes #2686 