### PR TITLE
BUG: initialize save_value field to fix uninitialized memory use

### DIFF
--- a/highs/simplex/SimplexStruct.h
+++ b/highs/simplex/SimplexStruct.h
@@ -249,7 +249,7 @@ struct HighsSimplexBadBasisChangeRecord {
   HighsInt variable_out;
   HighsInt variable_in;
   BadBasisChangeReason reason;
-  double save_value;
+  double save_value = 0.0;
 };
 
 struct HighsRayRecord {


### PR DESCRIPTION
When a HighsSimplexBadBasisChangeRecord is created, save_value is not set until later in applyTabooRowOut/applyTabooVariableIn. Pushing the struct with an uninitialized field copies garbage memory.

Found via Coverity static analysis