### PR TITLE
Initialize nowactiveatlower in ratiotest_textbook

### DIFF
--- a/highs/qpsolver/ratiotest.cpp
+++ b/highs/qpsolver/ratiotest.cpp
@@ -24,6 +24,7 @@ static RatiotestResult ratiotest_textbook(Runtime& rt, const QpVector& p,
   RatiotestResult result;
   result.limitingconstraint = -1;
   result.alpha = alphastart;
+  result.nowactiveatlower = false;
 
   // check ratio towards variable bounds
   for (HighsInt j = 0; j < p.num_nz; j++) {


### PR DESCRIPTION
The nowactiveatlower field was only set inside the conditional blocks when a limiting constraint was found (alpha_i < result.alpha). If both loops completed without finding a limiting constraint, the field remained uninitialized.

Uncovered by Coverity static analysis