### PR TITLE
Upgrade relaxed to acquire

### DIFF
--- a/highs/parallel/HighsTask.h
+++ b/highs/parallel/HighsTask.h
@@ -122,7 +122,7 @@ class HighsTask {
     uintptr_t xormask = reinterpret_cast<uintptr_t>(owner) ^
                         reinterpret_cast<uintptr_t>(stealer);
     uintptr_t state =
-        metadata.stealer.fetch_xor(xormask, std::memory_order_relaxed);
+        metadata.stealer.fetch_xor(xormask, std::memory_order_acquire);
 
     assert(stealer != nullptr);
 


### PR DESCRIPTION
On `hmw-mt` the thread sanitizer occasionally fails unless this line is changed. I am unsure if this is a complete fix.

The failure broken down into steps:
- Threads are spawned
- Thread X writes some data (the only thread that is able to write to this place).
- The main thread calls `taskWait()`
- The main thread after waiting (should be the only active thread) reads the data 
Issue: The data being read in is different to what was written

Unless I'm using the wrong `highs::parallel` calls, then one of the two cases must be happening.
1. `taskWait()` is returning while a task is still active (I doubt this because then there'd be odd errors flying all over the place)
2. The main thread is somehow not synchronised correctly, and not recognising the "new" data. (If this is true, then I'm struggling to understand why this change fixes the issue)

There could also be something else I'm missing.......