### PR TITLE
Change names to Metis api

### DIFF
--- a/extern/metis/libmetis/auxapi.c
+++ b/extern/metis/libmetis/auxapi.c
@@ -17,7 +17,7 @@
     \param options points to an array of size at least METIS_NOPTIONS.
 */
 /*************************************************************************/
-int METIS_SetDefaultOptions(idx_t *options)
+int Highs_METIS_SetDefaultOptions(idx_t *options)
 {
   iset(METIS_NOPTIONS, -1, options);
 

--- a/extern/metis/libmetis/ometis.c
+++ b/extern/metis/libmetis/ometis.c
@@ -40,7 +40,7 @@
            the original and permuted matrices, then A[i] = A'[iperm[i]].
 */
 /*************************************************************************/
-int METIS_NodeND(idx_t *nvtxs, const idx_t *xadj, const idx_t *adjncy, idx_t *vwgt,
+int Highs_METIS_NodeND(idx_t *nvtxs, const idx_t *xadj, const idx_t *adjncy, idx_t *vwgt,
           idx_t *options, idx_t *perm, idx_t *iperm) 
 {
   idx_t i, ii, j, l, nnvtxs=0;

--- a/extern/metis/metis.h
+++ b/extern/metis/metis.h
@@ -191,10 +191,10 @@ typedef __int64 int64_t;
 extern "C" {
 #endif
 
-METIS_API(int) METIS_NodeND(idx_t *nvtxs, const idx_t *xadj, const idx_t *adjncy, idx_t *vwgt,
+METIS_API(int) Highs_METIS_NodeND(idx_t *nvtxs, const idx_t *xadj, const idx_t *adjncy, idx_t *vwgt,
                   idx_t *options, idx_t *perm, idx_t *iperm);
 
-METIS_API(int) METIS_SetDefaultOptions(idx_t *options);
+METIS_API(int) Highs_METIS_SetDefaultOptions(idx_t *options);
 
 #ifdef __cplusplus
 }

--- a/highs/ipm/hipo/factorhighs/Analyse.cpp
+++ b/highs/ipm/hipo/factorhighs/Analyse.cpp
@@ -122,7 +122,7 @@ Int Analyse::getPermutation() {
     // ----- METIS ----------------
     // ----------------------------
     idx_t options[METIS_NOPTIONS];
-    METIS_SetDefaultOptions(options);
+    Highs_METIS_SetDefaultOptions(options);
     options[METIS_OPTION_SEED] = kMetisSeed;
 
     // set logging of Metis depending on debug level
@@ -135,7 +135,7 @@ Int Analyse::getPermutation() {
 
     if (log_) log_->printDevInfo("Running Metis\n");
 
-    Int status = METIS_NodeND(&n_, temp_ptr.data(), temp_rows.data(), NULL,
+    Int status = Highs_METIS_NodeND(&n_, temp_ptr.data(), temp_rows.data(), NULL,
                               options, perm_.data(), iperm_.data());
 
     if (log_) log_->printDevInfo("Metis done\n");


### PR DESCRIPTION
Change names to Metis API within HiGHS, to avoid conflicting with external Metis when HiGHS is linked in some other project.

Closes #2823.