### PR TITLE
Fix warnings

### DIFF
--- a/extern/rcm/rcm.cpp
+++ b/extern/rcm/rcm.cpp
@@ -10,7 +10,7 @@ const HighsInt offset = 1;
 
 //****************************************************************************80
 
-void degree(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
+static void degree(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
             const HighsInt adj[], HighsInt mask[], HighsInt deg[],
             HighsInt* iccsze, HighsInt ls[], HighsInt node_num)
 
@@ -149,7 +149,7 @@ void degree(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
 }
 //****************************************************************************80
 
-void i4vec_reverse(HighsInt n, HighsInt a[])
+static void i4vec_reverse(HighsInt n, HighsInt a[])
 
 //****************************************************************************80
 //
@@ -204,7 +204,7 @@ void i4vec_reverse(HighsInt n, HighsInt a[])
 }
 //****************************************************************************80
 
-void level_set(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
+static void level_set(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
                const HighsInt adj[], HighsInt mask[], HighsInt* level_num,
                HighsInt level_row[], HighsInt level[], HighsInt node_num)
 
@@ -341,7 +341,7 @@ void level_set(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
 }
 //****************************************************************************80
 
-HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
+static HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
              const HighsInt adj[], HighsInt mask[], HighsInt perm[],
              HighsInt* iccsze, HighsInt node_num)
 
@@ -561,7 +561,7 @@ HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
 }
 //****************************************************************************80
 
-void root_find(HighsInt* root, HighsInt adj_num, const HighsInt adj_row[],
+static void root_find(HighsInt* root, HighsInt adj_num, const HighsInt adj_row[],
                const HighsInt adj[], HighsInt mask[], HighsInt* level_num,
                HighsInt level_row[], HighsInt level[], HighsInt node_num)
 

--- a/highs/ipm/hipo/auxiliary/Auxiliary.cpp
+++ b/highs/ipm/hipo/auxiliary/Auxiliary.cpp
@@ -9,7 +9,7 @@ void inversePerm(const std::vector<Int>& perm, std::vector<Int>& iperm) {
   // perm[i] : i-th entry to use in the new order.
   // iperm[i]: where entry i is located in the new order.
 
-  for (Int i = 0; i < perm.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(perm.size()); ++i) {
     iperm[perm[i]] = i;
   }
 }
@@ -210,8 +210,9 @@ Int64 getDiagStart(Int n, Int k, Int nb, Int n_blocks,
 
 Int maxDepthTree(const std::vector<Int>& parent) {
   Int max_depth = 0;
-  std::vector<Int> depth(parent.size(), -1);
-  for (Int i = 0; i < parent.size(); ++i) {
+  Int n = parent.size();
+  std::vector<Int> depth(n, -1);
+  for (Int i = 0; i < n; ++i) {
     Int node = i;
     Int value = 1;
     while (node != -1) {

--- a/highs/ipm/hipo/auxiliary/Auxiliary.h
+++ b/highs/ipm/hipo/auxiliary/Auxiliary.h
@@ -50,14 +50,14 @@ template <typename T>
 void permuteVector(std::vector<T>& v, const std::vector<Int>& perm) {
   // Permute vector v according to permutation perm.
   std::vector<T> temp_v(v);
-  for (Int i = 0; i < v.size(); ++i) v[i] = temp_v[perm[i]];
+  for (Int i = 0; i < static_cast<Int>(v.size()); ++i) v[i] = temp_v[perm[i]];
 }
 
 template <typename T>
 void permuteVectorInverse(std::vector<T>& v, const std::vector<Int>& iperm) {
   // Permute vector v according to inverse permutation iperm.
   std::vector<T> temp_v(v);
-  for (Int i = 0; i < v.size(); ++i) v[iperm[i]] = temp_v[i];
+  for (Int i = 0; i < static_cast<Int>(v.size()); ++i) v[iperm[i]] = temp_v[i];
 }
 
 template <typename T>

--- a/highs/ipm/hipo/auxiliary/VectorOperations.cpp
+++ b/highs/ipm/hipo/auxiliary/VectorOperations.cpp
@@ -7,46 +7,46 @@ namespace hipo {
 
 void vectorAdd(std::vector<double>& v1, const std::vector<double>& v2,
                double beta, double alpha) {
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] = alpha * v1[i] + beta * v2[i];
   }
 }
 
 void vectorAdd(std::vector<double>& v1, const double alpha) {
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] += alpha;
   }
 }
 
 void vectorMultiply(std::vector<double>& v1, const std::vector<double>& v2,
                     double alpha, double beta) {
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] = alpha * v1[i] * v2[i] + beta;
   }
 }
 
 void vectorAddMult(std::vector<double>& v1, const std::vector<double>& v2,
                    const std::vector<double>& v3, double beta, double alpha) {
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] = alpha * v1[i] + beta * v2[i] * v3[i];
   }
 }
 
 void vectorDivide(std::vector<double>& v1, const std::vector<double>& v2) {
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] /= v2[i];
   }
 }
 
 void vectorScale(std::vector<double>& v1, double alpha) {
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] *= alpha;
   }
 }
 
 double dotProd(const std::vector<double>& v1, const std::vector<double>& v2) {
   double result{};
-  for (Int i = 0; i < v1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     result += v1[i] * v2[i];
   }
   return result;
@@ -54,7 +54,7 @@ double dotProd(const std::vector<double>& v1, const std::vector<double>& v2) {
 
 double norm2(const std::vector<double>& x) {
   double norm{};
-  for (Int i = 0; i < x.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x.size()); ++i) {
     norm += (x[i] * x[i]);
   }
   return std::sqrt(norm);
@@ -62,10 +62,10 @@ double norm2(const std::vector<double>& x) {
 
 double norm2(const std::vector<double>& x0, const std::vector<double>& x1) {
   double norm{};
-  for (Int i = 0; i < x0.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x0.size()); ++i) {
     norm += (x0[i] * x0[i]);
   }
-  for (Int i = 0; i < x1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x1.size()); ++i) {
     norm += (x1[i] * x1[i]);
   }
   return std::sqrt(norm);
@@ -73,7 +73,7 @@ double norm2(const std::vector<double>& x0, const std::vector<double>& x1) {
 
 double infNorm(const std::vector<double>& x) {
   double norm{};
-  for (Int i = 0; i < x.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x.size()); ++i) {
     norm = std::max(norm, std::fabs(x[i]));
   }
   return norm;
@@ -81,10 +81,10 @@ double infNorm(const std::vector<double>& x) {
 
 double infNorm(const std::vector<double>& x0, const std::vector<double>& x1) {
   double norm{};
-  for (Int i = 0; i < x0.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x0.size()); ++i) {
     norm = std::max(norm, std::fabs(x0[i]));
   }
-  for (Int i = 0; i < x1.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x1.size()); ++i) {
     norm = std::max(norm, std::fabs(x1[i]));
   }
   return norm;
@@ -93,7 +93,7 @@ double infNorm(const std::vector<double>& x0, const std::vector<double>& x1) {
 double infNormDiff(const std::vector<double>& x, const std::vector<double>& y) {
   assert(x.size() == y.size());
   double inf_norm_diff = 0;
-  for (Int i = 0; i < Int(x.size()); i++) {
+  for (Int i = 0; i < static_cast<Int>(x.size()); i++) {
     double diff = std::fabs(x[i] - y[i]);
     inf_norm_diff = std::max(diff, inf_norm_diff);
   }
@@ -101,14 +101,14 @@ double infNormDiff(const std::vector<double>& x, const std::vector<double>& y) {
 }
 
 bool isNanVector(const std::vector<double>& x) {
-  for (Int i = 0; i < x.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x.size()); ++i) {
     if (std::isnan(x[i])) return true;
   }
   return false;
 }
 
 bool isInfVector(const std::vector<double>& x) {
-  for (Int i = 0; i < x.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(x.size()); ++i) {
     if (std::isinf(x[i])) return true;
   }
   return false;

--- a/highs/ipm/hipo/factorhighs/Analyse.cpp
+++ b/highs/ipm/hipo/factorhighs/Analyse.cpp
@@ -801,7 +801,8 @@ void Analyse::snPattern() {
 
   // compute column pointers of L
   std::vector<Int64> work(sn_indices_.size());
-  for (Int i = 0; i < sn_indices_.size(); ++i) work[i] = sn_indices_[i];
+  for (Int i = 0; i < static_cast<Int>(sn_indices_.size()); ++i)
+    work[i] = sn_indices_[i];
   counts2Ptr(ptr_sn_, work);
 
   // consider each row
@@ -1079,7 +1080,7 @@ void Analyse::reorderChildren() {
 
     // modify linked lists with new order of children
     head[sn] = children.front().first;
-    for (Int i = 0; i < children.size() - 1; ++i) {
+    for (Int i = 0; i < static_cast<Int>(children.size()) - 1; ++i) {
       next[children[i].first] = children[i + 1].first;
     }
     next[children.back().first] = -1;

--- a/highs/ipm/hipo/factorhighs/CliqueStack.cpp
+++ b/highs/ipm/hipo/factorhighs/CliqueStack.cpp
@@ -23,7 +23,7 @@ double* CliqueStack::setup(Int64 clique_size, bool& reallocation) {
   if (clique_size > 0) {
     // This should not trigger reallocation, because the resize in init is done
     // with the maximum possible size of the stack.
-    if (top_ + clique_size > stack_.size()) {
+    if (top_ + clique_size > static_cast<Int64>(stack_.size())) {
       reallocation = true;
       stack_.resize(top_ + clique_size, 0.0);
     }

--- a/highs/ipm/hipo/factorhighs/KrylovMethodsIpm.cpp
+++ b/highs/ipm/hipo/factorhighs/KrylovMethodsIpm.cpp
@@ -72,11 +72,12 @@ void NeDiagPrec::reset(const HighsSparseMatrix& A,
   }
 
   // compute inverse of diagonal entries
-  for (Int i = 0; i < diag.size(); ++i) diag[i] = 1.0 / diag[i];
+  for (Int i = 0; i < static_cast<Int>(diag.size()); ++i)
+    diag[i] = 1.0 / diag[i];
 }
 void NeDiagPrec::apply(std::vector<double>& x) const {
   // apply diagonal preconditioner
-  for (Int i = 0; i < diag.size(); ++i) x[i] *= diag[i];
+  for (Int i = 0; i < static_cast<Int>(diag.size()); ++i) x[i] *= diag[i];
 }
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/CurtisReidScaling.cpp
+++ b/highs/ipm/hipo/ipm/CurtisReidScaling.cpp
@@ -82,7 +82,8 @@ class CRscalingPrec : public AbstractMatrix {
   void apply(std::vector<double>& x) const override {
     Int m = M_.size();
     for (Int i = 0; i < m; ++i) x[i] /= std::max(M_[i], 1.0);
-    for (Int j = 0; j < N_.size(); ++j) x[m + j] /= std::max(N_[j], 1.0);
+    for (Int j = 0; j < static_cast<Int>(N_.size()); ++j)
+      x[m + j] /= std::max(N_[j], 1.0);
   }
 };
 

--- a/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
@@ -530,7 +530,7 @@ Int FactorHiGHSSolver::chooseOrdering(const std::vector<Int>& rows,
   std::vector<bool> status(orderings_to_try.size(), 0);
   Int num_success = 0;
 
-  for (Int i = 0; i < orderings_to_try.size(); ++i) {
+  for (Int i = 0; i < static_cast<Int>(orderings_to_try.size()); ++i) {
     clock.start();
     status[i] =
         FH_.analyse(symbolics[i], rows, ptr, signs, orderings_to_try[i]);

--- a/highs/ipm/hipo/ipm/Iterate.cpp
+++ b/highs/ipm/hipo/ipm/Iterate.cpp
@@ -626,12 +626,12 @@ void Iterate::residuals6x6(const NewtonDir& d) {
 }
 
 void Iterate::assertConsistency(Int n, Int m) const {
-  assert(x.size() == n);
-  assert(xl.size() == n);
-  assert(xu.size() == n);
-  assert(y.size() == m);
-  assert(zl.size() == n);
-  assert(zu.size() == n);
+  assert(static_cast<Int>(x.size()) == n);
+  assert(static_cast<Int>(xl.size()) == n);
+  assert(static_cast<Int>(xu.size()) == n);
+  assert(static_cast<Int>(y.size()) == m);
+  assert(static_cast<Int>(zl.size()) == n);
+  assert(static_cast<Int>(zu.size()) == n);
 }
 
 void Iterate::makeStep(double alpha_primal, double alpha_dual) {

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -48,10 +48,13 @@ Int Model::checkData() const {
   if (n_ <= 0 || m_ < 0) return kStatusBadModel;
 
   // Vectors are of correct size
-  if (c_.size() != n_ || b_.size() != m_ || lower_.size() != n_ ||
-      upper_.size() != n_ || constraints_.size() != m_ ||
-      A_.start_.size() != n_ + 1 || A_.index_.size() != A_.start_.back() ||
-      A_.value_.size() != A_.start_.back())
+  if (static_cast<Int>(c_.size()) != n_ || static_cast<Int>(b_.size()) != m_ ||
+      static_cast<Int>(lower_.size()) != n_ ||
+      static_cast<Int>(upper_.size()) != n_ ||
+      static_cast<Int>(constraints_.size()) != m_ ||
+      static_cast<Int>(A_.start_.size()) != n_ + 1 ||
+      static_cast<Int>(A_.index_.size()) != A_.start_.back() ||
+      static_cast<Int>(A_.value_.size()) != A_.start_.back())
     return kStatusBadModel;
 
   // Hessian is ok, for QPs only

--- a/highs/ipm/hipo/ipm/PreProcess.cpp
+++ b/highs/ipm/hipo/ipm/PreProcess.cpp
@@ -8,13 +8,13 @@
 namespace hipo {
 
 void PreprocessorPoint::assertConsistency(Int n, Int m) const {
-  assert(x.size() == n);
-  assert(xl.size() == n);
-  assert(xu.size() == n);
-  assert(slack.size() == m);
-  assert(y.size() == m);
-  assert(zl.size() == n);
-  assert(zu.size() == n);
+  assert(static_cast<Int>(x.size()) == n);
+  assert(static_cast<Int>(xl.size()) == n);
+  assert(static_cast<Int>(xu.size()) == n);
+  assert(static_cast<Int>(slack.size()) == m);
+  assert(static_cast<Int>(y.size()) == m);
+  assert(static_cast<Int>(zl.size()) == n);
+  assert(static_cast<Int>(zu.size()) == n);
 }
 
 void PreprocessEmptyRows::apply(Model& model) {
@@ -189,7 +189,8 @@ void PreprocessFixedVars::apply(Model& model) {
     Int next = 0;
     Int copy_to = 0;
     for (Int i = 0; i < n; ++i) {
-      if (next < index_to_remove.size() && i == index_to_remove[next]) {
+      if (next < static_cast<Int>(index_to_remove.size()) &&
+          i == index_to_remove[next]) {
         ++next;
         continue;
       } else {
@@ -248,13 +249,13 @@ void PreprocessFixedVars::undo(PreprocessorPoint& point, const Model& model,
         // need to do this after all x have been computed, due to Q*x term
         const auto& dataj = data.at(j);
         double z = dataj.c;
-        for (Int i = 0; i < dataj.indA.size(); ++i) {
+        for (Int i = 0; i < static_cast<Int>(dataj.indA.size()); ++i) {
           const Int row = dataj.indA[i];
           const double val = dataj.valA[i];
           z -= val * point.y[row];
         }
         if (model.qp()) {
-          for (Int i = 0; i < dataj.indQ.size(); ++i) {
+          for (Int i = 0; i < static_cast<Int>(dataj.indQ.size()); ++i) {
             const Int row = dataj.indQ[i];
             const double val = dataj.valQ[i];
             z += val * new_x[row];
@@ -548,7 +549,7 @@ void PreprocessFormulation::print(std::stringstream& stream) const {
   stream << "Added " << n_post - n_pre << " slacks\n";
 }
 
-#define APPLY_ACTION(T)                                       \
+#define APPLY_ACTION(T)                                      \
   stack.push_back(std::unique_ptr<PreprocessAction>(new T)); \
   stack.back()->apply(model);
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -425,7 +425,7 @@ double Solver::stepToBoundary(const std::vector<double>& x,
   double alpha = 1.0;
   Int bl = -1;
 
-  for (Int i = 0; i < x.size(); ++i) {
+  for (Int i = 0; i < n_; ++i) {
     if ((lo && model_.hasLb(i)) || (!lo && model_.hasUb(i))) {
       double c = (cor ? (*cor)[i] * weight : 0.0);
       if (x[i] + alpha * (dx[i] + c) < 0.0) {


### PR DESCRIPTION
Get rid of compilation warnings in HiPO, due to undeclared functions in extern/rcm.cpp and due to comparisons of HighsInt and size_t.