### PR TITLE
Stuffing logging in HPresolve.cpp is now kDetailed rather than kInfo and has a line feed

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4823,8 +4823,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
   HPRESOLVE_CHECKED_CALL(checkRow(row, model->row_lower_[row], HighsInt{-1}));
 
   if (numFixedCols > 0)
-    highsLogDev(options->log_options, HighsLogType::kInfo,
-                "Singleton column stuffing fixed %d columns",
+    highsLogDev(options->log_options, HighsLogType::kDetailed,
+                "Singleton column stuffing fixed %d columns\n",
                 static_cast<int>(numFixedCols));
 
   return Result::kOk;


### PR DESCRIPTION
Line 4826 of `HPresolve.cpp` was being printed whenever `highs_log_dev` was positive, and had no line feed character, so all "stuffing" statements were on one line. Since the number of stuffing statements might be verbose, the logging is now `HighsLogType::kDetailed` rather than `HighsLogType::kInfo`, and a line feed has been added.