### PR TITLE
Bug fixes for getIis

### DIFF
--- a/highs/lp_data/HighsIis.cpp
+++ b/highs/lp_data/HighsIis.cpp
@@ -641,13 +641,6 @@ HighsStatus HighsIis::compute(const HighsLp& lp, const HighsOptions& options,
   HighsStatus run_status = highs.passModel(lp);
   assert(run_status == HighsStatus::kOk);
   if (basis) highs.setBasis(*basis);
-
-  // Initial logging
-  this->clearLogInfo();
-  HighsInt iter = 0;
-  highsLogUser(log_options, HighsLogType::kInfo,
-               "\nRunning deletion filter to identify an IIS\n");
-  this->reportIteration(options, iter, num_rows, true);
   // Zero the objective
   std::vector<double> cost;
   cost.assign(lp.num_col_, 0);
@@ -780,6 +773,13 @@ HighsStatus HighsIis::compute(const HighsLp& lp, const HighsOptions& options,
   assert(highs.getModelStatus() == HighsModelStatus::kInfeasible);
   IisModelStatus iis_status = kIisModelStatusIrreducible;
   HighsStatus search_return_status = HighsStatus::kOk;
+
+  // Initial logging
+  this->clearLogInfo();
+  HighsInt iter = 0;
+  highsLogUser(log_options, HighsLogType::kInfo,
+               "\nRunning deletion filter to identify an IIS\n");
+  this->reportIteration(options, iter, num_rows, true);
 
   // Pass twice: rows before columns, or columns before rows, according to
   // row_priority

--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -2101,16 +2101,13 @@ HighsStatus Highs::getIisInterface() {
     return_status = this->elasticityFilter(-1.0, -1.0, 1.0, nullptr, nullptr,
                                            nullptr, true);
   }
-  // Do not continue if not using kIisStrategyIrreducible or if time limit is
-  // reached
-  if (!(kIisStrategyIrreducible & this->options_.iis_strategy) ||
-      (this->iis_.status_ == kIisModelStatusTimeLimit))
+  // Do not continue if not using kIisStrategyIrreducible
+  if (!(kIisStrategyIrreducible & this->options_.iis_strategy))
     return this->getIisInterfaceReturn(return_status, original_options,
                                        original_callback_active);
-
   // If neither ray and lp options were requested or if they fail to produce a
   // valid IS, make one consisting of all constraints
-  if (!this->iis_.valid_) {
+  if (!this->iis_.valid_ || iis_.status_ != kIisModelStatusReducible) {
     this->iis_.valid_ = true;
     this->iis_.status_ = kIisModelStatusReducible;
     for (HighsInt iRow = 0; iRow < lp.num_row_; iRow++)
@@ -2531,11 +2528,12 @@ HighsStatus Highs::elasticityFilter(const double global_lower_penalty,
 
   if (write_model) this->writeModel("elastic.mps");
   // Initial logging
-  if (get_iis)
+  if (get_iis) {
     highsLogUser(
         options_.log_options, HighsLogType::kInfo,
         "Running elasticity filter to identify an infeasible subset of rows\n");
-
+    iis.reportIteration(options_, HighsInt(0), HighsInt(0), true);
+  }
   // Working with a copy of the IIS so clear this->iis_
   this->iis_.clear();
   // Lambda for gathering data when solving an LP
@@ -2605,6 +2603,7 @@ HighsStatus Highs::elasticityFilter(const double global_lower_penalty,
   std::unordered_set<HighsInt> row_set;
 
   for (;;) {
+    loop_k++;
     if (kIisDevReport)
       printf("\nElasticity filter pass %d\n==============\n", int(loop_k));
     HighsInt num_fixed = 0;
@@ -2651,19 +2650,18 @@ HighsStatus Highs::elasticityFilter(const double global_lower_penalty,
         }
       }
     }
-    // Report on iteration
-    bool force = loop_k == 0;
-    iis.reportIteration(options_, loop_k + 1, HighsInt(row_set.size()), force);
 
     if (num_fixed == 0) {
       // No elastic variables were positive, so problem is feasible
       iis.status_ = kIisModelStatusFeasible;
+      iis.reportIteration(options_, loop_k, HighsInt(row_set.size()), true);
       break;
     }
     HighsStatus run_status = solveLp();
+    HighsModelStatus model_status = this->getModelStatus();
     if (run_status != HighsStatus::kOk) {
       // Solve failed
-      if (this->model_status_ == HighsModelStatus::kTimeLimit) {
+      if (model_status == HighsModelStatus::kTimeLimit) {
         iis.status_ = kIisModelStatusTimeLimit;
 
         highsLogUser(
@@ -2684,14 +2682,10 @@ HighsStatus Highs::elasticityFilter(const double global_lower_penalty,
           original_col_lower, original_col_upper, original_integrality);
     }
     if (kIisDevReport) this->writeSolution("", kSolutionStylePretty);
-    HighsModelStatus model_status = this->getModelStatus();
-    if (model_status == HighsModelStatus::kInfeasible) break;
-    loop_k++;
+    bool terminate = (model_status == HighsModelStatus::kInfeasible);
+    iis.reportIteration(options_, loop_k, HighsInt(row_set.size()), terminate);
+    if (terminate) break;
   }
-
-  // Final report
-  iis.reportIteration(options_, loop_k + 1, HighsInt(row_set.size()), true);
-
   HighsInt num_enforced_col_ecol = 0;
   HighsInt num_enforced_row_ecol = 0;
   if (has_elastic_columns) {
@@ -2741,12 +2735,14 @@ HighsStatus Highs::elasticityFilter(const double global_lower_penalty,
   if (iis.status_ == kIisModelStatusFeasible) {
     assert(num_enforced_col_ecol == 0 && num_enforced_row_ecol == 0);
     assert(num_iis_row == 0);
+    highsLogUser(options_.log_options, HighsLogType::kInfo,
+                 "Elasticity filter failed to reproduce infeasibility\n");
+  } else {
+    highsLogUser(options_.log_options, HighsLogType::kInfo,
+                 "Elasticity filter after %d passes found an infeasible subset "
+                 "of %d rows\n",
+                 int(loop_k), row_set.size());
   }
-
-  highsLogUser(options_.log_options, HighsLogType::kInfo,
-               "Elasticity filter after %d passes found an infeasible subset "
-               "of %d rows\n",
-               int(loop_k + 1), row_set.size());
 
   iis.valid_ = true;
   iis.strategy_ = this->options_.iis_strategy;


### PR DESCRIPTION
- Fixed an issue with near-feasible models where the model status could flip from infeasible to feasible during elasticity filtering: now falls back to the original constraint set and, if requested, proceeds to deletion filtering.
- Improved time-out handling from elasticity filter: If time limit is reached, fall back to the original constraint set and allow deletion filtering to handle the exit
- Improved logging consistency between elasticity filtering and deletion filtering.