### PR TITLE
style: remove unused meson variables

### DIFF
--- a/highs/meson.build
+++ b/highs/meson.build
@@ -346,14 +346,14 @@ if get_option('with_fortran')
   _fsrcs = [
     'interfaces/highs_fortran_api.f90'
   ]
-  fortran_lib = library('FortranHighs',
-                        _fsrcs,
-                        dependencies: _deps,
-                        cpp_args: _args,
-                        link_with: highslib,
-                        include_directories: _incdirs,
-                        pic: true,
-                        install: do_install)
+  library('FortranHighs',
+          _fsrcs,
+          dependencies: _deps,
+          cpp_args: _args,
+          link_with: highslib,
+          include_directories: _incdirs,
+          pic: true,
+          install: do_install)
 endif
 
 # C#
@@ -362,14 +362,14 @@ if get_option('with_csharp')
   _cs_srcs = [
     'interfaces/highs_csharp_api.cs'
   ]
-  cs_lib = library('HighsCsharp',
-                        _cs_srcs,
-                        dependencies: _deps,
-                        cpp_args: _args,
-                        link_with: highslib,
-                        include_directories: _incdirs,
-                        pic: true,
-                        install: do_install)
+  library('HighsCsharp',
+          _cs_srcs,
+          dependencies: _deps,
+          cpp_args: _args,
+          link_with: highslib,
+          include_directories: _incdirs,
+          pic: true,
+          install: do_install)
 endif
 
 highspy_cpp = files([


### PR DESCRIPTION
There is no need to assign these libraries to a variable if we don't need to call any methods on them. Upstream docs: https://mesonbuild.com/Reference-manual_functions_library.html