### PR TITLE
Pass by reference in freeVector

### DIFF
--- a/highs/ipm/hipo/auxiliary/Auxiliary.h
+++ b/highs/ipm/hipo/auxiliary/Auxiliary.h
@@ -72,7 +72,7 @@ void printTest(const std::vector<T>& v, const std::string s) {
 }
 
 template <typename T>
-void freeVector(std::vector<T> v) {
+void freeVector(std::vector<T>& v) {
   // Give up memory allocated to v.
   // (technically shrink_to_fit does not guarantee to deallocate)
   v.clear();


### PR DESCRIPTION
I accidentally passed a vector by value instead of reference in HiPO.
This is causing excessive memory usage and poor performance.
Closes #2760.