### PR TITLE
Fix incorrect decrement value

### DIFF
--- a/highs/mip/HighsImplications.cpp
+++ b/highs/mip/HighsImplications.cpp
@@ -718,7 +718,7 @@ void HighsImplications::cleanupVarbounds(HighsInt col) {
     HighsInt numVubs = 0;
     vubs[col].for_each([&](HighsInt vubCol, VarBound& vub) { numVubs++; });
     HighsInt numVlbs = 0;
-    vlbs[col].for_each([&](HighsInt vlbCol, VarBound& vub) { numVlbs++; });
+    vlbs[col].for_each([&](HighsInt vlbCol, VarBound& vlb) { numVlbs++; });
     numVarBounds -= numVubs + numVlbs;
     vlbs[col].clear();
     vubs[col].clear();

--- a/highs/mip/HighsImplications.cpp
+++ b/highs/mip/HighsImplications.cpp
@@ -715,8 +715,11 @@ void HighsImplications::cleanupVarbounds(HighsInt col) {
   double lb = mipsolver.mipdata_->domain.col_lower_[col];
 
   if (ub == lb) {
-    numVarBounds -= vlbs.size();
-    numVarBounds -= vubs.size();
+    HighsInt numVubs = 0;
+    vubs[col].for_each([&](HighsInt vubCol, VarBound& vub) { numVubs++; });
+    HighsInt numVlbs = 0;
+    vlbs[col].for_each([&](HighsInt vlbCol, VarBound& vub) { numVlbs++; });
+    numVarBounds -= numVubs + numVlbs;
     vlbs[col].clear();
     vubs[col].clear();
     return;


### PR DESCRIPTION
Small fix I found while looking at something else. I was decrementing `numVarBounds` by the size of the tree structure instead of the number of variable bounds attached to the column.
I couldn't find any way to query the number of nodes cleanly, so I've calculated it myself. 