### PR TITLE
check/TestMipSolver.cpp: add tolerance to a few tests

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1211,7 +1211,8 @@ TEST_CASE("get-fixed-lp", "[highs_test_mip_solver]") {
   h.setOptionValue("presolve", kHighsOffString);
   REQUIRE(h.run() == HighsStatus::kOk);
 
-  REQUIRE(h.getInfo().objective_function_value == mip_optimal_objective);
+  REQUIRE(std::abs(h.getInfo().objective_function_value - mip_optimal_objective)
+	  < double_equal_tolerance);
   // In calling changeColsBounds, the incumbent solution was always
   // cleared, so there was no information from which to construct an
   // advanced basis. Hence simplex starts from a logical basis and
@@ -1230,7 +1231,8 @@ TEST_CASE("get-fixed-lp", "[highs_test_mip_solver]") {
   h.setSolution(solution);
   REQUIRE(h.run() == HighsStatus::kOk);
 
-  REQUIRE(h.getInfo().objective_function_value == mip_optimal_objective);
+  REQUIRE(std::abs(h.getInfo().objective_function_value - mip_optimal_objective)
+	  < double_equal_tolerance);
   REQUIRE(h.getInfo().simplex_iteration_count == 0);
 
   // Now re-load the MIP, re-solve, and get the fixed LP
@@ -1246,14 +1248,16 @@ TEST_CASE("get-fixed-lp", "[highs_test_mip_solver]") {
   REQUIRE(h.passModel(fixed_lp) == HighsStatus::kOk);
   REQUIRE(h.run() == HighsStatus::kOk);
 
-  REQUIRE(h.getInfo().objective_function_value == mip_optimal_objective);
+  REQUIRE(std::abs(h.getInfo().objective_function_value - mip_optimal_objective)
+	  < double_equal_tolerance);
 
   // Now run from saved solution (without presolve)
   h.clearSolver();
   h.setSolution(solution);
   REQUIRE(h.run() == HighsStatus::kOk);
 
-  REQUIRE(h.getInfo().objective_function_value == mip_optimal_objective);
+  REQUIRE(std::abs(h.getInfo().objective_function_value - mip_optimal_objective)
+	  < double_equal_tolerance);
   REQUIRE(h.getInfo().simplex_iteration_count == 0);
 
   REQUIRE(h.readModel(model_file) == HighsStatus::kOk);
@@ -1369,7 +1373,8 @@ TEST_CASE("row-fixed-lp", "[highs_test_mip_solver]") {
                      solution.row_value.data());
   h.setOptionValue("presolve", kHighsOffString);
   REQUIRE(h.run() == HighsStatus::kOk);
-  REQUIRE(h.getInfo().objective_function_value <= mip_optimal_objective);
+  REQUIRE(h.getInfo().objective_function_value
+	  <= mip_optimal_objective + double_equal_tolerance);
 
   h.resetGlobalScheduler(true);
 }


### PR DESCRIPTION
We add tolerance to a few comparisons to fix a family of test failures that look like,

```
.../check/TestMipSolver.cpp:1162: FAILED:
  REQUIRE( h.getInfo().objective_function_value == mip_optimal_objective )
with expansion:
  1201500.0 == 1201499.9999999998
```

A `double_equal_tolerance = 1e-5` was already defined in this file, so we have used that as the absolute tolerance.