### PR TITLE
Added support for scalar division to highspy

### DIFF
--- a/highs/highspy/highs.py
+++ b/highs/highspy/highs.py
@@ -1701,6 +1701,15 @@ class highs_var(object):
         else:
             return highs_linear_expression(self).__ge__(other)
 
+    # self / scalar
+    def __truediv__(self, other: Union[float, int, highs_linear_expression]):
+        expr = highs_linear_expression(self)
+        expr /= other
+        return expr
+
+    # scalar / self
+    def __rtruediv__(self, other: Union[float, int, highs_linear_expression]):
+        raise Exception("Only division of a linear expression by a scalar is allowed.")
 
 # highs constraint
 class highs_cons(object):
@@ -2243,6 +2252,32 @@ class highs_linear_expression(object):
 
             self.constant = (self.constant or 0.0) - float(other)
             return self
+        
+    # expr / scalar
+    def __truediv__(self, other: Union[float, int, highs_linear_expression]):
+        copy = highs_linear_expression(self)
+        copy /= other
+        return copy
+
+    # expr /= scalar
+    def __itruediv__(self, other: Union[float, int, highs_linear_expression]):
+        if isinstance(other, (float, int)):
+            divisor = float(other)
+
+        elif isinstance(other, highs_linear_expression) and other.idxs == [] and other.constant is not None:
+            divisor = float(other.constant)
+
+        else:
+            raise Exception("Only division by a scalar is allowed.")
+
+        if divisor == 0:
+            raise ZeroDivisionError("division by zero")
+
+        return self.__imul__(1.0 / divisor)
+
+    # scalar / expr
+    def __rtruediv__(self, other: Union[float, int, highs_var, highs_linear_expression]):
+        raise Exception("Only division of a linear expression by a scalar is allowed.")        
 
     def __imul__(self, other: Union[float, int, highs_var, highs_linear_expression]):
         if isinstance(other, (float, int)):

--- a/tests/test_highspy.py
+++ b/tests/test_highspy.py
@@ -2043,6 +2043,36 @@ class TestHighsLinearExpressionPy(unittest.TestCase):
         e1 *= x - 4 <= 3
         self.assertEqualExpr(e1, [x], [1], None, [-self.h.inf, 7])
 
+    def test_divide(self):
+        x, y = self.x[0:2]
+
+        expr = x / 4
+        self.assertEqualExpr(expr, [x], [0.25])
+
+        expr = (x + 2 * y + 8) / 4
+        self.assertEqualExpr(expr, [x, y], [0.25, 0.5], 2)
+
+        expr = (4 <= x + 2 * y <= 8) / 2
+        self.assertEqualExpr(expr, [x, y], [0.5, 1], None, [2, 4])
+
+        expr = (x + 2 * y) / highs_linear_expression(4)
+        self.assertEqualExpr(expr, [x, y], [0.25, 0.5])
+
+        expr = x + 2 * y + 8
+        expr /= 4
+        self.assertEqualExpr(expr, [x, y], [0.25, 0.5], 2)
+
+        expr = 4 <= x + 2 * y <= 8
+        expr /= -2
+        self.assertEqualExpr(expr, [x, y], [-0.5, -1], None, [-4, -2])
+
+        self.assertRaises(Exception, lambda: x / y)
+        self.assertRaises(Exception, lambda: (x + y) / (x + 1))
+        self.assertRaises(Exception, lambda: 2 / x)
+        self.assertRaises(Exception, lambda: 2 / (x + y))
+        self.assertRaises(ZeroDivisionError, lambda: x / 0)
+        self.assertRaises(ZeroDivisionError, lambda: (x + y) / highs_linear_expression(0))
+
     def test_simplify(self):
         x, y, z = self.x[0:3]
 


### PR DESCRIPTION
Allows scalar division.  Small change for pythonic syntax + unit tests.  Some usage examples: 

| Expression | Result | Notes |
|---|---|---|
| `x / 4` | `0.25 * x` | Divide a variable by a scalar |
| `(x + 2 * y + 8) / 4` | `0.25 * x + 0.5 * y + 2` | Divide a linear expression including a constant |
| `(4 <= x + 2 * y <= 8) / 2` | `2 <= 0.5 * x + y <= 4` | Divide a bounded expression by a _positive_ scalar |
| `(4 <= x + 2 * y <= 8) / -2` | `-4 <= -0.5 * x - y <= -2` | Divide a bounded expression by a _negative_ scalar. **Notice change in bounds.** |
| `(x + 2 * y) / highs_linear_expression(4)` | `0.25 * x + 0.5 * y` | Scalar-valued expressions are also allowed as divisors |
| `expr /= 4` | In-place scaling | Works for mutable linear expressions |
| `X / 2` | elementwise scaling of every variable in X | X can be a `highspyarray`, for example from `h.addVariables(2, 3)` |

Invalid operations:

| Expression | Behavior |
|---|---|
| `x / y` | Raises an exception |
| `(x + y) / (x + 1)` | Raises an exception |
| `2 / x` | Raises an exception |
| `2 / (x + y)` | Raises an exception |
| `x / 0` | Raises `ZeroDivisionError` |
| `(x + y) / highs_linear_expression(0)` | Raises `ZeroDivisionError` |