### PR TITLE
Set basic duals to zero

### DIFF
--- a/highs/simplex/HEkk.cpp
+++ b/highs/simplex/HEkk.cpp
@@ -2291,6 +2291,11 @@ bool HEkk::lpFactorRowCompatible(const HighsInt expectedNumRow) const {
   return consistent_num_row;
 }
 
+void HEkk::zeroBasicDuals() {
+  for (HighsInt iRow = 0; iRow < lp_.num_row_; iRow++)
+    info_.workDual_[basis_.basicIndex_[iRow]] = 0;
+}
+
 void HEkk::setNonbasicMove() {
   const bool have_solution = false;
   // Don't have a simplex basis since nonbasicMove is not set up.
@@ -3585,6 +3590,7 @@ HighsStatus HEkk::returnFromSolve(const HighsStatus return_status) {
       break;
     }
   }
+  this->zeroBasicDuals();
   assert(info_.num_primal_infeasibilities >= 0);
   assert(info_.num_dual_infeasibilities >= 0);
   if (info_.num_primal_infeasibilities == 0) {

--- a/highs/simplex/HEkk.h
+++ b/highs/simplex/HEkk.h
@@ -140,6 +140,8 @@ class HEkk {
   bool lpFactorRowCompatible() const;
   bool lpFactorRowCompatible(const HighsInt expectedNumRow) const;
 
+  void zeroBasicDuals();
+
   // Interface methods
   void appendColsToVectors(const HighsInt num_new_col,
                            const vector<double>& colCost,


### PR DESCRIPTION
Now that complementarity violations are being computed, they can result from nonzero dual values for basic variables being computed as $B^T\pi-c_B$. Since these are zero using exact arithmetic, they are now zeroed. The numerical error corresponding to nonzero values of $B^T\pi-c_B$ is now exhibited by nonzero residuals in the dual equations. 