### PR TITLE
Use std::move in OpenNode constructor

### DIFF
--- a/highs/mip/HighsNodeQueue.cpp
+++ b/highs/mip/HighsNodeQueue.cpp
@@ -57,9 +57,10 @@ class HighsNodeQueue::NodeLowerRbTree : public CacheMinRbTree<NodeLowerRbTree> {
     return nodeQueue->nodes[node].lowerLinks;
   }
   std::tuple<double, HighsInt, double, int64_t> getKey(int64_t node) const {
-    return std::make_tuple(nodeQueue->nodes[node].lower_bound,
-                           HighsInt(nodeQueue->nodes[node].domchgstack.size()),
-                           nodeQueue->nodes[node].estimate, node);
+    return std::make_tuple(
+        nodeQueue->nodes[node].lower_bound,
+        static_cast<HighsInt>(nodeQueue->nodes[node].domchgstack.size()),
+        nodeQueue->nodes[node].estimate, node);
   }
 };
 

--- a/highs/mip/HighsNodeQueue.cpp
+++ b/highs/mip/HighsNodeQueue.cpp
@@ -56,7 +56,7 @@ class HighsNodeQueue::NodeLowerRbTree : public CacheMinRbTree<NodeLowerRbTree> {
   const RbTreeLinks<int64_t>& getRbTreeLinks(int64_t node) const {
     return nodeQueue->nodes[node].lowerLinks;
   }
-  std::tuple<double, HighsInt, double, int64_t> getKey(HighsInt node) const {
+  std::tuple<double, HighsInt, double, int64_t> getKey(int64_t node) const {
     return std::make_tuple(nodeQueue->nodes[node].lower_bound,
                            HighsInt(nodeQueue->nodes[node].domchgstack.size()),
                            nodeQueue->nodes[node].estimate, node);

--- a/highs/mip/HighsNodeQueue.h
+++ b/highs/mip/HighsNodeQueue.h
@@ -162,8 +162,8 @@ class HighsNodeQueue {
     OpenNode(std::vector<HighsDomainChange>&& domchgstack,
              std::vector<HighsInt>&& branchings, double lower_bound,
              double estimate, HighsInt depth)
-        : domchgstack(domchgstack),
-          branchings(branchings),
+        : domchgstack(std::move(domchgstack)),
+          branchings(std::move(branchings)),
           lower_bound(lower_bound),
           estimate(estimate),
           depth(depth),


### PR DESCRIPTION
Vectors `domchgstack` and `branchings` are rvalue references. I think the intention was to move them, but they are currently copied (which may be less efficient).