### PR TITLE
Fixed errors exposed by AI agent that do not lead to incorrect execution

### DIFF
--- a/highs/simplex/HEkkDual.cpp
+++ b/highs/simplex/HEkkDual.cpp
@@ -375,7 +375,7 @@ HighsStatus HEkkDual::solve(const bool pass_force_phase2) {
         highsLogDev(options.log_options, HighsLogType::kWarning,
                     "HEkkDual:: Primal simplex clean up yields optimality, "
                     "but with %" HIGHSINT_FORMAT
-                    " (max %g) primal infeasibilities and " HIGHSINT_FORMAT
+                    " (max %g) primal infeasibilities and %" HIGHSINT_FORMAT
                     " (max %g) dual infeasibilities\n",
                     info.num_primal_infeasibilities,
                     info.max_primal_infeasibility,

--- a/highs/simplex/HEkkDualMulti.cpp
+++ b/highs/simplex/HEkkDualMulti.cpp
@@ -843,9 +843,9 @@ void HEkkDual::majorUpdatePrimal() {
         // Update steepest edge weights
         HVector* Row = finish->row_ep;
         double Kai = -2 / finish->alpha_row;
-        ekk_instance_.updateDualSteepestEdgeWeights(row_out, variable_in, Col,
-                                                    new_pivotal_edge_weight,
-                                                    Kai, Row->array.data());
+        ekk_instance_.updateDualSteepestEdgeWeights(
+            finish->row_out, finish->variable_in, Col, new_pivotal_edge_weight,
+            Kai, Row->array.data());
       } else if (edge_weight_mode == EdgeWeightMode::kDevex &&
                  !new_devex_framework) {
         // Update Devex weights

--- a/highs/simplex/HEkkDualMulti.cpp
+++ b/highs/simplex/HEkkDualMulti.cpp
@@ -891,9 +891,9 @@ void HEkkDual::majorUpdatePrimal() {
         // Devex
         for (HighsInt jFn = 0; jFn < iFn; jFn++) {
           HighsInt jRow = multi_finish[jFn].row_out;
-          const double aa_iRow = colArray[iRow];
-          edge_weight[jRow] = max(edge_weight[jRow],
-                                  new_pivotal_edge_weight * aa_iRow * aa_iRow);
+          const double value = colArray[jRow];
+          edge_weight[jRow] =
+              max(edge_weight[jRow], new_pivotal_edge_weight * value * value);
         }
         edge_weight[iRow] = new_pivotal_edge_weight;
         num_devex_iterations++;

--- a/highs/simplex/HEkkPrimal.cpp
+++ b/highs/simplex/HEkkPrimal.cpp
@@ -314,7 +314,7 @@ HighsStatus HEkkPrimal::solve(const bool pass_force_phase2) {
       highsLogDev(options.log_options, HighsLogType::kWarning,
                   "HEkkPrimal:: Dual simplex clean up yields  optimality, but "
                   "with %" HIGHSINT_FORMAT
-                  " (max %g) primal infeasibilities and " HIGHSINT_FORMAT
+                  " (max %g) primal infeasibilities and %" HIGHSINT_FORMAT
                   " (max %g) dual infeasibilities\n",
                   info.num_primal_infeasibilities,
                   info.max_primal_infeasibility, info.num_dual_infeasibilities,
@@ -813,7 +813,7 @@ void HEkkPrimal::iterate() {
         ekk_instance_.iteration_count_ >= from_check_iter &&
         ekk_instance_.iteration_count_ <= to_check_iter;
     if (ekk_instance_.debug_iteration_report_) {
-      printf("HEkkDual::iterate Debug iteration %d\n",
+      printf("HEkkPrimal::iterate Debug iteration %d\n",
              (int)ekk_instance_.iteration_count_);
     }
   }


### PR DESCRIPTION
The first is a missing "%" in a logging statement that's never executed. I guess that the use of `HIGHSINT_FORMAT` leads to the compiler failing to spot it.

The second is, an error, but the two parameter values are associated with a development check that's not executed. In development, the check was used in the context of the serial dual simplex solver, so this error for the parallel dual simplex solver was never exposed. 