### PR TITLE
Silence one unused-variable warning in `highs_bindings.cpp`

### DIFF
--- a/highs/highs_bindings.cpp
+++ b/highs/highs_bindings.cpp
@@ -357,7 +357,6 @@ std::tuple<HighsStatus, dense_array_t<double>> highs_getReducedRow(
 std::tuple<HighsStatus, dense_array_t<double>, HighsInt,
            dense_array_t<HighsInt>>
 highs_getReducedRowSparse(Highs* h, HighsInt row) {
-  HighsInt num_col = h->getNumCol();
   HighsInt num_row = h->getNumRow();
 
   HighsStatus status = HighsStatus::kOk;


### PR DESCRIPTION
Warning with GCC 14.3.0 was:
```
../subprojects/highs/src/highs_bindings.cpp: In function 'std::tuple<HighsStatus, pybind11::array_t<double, 17>, int, pybind11::array_t<int, 17> > highs_getReducedRowSparse(Highs*, HighsInt)':
../subprojects/highs/src/highs_bindings.cpp:335:12: warning: unused variable 'num_col' [-Wunused-variable]
  335 |   HighsInt num_col = h->getNumCol();
      |            ^~~~~~~
```