### PR TITLE
Round bounds before calling changeColBounds

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -445,7 +445,8 @@ HPresolve::StatusResult HPresolve::convertImpliedInteger(HighsInt col,
 
   // round and update bounds
   return StatusResult(
-      changeColBounds(col, model->col_lower_[col], model->col_upper_[col]));
+      changeColBounds(col, std::ceil(model->col_lower_[col] - primal_feastol),
+                      std::floor(model->col_upper_[col] + primal_feastol)));
 }
 
 void HPresolve::link(HighsInt pos) {
@@ -5675,8 +5676,9 @@ HPresolve::Result HPresolve::initialRowAndColPresolve(
     if (colDeleted[col]) continue;
     // round and update bounds
     if (model->integrality_[col] != HighsVarType::kContinuous)
-      HPRESOLVE_CHECKED_CALL(
-          changeColBounds(col, model->col_lower_[col], model->col_upper_[col]));
+      HPRESOLVE_CHECKED_CALL(changeColBounds(
+          col, std::ceil(model->col_lower_[col] - primal_feastol),
+          std::floor(model->col_upper_[col] + primal_feastol)));
     HPRESOLVE_CHECKED_CALL(colPresolve(postsolve_stack, col));
     changedColFlag[col] = false;
   }


### PR DESCRIPTION
Spotted this while going through `HPresolve`: If you pass `model->col_lower` or `model->col_upper` to `changeColBounds` then it will not perform the tightening based on potential integrality upgrades because the `<` `>` condition isn't satisfied. I think we're then not updating some bounds that we could have been tightening. 

Other option: Add something like `bool force` to `changeColBounds` for these cases. (if there's a strong preference to make sure integer rounding is only done in one spot)