### PR TITLE
Fix failing HiPO CI tests

### DIFF
--- a/.github/workflows/hipo.yml
+++ b/.github/workflows/hipo.yml
@@ -14,24 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout metis overlay ports
-        uses: actions/checkout@v4
-        with:
-          repository: galabovaa/metis-overlay-ports
-          ref: main
-          path: overlay-ports
-
-      - name: List overlay contents
-        shell: pwsh
-        run: Get-ChildItem -Recurse "$env:GITHUB_WORKSPACE/overlay-ports"
-
-      - name: Install metis with overlay port
-        shell: pwsh
-        run: |
-          vcpkg install metis gklib `
-          --overlay-ports="$env:GITHUB_WORKSPACE/overlay-ports/ports/metis" `
-          --overlay-ports="$env:GITHUB_WORKSPACE/overlay-ports/ports/gklib"
-
       - name: Install OpenBLAS
         shell: pwsh
         run: vcpkg install openblas[threads]
@@ -111,55 +93,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout GKlib
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/GKlib
-          ref: master
-          path: GKlib
-
-      - name: Checkout METIS
-        uses: actions/checkout@v4
-        with:
-          repository: KarypisLab/METIS
-          ref: master
-          path: METIS
-
-      - name: Create installs dir
-        working-directory: ${{runner.workspace}}
-        run: |
-          mkdir installs
-          ls
-
-      - name: Install GKlib
-        run: |
-          cd GKlib
-          make config shared=1 prefix=${{runner.workspace}}/installs
-          make
-          make install
-
-      # - name: Check installs
-      #   working-directory: ${{runner.workspace}}
-      #   run: |
-      #     cd installs
-      #     ls
-      #     ls lib
-
-      - name: Copy GKlib shared (bug)
-        working-directory: ${{runner.workspace}}
-        run: |
-          cd installs
-          cd lib
-          ln libGKlib.so.0 libGKlib.so
-          ls
-
-      - name: Install METIS
-        run: |
-          cd METIS
-          make config shared=1 prefix=${{runner.workspace}}/installs
-          make
-          make install
-
       # no default blas available on runner
 
       - name: Cache APT packages
@@ -184,9 +117,7 @@ jobs:
         run: |
           cmake $GITHUB_WORKSPACE -DHIPO=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
-          -DALL_TESTS=${{ matrix.all_tests }} \
-          -DMETIS_ROOT=${{runner.workspace}}/installs \
-          -DGKLIB_ROOT=${{runner.workspace}}/installs
+          -DALL_TESTS=${{ matrix.all_tests }}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
We still had some CI tests using GKlib and Metis, which where fetching from the original repository. These are now failing due to small changes to their build system.