### PR TITLE
mip: Fix use-after-move in HighsLpRelaxation::loadModel

### DIFF
--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -237,11 +237,12 @@ void HighsLpRelaxation::loadModel() {
   for (HighsInt i = 0; i != lpmodel.num_row_; ++i)
     lprows.push_back(LpRow::model(i));
   lpmodel.integrality_.clear();
+  HighsInt num_col = lpmodel.num_col_;
   lpsolver.clearSolver();
   lpsolver.clearModel();
   lpsolver.passModel(std::move(lpmodel));
-  colLbBuffer.resize(lpmodel.num_col_);
-  colUbBuffer.resize(lpmodel.num_col_);
+  colLbBuffer.resize(num_col);
+  colUbBuffer.resize(num_col);
 }
 
 void HighsLpRelaxation::resetToGlobalDomain() {


### PR DESCRIPTION
Save lpmodel.num_col_ before passing lpmodel via std::move to lpsolver.passModel(). After the move, lpmodel is in a valid but unspecified state, making access to its members undefined behavior.

Found by Coverity static analysis.