### PR TITLE
Mangle symbols of metis, amd, rcm

### DIFF
--- a/.github/workflows/hipo-mangle.yml
+++ b/.github/workflows/hipo-mangle.yml
@@ -1,0 +1,80 @@
+name: hipo-mangle
+
+on: [push, pull_request]
+
+jobs:
+  check-metis:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Release]
+        all_tests: [OFF]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout METIS
+        uses: actions/checkout@v4
+        with:
+          repository: galabovaa/METIS
+          ref: 510-w
+          path: METIS
+
+      - name: Create installs dir
+        working-directory: ${{runner.workspace}}
+        run: |
+          mkdir installs
+          ls
+
+      - name: Install METIS
+        run: |
+          cmake \
+          -S $GITHUB_WORKSPACE/METIS \
+          -B build \
+          -DGKLIB_PATH=${{ github.workspace }}/METIS/GKlib \
+          -DCMAKE_INSTALL_PREFIX=${{ runner.workspace }}/installs
+          cmake --build build
+          cmake --install build
+
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake $GITHUB_WORKSPACE -DHIPO=ON -DBUILD_OPENBLAS=ON \
+            -DALL_TESTS=${{ matrix.all_tests }}
+
+      - name: Build HiGHS
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake --build . -j2
+
+      - name: Generate METIS symbols
+        working-directory: ${{runner.workspace}}
+        run: |
+          nm installs/lib/libmetis.a | grep -e "[tT] [^ ]+$" -oE | sort > metis.txt
+
+      - name: Generate HiGHS symbols
+        working-directory: ${{runner.workspace}}
+        run: |
+          nm build/lib/libhighs.a | grep -e "[tT] [^ ]+$" -oE | sort > highs.txt
+
+      - name: Compare symbols
+        working-directory: ${{runner.workspace}}
+        run: comm -12 highs.txt metis.txt > common.txt
+
+      - name: Check
+        working-directory: ${{runner.workspace}}
+        run: |
+          if [[ "$(wc -l < common.txt)" -eq 0 ]]; then 
+            exit 0
+          fi
+          echo "Metis symbols"
+          cat metis.txt
+          echo "Highs symbols"
+          cat highs.txt
+          echo "Common symbols"
+          cat compare.txt
+          exit 1

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -304,6 +304,7 @@ set(hipo_orderings_headers
     ../extern/metis/GKlib/gk_arch.h
     ../extern/metis/GKlib/gk_defs.h
     ../extern/metis/GKlib/gk_macros.h
+    ../extern/metis/GKlib/gk_mangle.h
     ../extern/metis/GKlib/gk_mkblas.h
     ../extern/metis/GKlib/gk_mkmemory.h
     ../extern/metis/GKlib/gk_mkpqueue.h
@@ -319,6 +320,7 @@ set(hipo_orderings_headers
     ../extern/metis/libmetis/defs.h
     ../extern/metis/libmetis/gklib_defs.h
     ../extern/metis/libmetis/macros.h
+    ../extern/metis/libmetis/metis_mangle.h
     ../extern/metis/libmetis/metislib.h
     ../extern/metis/libmetis/proto.h
     ../extern/metis/libmetis/stdheaders.h

--- a/extern/amd/amd_1.c
+++ b/extern/amd/amd_1.c
@@ -26,7 +26,7 @@
 
 #include "amd_internal.h"
 
-void amd_1
+void Highs_amd_1
 (
     amd_int n,		/* n > 0 */
     const amd_int Ap [ ],	/* input of size n+1, not modified */

--- a/extern/amd/amd_2.c
+++ b/extern/amd/amd_2.c
@@ -19,7 +19,7 @@
 /* === clear_flag ========================================================== */
 /* ========================================================================= */
 
-static amd_int clear_flag (amd_int wflg, amd_int wbig, amd_int W [ ], amd_int n)
+static amd_int Highs_amd_clear_flag (amd_int wflg, amd_int wbig, amd_int W [ ], amd_int n)
 {
     amd_int x ;
     if (wflg < 2 || wflg >= wbig)
@@ -624,7 +624,7 @@ void Highs_amd_2
 
     /* initialize wflg */
     wbig = amd_int_max - n ;
-    wflg = clear_flag (0, wbig, W, n) ;
+    wflg = Highs_amd_clear_flag (0, wbig, W, n) ;
 
     /* --------------------------------------------------------------------- */
     /* initialize degree lists and eliminate dense and empty rows */
@@ -992,7 +992,7 @@ void Highs_amd_2
 	/* With the current value of wflg, wflg+n must not cause integer
 	 * overflow */
 
-	wflg = clear_flag (wflg, wbig, W, n) ;
+	wflg = Highs_amd_clear_flag (wflg, wbig, W, n) ;
 
 /* ========================================================================= */
 /* COMPUTE (W [e] - wflg) = |Le\Lme| FOR ALL ELEMENTS */
@@ -1274,7 +1274,7 @@ void Highs_amd_2
 	/* make sure that wflg+n does not cause integer overflow */
 	lemax =  MAX (lemax, degme) ;
 	wflg += lemax ;
-	wflg = clear_flag (wflg, wbig, W, n) ;
+	wflg = Highs_amd_clear_flag (wflg, wbig, W, n) ;
 	/*  at this point, W [0..n-1] < wflg holds */
 
 /* ========================================================================= */
@@ -1682,7 +1682,7 @@ void Highs_amd_2
 /* postorder the assembly tree */
 /* ========================================================================= */
 
-    amd_postorder (n, Pe, Nv, Elen,
+    Highs_amd_postorder (n, Pe, Nv, Elen,
 	W,			/* output order */
 	Head, Next, Last) ;	/* workspace */
 

--- a/extern/amd/amd_aat.c
+++ b/extern/amd/amd_aat.c
@@ -17,7 +17,7 @@
 
 #include "amd_internal.h"
 
-size_t amd_aat	/* returns nz in A+A' */
+size_t Highs_amd_aat	/* returns nz in A+A' */
 (
     amd_int n,
     const amd_int Ap [ ],

--- a/extern/amd/amd_internal.h
+++ b/extern/amd/amd_internal.h
@@ -79,7 +79,7 @@
 /* AMD routine definitions (not user-callable) */
 /* ------------------------------------------------------------------------- */
 
-size_t amd_aat
+size_t Highs_amd_aat
 (
     amd_int n,
     const amd_int Ap [ ],
@@ -89,7 +89,7 @@ size_t amd_aat
     double Info [ ]
 ) ;
 
-void amd_1
+void Highs_amd_1
 (
     amd_int n,
     const amd_int Ap [ ],
@@ -103,7 +103,7 @@ void amd_1
     double Info [ ]
 ) ;
 
-void amd_postorder
+void Highs_amd_postorder
 (
     amd_int nn,
     amd_int Parent [ ],
@@ -115,7 +115,7 @@ void amd_postorder
     amd_int Stack [ ]
 ) ;
 
-amd_int amd_post_tree
+amd_int Highs_amd_post_tree
 (
     amd_int root,
     amd_int k,
@@ -125,7 +125,7 @@ amd_int amd_post_tree
     amd_int Stack [ ]
 ) ;
 
-void amd_preprocess
+void Highs_amd_preprocess
 (
     amd_int n,
     const amd_int Ap [ ],

--- a/extern/amd/amd_order.c
+++ b/extern/amd/amd_order.c
@@ -118,7 +118,7 @@ int Highs_amd_order
 	    return (AMD_OUT_OF_MEMORY) ;
 	}
 	/* use Len and Pinv as workspace to create R = A' */
-	amd_preprocess (n, Ap, Ai, Rp, Ri, Len, Pinv) ;
+	Highs_amd_preprocess (n, Ap, Ai, Rp, Ri, Len, Pinv) ;
 	Cp = Rp ;
 	Ci = Ri ;
     }
@@ -135,7 +135,7 @@ int Highs_amd_order
     /* determine the symmetry and count off-diagonal nonzeros in A+A' */
     /* --------------------------------------------------------------------- */
 
-    nzaat = amd_aat (n, Cp, Ci, Len, P, Info) ;
+    nzaat = Highs_amd_aat (n, Cp, Ci, Len, P, Info) ;
     
     
 
@@ -179,7 +179,7 @@ int Highs_amd_order
     /* order the matrix */
     /* --------------------------------------------------------------------- */
 
-    amd_1 (n, Cp, Ci, P, Pinv, Len, slen, S, Control, Info) ;
+    Highs_amd_1 (n, Cp, Ci, P, Pinv, Len, slen, S, Control, Info) ;
 
     /* --------------------------------------------------------------------- */
     /* free the workspace */

--- a/extern/amd/amd_post_tree.c
+++ b/extern/amd/amd_post_tree.c
@@ -12,7 +12,7 @@
 
 #include "amd_internal.h"
 
-amd_int amd_post_tree
+amd_int Highs_amd_post_tree
 (
     amd_int root,			/* root of the tree */
     amd_int k,			/* start numbering at k */
@@ -42,7 +42,7 @@ amd_int amd_post_tree
     i = root ;
     for (f = Child [i] ; f != EMPTY ; f = Sibling [f])
     {
-	k = amd_post_tree (f, k, Child, Sibling, Order, Stack, nn) ;
+	k = Highs_amd_post_tree (f, k, Child, Sibling, Order, Stack, nn) ;
     }
     Order [i] = k++ ;
     return (k) ;

--- a/extern/amd/amd_postorder.c
+++ b/extern/amd/amd_postorder.c
@@ -12,7 +12,7 @@
 
 #include "amd_internal.h"
 
-void amd_postorder
+void Highs_amd_postorder
 (
     /* inputs, not modified on output: */
     amd_int nn,		/* nodes are in the range 0..nn-1 */
@@ -134,7 +134,7 @@ void amd_postorder
 	if (Parent [i] == EMPTY && Nv [i] > 0)
 	{
 	    
-	    k = amd_post_tree (i, k, Child, Sibling, Order, Stack) ;
+	    k = Highs_amd_post_tree (i, k, Child, Sibling, Order, Stack) ;
 	}
     }
 }

--- a/extern/amd/amd_preprocess.c
+++ b/extern/amd/amd_preprocess.c
@@ -22,7 +22,7 @@
  * On input, the condition (AMD_valid (n,n,Ap,Ai) != AMD_INVALID) must hold.
  */
 
-void amd_preprocess
+void Highs_amd_preprocess
 (
     amd_int n,		/* input matrix: A is n-by-n */
     const amd_int Ap [ ],	/* size n+1 */

--- a/extern/metis/GKlib/gk_macros.h
+++ b/extern/metis/GKlib/gk_macros.h
@@ -21,7 +21,7 @@
 #define INC_DEC(a, b, val) do {(a) += (val); (b) -= (val);} while(0)
 
 #define ONEOVERRANDMAX (1.0/(RAND_MAX+1.0))
-#define RandomInRange(u, rng_state) ((int) (ONEOVERRANDMAX*(u)*my_rand_r(rng_state)))
+#define RandomInRange(u, rng_state) ((int) (ONEOVERRANDMAX*(u)*gk_rand_r(rng_state)))
 #define RandomInRange_r(s, u) ((int) (ONEOVERRANDMAX*(u)*rand_r(s)))
 
 /*-------------------------------------------------------------

--- a/extern/metis/GKlib/gk_mangle.h
+++ b/extern/metis/GKlib/gk_mangle.h
@@ -1,0 +1,27 @@
+#ifndef HIGHS_GKLIB_MANGLE_H
+#define HIGHS_GKLIB_MANGLE_H
+
+
+/* memory.c */
+#define gk_free             Highs_gk_free
+
+/* error.c */
+#define gk_errexit          Highs_gk_errexit
+
+/* random.c */
+#define gk_randint64        Highs_gk_randint64
+#define gk_randint32        Highs_gk_randint32
+#define gk_rand_r           Highs_gk_rand_r
+
+
+/* mcore.c */
+#define gk_mcoreCreate      Highs_gk_mcoreCreate
+#define gk_mcoreDestroy     Highs_gk_mcoreDestroy
+#define gk_mcoreMalloc      Highs_gk_mcoreMalloc
+#define gk_mcorePush        Highs_gk_mcorePush
+#define gk_mcorePop         Highs_gk_mcorePop
+#define gk_mcoreAdd         Highs_gk_mcoreAdd
+#define gk_mcoreDel         Highs_gk_mcoreDel
+
+
+#endif

--- a/extern/metis/GKlib/gk_proto.h
+++ b/extern/metis/GKlib/gk_proto.h
@@ -10,6 +10,8 @@
 #ifndef _GK_PROTO_H_
 #define _GK_PROTO_H_
 
+#include "gk_mangle.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,7 +31,7 @@ void gk_errexit(char *,...);
  *-------------------------------------------------------------*/
 uint64_t gk_randint64(unsigned *rng_state);
 uint32_t gk_randint32(unsigned *rng_state);
-int my_rand_r(unsigned *rng_state);
+int gk_rand_r(unsigned *rng_state);
 
 
 /* mcore.c */

--- a/extern/metis/GKlib/random.c
+++ b/extern/metis/GKlib/random.c
@@ -13,7 +13,7 @@
 /*************************************************************************/
 /*! Define function rand_r, which may not exist on certain machines */
 /*************************************************************************/
-int my_rand_r(unsigned *rng_state) {
+int gk_rand_r(unsigned *rng_state) {
   // Linear congruential generator, with values from wikipedia
   int result = ((*rng_state * 1103515245) + 12345) & 0x7fffffff;
   *rng_state = result;
@@ -23,15 +23,15 @@ int my_rand_r(unsigned *rng_state) {
 /* generates a random number on [0, 2^64-1]-interval */
 uint64_t gk_randint64(unsigned *rng_state)
 {
-uint64_t piece_1 = ((uint64_t) my_rand_r(rng_state)) << 32;
-uint64_t piece_2 = ((uint64_t) my_rand_r(rng_state));
+uint64_t piece_1 = ((uint64_t) gk_rand_r(rng_state)) << 32;
+uint64_t piece_2 = ((uint64_t) gk_rand_r(rng_state));
   return (uint64_t)(piece_1 | piece_2);
 }
 
 /* generates a random number on [0, 2^32-1]-interval */
 uint32_t gk_randint32(unsigned *rng_state)
 {
-  return (uint32_t)my_rand_r(rng_state);
+  return (uint32_t)gk_rand_r(rng_state);
 }
 
 

--- a/extern/metis/libmetis/gklib_defs.h
+++ b/extern/metis/libmetis/gklib_defs.h
@@ -10,6 +10,8 @@
 #ifndef _LIBMETIS_GKLIB_H_
 #define _LIBMETIS_GKLIB_H_
 
+#include "metis_mangle.h"
+
 /*************************************************************************
 * Define various data structure using GKlib's templates.
 **************************************************************************/

--- a/extern/metis/libmetis/metis_mangle.h
+++ b/extern/metis/libmetis/metis_mangle.h
@@ -1,0 +1,164 @@
+#ifndef HIGHS_METIS_MANGLE_H
+#define HIGHS_METIS_MANGLE_H
+
+/* balance.c */
+#define Balance2Way                         Highs_metis_Balance2Way
+#define Bnd2WayBalance                      Highs_metis_Bnd2WayBalance
+#define General2WayBalance                  Highs_metis_General2WayBalance
+#define McGeneral2WayBalance                Highs_metis_McGeneral2WayBalance
+
+/* bucketsort.c */
+#define BucketSortKeysInc                   Highs_metis_BucketSortKeysInc
+
+/* coarsen.c */
+#define CoarsenGraph                        Highs_metis_CoarsenGraph
+#define CoarsenGraphNlevels                 Highs_metis_CoarsenGraphNlevels
+#define Match_RM                            Highs_metis_Match_RM
+#define Match_SHEM                          Highs_metis_Match_SHEM
+#define Match_2Hop                          Highs_metis_Match_2Hop
+#define Match_2HopAny                       Highs_metis_Match_2HopAny
+#define Match_2HopAll                       Highs_metis_Match_2HopAll
+#define PrintCGraphStats                    Highs_metis_PrintCGraphStats
+#define CreateCoarseGraph                   Highs_metis_CreateCoarseGraph
+#define SetupCoarseGraph                    Highs_metis_SetupCoarseGraph
+#define ReAdjustMemory                      Highs_metis_ReAdjustMemory
+
+/* compress.c */
+#define CompressGraph                       Highs_metis_CompressGraph
+#define PruneGraph                          Highs_metis_PruneGraph
+
+/* contig.c */
+#define FindSepInducedComponents            Highs_metis_FindSepInducedComponents
+
+/* fm.c */
+#define FM_2WayRefine                       Highs_metis_FM_2WayRefine
+#define FM_2WayCutRefine                    Highs_metis_FM_2WayCutRefine
+#define FM_Mc2WayCutRefine                  Highs_metis_FM_Mc2WayCutRefine
+#define SelectQueue                         Highs_metis_SelectQueue
+#define Print2WayRefineStats                Highs_metis_Print2WayRefineStats
+
+/* graph.c */
+#define SetupGraph                          Highs_metis_SetupGraph
+#define SetupGraph_tvwgt                    Highs_metis_SetupGraph_tvwgt
+#define SetupGraph_label                    Highs_metis_SetupGraph_label
+#define SetupSplitGraph                     Highs_metis_SetupSplitGraph
+#define CreateGraph                         Highs_metis_CreateGraph
+#define InitGraph                           Highs_metis_InitGraph
+#define FreeSData                           Highs_metis_FreeSData
+#define FreeRData                           Highs_metis_FreeRData
+#define FreeGraph                           Highs_metis_FreeGraph
+
+/* initpart.c */
+#define InitSeparator                       Highs_metis_InitSeparator
+#define RandomBisection                     Highs_metis_RandomBisection
+#define GrowBisection                       Highs_metis_GrowBisection
+#define GrowBisectionNode                   Highs_metis_GrowBisectionNode
+
+/* mcutil.c */
+#define ivecle                              Highs_metis_ivecle
+#define ivecaxpylez                         Highs_metis_ivecaxpylez
+#define BetterVBalance                      Highs_metis_BetterVBalance
+#define BetterBalance2Way                   Highs_metis_BetterBalance2Way
+#define ComputeLoadImbalance                Highs_metis_ComputeLoadImbalance
+#define ComputeLoadImbalanceDiff            Highs_metis_ComputeLoadImbalanceDiff
+#define ComputeLoadImbalanceDiffVec         Highs_metis_ComputeLoadImbalanceDiffVec
+
+/* mmd.c */
+#define genmmd                              Highs_metis_genmmd
+#define mmdelm                              Highs_metis_mmdelm
+#define mmdint                              Highs_metis_mmdint
+#define mmdnum                              Highs_metis_mmdnum
+#define mmdupd                              Highs_metis_mmdupd
+
+/* ometis.c */
+#define MlevelNestedDissection              Highs_metis_MlevelNestedDissection
+#define MlevelNestedDissectionCC            Highs_metis_MlevelNestedDissectionCC
+#define MlevelNodeBisectionMultiple         Highs_metis_MlevelNodeBisectionMultiple
+#define MlevelNodeBisectionL2               Highs_metis_MlevelNodeBisectionL2
+#define MlevelNodeBisectionL1               Highs_metis_MlevelNodeBisectionL1
+#define SplitGraphOrder                     Highs_metis_SplitGraphOrder
+#define SplitGraphOrderCC                   Highs_metis_SplitGraphOrderCC
+#define MMDOrder                            Highs_metis_MMDOrder
+
+/* options.c */
+#define SetupCtrl                           Highs_metis_SetupCtrl
+#define Setup2WayBalMultipliers             Highs_metis_Setup2WayBalMultipliers
+#define PrintCtrl                           Highs_metis_PrintCtrl
+#define CheckParams                         Highs_metis_CheckParams
+#define FreeCtrl                            Highs_metis_FreeCtrl
+
+/* refine.c */
+#define Allocate2WayPartitionMemory         Highs_metis_Allocate2WayPartitionMemory
+#define Compute2WayPartitionParams          Highs_metis_Compute2WayPartitionParams
+
+/* separator.c */
+#define ConstructSeparator                  Highs_metis_ConstructSeparator
+
+/* sfm.c */
+#define FM_2WayNodeRefine2Sided             Highs_metis_FM_2WayNodeRefine2Sided
+#define FM_2WayNodeRefine1Sided             Highs_metis_FM_2WayNodeRefine1Sided
+#define FM_2WayNodeBalance                  Highs_metis_FM_2WayNodeBalance
+
+/* srefine.c */
+#define Refine2WayNode                      Highs_metis_Refine2WayNode
+#define Allocate2WayNodePartitionMemory     Highs_metis_Allocate2WayNodePartitionMemory
+#define Compute2WayNodePartitionParams      Highs_metis_Compute2WayNodePartitionParams
+#define Project2WayNodePartition            Highs_metis_Project2WayNodePartition
+
+/* util.c */
+#define iargmax_nrm                         Highs_metis_iargmax_nrm
+#define iargmax2_nrm                        Highs_metis_iargmax2_nrm
+
+/* wspace.c */
+#define AllocateWorkSpace                   Highs_metis_AllocateWorkSpace
+#define FreeWorkSpace                       Highs_metis_FreeWorkSpace
+#define wspacemalloc                        Highs_metis_wspacemalloc
+#define wspacepush                          Highs_metis_wspacepush
+#define wspacepop                           Highs_metis_wspacepop
+#define iwspacemalloc                       Highs_metis_iwspacemalloc
+#define rwspacemalloc                       Highs_metis_rwspacemalloc
+#define ikvwspacemalloc                     Highs_metis_ikvwspacemalloc
+
+
+/* GKlib macros */
+#define iaxpy                               Highs_metis_iaxpy
+#define isum                                Highs_metis_isum
+#define imalloc                             Highs_metis_imalloc
+#define irealloc                            Highs_metis_irealloc
+#define ismalloc                            Highs_metis_ismalloc
+#define iset                                Highs_metis_iset
+#define icopy                               Highs_metis_icopy
+#define rmalloc                             Highs_metis_rmalloc
+#define rrealloc                            Highs_metis_rrealloc
+#define rsmalloc                            Highs_metis_rsmalloc
+#define rset                                Highs_metis_rset
+#define rcopy                               Highs_metis_rcopy
+#define ikvmalloc                           Highs_metis_ikvmalloc
+#define ikvrealloc                          Highs_metis_ikvrealloc
+#define ikvsmalloc                          Highs_metis_ikvsmalloc
+#define ikvset                              Highs_metis_ikvset
+#define ikvcopy                             Highs_metis_ikvcopy
+#define rkvmalloc                           Highs_metis_rkvmalloc
+#define rkvrealloc                          Highs_metis_rkvrealloc
+#define rkvsmalloc                          Highs_metis_rkvsmalloc
+#define rkvset                              Highs_metis_rkvset
+#define rkvcopy                             Highs_metis_rkvcopy
+#define rpqCreate                           Highs_metis_rpqCreate
+#define rpqInit                             Highs_metis_rpqInit
+#define rpqReset                            Highs_metis_rpqReset
+#define rpqFree                             Highs_metis_rpqFree
+#define rpqDestroy                          Highs_metis_rpqDestroy
+#define rpqLength                           Highs_metis_rpqLength
+#define rpqInsert                           Highs_metis_rpqInsert
+#define rpqDelete                           Highs_metis_rpqDelete
+#define rpqUpdate                           Highs_metis_rpqUpdate
+#define rpqGetTop                           Highs_metis_rpqGetTop
+#define rpqSeeTopVal                        Highs_metis_rpqSeeTopVal
+#define rpqSeeTopKey                        Highs_metis_rpqSeeTopKey
+#define irand                               Highs_metis_irand
+#define irandInRange                        Highs_metis_irandInRange
+#define irandArrayPermute                   Highs_metis_irandArrayPermute
+#define isortd                              Highs_metis_isortd
+#define ikvsorti                            Highs_metis_ikvsorti
+
+#endif

--- a/extern/metis/libmetis/metislib.h
+++ b/extern/metis/libmetis/metislib.h
@@ -24,6 +24,8 @@
 #include "macros.h"
 #include "proto.h"
 
+#include "ipm/hipo/auxiliary/OrderingPrint.h"
+
 
 #if defined(COMPILER_MSC) && (_MSC_VER < 1900)
 #if defined(rint)

--- a/extern/metis/libmetis/proto.h
+++ b/extern/metis/libmetis/proto.h
@@ -15,7 +15,7 @@
 #ifndef _LIBMETIS_PROTO_H_
 #define _LIBMETIS_PROTO_H_
 
-#include "ipm/hipo/auxiliary/OrderingPrint.h"
+#include "metis_mangle.h"
 
 /* auxapi.c */
 

--- a/extern/rcm/rcm.cpp
+++ b/extern/rcm/rcm.cpp
@@ -10,7 +10,7 @@ const HighsInt offset = 1;
 
 //****************************************************************************80
 
-static void degree(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
+static void Highs_rcm_degree(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
             const HighsInt adj[], HighsInt mask[], HighsInt deg[],
             HighsInt* iccsze, HighsInt ls[], HighsInt node_num)
 
@@ -149,7 +149,7 @@ static void degree(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
 }
 //****************************************************************************80
 
-static void i4vec_reverse(HighsInt n, HighsInt a[])
+static void Highs_rcm_i4vec_reverse(HighsInt n, HighsInt a[])
 
 //****************************************************************************80
 //
@@ -204,7 +204,7 @@ static void i4vec_reverse(HighsInt n, HighsInt a[])
 }
 //****************************************************************************80
 
-static void level_set(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
+static void Highs_rcm_level_set(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
                const HighsInt adj[], HighsInt mask[], HighsInt* level_num,
                HighsInt level_row[], HighsInt level[], HighsInt node_num)
 
@@ -341,7 +341,7 @@ static void level_set(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
 }
 //****************************************************************************80
 
-static HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
+static HighsInt Highs_rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
              const HighsInt adj[], HighsInt mask[], HighsInt perm[],
              HighsInt* iccsze, HighsInt node_num)
 
@@ -458,7 +458,7 @@ static HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
   //
   //  Find the degrees of the nodes in the component specified by MASK and ROOT.
   //
-  degree(root, adj_num, adj_row, adj, mask, deg, iccsze, perm, node_num);
+  Highs_rcm_degree(root, adj_num, adj_row, adj, mask, deg, iccsze, perm, node_num);
   //
   //  If the connected component size is less than 1, something is wrong.
   //
@@ -551,7 +551,7 @@ static HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
   //  We now have the Cuthill-McKee ordering.
   //  Reverse it to get the Reverse Cuthill-McKee ordering.
   //
-  i4vec_reverse(*iccsze, perm);
+  Highs_rcm_i4vec_reverse(*iccsze, perm);
   //
   //  Free memory.
   //
@@ -561,7 +561,7 @@ static HighsInt rcm(HighsInt root, HighsInt adj_num, const HighsInt adj_row[],
 }
 //****************************************************************************80
 
-static void root_find(HighsInt* root, HighsInt adj_num, const HighsInt adj_row[],
+static void Highs_rcm_root_find(HighsInt* root, HighsInt adj_num, const HighsInt adj_row[],
                const HighsInt adj[], HighsInt mask[], HighsInt* level_num,
                HighsInt level_row[], HighsInt level[], HighsInt node_num)
 
@@ -670,7 +670,7 @@ static void root_find(HighsInt* root, HighsInt adj_num, const HighsInt adj_row[]
   //
   //  Determine the level structure rooted at ROOT.
   //
-  level_set(*root, adj_num, adj_row, adj, mask, level_num, level_row, level,
+  Highs_rcm_level_set(*root, adj_num, adj_row, adj, mask, level_num, level_row, level,
             node_num);
   //
   //  Count the number of nodes in this level structure.
@@ -725,7 +725,7 @@ static void root_find(HighsInt* root, HighsInt adj_num, const HighsInt adj_row[]
     //
     //  Generate the rooted level structure associated with this node.
     //
-    level_set(*root, adj_num, adj_row, adj, mask, &level_num2, level_row, level,
+    Highs_rcm_level_set(*root, adj_num, adj_row, adj, mask, &level_num2, level_row, level,
               node_num);
     //
     //  If the number of levels did not increase, accept the new ROOT.
@@ -838,12 +838,12 @@ HighsInt Highs_genrcm(HighsInt node_num, HighsInt adj_num,
       //  Find a pseudo-peripheral node ROOT.  The level structure found by
       //  ROOT_FIND is stored starting at PERM(NUM).
       //
-      root_find(&root, adj_num, adj_row, adj, mask, &level_num, level_row,
+      Highs_rcm_root_find(&root, adj_num, adj_row, adj, mask, &level_num, level_row,
                 perm + num - 1, node_num);
       //
       //  RCM orders the component using ROOT as the starting node.
       //
-      if (rcm(root, adj_num, adj_row, adj, mask, perm + num - 1, &iccsze,
+      if (Highs_rcm(root, adj_num, adj_row, adj, mask, perm + num - 1, &iccsze,
               node_num)) {
         delete[] level_row;
         delete[] mask;


### PR DESCRIPTION
- All symbols exported by metis, amd and rcm are now mangled with ``Highs_`` in front of the symbol name.
- I added a new workflow that checks that there is no conflict with the symbols of Metis from github. The test uses ``nm`` to extract the symbols within the text section of ``libhighs`` and ``libmetis``. It then uses ``comm`` to find the common symbols and checks that the list of common symbols is empty. This test fails using ``latest``, returning the expected 11 duplicate symbols, while it passes on this branch after mangling.