### PR TITLE
Limit the parallelism in julia-tests.yml

### DIFF
--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -115,4 +115,9 @@ jobs:
       - shell: julia --color=yes {0}
         run: |
           using Pkg
-          Pkg.test("HiGHS")
+          # HiGHS uses (N+1)/2 threads. HiGHS.jl parallelises the tests and, in
+          # the default setting, it may use up to 4 parallel jobs. This means
+          # HiGHS may attempt to start up to 2(N+1) threads and we get unhandled
+          # exceptions on macOS and a SIGTERM on linux. To work around this
+          # issue, limit the number of parallel tests in HiGHS.jl to 1.
+          Pkg.test("HiGHS"; test_args=["--jobs=1"])

--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -118,6 +118,6 @@ jobs:
           # HiGHS uses (N+1)/2 threads. HiGHS.jl parallelises the tests and, in
           # the default setting, it may use up to 4 parallel jobs. This means
           # HiGHS may attempt to start up to 2(N+1) threads and we get unhandled
-          # exceptions on macOS and a SIGTERM on linux. To work around this
-          # issue, limit the number of parallel tests in HiGHS.jl to 1.
-          Pkg.test("HiGHS"; test_args=["--jobs=1"])
+          # exceptions on macOS and a SIGTERM on linux. To avoid these errors,
+          # opt out of running the tests in parallel.
+          Pkg.test("HiGHS"; test_args=["--parallel=false"])


### PR DESCRIPTION
Limit the number of parallel tests in HiGHS.jl to 1 to avoid issues with thread management on macOS and Linux.

Discussed with @galabovaa via email

> Hi Oscar,
> 
> We are having failures on latest, I think due to the number of tests run in parallel
> 
> https://github.com/jump-dev/HiGHS.jl/blob/7345ec0de7b722e5cc9f0e91eb9a22765eabd68c/test/runtests.jl#L10
> 
> It is hardcoded here so I can't overwrite it in the HiGHS test workflow. It appears that often, but not always, some thread limit on the CI is hit.
> 
> See https://github.com/ERGO-Code/HiGHS/actions/runs/25165647977/job/73773337968 
> 
> Could you please lower that to 2 or 1 maybe? 
> 
> Thank you, 
> Ivet 

I fixed the hard-coded `--jobs=4` in HiGHS.jl: https://github.com/jump-dev/HiGHS.jl/pull/339, so now we can mess with it here. 

I don't know if this is a thing we should fix in ERGO-Code/HiGHS, where we more gracefully catch situations in which the number of threads is oversubscribed, or if we should fix this in HiGHS.jl by limiting the number of threads based on how many parallel jobs there are.