### PR TITLE
Expand param description

### DIFF
--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -1219,8 +1219,8 @@ class HighsOptions : public HighsOptionsStruct {
 
     record_bool = new OptionRecordBool(
         "mip_allow_cut_separation_at_nodes",
-        "Whether cut separation at nodes (after root) is permitted", advanced,
-        &mip_allow_cut_separation_at_nodes, true);
+        "Whether cut separation at nodes other than the root node is permitted",
+        advanced, &mip_allow_cut_separation_at_nodes, true);
     records.push_back(record_bool);
 
     record_double = new OptionRecordDouble(


### PR DESCRIPTION
This comes via a request from @svigerske in #2678 

@svigerske I don't think there's any desire to expand this parameter to something like "don't separate for nodes after a certain depth". Do you think values outside default and 0 are commonly used?

@galabovaa Does this automatically get updated in the documentation?