### PR TITLE
Fix 2723

### DIFF
--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -19,7 +19,7 @@
 
 const std::string kHighsCopyrightStatement =
 #ifdef HIPO
-    "Copyright (c) 2026 under BSD 3-Clause license terms";
+    "Copyright (c) 2026 under Apache 2.0 license terms";
 #else
     "Copyright (c) 2026 under MIT licence terms";
 #endif


### PR DESCRIPTION
Now using `Copyright (c) 2026 under Apache 2.0 license terms` for `kHighsCopyrightStatement` when building HiPO