### PR TITLE
Fix 2957

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1419,11 +1419,10 @@ TEST_CASE("issue-2957", "[highs_test_mip_solver]") {
   lp.a_matrix_.index_ = {0, 1};
   lp.a_matrix_.value_ = {1, 1};
   Highs highs;
-  highs.passModel(lp);
   highs.setOptionValue("output_flag", dev_run);
   highs.setOptionValue("mip_rel_gap", 0);
   highs.setOptionValue("mip_abs_gap", 0);
-  highs.readModel(filename);
+  highs.passModel(lp);
   const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;
   const double optimal_objective = 28.2;
   solve(highs, kHighsOnString, require_model_status, optimal_objective);

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1404,3 +1404,27 @@ TEST_CASE("issue-2173", "[highs_test_mip_solver]") {
   const double optimal_objective = -26770.8075489;
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
 }
+
+TEST_CASE("issue-2957", "[highs_test_mip_solver]") {
+  HighsLp lp;
+  lp.num_col_ = 2;
+  lp.num_row_ = 1;
+  lp.col_cost_ = {1, 2};
+  lp.col_lower_ = {0, 8};
+  lp.col_upper_ = {20, 20};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kContinuous};
+  lp.row_lower_ = {20.1};
+  lp.row_upper_ = {kHighsInf};
+  lp.a_matrix_.start_ = {0, 1, 2};
+  lp.a_matrix_.index_ = {0, 1};
+  lp.a_matrix_.value_ = {1, 1};
+  Highs highs;
+  highs.passModel(lp);
+  highs.setOptionValue("output_flag", dev_run);
+  highs.setOptionValue("mip_rel_gap", 0);
+  highs.setOptionValue("mip_abs_gap", 0);
+  highs.readModel(filename);
+  const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;
+  const double optimal_objective = 28.2;
+  solve(highs, kHighsOnString, require_model_status, optimal_objective);
+}

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1416,7 +1416,7 @@ TEST_CASE("issue-2957", "[highs_test_mip_solver]") {
   lp.row_lower_ = {20.1};
   lp.row_upper_ = {kHighsInf};
   lp.a_matrix_.start_ = {0, 1, 2};
-  lp.a_matrix_.index_ = {0, 1};
+  lp.a_matrix_.index_ = {0, 0};
   lp.a_matrix_.value_ = {1, 1};
   Highs highs;
   highs.setOptionValue("output_flag", dev_run);

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5017,7 +5017,10 @@ HPresolve::Result HPresolve::singletonColStuffing(
   // lambda for storing a candidate
   auto addCandidate = [&](std::vector<candidate>& candidates, HighsInt col,
                           double val, HighsInt direction, double& minWeight,
-                          double& maxWeight, bool& allInteger) {
+                          double& maxWeight, bool& hasInteger,
+                          bool& allInteger) {
+    hasInteger =
+        hasInteger || model->integrality_[col] == HighsVarType::kInteger;
     allInteger =
         allInteger && model->integrality_[col] == HighsVarType::kInteger;
     minWeight = std::min(minWeight, direction * val);
@@ -5034,6 +5037,68 @@ HPresolve::Result HPresolve::singletonColStuffing(
     return Result::kOk;
   };
 
+  // lambda for computing candidates for stuffing
+  auto computeCandidates =
+      [&](HighsInt row, HighsInt direction, std::vector<candidate>& candidates,
+          HighsCDouble& sumLower, HighsCDouble& sumUpper, bool& sumLowerFinite,
+          bool& sumUpperFinite, bool& hasInteger, bool& allInteger,
+          double& minWeight, double& maxWeight, bool allowIntegerCandidates) {
+        // vectors for candidates and activity bounds
+        candidates.clear();
+        candidates.reserve(rowsize[row]);
+        sumLower = 0.0;
+        sumUpper = 0.0;
+        sumLowerFinite = true;
+        sumUpperFinite = true;
+        hasInteger = false;
+        allInteger = true;
+        minWeight = kHighsInf;
+        maxWeight = -kHighsInf;
+
+        for (auto& nz : getRowVector(row)) {
+          // get column index, coefficient, cost and bounds
+          HighsInt j = nz.index();
+          double aj = direction * nz.value();
+          double cj = model->col_cost_[j];
+          double sumLowerBound = model->col_lower_[j];
+          double sumUpperBound = model->col_upper_[j];
+          bool isCandidate = allowIntegerCandidates ||
+                             model->integrality_[j] != HighsVarType::kInteger;
+
+          if (isSingleton(j)) {
+            // check singleton
+            if (aj > 0) {
+              if (cj >= 0)
+                // dual fixing: fix to lower bound
+                sumUpperBound = sumLowerBound;
+              else if (isCandidate) {
+                // candidate for stuffing
+                sumUpperBound = sumLowerBound;
+                addCandidate(candidates, j, aj, HighsInt{1}, minWeight,
+                             maxWeight, hasInteger, allInteger);
+              }
+            } else {
+              if (cj <= 0)
+                // dual fixing: fix to upper bound
+                sumLowerBound = sumUpperBound;
+              else if (isCandidate) {
+                // candidate for stuffing; multiply column with -1
+                sumLowerBound = sumUpperBound;
+                addCandidate(candidates, j, aj, HighsInt{-1}, minWeight,
+                             maxWeight, hasInteger, allInteger);
+              }
+            }
+          }
+          // update activities
+          if (aj < 0) std::swap(sumLowerBound, sumUpperBound);
+          updateActivityBounds(sumLower, sumUpper, sumLowerFinite,
+                               sumUpperFinite, aj, sumLowerBound,
+                               sumUpperBound);
+          if (!sumLowerFinite && !sumUpperFinite) return false;
+        }
+        return true;
+      };
+
   // lambda for actual stuffing
   auto checkRow = [&](HighsInt row, double rhs, HighsInt direction) {
     // skip row if rhs is not finite
@@ -5041,58 +5106,33 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
     // vectors for candidates and activity bounds
     std::vector<candidate> candidates;
-    candidates.reserve(rowsize[row]);
-    HighsCDouble sumLower = 0.0;
-    HighsCDouble sumUpper = 0.0;
-    bool sumLowerFinite = true;
-    bool sumUpperFinite = true;
-    bool allInteger = true;
-    double minWeight = kHighsInf;
-    double maxWeight = -kHighsInf;
+    HighsCDouble sumLower;
+    HighsCDouble sumUpper;
+    bool sumLowerFinite;
+    bool sumUpperFinite;
+    bool hasInteger;
+    bool allInteger;
+    double minWeight;
+    double maxWeight;
 
-    for (auto& nz : getRowVector(row)) {
-      // get column index, coefficient, cost and bounds
-      HighsInt j = nz.index();
-      double aj = direction * nz.value();
-      double cj = model->col_cost_[j];
-      double sumLowerBound = model->col_lower_[j];
-      double sumUpperBound = model->col_upper_[j];
-      if (isSingleton(j)) {
-        // check singleton
-        if (aj > 0) {
-          // use lower bound
-          sumUpperBound = sumLowerBound;
-          // candidate for stuffing?
-          if (cj < 0)
-            addCandidate(candidates, j, aj, HighsInt{1}, minWeight, maxWeight,
-                         allInteger);
-        } else {
-          // use upper bound
-          sumLowerBound = sumUpperBound;
-          // candidate for stuffing? multiply column with -1
-          if (cj > 0)
-            addCandidate(candidates, j, aj, HighsInt{-1}, minWeight, maxWeight,
-                         allInteger);
-        }
-      } else if (aj < 0)
-        std::swap(sumLowerBound, sumUpperBound);
-      // update activities
-      updateActivityBounds(sumLower, sumUpper, sumLowerFinite, sumUpperFinite,
-                           aj, sumLowerBound, sumUpperBound);
-      if (!sumLowerFinite && !sumUpperFinite) return Result::kOk;
+    // compute candidates
+    while (true) {
+      if (computeCandidates(row, direction, candidates, sumLower, sumUpper,
+                            sumLowerFinite, sumUpperFinite, hasInteger,
+                            allInteger, minWeight, maxWeight, true)) {
+        // all columns need to have same weights if we only have integer columns
+        if (!hasInteger || (allInteger && minWeight == maxWeight)) break;
+      }
+
+      // recompute candidates without integer columns
+      if (hasInteger &&
+          computeCandidates(row, direction, candidates, sumLower, sumUpper,
+                            sumLowerFinite, sumUpperFinite, hasInteger,
+                            allInteger, minWeight, maxWeight, false))
+        break;
+
+      return Result::kOk;
     }
-
-    // all columns need to have same weights if we only have integer columns
-    if (allInteger && minWeight != maxWeight) return Result::kOk;
-
-    // remove integer columns if there are also continuous ones
-    if (!allInteger)
-      candidates.erase(std::remove_if(candidates.begin(), candidates.end(),
-                                      [&](const candidate& p) {
-                                        return model->integrality_[p.col] ==
-                                               HighsVarType::kInteger;
-                                      }),
-                       candidates.end());
 
     // sort candidates
     sortCols(candidates);

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5099,6 +5099,33 @@ HPresolve::Result HPresolve::singletonColStuffing(
         return true;
       };
 
+  // lambda for computing candidates for stuffing
+  auto checkCandidates =
+      [&](HighsInt row, HighsInt direction, std::vector<candidate>& candidates,
+          HighsCDouble& sumLower, HighsCDouble& sumUpper, bool& sumLowerFinite,
+          bool& sumUpperFinite, bool& hasInteger, bool& allInteger,
+          double& minWeight, double& maxWeight) {
+        // compute candidates
+        if (computeCandidates(row, direction, candidates, sumLower, sumUpper,
+                              sumLowerFinite, sumUpperFinite, hasInteger,
+                              allInteger, minWeight, maxWeight, true)) {
+          // all columns need to have same weights if we only have integer
+          // columns
+          if (!hasInteger || (allInteger && minWeight == maxWeight))
+            return true;
+        } else
+          allInteger = false;
+
+        // recompute candidates without integer columns
+        if (hasInteger && !allInteger &&
+            computeCandidates(row, direction, candidates, sumLower, sumUpper,
+                              sumLowerFinite, sumUpperFinite, hasInteger,
+                              allInteger, minWeight, maxWeight, false))
+          return true;
+
+        return false;
+      };
+
   // lambda for actual stuffing
   auto checkRow = [&](HighsInt row, double rhs, HighsInt direction) {
     // skip row if rhs is not finite
@@ -5116,23 +5143,10 @@ HPresolve::Result HPresolve::singletonColStuffing(
     double maxWeight;
 
     // compute candidates
-    while (true) {
-      if (computeCandidates(row, direction, candidates, sumLower, sumUpper,
-                            sumLowerFinite, sumUpperFinite, hasInteger,
-                            allInteger, minWeight, maxWeight, true)) {
-        // all columns need to have same weights if we only have integer columns
-        if (!hasInteger || (allInteger && minWeight == maxWeight)) break;
-      }
-
-      // recompute candidates without integer columns
-      if (hasInteger &&
-          computeCandidates(row, direction, candidates, sumLower, sumUpper,
-                            sumLowerFinite, sumUpperFinite, hasInteger,
-                            allInteger, minWeight, maxWeight, false))
-        break;
-
+    if (!checkCandidates(row, direction, candidates, sumLower, sumUpper,
+                         sumLowerFinite, sumUpperFinite, hasInteger, allInteger,
+                         minWeight, maxWeight))
       return Result::kOk;
-    }
 
     // sort candidates
     sortCols(candidates);

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5100,7 +5100,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
                              std::vector<candidate>& candidates,
                              HighsCDouble& sumLower, HighsCDouble& sumUpper,
                              bool& sumLowerFinite, bool& sumUpperFinite) {
-    // indicators for integer candidates and weights
+    // number of integer candidates and weights
     size_t numIntegerCandidates;
     double minWeight;
     double maxWeight;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5099,32 +5099,40 @@ HPresolve::Result HPresolve::singletonColStuffing(
         return true;
       };
 
-  // lambda for computing candidates for stuffing
-  auto checkCandidates =
-      [&](HighsInt row, HighsInt direction, std::vector<candidate>& candidates,
-          HighsCDouble& sumLower, HighsCDouble& sumUpper, bool& sumLowerFinite,
-          bool& sumUpperFinite, bool& hasInteger, bool& allInteger,
-          double& minWeight, double& maxWeight) {
-        // compute candidates
-        if (computeCandidates(row, direction, candidates, sumLower, sumUpper,
-                              sumLowerFinite, sumUpperFinite, hasInteger,
-                              allInteger, minWeight, maxWeight, true)) {
-          // all columns need to have same weights if we only have integer
-          // columns
-          if (!hasInteger || (allInteger && minWeight == maxWeight))
-            return true;
-        } else
-          allInteger = false;
+  // lambda for computing and checking candidates for stuffing
+  auto checkCandidates = [&](HighsInt row, HighsInt direction,
+                             std::vector<candidate>& candidates,
+                             HighsCDouble& sumLower, HighsCDouble& sumUpper,
+                             bool& sumLowerFinite, bool& sumUpperFinite) {
+    // indicators for integer candidates and weights
+    bool hasInteger;
+    bool allInteger;
+    double minWeight;
+    double maxWeight;
 
-        // recompute candidates without integer columns
-        if (hasInteger && !allInteger &&
-            computeCandidates(row, direction, candidates, sumLower, sumUpper,
-                              sumLowerFinite, sumUpperFinite, hasInteger,
-                              allInteger, minWeight, maxWeight, false))
-          return true;
+    // compute candidates
+    if (computeCandidates(row, direction, candidates, sumLower, sumUpper,
+                          sumLowerFinite, sumUpperFinite, hasInteger,
+                          allInteger, minWeight, maxWeight, true)) {
+      // return if there are no integer columns
+      if (!hasInteger) return true;
+      // all columns need to have same weights if we only have integer
+      // columns
+      if (allInteger) {
+        if (minWeight != maxWeight) return false;
+        return true;
+      }
+    }
 
-        return false;
-      };
+    // recompute candidates without integer columns
+    if (hasInteger &&
+        computeCandidates(row, direction, candidates, sumLower, sumUpper,
+                          sumLowerFinite, sumUpperFinite, hasInteger,
+                          allInteger, minWeight, maxWeight, false))
+      return true;
+
+    return false;
+  };
 
   // lambda for actual stuffing
   auto checkRow = [&](HighsInt row, double rhs, HighsInt direction) {
@@ -5137,15 +5145,10 @@ HPresolve::Result HPresolve::singletonColStuffing(
     HighsCDouble sumUpper;
     bool sumLowerFinite;
     bool sumUpperFinite;
-    bool hasInteger;
-    bool allInteger;
-    double minWeight;
-    double maxWeight;
 
     // compute candidates
     if (!checkCandidates(row, direction, candidates, sumLower, sumUpper,
-                         sumLowerFinite, sumUpperFinite, hasInteger, allInteger,
-                         minWeight, maxWeight))
+                         sumLowerFinite, sumUpperFinite))
       return Result::kOk;
 
     // sort candidates

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4982,7 +4982,11 @@ HPresolve::Result HPresolve::singletonColStuffing(
   // count number of fixed columns
   HighsInt numFixedCols = 0;
 
-  typedef std::tuple<HighsInt, double, HighsInt> candidate;
+  struct candidate {
+    HighsInt col;
+    double val;
+    HighsInt multiplier;
+  };
 
   auto isSingleton = [&](HighsInt col) {
     return (!colDeleted[col] && colsize[col] == 1 &&
@@ -4991,9 +4995,9 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
   auto sortCols = [&](std::vector<candidate>& vec) {
     pdqsort(vec.begin(), vec.end(),
-            [&](const candidate& col1, const candidate& col2) {
-              return model->col_cost_[std::get<0>(col1)] / std::get<1>(col1) <
-                     model->col_cost_[std::get<0>(col2)] / std::get<1>(col2);
+            [&](const candidate& c1, const candidate& c2) {
+              return model->col_cost_[c1.col] / c1.val <
+                     model->col_cost_[c2.col] / c2.val;
             });
   };
 
@@ -5018,7 +5022,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
         allInteger && model->integrality_[col] == HighsVarType::kInteger;
     minWeight = std::min(minWeight, direction * val);
     maxWeight = std::max(maxWeight, direction * val);
-    candidates.push_back(std::make_tuple(col, val, direction));
+    candidates.push_back(candidate{col, val, direction});
   };
 
   // lambda for fixing a variable
@@ -5083,40 +5087,36 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
     // remove integer columns if there are also continuous ones
     if (!allInteger)
-      candidates.erase(
-          std::remove_if(candidates.begin(), candidates.end(),
-                         [&](const candidate& p) {
-                           return model->integrality_[std::get<0>(p)] ==
-                                  HighsVarType::kInteger;
-                         }),
-          candidates.end());
+      candidates.erase(std::remove_if(candidates.begin(), candidates.end(),
+                                      [&](const candidate& p) {
+                                        return model->integrality_[p.col] ==
+                                               HighsVarType::kInteger;
+                                      }),
+                       candidates.end());
 
     // sort candidates
     sortCols(candidates);
 
     // check candidates
     for (const auto& t : candidates) {
-      // get variable index, coefficient and multiplier (-1 if sign was flipped)
-      HighsInt j = std::get<0>(t);
-      double aj = std::get<1>(t);
-      HighsInt multiplier = std::get<2>(t);
       // both bounds have to be finite
-      if (model->col_lower_[j] == -kHighsInf ||
-          model->col_upper_[j] == kHighsInf)
+      if (model->col_lower_[t.col] == -kHighsInf ||
+          model->col_upper_[t.col] == kHighsInf)
         break;
       // compute delta (bound difference)
-      HighsCDouble delta = multiplier * aj *
-                           (static_cast<HighsCDouble>(model->col_upper_[j]) -
-                            static_cast<HighsCDouble>(model->col_lower_[j]));
+      HighsCDouble delta =
+          t.multiplier * t.val *
+          (static_cast<HighsCDouble>(model->col_upper_[t.col]) -
+           static_cast<HighsCDouble>(model->col_lower_[t.col]));
       // check if variable can be fixed
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
         numFixedCols++;
-        HPRESOLVE_CHECKED_CALL(fixCol(j, multiplier));
+        HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
                  direction * rhs <= sumLower + primal_feastol) {
         numFixedCols++;
-        HPRESOLVE_CHECKED_CALL(fixCol(j, -multiplier));
+        HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5017,12 +5017,9 @@ HPresolve::Result HPresolve::singletonColStuffing(
   // lambda for storing a candidate
   auto addCandidate = [&](std::vector<candidate>& candidates, HighsInt col,
                           double val, HighsInt direction, double& minWeight,
-                          double& maxWeight, bool& hasInteger,
-                          bool& allInteger) {
-    hasInteger =
-        hasInteger || model->integrality_[col] == HighsVarType::kInteger;
-    allInteger =
-        allInteger && model->integrality_[col] == HighsVarType::kInteger;
+                          double& maxWeight, size_t& numIntegerCandidates) {
+    if (model->integrality_[col] == HighsVarType::kInteger)
+      numIntegerCandidates++;
     minWeight = std::min(minWeight, direction * val);
     maxWeight = std::max(maxWeight, direction * val);
     candidates.push_back(candidate{col, val, direction});
@@ -5038,66 +5035,65 @@ HPresolve::Result HPresolve::singletonColStuffing(
   };
 
   // lambda for computing candidates for stuffing
-  auto computeCandidates =
-      [&](HighsInt row, HighsInt direction, std::vector<candidate>& candidates,
-          HighsCDouble& sumLower, HighsCDouble& sumUpper, bool& sumLowerFinite,
-          bool& sumUpperFinite, bool& hasInteger, bool& allInteger,
-          double& minWeight, double& maxWeight, bool allowIntegerCandidates) {
-        // vectors for candidates and activity bounds
-        candidates.clear();
-        candidates.reserve(rowsize[row]);
-        sumLower = 0.0;
-        sumUpper = 0.0;
-        sumLowerFinite = true;
-        sumUpperFinite = true;
-        hasInteger = false;
-        allInteger = true;
-        minWeight = kHighsInf;
-        maxWeight = -kHighsInf;
+  auto computeCandidates = [&](HighsInt row, HighsInt direction,
+                               std::vector<candidate>& candidates,
+                               HighsCDouble& sumLower, HighsCDouble& sumUpper,
+                               bool& sumLowerFinite, bool& sumUpperFinite,
+                               size_t& numIntegerCandidates, double& minWeight,
+                               double& maxWeight, bool allowIntegerCandidates) {
+    // vectors for candidates and activity bounds
+    candidates.clear();
+    candidates.reserve(rowsize[row]);
+    sumLower = 0.0;
+    sumUpper = 0.0;
+    sumLowerFinite = true;
+    sumUpperFinite = true;
+    numIntegerCandidates = 0;
+    minWeight = kHighsInf;
+    maxWeight = -kHighsInf;
 
-        for (auto& nz : getRowVector(row)) {
-          // get column index, coefficient, cost and bounds
-          HighsInt j = nz.index();
-          double aj = direction * nz.value();
-          double cj = model->col_cost_[j];
-          double sumLowerBound = model->col_lower_[j];
-          double sumUpperBound = model->col_upper_[j];
-          bool isCandidate = allowIntegerCandidates ||
-                             model->integrality_[j] != HighsVarType::kInteger;
+    for (auto& nz : getRowVector(row)) {
+      // get column index, coefficient, cost and bounds
+      HighsInt j = nz.index();
+      double aj = direction * nz.value();
+      double cj = model->col_cost_[j];
+      double sumLowerBound = model->col_lower_[j];
+      double sumUpperBound = model->col_upper_[j];
+      bool isCandidate = allowIntegerCandidates ||
+                         model->integrality_[j] != HighsVarType::kInteger;
 
-          if (isSingleton(j)) {
-            // check singleton
-            if (aj > 0) {
-              if (cj >= 0)
-                // dual fixing: fix to lower bound
-                sumUpperBound = sumLowerBound;
-              else if (isCandidate) {
-                // candidate for stuffing
-                sumUpperBound = sumLowerBound;
-                addCandidate(candidates, j, aj, HighsInt{1}, minWeight,
-                             maxWeight, hasInteger, allInteger);
-              }
-            } else {
-              if (cj <= 0)
-                // dual fixing: fix to upper bound
-                sumLowerBound = sumUpperBound;
-              else if (isCandidate) {
-                // candidate for stuffing; multiply column with -1
-                sumLowerBound = sumUpperBound;
-                addCandidate(candidates, j, aj, HighsInt{-1}, minWeight,
-                             maxWeight, hasInteger, allInteger);
-              }
-            }
+      if (isSingleton(j)) {
+        // check singleton
+        if (aj > 0) {
+          if (cj >= 0)
+            // dual fixing: fix to lower bound
+            sumUpperBound = sumLowerBound;
+          else if (isCandidate) {
+            // candidate for stuffing
+            sumUpperBound = sumLowerBound;
+            addCandidate(candidates, j, aj, HighsInt{1}, minWeight, maxWeight,
+                         numIntegerCandidates);
           }
-          // update activities
-          if (aj < 0) std::swap(sumLowerBound, sumUpperBound);
-          updateActivityBounds(sumLower, sumUpper, sumLowerFinite,
-                               sumUpperFinite, aj, sumLowerBound,
-                               sumUpperBound);
-          if (!sumLowerFinite && !sumUpperFinite) return false;
+        } else {
+          if (cj <= 0)
+            // dual fixing: fix to upper bound
+            sumLowerBound = sumUpperBound;
+          else if (isCandidate) {
+            // candidate for stuffing; multiply column with -1
+            sumLowerBound = sumUpperBound;
+            addCandidate(candidates, j, aj, HighsInt{-1}, minWeight, maxWeight,
+                         numIntegerCandidates);
+          }
         }
-        return true;
-      };
+      }
+      // update activities
+      if (aj < 0) std::swap(sumLowerBound, sumUpperBound);
+      updateActivityBounds(sumLower, sumUpper, sumLowerFinite, sumUpperFinite,
+                           aj, sumLowerBound, sumUpperBound);
+      if (!sumLowerFinite && !sumUpperFinite) return false;
+    }
+    return true;
+  };
 
   // lambda for computing and checking candidates for stuffing
   auto checkCandidates = [&](HighsInt row, HighsInt direction,
@@ -5105,30 +5101,29 @@ HPresolve::Result HPresolve::singletonColStuffing(
                              HighsCDouble& sumLower, HighsCDouble& sumUpper,
                              bool& sumLowerFinite, bool& sumUpperFinite) {
     // indicators for integer candidates and weights
-    bool hasInteger;
-    bool allInteger;
+    size_t numIntegerCandidates;
     double minWeight;
     double maxWeight;
 
     // compute candidates
     if (computeCandidates(row, direction, candidates, sumLower, sumUpper,
-                          sumLowerFinite, sumUpperFinite, hasInteger,
-                          allInteger, minWeight, maxWeight, true)) {
+                          sumLowerFinite, sumUpperFinite, numIntegerCandidates,
+                          minWeight, maxWeight, true)) {
       // return if there are no integer columns
-      if (!hasInteger) return true;
+      if (numIntegerCandidates == 0) return true;
       // all columns need to have same weights if we only have integer
       // columns
-      if (allInteger) {
+      if (numIntegerCandidates == candidates.size()) {
         if (minWeight != maxWeight) return false;
         return true;
       }
     }
 
     // recompute candidates without integer columns
-    if (hasInteger &&
+    if (numIntegerCandidates > 0 &&
         computeCandidates(row, direction, candidates, sumLower, sumUpper,
-                          sumLowerFinite, sumUpperFinite, hasInteger,
-                          allInteger, minWeight, maxWeight, false))
+                          sumLowerFinite, sumUpperFinite, numIntegerCandidates,
+                          minWeight, maxWeight, false))
       return true;
 
     return false;


### PR DESCRIPTION
Fix #2957 
- Recompute row activity in `HPresolve::singletonColStuffing` when integer columns cannot be used.
- Added a test.
- Testing on 850+ MIPs did not reveal any issues.