### PR TITLE
Install readme and license files to the right location

### DIFF
--- a/.github/workflows/check-python-package.yml
+++ b/.github/workflows/check-python-package.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          python3 -m pip install build setuptools twine
+          python3 -m pip install build setuptools twine 'packaging>=24.2'
           python3 -m build --sdist
           python3 -m build --wheel
           twine check dist/*
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          python3 -m pip install build setuptools twine --break-system-packages
+          python3 -m pip install build setuptools twine 'packaging>=24.2' --break-system-packages
           python3 -m build --sdist
           python3 -m build --wheel
           twine check dist/*
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          py -m pip install build setuptools twine
+          py -m pip install build setuptools twine 'packaging>=24.2'
           py -m build --sdist
           py -m build --wheel
           py -m twine check dist/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,13 +569,7 @@ if(ZLIB AND NOT TARGET ZLIB::ZLIB)
   find_package(ZLIB 1.2.3)
 endif()
 
-if (CMAKE_INSTALL_DOCDIR STREQUAL "" OR NOT BUILD_CXX)
-  install(FILES
-      README.md
-      LICENSE.txt
-      THIRD_PARTY_NOTICES.md
-      DESTINATION .)
-else()
+if (NOT CMAKE_INSTALL_DOCDIR STREQUAL "" AND BUILD_CXX)
   install(FILES
       README.md
       LICENSE.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,13 @@ version = "1.14.0.dev1"
 description = "A thin set of pybind11 wrappers to HiGHS"
 authors = [{ name = "HiGHS developers", email = "highsopt@gmail.com" }]
 readme = "README.md"
+license = "MIT"
 
 requires-python = ">=3.8"
 dependencies = ["numpy", "typing_extensions; python_version < '3.10'"]
 
 classifiers = [
   # "Development Status :: 4 - Beta",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ description = "A thin set of pybind11 wrappers to HiGHS"
 authors = [{ name = "HiGHS developers", email = "highsopt@gmail.com" }]
 readme = "README.md"
 license = "MIT"
+license-files = [
+  "LICENSE.txt",
+  "THIRD_PARTY_NOTICES.md",
+]
 
 requires-python = ">=3.8"
 dependencies = ["numpy", "typing_extensions; python_version < '3.10'"]
@@ -53,8 +57,6 @@ sdist.include = [
   "highspy/_core/*.pyi",
   "tests/test_highspy.py",
   "Version.txt",
-  "LICENSE",
-  "README.md",
   "highs/HConfig.h.in",
   "highs",
   "external",


### PR DESCRIPTION
- Fixes #2999.

With this fix, the sdist `highspy-1.14.0.tar.gz` still contains

```
highspy-1.14.0/LICENSE.txt
highspy-1.14.0/README.md
highspy-1.14.0/THIRD_PARTY_NOTICES.md
```

and the wheel `highspy-1.14.0-cp314-cp314-linux_x86_64.whl` contains

```
highspy-1.14.0.dist-info/licenses/THIRD_PARTY_NOTICES.md
highspy-1.14.0.dist-info/licenses/LICENSE.txt
highspy-1.14.0.dist-info/METADATA
```

where `METADATA` lists `License-Expression: MIT`, `License-File: LICENSE.txt`, `License-File: THIRD_PARTY_NOTICES.md`, and includes the contents of `README.md`.

Documentation:

- `pyproject.toml` [`license`](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license), [`license-files`](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license-files)
- core metadata [`License-Expression`](https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata-license-expression), [`License-File`](https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata-license-file), [`Classifier`](https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use) (deprecated for `License ::` in favor of `License-Expression`)