### PR TITLE
Remove METIS and GKlib from GitHub actions

### DIFF
--- a/.github/julia/build_tarballs.jl
+++ b/.github/julia/build_tarballs.jl
@@ -35,7 +35,6 @@ cmake -DCMAKE_INSTALL_PREFIX=${prefix} \
     -DZLIB_USE_STATIC_LIBS=${BUILD_STATIC} \
     -DHIPO=ON \
     -DBLAS_LIBRARIES="${libdir}/libopenblas.${dlext}" \
-    -DMETIS_ROOT=${prefix} \
     ..
 
 if [[ "${target}" == *-linux-* ]]; then
@@ -63,7 +62,6 @@ platforms = expand_cxxstring_abis(platforms)
 dependencies = [
     Dependency("CompilerSupportLibraries_jll"),
     Dependency("Zlib_jll"),
-    Dependency("METIS_jll"),
     Dependency("OpenBLAS32_jll"),
     HostBuildDependency(PackageSpec(; name="CMake_jll")),
 ]

--- a/.github/workflows/hipo-macos.yml
+++ b/.github/workflows/hipo-macos.yml
@@ -14,47 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout GKlib
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/GKlib
-          ref: master
-          path: GKlib
-
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/METIS
-          ref: master
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install GKlib
-        run: |
-          cd GKlib
-          make config prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      - name: Install METIS
-        run: |
-          cd METIS
-          make config prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      - name: Check METIS and GKlib
-        working-directory: ${{runner.workspace}}
-        run: |
-          cd installs
-          ls
-          ls lib
-
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -63,9 +22,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs \
-          -DGKLIB_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -92,37 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 510-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs \
-          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-          cmake --build build --parallel
-          cmake --install build
-
-      - name: Check METIS and GKlib
-        working-directory: ${{runner.workspace}}
-        run: |
-          cd installs
-          ls
-          ls lib
-
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -131,10 +57,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs \
-
-        # -DGKLIB_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -161,37 +84,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs \
-          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-          cmake --build build --parallel
-          cmake --install build
-
-      - name: Check METIS and GKlib
-        working-directory: ${{runner.workspace}}
-        run: |
-          cd installs
-          ls
-          ls lib
-
       - name: Create Build Environment
         run: cmake -E make_directory ${{runner.workspace}}/build
 
@@ -200,10 +92,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs \
-
-        # -DGKLIB_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/hipo-ubuntu-cblas.yml
+++ b/.github/workflows/hipo-ubuntu-cblas.yml
@@ -15,57 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout GKlib
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/GKlib
-          ref: master
-          path: GKlib
-
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/METIS
-          ref: master
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install GKlib
-        run: |
-          cd GKlib
-          make config shared=1 prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      # - name: Check installs
-      #   working-directory: ${{runner.workspace}}
-      #   run: |
-      #     cd installs
-      #     ls
-      #     ls lib
-
-      - name: Copy GKlib shared (bug)
-        working-directory: ${{runner.workspace}}
-        run: |
-          cd installs
-          cd lib
-          ln libGKlib.so.0 libGKlib.so
-          ls
-
-      - name: Install METIS
-        run: |
-          cd METIS
-          make config shared=1 prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      # no default blas available on runner
-
       - name: Cache APT packages
         uses: actions/cache@v4
         with:
@@ -88,9 +37,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs \
-          -DGKLIB_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/hipo-ubuntu.yml
+++ b/.github/workflows/hipo-ubuntu.yml
@@ -14,57 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout GKlib
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/GKlib
-          ref: master
-          path: GKlib
-
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/METIS
-          ref: master
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install GKlib
-        run: |
-          cd GKlib
-          make config shared=1 prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      # - name: Check installs
-      #   working-directory: ${{runner.workspace}}
-      #   run: |
-      #     cd installs
-      #     ls
-      #     ls lib
-
-      - name: Copy GKlib shared (bug)
-        working-directory: ${{runner.workspace}}
-        run: |
-          cd installs
-          cd lib
-          ln libGKlib.so.0 libGKlib.so
-          ls
-
-      - name: Install METIS
-        run: |
-          cd METIS
-          make config shared=1 prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      # no default blas available on runner
-
       - name: Cache APT packages
         uses: actions/cache@v4
         with:
@@ -87,9 +36,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs \
-          -DGKLIB_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -116,32 +63,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 510-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs \
-          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
-
       - name: Cache APT packages
         uses: actions/cache@v4
         with:
@@ -164,8 +85,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -192,32 +112,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs \
-          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
-
       - name: Cache APT packages
         uses: actions/cache@v4
         with:
@@ -240,8 +134,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/hipo-win.yml
+++ b/.github/workflows/hipo-win.yml
@@ -14,24 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout metis overlay ports
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/metis-overlay-ports
-          ref: main
-          path: overlay-ports
-
-      - name: List overlay contents
-        shell: pwsh
-        run: Get-ChildItem -Recurse "$env:GITHUB_WORKSPACE/overlay-ports"
-
-      - name: Install metis with overlay port
-        shell: pwsh
-        run: |
-          vcpkg install metis gklib `
-          --overlay-ports="$env:GITHUB_WORKSPACE/overlay-ports/ports/metis" `
-          --overlay-ports="$env:GITHUB_WORKSPACE/overlay-ports/ports/gklib"
-
       - name: Install OpenBLAS
         shell: pwsh
         run: vcpkg install openblas[threads]
@@ -76,32 +58,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 510-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          ls
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        shell: pwsh
-        run: |
-          cd METIS
-          pwd
-          cmake -S. -B build `
-          -DGKLIB_PATH="$env:GITHUB_WORKSPACE/METIS/GKlib" `
-          -DCMAKE_INSTALL_PREFIX="${{ runner.workspace }}/installs" `
-          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-          cmake --build build --parallel --config ${{ matrix.config }}
-          cmake --install build --config ${{ matrix.config }}
-
       - name: Install OpenBLAS
         shell: pwsh
         run: vcpkg install openblas[threads]
@@ -114,7 +70,6 @@ jobs:
           -B "${{ runner.workspace }}/build" `
           -DHIPO=ON `
           -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" `
-          -DMETIS_ROOT="${{ runner.workspace }}/installs" `
           -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
@@ -147,32 +102,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          ls
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        shell: pwsh
-        run: |
-          cd METIS
-          pwd
-          cmake -S. -B build `
-          -DGKLIB_PATH="$env:GITHUB_WORKSPACE/METIS/GKlib" `
-          -DCMAKE_INSTALL_PREFIX="${{ runner.workspace }}/installs" `
-          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
-          cmake --build build --parallel --config ${{ matrix.config }}
-          cmake --install build --config ${{ matrix.config }}
-
       - name: Install OpenBLAS
         shell: pwsh
         run: vcpkg install openblas[threads]
@@ -185,7 +114,6 @@ jobs:
           -B "${{ runner.workspace }}/build" `
           -DHIPO=ON `
           -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" `
-          -DMETIS_ROOT="${{ runner.workspace }}/installs" `
           -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build

--- a/.github/workflows/valgrind-hipo-md.yml
+++ b/.github/workflows/valgrind-hipo-md.yml
@@ -8,35 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install valgrind
-
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
 
       - name: Cache APT packages
         uses: actions/cache@v4
@@ -61,8 +35,7 @@ jobs:
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DALL_TESTS=ON \
-          -DBLA_VENDOR=OpenBLAS \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
+          -DBLA_VENDOR=OpenBLAS
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -105,32 +78,6 @@ jobs:
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install valgrind
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
-
       - name: Cache APT packages
         uses: actions/cache@v4
         with:
@@ -157,8 +104,7 @@ jobs:
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DALL_TESTS=ON \
-          -DBLA_VENDOR=OpenBLAS \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
+          -DBLA_VENDOR=OpenBLAS
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -202,32 +148,6 @@ jobs:
 
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install valgrind
-      
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
 
       - name: Cache APT packages
         uses: actions/cache@v4
@@ -255,9 +175,7 @@ jobs:
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DALL_TESTS=ON \
-          -DBLA_VENDOR=OpenBLAS \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
-
+          -DBLA_VENDOR=OpenBLAS
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -289,7 +207,7 @@ jobs:
             exit 0
           fi
           exit 1
-      
+
       - name: Test C example
         working-directory: ${{runner.workspace}}/build
         shell: bash

--- a/.github/workflows/valgrind-hipo.yml
+++ b/.github/workflows/valgrind-hipo.yml
@@ -8,34 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install valgrind
-
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
 
       - name: Cache APT packages
         uses: actions/cache@v4
@@ -60,8 +35,7 @@ jobs:
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DALL_TESTS=ON \
-          -DBLA_VENDOR=OpenBLAS \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
+          -DBLA_VENDOR=OpenBLAS
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -104,31 +78,6 @@ jobs:
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install valgrind
 
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
-
       - name: Cache APT packages
         uses: actions/cache@v4
         with:
@@ -155,8 +104,7 @@ jobs:
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DALL_TESTS=ON \
-          -DBLA_VENDOR=OpenBLAS \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
+          -DBLA_VENDOR=OpenBLAS
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -200,31 +148,6 @@ jobs:
 
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install valgrind
-      
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/METIS
-          ref: 521-ts
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install METIS
-        run: |
-          cmake \
-          -S $GITHUB_WORKSPACE/METIS \
-          -B build \
-          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
-          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
-          cmake --build build --parallel
-          cmake --install build
-
-      # no default blas available on runner
 
       - name: Cache APT packages
         uses: actions/cache@v4
@@ -252,9 +175,7 @@ jobs:
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=Debug \
           -DALL_TESTS=ON \
-          -DBLA_VENDOR=OpenBLAS \
-          -DMETIS_ROOT=${{runner.workspace}}/installs
-
+          -DBLA_VENDOR=OpenBLAS
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -286,7 +207,7 @@ jobs:
             exit 0
           fi
           exit 1
-      
+
       - name: Test C example
         working-directory: ${{runner.workspace}}/build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,9 +189,6 @@ endif()
 
 # HiPO deps
 if(HIPO)
-  # find_package(METIS REQUIRED)
-  # find_package(GKlib REQUIRED)
-  # does not work with outdated CMake
   include(FindHipoDeps)
 endif()
 


### PR DESCRIPTION
Follow-up to https://github.com/ERGO-Code/HiGHS/pull/2699

We need to remove the manually installed versions of metis and gklib in CI to ensure we're actually using the vendored copies.