### PR TITLE
Improvements to free variables in HiPO

### DIFF
--- a/check/TestHipo.cpp
+++ b/check/TestHipo.cpp
@@ -112,11 +112,19 @@ TEST_CASE("test-hipo-qp", "[highs_hipo]") {
   highs.resetGlobalScheduler(true);
 }
 
-TEST_CASE("test-hipo-infeas", "[highs)hipo]") {
+TEST_CASE("test-hipo-infeas", "[highs_hipo]") {
   const HighsModelStatus expected_status = HighsModelStatus::kInfeasible;
   Highs highs;
   runHipoTest(highs, "bgetam.mps", 0, expected_status, "off");
   runHipoTest(highs, "forest6.mps", 0, expected_status, "off");
   runHipoTest(highs, "klein1.mps", 0, expected_status, "off");
+  highs.resetGlobalScheduler(true);
+}
+
+TEST_CASE("test-hipo-freevar", "[highs_hipo]") {
+  const HighsModelStatus expected_status = HighsModelStatus::kOptimal;
+  Highs highs;
+  runHipoTest(highs, "perold.mps", -9.381e3, expected_status, "on");
+  runHipoTest(highs, "perold.mps", -9.381e3, expected_status, "off");
   highs.resetGlobalScheduler(true);
 }

--- a/check/instances/perold.mps
+++ b/check/instances/perold.mps
@@ -1,0 +1,4481 @@
+NAME          PEROLD   (PILOT1)
+ROWS
+ E  DCOL01
+ E  DCRO01
+ E  DROP01
+ E  DGAS01
+ E  DELE01
+ E  MURN01
+ E  MURC01
+ E  MURE01
+ E  MURF01
+ E  MPLU01
+ E  MTLN01
+ E  MSPF01
+ E  RMMC01
+ L  URXT01
+ E  KODR01
+ E  BOIP01
+ E  OSRB01
+ E  OTRB01
+ E  BORS01
+ E  KGDR01
+ E  BGSF01
+ E  BGRS01
+ L  OVXT01
+ L  GVXT01
+ E  ODPL01
+ E  GDPL01
+ E  NRGP01
+ E  KLWR01
+ E  KLWP01
+ E  KMMC01
+ E  KENR01
+ E  KFBR01
+ E  KRPR01
+ E  KECM01
+ E  KWCM01
+ E  KCLQ01
+ E  KREF01
+ E  KOSE01
+ E  KCFP01
+ E  KOFP01
+ E  KGFP01
+ E  KCGL01
+ E  KCGH01
+ E  KHYD01
+ E  KGEO01
+ E  KAGR01
+ E  KMNG01
+ E  KEIM01
+ E  KENM01
+ E  KTAW01
+ E  KTRD01
+ E  KMAC01
+ E  DNRG01
+ E  BCOL01
+ E  BCRO01
+ E  BROP01
+ E  BGAS01
+ E  BELE01
+ G  BAGR01
+ G  BMNG01
+ G  BEIM01
+ G  BENM01
+ G  BTAW01
+ G  BTRD01
+ G  BMAC01
+ E  BIMP01
+ E  BEXP01
+ G  BTRB01
+ L  LTAW01
+ E  POPL01
+ L  WRKF01
+ E  ECAP01
+ E  CEEA01
+ E  CNEA01
+ E  ETDE01
+ E  DCOL02
+ E  DCRO02
+ E  DROP02
+ E  DGAS02
+ E  DELE02
+ E  MURN02
+ E  MURC02
+ E  MURE02
+ E  MURF02
+ E  MPLU02
+ E  MTLN02
+ E  MSPF02
+ E  RMMC02
+ L  URXT02
+ E  KODR02
+ E  BOIP02
+ E  OSRB02
+ E  OTRB02
+ E  BORS02
+ E  KGDR02
+ E  BGSF02
+ E  BGRS02
+ L  OVXT02
+ L  GVXT02
+ E  ODPL02
+ E  GDPL02
+ E  NRGP02
+ G  PELE02
+ E  KLWR02
+ E  KLWP02
+ E  KMMC02
+ E  KENR02
+ E  KFBR02
+ E  KRPR02
+ E  KECM02
+ E  KWCM02
+ E  KCLQ02
+ E  KREF02
+ E  KOSE02
+ E  KCFP02
+ E  KOFP02
+ E  KGFP02
+ E  KCGL02
+ E  KCGH02
+ E  KHYD02
+ E  KGEO02
+ E  KAGR02
+ E  KMNG02
+ E  KEIM02
+ E  KENM02
+ E  KTAW02
+ E  KTRD02
+ E  KMAC02
+ E  DNRG02
+ E  BCOL02
+ E  BCRO02
+ E  BROP02
+ E  BGAS02
+ E  BELE02
+ G  BAGR02
+ G  BMNG02
+ G  BEIM02
+ G  BENM02
+ G  BTAW02
+ G  BTRD02
+ G  BMAC02
+ E  BIMP02
+ E  BEXP02
+ G  BTRB02
+ L  LTAW02
+ E  POPL02
+ L  WRKF02
+ E  ECAP02
+ G  UMOB02
+ G  TEEA02
+ E  CEEA02
+ G  TNEA02
+ E  CNEA02
+ E  ETDE02
+ E  DCOL03
+ E  DCRO03
+ E  DROP03
+ E  DGAS03
+ E  DELE03
+ E  MURN03
+ E  MURC03
+ E  MURE03
+ E  MURF03
+ E  MPLU03
+ E  MTLN03
+ E  MSPF03
+ E  RMMC03
+ L  URXT03
+ E  KODR03
+ E  BOIP03
+ E  OSRB03
+ E  OTRB03
+ E  BORS03
+ E  KGDR03
+ E  BGSF03
+ E  BGRS03
+ L  OVXT03
+ L  GVXT03
+ E  ODPL03
+ E  GDPL03
+ E  NRGP03
+ G  PELE03
+ E  KLWR03
+ E  KLWP03
+ E  KMMC03
+ E  KENR03
+ E  KFBR03
+ E  KRPR03
+ E  KECM03
+ E  KWCM03
+ E  KCLQ03
+ E  KREF03
+ E  KOSE03
+ E  KCFP03
+ E  KOFP03
+ E  KGFP03
+ E  KCGL03
+ E  KCGH03
+ E  KHYD03
+ E  KGEO03
+ E  KAGR03
+ E  KMNG03
+ E  KEIM03
+ E  KENM03
+ E  KTAW03
+ E  KTRD03
+ E  KMAC03
+ E  DNRG03
+ E  BCOL03
+ E  BCRO03
+ E  BROP03
+ E  BGAS03
+ E  BELE03
+ G  BAGR03
+ G  BMNG03
+ G  BEIM03
+ G  BENM03
+ G  BTAW03
+ G  BTRD03
+ G  BMAC03
+ E  BIMP03
+ E  BEXP03
+ G  BTRB03
+ L  LTAW03
+ E  POPL03
+ L  WRKF03
+ E  ECAP03
+ G  UMOB03
+ G  TEEA03
+ E  CEEA03
+ G  TNEA03
+ E  CNEA03
+ E  ETDE03
+ E  DCOL04
+ E  DCRO04
+ E  DROP04
+ E  DGAS04
+ E  DELE04
+ E  MURN04
+ E  MURC04
+ E  MURE04
+ E  MURF04
+ E  MPLU04
+ E  MTLN04
+ E  MSPF04
+ E  RMMC04
+ L  URXT04
+ E  KODR04
+ E  BOIP04
+ E  OSRB04
+ E  OTRB04
+ E  BORS04
+ E  KGDR04
+ E  BGSF04
+ E  BGRS04
+ L  OVXT04
+ L  GVXT04
+ E  ODPL04
+ E  GDPL04
+ E  NRGP04
+ G  PELE04
+ E  KLWR04
+ E  KLWP04
+ E  KMMC04
+ E  KENR04
+ E  KFBR04
+ E  KRPR04
+ E  KECM04
+ E  KWCM04
+ E  KCLQ04
+ E  KREF04
+ E  KOSE04
+ E  KCFP04
+ E  KOFP04
+ E  KGFP04
+ E  KCGL04
+ E  KCGH04
+ E  KHYD04
+ E  KGEO04
+ E  KAGR04
+ E  KMNG04
+ E  KEIM04
+ E  KENM04
+ E  KTAW04
+ E  KTRD04
+ E  KMAC04
+ E  DNRG04
+ E  BCOL04
+ E  BCRO04
+ E  BROP04
+ E  BGAS04
+ E  BELE04
+ G  BAGR04
+ G  BMNG04
+ G  BEIM04
+ G  BENM04
+ G  BTAW04
+ G  BTRD04
+ G  BMAC04
+ E  BIMP04
+ E  BEXP04
+ G  BTRB04
+ L  LTAW04
+ E  POPL04
+ L  WRKF04
+ E  ECAP04
+ G  UMOB04
+ G  TEEA04
+ E  CEEA04
+ G  TNEA04
+ E  CNEA04
+ E  ETDE04
+ E  DCOL05
+ E  DCRO05
+ E  DROP05
+ E  DGAS05
+ E  DELE05
+ E  MURN05
+ E  MURC05
+ E  MURE05
+ E  MURF05
+ E  MPLU05
+ E  MTLN05
+ E  MSPF05
+ E  RMMC05
+ L  URXT05
+ E  KODR05
+ E  BOIP05
+ E  OSRB05
+ E  OTRB05
+ E  BORS05
+ E  KGDR05
+ E  BGSF05
+ E  BGRS05
+ L  OVXT05
+ L  GVXT05
+ E  ODPL05
+ E  GDPL05
+ E  NRGP05
+ G  PELE05
+ E  KLWR05
+ E  KLWP05
+ E  KMMC05
+ E  KENR05
+ E  KFBR05
+ E  KRPR05
+ E  KECM05
+ E  KWCM05
+ E  KCLQ05
+ E  KREF05
+ E  KOSE05
+ E  KCFP05
+ E  KOFP05
+ E  KGFP05
+ E  KCGL05
+ E  KCGH05
+ E  KHYD05
+ E  KGEO05
+ E  KAGR05
+ E  KMNG05
+ E  KEIM05
+ E  KENM05
+ E  KTAW05
+ E  KTRD05
+ E  KMAC05
+ E  DNRG05
+ E  BCOL05
+ E  BCRO05
+ E  BROP05
+ E  BGAS05
+ E  BELE05
+ G  BAGR05
+ G  BMNG05
+ G  BEIM05
+ G  BENM05
+ G  BTAW05
+ G  BTRD05
+ G  BMAC05
+ E  BIMP05
+ E  BEXP05
+ G  BTRB05
+ L  LTAW05
+ E  POPL05
+ L  WRKF05
+ E  ECAP05
+ G  UMOB05
+ G  TEEA05
+ E  CEEA05
+ G  TNEA05
+ E  CNEA05
+ E  ETDE05
+ E  DCOL06
+ E  DCRO06
+ E  DROP06
+ E  DGAS06
+ E  DELE06
+ E  MURN06
+ E  MURC06
+ E  MURE06
+ E  MURF06
+ E  MPLU06
+ E  MTLN06
+ E  MSPF06
+ E  RMMC06
+ L  URXT06
+ E  KODR06
+ E  BOIP06
+ E  OSRB06
+ E  OTRB06
+ E  BORS06
+ E  KGDR06
+ E  BGSF06
+ E  BGRS06
+ L  OVXT06
+ L  GVXT06
+ E  ODPL06
+ E  GDPL06
+ E  NRGP06
+ G  PELE06
+ E  KLWR06
+ E  KLWP06
+ E  KMMC06
+ E  KENR06
+ E  KFBR06
+ E  KRPR06
+ E  KECM06
+ E  KWCM06
+ E  KCLQ06
+ E  KREF06
+ E  KOSE06
+ E  KCFP06
+ E  KOFP06
+ E  KGFP06
+ E  KCGL06
+ E  KCGH06
+ E  KHYD06
+ E  KGEO06
+ E  KAGR06
+ E  KMNG06
+ E  KEIM06
+ E  KENM06
+ E  KTAW06
+ E  KTRD06
+ E  KMAC06
+ E  DNRG06
+ E  BCOL06
+ E  BCRO06
+ E  BROP06
+ E  BGAS06
+ E  BELE06
+ G  BAGR06
+ G  BMNG06
+ G  BEIM06
+ G  BENM06
+ G  BTAW06
+ G  BTRD06
+ G  BMAC06
+ E  BIMP06
+ E  BEXP06
+ G  BTRB06
+ L  LTAW06
+ E  POPL06
+ L  WRKF06
+ E  ECAP06
+ G  UMOB06
+ G  TEEA06
+ E  CEEA06
+ G  TNEA06
+ E  CNEA06
+ E  ETDE06
+ E  DCOL07
+ E  DCRO07
+ E  DROP07
+ E  DGAS07
+ E  DELE07
+ E  MURN07
+ E  MURC07
+ E  MURE07
+ E  MURF07
+ E  MPLU07
+ E  MTLN07
+ E  MSPF07
+ E  RMMC07
+ L  URXT07
+ E  KODR07
+ E  BOIP07
+ E  OSRB07
+ E  OTRB07
+ E  BORS07
+ E  KGDR07
+ E  BGSF07
+ E  BGRS07
+ L  OVXT07
+ L  GVXT07
+ E  ODPL07
+ E  GDPL07
+ E  NRGP07
+ G  PELE07
+ E  KLWR07
+ E  KLWP07
+ E  KMMC07
+ E  KENR07
+ E  KFBR07
+ E  KRPR07
+ E  KECM07
+ E  KWCM07
+ E  KCLQ07
+ E  KREF07
+ E  KOSE07
+ E  KCFP07
+ E  KOFP07
+ E  KGFP07
+ E  KCGL07
+ E  KCGH07
+ E  KHYD07
+ E  KGEO07
+ E  KAGR07
+ E  KMNG07
+ E  KEIM07
+ E  KENM07
+ E  KTAW07
+ E  KTRD07
+ E  KMAC07
+ E  DNRG07
+ E  BCOL07
+ E  BCRO07
+ E  BROP07
+ E  BGAS07
+ E  BELE07
+ G  BAGR07
+ G  BMNG07
+ G  BEIM07
+ G  BENM07
+ G  BTAW07
+ G  BTRD07
+ G  BMAC07
+ E  BIMP07
+ E  BEXP07
+ G  BTRB07
+ L  LTAW07
+ E  POPL07
+ L  WRKF07
+ E  ECAP07
+ G  UMOB07
+ G  TEEA07
+ E  CEEA07
+ G  TNEA07
+ E  CNEA07
+ E  ETDE07
+ E  DCOL08
+ E  DCRO08
+ E  DROP08
+ E  DGAS08
+ E  DELE08
+ E  MURN08
+ E  MURC08
+ E  MURE08
+ E  MURF08
+ E  MPLU08
+ E  MTLN08
+ E  MSPF08
+ E  RMMC08
+ L  URXT08
+ E  KODR08
+ E  BOIP08
+ E  OSRB08
+ E  OTRB08
+ E  BORS08
+ E  KGDR08
+ E  BGSF08
+ E  BGRS08
+ L  OVXT08
+ L  GVXT08
+ E  ODPL08
+ E  GDPL08
+ E  NRGP08
+ G  PELE08
+ E  KLWR08
+ E  KLWP08
+ E  KMMC08
+ E  KENR08
+ E  KFBR08
+ E  KRPR08
+ E  KECM08
+ E  KWCM08
+ E  KCLQ08
+ E  KREF08
+ E  KOSE08
+ E  KCFP08
+ E  KOFP08
+ E  KGFP08
+ E  KCGL08
+ E  KCGH08
+ E  KHYD08
+ E  KGEO08
+ E  KAGR08
+ E  KMNG08
+ E  KEIM08
+ E  KENM08
+ E  KTAW08
+ E  KTRD08
+ E  KMAC08
+ E  DNRG08
+ E  BCOL08
+ E  BCRO08
+ E  BROP08
+ E  BGAS08
+ E  BELE08
+ G  BAGR08
+ G  BMNG08
+ G  BEIM08
+ G  BENM08
+ G  BTAW08
+ G  BTRD08
+ G  BMAC08
+ E  BIMP08
+ E  BEXP08
+ G  BTRB08
+ L  LTAW08
+ E  POPL08
+ L  WRKF08
+ E  ECAP08
+ G  UMOB08
+ E  CEEA08
+ E  CNEA08
+ N  OBJ
+COLUMNS
+    PLWU01    DELE01             -1.   BELE01              .9
+    PLWU01    MURE01      -20.867584   MSPF01       20.867584
+    PLWU01    KLWR01        2.222221   KLWR02       -2.222221
+    PLWU01    NRGP01         -10.355
+    PLWP01    DELE01             -1.   BELE01              .9
+    PLWP01    MURN01      -27.914734   MPLU01       -1.529699
+    PLWP01    MSPF01       29.444443   KLWP01        2.222221
+    PLWP01    KLWP02       -2.222221   NRGP01         -10.355
+    PNR101    BELE01          -.0027   MURN01       -9.192495
+    PNR101    MURE01          1.2595   MTLN01           7.933
+    PNR101    KENR01              1.   KENR02             -1.
+    PNR201    BELE01          -.0027   MURC01          -8.261
+    PNR201    MURE01        1.459499   MTLN01        6.801496
+    PNR201    KENR01              1.   KENR02             -1.
+    PNR301    BELE01          -.0027   MURN01         -10.793
+    PNR301    MURF01        2.112499   MTLN01        8.680496
+    PNR301    KENR01              1.   KENR02             -1.
+    PMMC01    RMMC01             -5.   BMNG01           -15.4
+    PMMC01    KMMC01              1.   KMMC02             -1.
+    PFBR01    DELE01             -1.   BELE01              .9
+    PFBR01    MPLU01         -1.3775   MTLN01      -15.662098
+    PFBR01    KFBR01       10.000003   KFBR02      -10.000003
+    PFBR01    NRGP01         -10.355
+    PRPR01    MURC01          27.715   MPLU01            1.11
+    PRPR01    MTLN01       19.069992   MSPF01            -50.
+    PRPR01    KRPR01              1.   KRPR02             -1.
+    PECM01    DCOL01          -.0258   BCOL01           .0258
+    PECM01    KECM01              1.   KECM02             -1.
+    PECM01    NRGP01          -.0258
+    PWCM01    DCOL01           -.016   BCOL01            .016
+    PWCM01    KWCM01              1.   KWCM02             -1.
+    PWCM01    NRGP01           -.016
+    PCLQ01    DROP01             -1.   BCOL01          -1.575
+    PCLQ01    BROP01              1.   KCLQ01              1.
+    PCLQ01    KCLQ02             -1.
+    PREF01    DROP01           -.549   BCRO01             -.6
+    PREF01    BROP01            .549   KREF01              1.
+    PREF01    KREF02             -1.
+    POSE01    DCRO01             -.6   BCRO01              .6
+    POSE01    KOSE01              1.   KOSE02             -1.
+    POSE01    NRGP01             -.6
+    PCFP01    DELE01             -1.   BCOL01         -10.355
+    PCFP01    BELE01              .9   KCFP01        1.851851
+    PCFP01    KCFP02       -1.851851
+    POFP01    DELE01             -1.   BROP01         -10.355
+    POFP01    BELE01              .9   KOFP01        1.886792
+    POFP01    KOFP02       -1.886792
+    PGFP01    DELE01             -1.   BGAS01         -10.355
+    PGFP01    BELE01              .9   KGFP01        1.886792
+    PGFP01    KGFP02       -1.886792
+    PCGL01    DELE01             -1.   BCOL01         -15.986
+    PCGL01    BELE01              .9   KCGL01              1.
+    PCGL01    KCGL02             -1.
+    PCGH01    DGAS01             -1.   BCOL01          -1.826
+    PCGH01    BGAS01              1.   KCGH01              1.
+    PCGH01    KCGH02             -1.
+    PHYD01    DELE01             -1.   BELE01              .9
+    PHYD01    KHYD01        1.851851   KHYD02       -1.851851
+    PHYD01    NRGP01         -10.355
+    PGEO01    DELE01             -1.   BELE01              .9
+    PGEO01    KGEO01        1.333333   KGEO02       -1.333333
+    PGEO01    NRGP01         -10.355
+    POF101    OVXT01              1.   KODR01           1800.
+    POF101    BOIP01            78.6   KODR02          -1800.
+    POF101    BOIP02           -78.6
+    POF201    OVXT01              1.   KODR01           3600.
+    POF201    BOIP01           136.5   KODR02          -3600.
+    POF201    BOIP02          -136.5
+    POF301    OVXT01              1.   KODR01           5400.
+    POF301    BOIP01           166.7   KODR02          -5400.
+    POF301    BOIP02          -166.7
+    PODR01    KODR01             -1.   ECAP01          -.0046
+    PODR01    CEEA01           .0046
+    POIP01    BOIP01             -1.   OSRB01          .00351
+    POIP01    OTRB01          .00039   ODPL01           .0135
+    POIP01    BORS02           .3135   OSRB02          .05065
+    POIP01    OTRB02          .04056   OSRB03          .01108
+    POIP01    OTRB03          .01525
+    POF401    OVXT01              1.   KODR01           7200.
+    POF401    BOIP01           182.6   KODR02          -7200.
+    POF401    BOIP02          -182.6
+    POF501    OVXT01              1.   KODR01           9000.
+    POF501    BOIP01           190.9   KODR02          -9000.
+    POF501    BOIP02          -190.9
+    POF601    OVXT01              1.   KODR01          10800.
+    POF601    BOIP01           195.2   KODR02         -10800.
+    POF601    BOIP02          -195.2
+    POF701    OVXT01              1.   KODR01          12600.
+    POF701    BOIP01           197.5   KODR02         -12600.
+    POF701    BOIP02          -197.5
+    PPOR01    ODPL01            .094   BORS01             -1.
+    PPOR01    BORS02              1.
+    PSRN01    OSRB01             -1.   OSRB02              1.
+    PSRA01    OSRB01             -1.   ODPL01            .043
+    PSRA01    BORS02              1.   ECAP01          -.0952
+    PSRA01    CEEA01           .0952
+    PTRN01    OTRB01             -1.   OTRB02              1.
+    PTRA01    OTRB01             -1.   ODPL01            .043
+    PTRA01    BORS02              1.   ECAP01          -.1558
+    PTRA01    CEEA01           .1558
+    PGF101    GVXT01              1.   KGDR01           1426.
+    PGF101    BGSF01            275.   KGDR02          -1426.
+    PGF101    BGSF02           -275.
+    PGF201    GVXT01              1.   KGDR01           2000.
+    PGF201    BGSF01      366.099854   KGDR02          -2000.
+    PGF201    BGSF02     -366.099854
+    PGF301    GVXT01              1.   KGDR01           3000.
+    PGF301    BGSF01      458.799805   KGDR02          -3000.
+    PGF301    BGSF02     -458.799805
+    PGDR01    KGDR01             -1.   ECAP01          -.0046
+    PGDR01    CEEA01           .0046
+    PGRA01    BGSF01             -1.   GDPL01            .043
+    PGRA01    BGRS02              1.
+    PGF401    GVXT01              1.   KGDR01           4000.
+    PGF401    BGSF01      504.599854   KGDR02          -4000.
+    PGF401    BGSF02     -504.599854
+    PGF501    GVXT01              1.   KGDR01           5000.
+    PGF501    BGSF01           527.5   KGDR02          -5000.
+    PGF501    BGSF02          -527.5
+    PGF601    GVXT01              1.   KGDR01           6000.
+    PGF601    BGSF01      538.899902   KGDR02          -6000.
+    PGF601    BGSF02     -538.899902
+    PGF701    GVXT01              1.   KGDR01           7000.
+    PGF701    BGSF01           544.5   KGDR02          -7000.
+    PGF701    BGSF02          -544.5
+    PGF801    GVXT01              1.   KGDR01           8000.
+    PGF801    BGSF01      547.299805   KGDR02          -8000.
+    PGF801    BGSF02     -547.299805
+    PPGR01    GDPL01            .094   BGRS01             -1.
+    PPGR01    BGRS02              1.
+    PGPR01    GDPL01             -1.   BCRO01            .198
+    PGPR01    BGAS01             .85   BGRS02             -5.
+    PGPR01    DCRO01          -1.198   DGAS01             -1.
+    PGPR01    NRGP01          -1.198
+    POPR01    ODPL01           -.167   BCRO01              1.
+    POPR01    BGAS01          .15555   BORS02           -.835
+    POPR01    DCRO01          -1.183   DGAS01           -.183
+    POPR01    NRGP01          -1.183
+    PNRG01    NRGP01              1.
+    KEEA01    TEEA02              .8   CEEA01             -1.
+    UCOL01    BCOL01             -1.
+    UCRO01    BCRO01             -1.
+    UROP01    BROP01             -1.
+    UGAS01    BGAS01             -1.
+    UELE01    BELE01             -1.
+    NURC01    MURC01             -1.   MURC02              1.
+    NURE01    MURE01             -1.   MURE02              1.
+    NURF01    MURF01             -1.   MURF02              1.
+    NPLU01    MPLU01             -1.   MPLU02              1.
+    NTLN01    MTLN01             -1.   MTLN02              1.
+    NSPF01    MSPF01             -1.   MSPF02              1.
+    UR101     MURN01      242.307831   RMMC01      242.307831
+    UR101     URXT01              1.   MURN02     -242.307831
+    UR101     RMMC02     -242.307831
+    UR201     MURN01      661.538818   RMMC01      681.538818
+    UR201     URXT01              1.   MURN02     -661.538818
+    UR201     RMMC02     -681.538818
+    UR301     MURN01     1288.462158   RMMC01     1523.077637
+    UR301     URXT01              1.   MURN02    -1288.462158
+    UR301     RMMC02    -1523.077637
+    UR401     MURN01     1950.000977   RMMC01     3084.617188
+    UR401     URXT01              1.   MURN02    -1950.000977
+    UR401     RMMC02    -3084.617188
+    UR501     MURN01     3638.463623   RMMC01     10114.62109
+    UR501     URXT01              1.   MURN02    -3638.463623
+    UR501     RMMC02    -10114.62109
+    UR601     MURN01     5438.460938   RMMC01     23614.62891
+    UR601     URXT01              1.   MURN02    -5438.460938
+    UR601     RMMC02    -23614.62891
+    ICOL01    BCOL01              1.   BIMP01          -1000.
+    ICRO01    BCRO01              1.   BIMP01    -1500.029785
+    IROP01    BROP01              1.   BIMP01    -1500.029785
+    IGAS01    BGAS01              1.   BIMP01    -1875.037109
+    IELE01    BELE01              1.   BIMP01    -15532.80469
+    JCOL01    BCOL01              1.   NRGP01             -1.
+    JCOL01    ECAP01          -3.333   CEEA01           3.333
+    JCRO01    BCRO01              1.   NRGP01             -1.
+    JCRO01    ECAP01          -3.333   CEEA01           3.333
+    JROP01    BROP01              1.   NRGP01             -1.
+    JROP01    ECAP01          -3.333   CEEA01           3.333
+    JGAS01    BGAS01              1.   NRGP01             -1.
+    JGAS01    ECAP01          -3.333   CEEA01           3.333
+    E1COL01   BCOL01             -1.   BTAW01      -85.984146
+    E1COL01   BTRD01       -3.289011   BEXP01           1000.
+    E1CRO01   BCRO01             -1.   BTAW01      -30.625748
+    E1CRO01   BEXP01     1500.029785
+    E1ROP01   BROP01             -1.   BTAW01      -70.309738
+    E1ROP01   BTRD01     -230.550491   BEXP01     1500.029785
+    E1GAS01   BGAS01             -1.   BTAW01      -76.420792
+    E1GAS01   BTRD01       -49.76236   BEXP01     1875.037109
+    E1ELE01   BELE01             -1.   BTRD01     -937.608643
+    E1ELE01   BEXP01     15532.80469
+    XCOL01    DCOL01        4.438329   BELE01        -.001258
+    XCOL01    BROP01        -.009637   BMNG01      -10.737742
+    XCOL01    BEIM01      -43.582611   BENM01      -30.318329
+    XCOL01    BTAW01       -8.842848   BTRD01     -121.652298
+    XCOL01    BMAC01      -41.056076   WRKF01         .046425
+    XCRO01    DCRO01        2.892097   BELE01        -.000506
+    XCRO01    BROP01        -.002062   BGAS01        -.007408
+    XCRO01    BMNG01      -34.323624   BEIM01      -29.450958
+    XCRO01    BENM01       -9.530361   BTAW01        -10.4619
+    XCRO01    BTRD01     -227.231018   BMAC01      -31.457352
+    XCRO01    WRKF01         .021354
+    XROP01    DROP01         .813213   BELE01         -.00034
+    XROP01    BCOL01        -.001514   BGAS01        -.025955
+    XROP01    BMNG01      -16.875412   BEIM01       -41.64917
+    XROP01    BENM01       -5.162801   BTAW01        -53.5159
+    XROP01    BTRD01      -81.333328   BMAC01       -3.506082
+    XROP01    WRKF01         .007051
+    XGAS01    DGAS01        1.380471   BELE01        -.000499
+    XGAS01    BCOL01        -.000874   BROP01        -.000706
+    XGAS01    BMNG01      -18.629242   BEIM01       -1.871531
+    XGAS01    BENM01        -.372872   BTAW01        -.243801
+    XGAS01    BTRD01      -47.828018   WRKF01         .005952
+    XELE01    DELE01         .054373   BAGR01       -1.282765
+    XELE01    BMNG01      -52.155487   BEIM01        -8.14335
+    XELE01    BENM01       -2.450525   BTAW01      -29.401871
+    XELE01    BTRD01     -148.124084   BMAC01       -3.821757
+    XELE01    WRKF01         .016189
+    XAGR01    KAGR01        1.111111   BCOL01        -.000313
+    XAGR01    BROP01         -.01547   BGAS01        -.000622
+    XAGR01    BELE01        -.000145   BAGR01      693.921387
+    XAGR01    BMNG01      -11.796776   BEIM01     -105.230377
+    XAGR01    BENM01       -8.735988   BTAW01      -19.273376
+    XAGR01    BTRD01       -132.6754   BMAC01       -6.567932
+    XAGR01    BIMP01        -.573897   KAGR02        -.888889
+    XMNG01    KMNG01        1.111111   BCOL01        -.000278
+    XMNG01    BROP01        -.016326   BGAS01          -.0016
+    XMNG01    BELE01        -.000122   BAGR01       -2.328505
+    XMNG01    BMNG01      972.447266   BEIM01     -134.663696
+    XMNG01    BENM01     -160.684525   BTAW01      -25.365646
+    XMNG01    BTRD01     -153.472351   BMAC01       -26.12706
+    XMNG01    BIMP01        -.894217   WRKF01         .038859
+    XMNG01    KMNG02        -.888889
+    XEIM01    KEIM01        1.111111   BCOL01        -.015447
+    XEIM01    BCRO01        -.000076   BROP01        -.009717
+    XEIM01    BGAS01        -.015198   BELE01        -.000533
+    XEIM01    BAGR01     -119.583542   BMNG01      -24.533279
+    XEIM01    BEIM01      731.984375   BENM01      -39.738663
+    XEIM01    BTAW01      -30.974686   BTRD01     -110.634079
+    XEIM01    BMAC01      -14.378268   BIMP01       -6.938498
+    XEIM01    WRKF01         .025369   KEIM02        -.888889
+    XENM01    KENM01        1.111111   BCOL01        -.000943
+    XENM01    BROP01        -.001951   BGAS01        -.003618
+    XENM01    BELE01        -.000314   BAGR01      -14.414824
+    XENM01    BMNG01       -5.079608   BEIM01     -159.277557
+    XENM01    BENM01       754.55127   BTAW01      -13.189252
+    XENM01    BTRD01      -99.108688   BMAC01      -34.243027
+    XENM01    BIMP01       -1.637574   WRKF01         .046102
+    XENM01    KENM02        -.888889
+    XTAW01    KTAW01        1.111111   BCOL01        -.000544
+    XTAW01    BCRO01         -.00019   BROP01        -.034464
+    XTAW01    BGAS01        -.002049   BELE01        -.000677
+    XTAW01    BAGR01        -.870055   BMNG01      -26.042328
+    XTAW01    BEIM01      -20.644028   BENM01      -10.381341
+    XTAW01    BTAW01      914.338867   BTRD01      -151.68219
+    XTAW01    BMAC01      -21.711823   BIMP01      -17.717484
+    XTAW01    WRKF01         .056178   KTAW02        -.888889
+    XTRD01    KTRD01        1.111111   BCOL01        -.001161
+    XTRD01    BCRO01        -.000099   BROP01        -.004447
+    XTRD01    BGAS01        -.004535   BELE01        -.000576
+    XTRD01    BAGR01       -5.705781   BMNG01       -18.54953
+    XTRD01    BEIM01      -23.171265   BENM01      -35.265518
+    XTRD01    BTAW01      -14.880653   BTRD01      825.474609
+    XTRD01    BMAC01       -8.531651   BIMP01       -1.058328
+    XTRD01    WRKF01         .073834   KTRD02        -.888889
+    XMAC01    KMAC01        1.111111   BCOL01        -.001101
+    XMAC01    BROP01         -.00272   BGAS01        -.002814
+    XMAC01    BELE01        -.000235   BMNG01       -8.258104
+    XMAC01    BEIM01     -132.072205   BENM01     -101.023422
+    XMAC01    BTAW01      -10.780818   BTRD01      -90.647217
+    XMAC01    BMAC01      747.764404   BIMP01        -.999022
+    XMAC01    WRKF01         .032378   KMAC02        -.888889
+    CONS01    OBJ          -1.019509   BIMP01          -19.51
+    CONS01    POPL01           1000.   DNRG01          -.0169
+    CONS01    BAGR01          -8.298   BMNG01      -66.047958
+    CONS01    BEIM01     -103.797958   BENM01     -115.218994
+    CONS01    BTAW01      -35.536987   BTRD01     -609.091797
+    CONS01    BMAC01      -41.043991
+    CNRG01    DNRG01              1.   BROP01          -.6431
+    CNRG01    BGAS01          -.2647   BELE01        -.027022
+    APCC01    POPL01          -213.5   UMOB02             -1.
+    GOVT01    BCOL01        -.001458   BROP01        -.006819
+    GOVT01    BGAS01        -.005441   BELE01        -.000551
+    GOVT01    BAGR01        7.501156   BMNG01     -179.188583
+    GOVT01    BEIM01      -29.199707   BENM01        -112.426
+    GOVT01    BTAW01      -24.609955   BTRD01     -552.763428
+    GOVT01    BMAC01      -89.739853   BIMP01         -22.646
+    CAPF01    BMNG01     -345.845703   BEIM01        -.755947
+    CAPF01    BENM01     -104.722321   BTAW01        -9.79188
+    CAPF01    BTRD01      -80.591064   BMAC01     -458.292969
+    CAPF01    BIMP01          -7.772   ECAP01              1.
+    KNEA01    TNEA02              .8   CNEA01             -1.
+    XIMP01    BIMP01              1.   BTRB01             -1.
+    XIMP01    LTAW01          -.0334
+    XEXP01    BEXP01             -1.   BTRB01              1.
+    IAGR01    BAGR01              1.   BTAW01        -.123939
+    IAGR01    BTRD01        -.097273   BIMP01             -1.
+    IMNG01    BMNG01              1.   BTAW01        -.144599
+    IMNG01    BTRD01        -.031359   BIMP01             -1.
+    IEIM01    BEIM01              1.   BTAW01        -.038321
+    IEIM01    BTRD01         -.05912   BIMP01             -1.
+    IENM01    BENM01              1.   BTAW01        -.019188
+    IENM01    BTRD01        -.084225   BIMP01             -1.
+    ITAW01    BTAW01              1.   BIMP01             -1.
+    ITAW01    LTAW01              1.
+    ITRD01    BTRD01              1.   BIMP01             -1.
+    IMAC01    BTAW01        -.015658   BTRD01        -.099167
+    IMAC01    BMAC01              1.   BIMP01             -1.
+    E1AGR01   BAGR01        -.818859   BTAW01        -.101489
+    E1AGR01   BTRD01        -.079653   BEXP01              1.
+    E1MNG01   BMNG01         -.85037   BTAW01        -.122963
+    E1MNG01   BTRD01        -.026667   BEXP01              1.
+    E1EIM01   BEIM01        -.911211   BTAW01        -.034918
+    E1EIM01   BTRD01        -.053871   BEXP01              1.
+    E1ENM01   BENM01        -.906279   BTAW01         -.01739
+    E1ENM01   BTRD01        -.076332   BEXP01              1.
+    E1TAW01   BTAW01             -1.   BEXP01              1.
+    E1TRD01   BTRD01             -1.   BEXP01              1.
+    E1MAC01   BTAW01        -.014045   BTRD01        -.088953
+    E1MAC01   BMAC01        -.897002   BEXP01              1.
+    E2AGR01   BAGR01        -.818859   BTAW01        -.101489
+    E2AGR01   BTRD01        -.079653   BEXP01         .401143
+    E2MNG01   BMNG01         -.85037   BTAW01        -.122963
+    E2MNG01   BTRD01        -.026667   BEXP01         .715021
+    E2EIM01   BEIM01        -.911211   BTAW01        -.034918
+    E2EIM01   BTRD01        -.053871   BEXP01         .604231
+    E2ENM01   BENM01        -.906279   BTAW01         -.01739
+    E2ENM01   BTRD01        -.076332   BEXP01         .515274
+    E2TAW01   BTAW01             -1.
+    E2TRD01   BTRD01             -1.
+    E2MAC01   BTAW01        -.014045   BTRD01        -.088953
+    E2MAC01   BMAC01        -.897002   BEXP01         .607638
+    ULWR01    KLWR01              1.   KLWR02             -1.
+    ULWP01    KLWP01              1.   KLWP02             -1.
+    UMMC01    KMMC01              1.   KMMC02             -1.
+    UENR01    KENR01              1.   KENR02             -1.
+    UFBR01    KFBR01              1.   KFBR02             -1.
+    URPR01    KRPR01              1.   KRPR02             -1.
+    UECM01    KECM01              1.   KECM02             -1.
+    UWCM01    KWCM01              1.   KWCM02             -1.
+    UCLQ01    KCLQ01              1.   KCLQ02             -1.
+    UREF01    KREF01              1.   KREF02             -1.
+    UOSE01    KOSE01              1.   KOSE02             -1.
+    UCFP01    KCFP01              1.   KCFP02             -1.
+    UOFP01    KOFP01              1.   KOFP02             -1.
+    UGFP01    KGFP01              1.   KGFP02             -1.
+    UCGL01    KCGL01              1.   KCGL02             -1.
+    UCGH01    KCGH01              1.   KCGH02             -1.
+    UHYD01    KHYD01              1.   KHYD02             -1.
+    UGEO01    KGEO01              1.   KGEO02             -1.
+    UAGR01    KAGR01              1.   KAGR02             -.8
+    UMNG01    KMNG01              1.   KMNG02             -.8
+    UEIM01    KEIM01              1.   KEIM02             -.8
+    UENM01    KENM01              1.   KENM02             -.8
+    UTAW01    KTAW01              1.   KTAW02             -.8
+    UTRD01    KTRD01              1.   KTRD02             -.8
+    UMAC01    KMAC01              1.   KMAC02             -.8
+    WLWR01    MURF02       -9.838104   MURF03      -39.352417
+    WLWR01    ECAP01      -33.585495   CEEA01       33.585495
+    WLWR01    ETDE01      -23.509842   KLWR02             -1.
+    WLWR01    KLWR03             -4.   KLWR08              1.
+    WLWP01    MURN02       -8.921747   MPLU02        -.276048
+    WLWP01    MURN03      -35.686981   MPLU03       -1.104192
+    WLWP01    ECAP01      -34.432404   CEEA01       34.432404
+    WLWP01    ETDE01      -24.102676   KLWP02             -1.
+    WLWP01    KLWP03             -4.   KLWP08              1.
+    WMMC01    ECAP01        -.032029   CEEA01         .032029
+    WMMC01    KMMC02             -3.   KMMC03             -2.
+    WMMC01    KMMC06              3.   KMMC07              2.
+    WENR01    ECAP01        -.224371   CEEA01         .224371
+    WENR01    KENR03             -4.   KENR04             -1.
+    WFBR01    MPLU02        -.465639   MTLN02       -5.033102
+    WFBR01    MPLU03       -1.862556   MTLN03      -20.132416
+    WFBR01    ECAP01      -44.428299   CEEA01       44.428299
+    WFBR01    ETDE01      -31.099808   KFBR02             -1.
+    WFBR01    KFBR03             -4.   KFBR08              1.
+    WRPR01    ECAP01       -2.096846   CEEA01        2.096846
+    WRPR01    KRPR03             -4.   KRPR04             -1.
+    WECM01    ECAP01        -.014564   CEEA01         .014564
+    WECM01    KECM02             -4.   KECM03             -1.
+    WECM01    KECM06              4.   KECM07              1.
+    WWCM01    ECAP01        -.005172   CEEA01         .005172
+    WWCM01    KWCM02             -5.   KWCM06              5.
+    WCLQ01    ECAP01       -6.160605   CEEA01        6.160605
+    WCLQ01    KCLQ02             -5.   KCLQ08              5.
+    WREF01    ECAP01        -.481851   CEEA01         .481851
+    WREF01    KREF02             -5.   KREF08              5.
+    WOSE01    ECAP01       -1.682063   CEEA01        1.682063
+    WOSE01    KOSE02             -5.   KOSE08              5.
+    WCFP01    ECAP01      -23.936646   CEEA01       23.936646
+    WCFP01    ETDE01      -16.755646   KCFP02             -3.
+    WCFP01    KCFP03             -2.   KCFP08              3.
+    WOFP01    ECAP01      -17.952484   CEEA01       17.952484
+    WOFP01    ETDE01      -12.566738   KOFP02             -4.
+    WOFP01    KOFP03             -1.   KOFP08              4.
+    WGFP01    ECAP01      -10.970949   CEEA01       10.970949
+    WGFP01    ETDE01       -7.679664   KGFP02             -4.
+    WGFP01    KGFP03             -1.   KGFP08              4.
+    WCGL01    ECAP01      -75.702805   CEEA01       75.702805
+    WCGL01    ETDE01      -52.991959   KCGL02             -5.
+    WCGL01    KCGL08              5.
+    WCGH01    ECAP01       -6.383089   CEEA01        6.383089
+    WCGH01    KCGH02             -5.   KCGH08              5.
+    WHYD01    ECAP01      -33.710693   CEEA01       33.710693
+    WHYD01    ETDE01      -23.597473   KHYD02             -5.
+    WHYD01    KHYD08              5.
+    WGEO01    ECAP01      -47.873169   CEEA01       47.873169
+    WGEO01    ETDE01      -33.511215   KGEO02             -5.
+    WGEO01    KGEO08              5.
+    WTDE01    ECAP01             -1.   CEEA01              1.
+    WTDE01    ETDE01              1.
+    WAGR01    ECAP01        -1.14185   CNEA01         1.14185
+    WAGR01    KAGR01             -1.   KAGR02             -4.
+    WMNG01    ECAP01        -.290702   CNEA01         .290702
+    WMNG01    KMNG01             -1.   KMNG02             -4.
+    WEIM01    ECAP01         -.64485   CNEA01          .64485
+    WEIM01    KEIM01             -1.   KEIM02             -4.
+    WENM01    ECAP01        -.403625   CNEA01         .403625
+    WENM01    KENM01             -1.   KENM02             -4.
+    WTAW01    ECAP01        -1.41581   CNEA01         1.41581
+    WTAW01    KTAW01             -1.   KTAW02             -4.
+    WTRD01    ECAP01        -1.08414   CNEA01         1.08414
+    WTRD01    KTRD01             -1.   KTRD02             -4.
+    WMAC01    ECAP01        -.362214   CNEA01         .362214
+    WMAC01    KMAC01             -1.   KMAC02             -4.
+    PLWU02    DELE02             -1.   BELE02              .9
+    PLWU02    MURE02      -20.867584   MSPF02       20.867584
+    PLWU02    KLWR02        1.538461   KLWR03       -1.538461
+    PLWU02    NRGP02         -10.355   PELE02             -1.
+    PLWP02    DELE02             -1.   BELE02              .9
+    PLWP02    MURN02      -27.914734   MPLU02       -1.529699
+    PLWP02    MSPF02       29.444443   KLWP02        1.538461
+    PLWP02    KLWP03       -1.538461   NRGP02         -10.355
+    PLWP02    PELE02             -1.
+    PNR102    BELE02          -.0027   MURN02       -9.192495
+    PNR102    MURE02          1.2595   MTLN02           7.933
+    PNR102    KENR02              1.   KENR03             -1.
+    PNR202    BELE02          -.0027   MURC02          -8.261
+    PNR202    MURE02        1.459499   MTLN02        6.801496
+    PNR202    KENR02              1.   KENR03             -1.
+    PNR302    BELE02          -.0027   MURN02         -10.793
+    PNR302    MURF02        2.112499   MTLN02        8.680496
+    PNR302    KENR02              1.   KENR03             -1.
+    PMMC02    RMMC02             -5.   BMNG02           -15.4
+    PMMC02    KMMC02              1.   KMMC03             -1.
+    PFBR02    DELE02             -1.   BELE02              .9
+    PFBR02    MPLU02         -1.3775   MTLN02      -15.662098
+    PFBR02    KFBR02       10.000003   KFBR03      -10.000003
+    PFBR02    NRGP02         -10.355   PELE02             -1.
+    PRPR02    MURC02          27.715   MPLU02            1.11
+    PRPR02    MTLN02       19.069992   MSPF02            -50.
+    PRPR02    KRPR02              1.   KRPR03             -1.
+    PECM02    DCOL02          -.0258   BCOL02           .0258
+    PECM02    KECM02              1.   KECM03             -1.
+    PECM02    NRGP02          -.0258
+    PWCM02    DCOL02           -.016   BCOL02            .016
+    PWCM02    KWCM02              1.   KWCM03             -1.
+    PWCM02    NRGP02           -.016
+    PCLQ02    DROP02             -1.   BCOL02          -1.575
+    PCLQ02    BROP02              1.   KCLQ02              1.
+    PCLQ02    KCLQ03             -1.
+    PREF02    DROP02           -.549   BCRO02             -.6
+    PREF02    BROP02            .549   KREF02              1.
+    PREF02    KREF03             -1.
+    POSE02    DCRO02             -.6   BCRO02              .6
+    POSE02    KOSE02              1.   KOSE03             -1.
+    POSE02    NRGP02             -.6
+    PCFP02    DELE02             -1.   BCOL02         -10.355
+    PCFP02    BELE02              .9   KCFP02        1.851851
+    PCFP02    KCFP03       -1.851851   PELE02              1.
+    POFP02    DELE02             -1.   BROP02         -10.355
+    POFP02    BELE02              .9   KOFP02        1.886792
+    POFP02    KOFP03       -1.886792
+    PGFP02    DELE02             -1.   BGAS02         -10.355
+    PGFP02    BELE02              .9   KGFP02        1.886792
+    PGFP02    KGFP03       -1.886792
+    PCGL02    DELE02             -1.   BCOL02         -15.986
+    PCGL02    BELE02              .9   KCGL02              1.
+    PCGL02    KCGL03             -1.
+    PCGH02    DGAS02             -1.   BCOL02          -1.826
+    PCGH02    BGAS02              1.   KCGH02              1.
+    PCGH02    KCGH03             -1.
+    PHYD02    DELE02             -1.   BELE02              .9
+    PHYD02    KHYD02        1.851851   KHYD03       -1.851851
+    PHYD02    NRGP02         -10.355
+    PGEO02    DELE02             -1.   BELE02              .9
+    PGEO02    KGEO02        1.333333   KGEO03       -1.333333
+    PGEO02    NRGP02         -10.355
+    POF102    OVXT02              1.   KODR02           1800.
+    POF102    BOIP02            78.6   KODR03          -1800.
+    POF102    BOIP03           -78.6
+    POF202    OVXT02              1.   KODR02           3600.
+    POF202    BOIP02           136.5   KODR03          -3600.
+    POF202    BOIP03          -136.5
+    POF302    OVXT02              1.   KODR02           5400.
+    POF302    BOIP02           166.7   KODR03          -5400.
+    POF302    BOIP03          -166.7
+    PODR02    KODR02             -1.   ECAP02           -.005
+    PODR02    CEEA02            .005
+    POIP02    BOIP02             -1.   OSRB02          .00351
+    POIP02    OTRB02          .00039   ODPL02           .0135
+    POIP02    BORS03           .3135   OSRB03          .05065
+    POIP02    OTRB03          .04056   OSRB04          .01108
+    POIP02    OTRB04          .01525
+    POF402    OVXT02              1.   KODR02           7200.
+    POF402    BOIP02           182.6   KODR03          -7200.
+    POF402    BOIP03          -182.6
+    POF502    OVXT02              1.   KODR02           9000.
+    POF502    BOIP02           190.9   KODR03          -9000.
+    POF502    BOIP03          -190.9
+    POF602    OVXT02              1.   KODR02          10800.
+    POF602    BOIP02           195.2   KODR03         -10800.
+    POF602    BOIP03          -195.2
+    POF702    OVXT02              1.   KODR02          12600.
+    POF702    BOIP02           197.5   KODR03         -12600.
+    POF702    BOIP03          -197.5
+    PPOR02    ODPL02            .094   BORS02             -1.
+    PPOR02    BORS03              1.
+    PSRN02    OSRB02             -1.   OSRB03              1.
+    PSRA02    OSRB02             -1.   ODPL02            .043
+    PSRA02    BORS03              1.   ECAP02          -.1246
+    PSRA02    CEEA02           .1246
+    PTRN02    OTRB02             -1.   OTRB03              1.
+    PTRA02    OTRB02             -1.   ODPL02            .043
+    PTRA02    BORS03              1.   ECAP02           -.208
+    PTRA02    CEEA02            .208
+    PGF102    GVXT02              1.   KGDR02           1426.
+    PGF102    BGSF02            275.   KGDR03          -1426.
+    PGF102    BGSF03           -275.
+    PGF202    GVXT02              1.   KGDR02           2000.
+    PGF202    BGSF02      366.099854   KGDR03          -2000.
+    PGF202    BGSF03     -366.099854
+    PGF302    GVXT02              1.   KGDR02           3000.
+    PGF302    BGSF02      458.799805   KGDR03          -3000.
+    PGF302    BGSF03     -458.799805
+    PGDR02    KGDR02             -1.   ECAP02           -.005
+    PGDR02    CEEA02            .005
+    PGRA02    BGSF02             -1.   GDPL02            .043
+    PGRA02    BGRS03              1.
+    PGF402    GVXT02              1.   KGDR02           4000.
+    PGF402    BGSF02      504.599854   KGDR03          -4000.
+    PGF402    BGSF03     -504.599854
+    PGF502    GVXT02              1.   KGDR02           5000.
+    PGF502    BGSF02           527.5   KGDR03          -5000.
+    PGF502    BGSF03          -527.5
+    PGF602    GVXT02              1.   KGDR02           6000.
+    PGF602    BGSF02      538.899902   KGDR03          -6000.
+    PGF602    BGSF03     -538.899902
+    PGF702    GVXT02              1.   KGDR02           7000.
+    PGF702    BGSF02           544.5   KGDR03          -7000.
+    PGF702    BGSF03          -544.5
+    PGF802    GVXT02              1.   KGDR02           8000.
+    PGF802    BGSF02      547.299805   KGDR03          -8000.
+    PGF802    BGSF03     -547.299805
+    PPGR02    GDPL02            .094   BGRS02             -1.
+    PPGR02    BGRS03              1.
+    PGPR02    GDPL02             -1.   BCRO02            .198
+    PGPR02    BGAS02             .85   BGRS03             -5.
+    PGPR02    DCRO02          -1.198   DGAS02             -1.
+    PGPR02    NRGP02          -1.198
+    POPR02    ODPL02           -.167   BCRO02              1.
+    POPR02    BGAS02          .15555   BORS03           -.835
+    POPR02    DCRO02          -1.183   DGAS02           -.183
+    POPR02    NRGP02          -1.183
+    PNRG02    NRGP02              1.
+    KEEA02    TEEA02            -1.8   TEEA03              .8
+    KEEA02    CEEA02             -1.
+    UCOL02    BCOL02             -1.
+    UCRO02    BCRO02             -1.
+    UROP02    BROP02             -1.
+    UGAS02    BGAS02             -1.
+    UELE02    BELE02             -1.
+    NURC02    MURC02             -1.   MURC03              1.
+    NURE02    MURE02             -1.   MURE03              1.
+    NURF02    MURF02             -1.   MURF03              1.
+    NPLU02    MPLU02             -1.   MPLU03              1.
+    NTLN02    MTLN02             -1.   MTLN03              1.
+    NSPF02    MSPF02             -1.   MSPF03              1.
+    UR102     MURN02      242.307831   RMMC02      242.307831
+    UR102     URXT02              1.   MURN03     -242.307831
+    UR102     RMMC03     -242.307831
+    UR202     MURN02      661.538818   RMMC02      681.538818
+    UR202     URXT02              1.   MURN03     -661.538818
+    UR202     RMMC03     -681.538818
+    UR302     MURN02     1288.462158   RMMC02     1523.077637
+    UR302     URXT02              1.   MURN03    -1288.462158
+    UR302     RMMC03    -1523.077637
+    UR402     MURN02     1950.000977   RMMC02     3084.617188
+    UR402     URXT02              1.   MURN03    -1950.000977
+    UR402     RMMC03    -3084.617188
+    UR502     MURN02     3638.463623   RMMC02     10114.62109
+    UR502     URXT02              1.   MURN03    -3638.463623
+    UR502     RMMC03    -10114.62109
+    UR602     MURN02     5438.460938   RMMC02     23614.62891
+    UR602     URXT02              1.   MURN03    -5438.460938
+    UR602     RMMC03    -23614.62891
+    ICOL02    BCOL02              1.   BIMP02          -1000.
+    ICRO02    BCRO02              1.   BIMP02    -1500.029785
+    IROP02    BROP02              1.   BIMP02    -1500.029785
+    IGAS02    BGAS02              1.   BIMP02    -1875.037109
+    IELE02    BELE02              1.   BIMP02    -15532.80469
+    JCOL02    BCOL02              1.   NRGP02             -1.
+    JCOL02    ECAP02          -3.333   CEEA02           3.333
+    JCRO02    BCRO02              1.   NRGP02             -1.
+    JCRO02    ECAP02          -3.333   CEEA02           3.333
+    JROP02    BROP02              1.   NRGP02             -1.
+    JROP02    ECAP02          -3.333   CEEA02           3.333
+    JGAS02    BGAS02              1.   NRGP02             -1.
+    JGAS02    ECAP02          -3.333   CEEA02           3.333
+    E1COL02   BCOL02             -1.   BTAW02      -85.984146
+    E1COL02   BTRD02       -3.289011   BEXP02           1000.
+    E1CRO02   BCRO02             -1.   BTAW02      -30.625748
+    E1CRO02   BEXP02     1500.029785
+    E1ROP02   BROP02             -1.   BTAW02      -70.309738
+    E1ROP02   BTRD02     -230.550491   BEXP02     1500.029785
+    E1GAS02   BGAS02             -1.   BTAW02      -76.420792
+    E1GAS02   BTRD02       -49.76236   BEXP02     1875.037109
+    E1ELE02   BELE02             -1.   BTRD02     -937.608643
+    E1ELE02   BEXP02     15532.80469
+    XCOL02    DCOL02        4.438329   BELE02        -.001258
+    XCOL02    BROP02        -.009637   BMNG02      -10.737742
+    XCOL02    BEIM02      -43.582611   BENM02      -30.318329
+    XCOL02    BTAW02       -8.842848   BTRD02     -121.652298
+    XCOL02    BMAC02      -41.056076   WRKF02         .046425
+    XCRO02    DCRO02        2.892097   BELE02        -.000506
+    XCRO02    BROP02        -.002062   BGAS02        -.007408
+    XCRO02    BMNG02      -34.323624   BEIM02      -29.450958
+    XCRO02    BENM02       -9.530361   BTAW02        -10.4619
+    XCRO02    BTRD02     -227.231018   BMAC02      -31.457352
+    XCRO02    WRKF02         .021354
+    XROP02    DROP02         .813213   BELE02         -.00034
+    XROP02    BCOL02        -.001514   BGAS02        -.025955
+    XROP02    BMNG02      -16.875412   BEIM02       -41.64917
+    XROP02    BENM02       -5.162801   BTAW02        -53.5159
+    XROP02    BTRD02      -81.333328   BMAC02       -3.506082
+    XROP02    WRKF02         .007051
+    XGAS02    DGAS02        1.380471   BELE02        -.000499
+    XGAS02    BCOL02        -.000874   BROP02        -.000706
+    XGAS02    BMNG02      -18.629242   BEIM02       -1.871531
+    XGAS02    BENM02        -.372872   BTAW02        -.243801
+    XGAS02    BTRD02      -47.828018   WRKF02         .005952
+    XELE02    DELE02         .054373   BAGR02       -1.282765
+    XELE02    BMNG02      -52.155487   BEIM02        -8.14335
+    XELE02    BENM02       -2.450525   BTAW02      -29.401871
+    XELE02    BTRD02     -148.124084   BMAC02       -3.821757
+    XELE02    WRKF02         .016189
+    XAGR02    KAGR02        1.111111   BCOL02        -.000309
+    XAGR02    BROP02        -.015238   BGAS02        -.000613
+    XAGR02    BELE02        -.000142   BAGR02      693.921387
+    XAGR02    BMNG02      -11.796776   BEIM02     -105.230377
+    XAGR02    BENM02       -8.735988   BTAW02      -19.273376
+    XAGR02    BTRD02       -132.6754   BMAC02       -6.567932
+    XAGR02    BIMP02        -.573897   KAGR03        -.888889
+    XMNG02    KMNG02        1.111111   BCOL02        -.000274
+    XMNG02    BROP02        -.016082   BGAS02        -.001576
+    XMNG02    BELE02        -.000121   BAGR02       -2.328505
+    XMNG02    BMNG02      972.447266   BEIM02     -134.663696
+    XMNG02    BENM02     -160.684525   BTAW02      -25.365646
+    XMNG02    BTRD02     -153.472351   BMAC02       -26.12706
+    XMNG02    BIMP02        -.894217   WRKF02         .038859
+    XMNG02    KMNG03        -.888889
+    XEIM02    KEIM02        1.111111   BCOL02        -.015215
+    XEIM02    BCRO02        -.000075   BROP02        -.009571
+    XEIM02    BGAS02         -.01497   BELE02        -.000525
+    XEIM02    BAGR02     -119.583542   BMNG02      -24.533279
+    XEIM02    BEIM02      731.984375   BENM02      -39.738663
+    XEIM02    BTAW02      -30.974686   BTRD02     -110.634079
+    XEIM02    BMAC02      -14.378268   BIMP02       -6.938498
+    XEIM02    WRKF02         .025369   KEIM03        -.888889
+    XENM02    KENM02        1.111111   BCOL02        -.000929
+    XENM02    BROP02        -.001921   BGAS02        -.003564
+    XENM02    BELE02        -.000309   BAGR02      -14.414824
+    XENM02    BMNG02       -5.079608   BEIM02     -159.277557
+    XENM02    BENM02       754.55127   BTAW02      -13.189252
+    XENM02    BTRD02      -99.108688   BMAC02      -34.243027
+    XENM02    BIMP02       -1.637574   WRKF02         .046102
+    XENM02    KENM03        -.888889
+    XTAW02    KTAW02        1.111111   BCOL02        -.000536
+    XTAW02    BCRO02        -.000187   BROP02        -.033947
+    XTAW02    BGAS02        -.002018   BELE02        -.000667
+    XTAW02    BAGR02        -.870055   BMNG02      -26.042328
+    XTAW02    BEIM02      -20.644028   BENM02      -10.381341
+    XTAW02    BTAW02      914.338867   BTRD02      -151.68219
+    XTAW02    BMAC02      -21.711823   BIMP02      -17.717484
+    XTAW02    WRKF02         .056178   KTAW03        -.888889
+    XTRD02    KTRD02        1.111111   BCOL02        -.001144
+    XTRD02    BCRO02        -.000097   BROP02         -.00438
+    XTRD02    BGAS02        -.004467   BELE02        -.000568
+    XTRD02    BAGR02       -5.705781   BMNG02       -18.54953
+    XTRD02    BEIM02      -23.171265   BENM02      -35.265518
+    XTRD02    BTAW02      -14.880653   BTRD02      825.474609
+    XTRD02    BMAC02       -8.531651   BIMP02       -1.058328
+    XTRD02    WRKF02         .073834   KTRD03        -.888889
+    XMAC02    KMAC02        1.111111   BCOL02        -.001085
+    XMAC02    BROP02        -.002679   BGAS02        -.002772
+    XMAC02    BELE02        -.000232   BMNG02       -8.258104
+    XMAC02    BEIM02     -132.072205   BENM02     -101.023422
+    XMAC02    BTAW02      -10.780818   BTRD02      -90.647217
+    XMAC02    BMAC02      747.764404   BIMP02        -.999022
+    XMAC02    WRKF02         .032378   KMAC03        -.888889
+    CONS02    OBJ          -1.019509   BIMP02          -19.51
+    CONS02    POPL02           1000.   DNRG02        -.016646
+    CONS02    BAGR02          -8.298   BMNG02      -66.047958
+    CONS02    BEIM02     -103.797958   BENM02     -115.218994
+    CONS02    BTAW02      -35.536987   BTRD02     -609.091797
+    CONS02    BMAC02      -41.043991
+    CNRG02    DNRG02              1.   BROP02          -.6296
+    CNRG02    BGAS02          -.2572   BELE02        -.033177
+    APCC02    POPL02     -222.799988   UMOB02              1.
+    APCC02    UMOB03             -1.
+    GOVT02    BCOL02        -.001458   BROP02        -.006819
+    GOVT02    BGAS02        -.005441   BELE02        -.000551
+    GOVT02    BAGR02        7.501156   BMNG02     -179.188583
+    GOVT02    BEIM02      -29.199707   BENM02        -112.426
+    GOVT02    BTAW02      -24.609955   BTRD02     -552.763428
+    GOVT02    BMAC02      -89.739853   BIMP02         -22.646
+    CAPF02    BMNG02     -345.845703   BEIM02        -.755947
+    CAPF02    BENM02     -104.722321   BTAW02        -9.79188
+    CAPF02    BTRD02      -80.591064   BMAC02     -458.292969
+    CAPF02    BIMP02          -7.772   ECAP02              1.
+    KNEA02    TNEA02            -1.8   TNEA03              .8
+    KNEA02    CNEA02             -1.
+    XIMP02    BIMP02              1.   BTRB02             -1.
+    XIMP02    LTAW02          -.0334
+    XEXP02    BEXP02             -1.   BTRB02              1.
+    IAGR02    BAGR02              1.   BTAW02        -.123939
+    IAGR02    BTRD02        -.097273   BIMP02             -1.
+    IMNG02    BMNG02              1.   BTAW02        -.144599
+    IMNG02    BTRD02        -.031359   BIMP02             -1.
+    IEIM02    BEIM02              1.   BTAW02        -.038321
+    IEIM02    BTRD02         -.05912   BIMP02             -1.
+    IENM02    BENM02              1.   BTAW02        -.019188
+    IENM02    BTRD02        -.084225   BIMP02             -1.
+    ITAW02    BTAW02              1.   BIMP02             -1.
+    ITAW02    LTAW02              1.
+    ITRD02    BTRD02              1.   BIMP02             -1.
+    IMAC02    BTAW02        -.015658   BTRD02        -.099167
+    IMAC02    BMAC02              1.   BIMP02             -1.
+    E1AGR02   BAGR02        -.818859   BTAW02        -.101489
+    E1AGR02   BTRD02        -.079653   BEXP02              1.
+    E1MNG02   BMNG02         -.85037   BTAW02        -.122963
+    E1MNG02   BTRD02        -.026667   BEXP02              1.
+    E1EIM02   BEIM02        -.911211   BTAW02        -.034918
+    E1EIM02   BTRD02        -.053871   BEXP02              1.
+    E1ENM02   BENM02        -.906279   BTAW02         -.01739
+    E1ENM02   BTRD02        -.076332   BEXP02              1.
+    E1TAW02   BTAW02             -1.   BEXP02              1.
+    E1TRD02   BTRD02             -1.   BEXP02              1.
+    E1MAC02   BTAW02        -.014045   BTRD02        -.088953
+    E1MAC02   BMAC02        -.897002   BEXP02              1.
+    E2AGR02   BAGR02        -.818859   BTAW02        -.101489
+    E2AGR02   BTRD02        -.079653   BEXP02         .401143
+    E2MNG02   BMNG02         -.85037   BTAW02        -.122963
+    E2MNG02   BTRD02        -.026667   BEXP02         .715021
+    E2EIM02   BEIM02        -.911211   BTAW02        -.034918
+    E2EIM02   BTRD02        -.053871   BEXP02         .604231
+    E2ENM02   BENM02        -.906279   BTAW02         -.01739
+    E2ENM02   BTRD02        -.076332   BEXP02         .515274
+    E2TAW02   BTAW02             -1.
+    E2TRD02   BTRD02             -1.
+    E2MAC02   BTAW02        -.014045   BTRD02        -.088953
+    E2MAC02   BMAC02        -.897002   BEXP02         .607638
+    ULWR02    KLWR02              1.   KLWR03             -1.
+    ULWP02    KLWP02              1.   KLWP03             -1.
+    UMMC02    KMMC02              1.   KMMC03             -1.
+    UENR02    KENR02              1.   KENR03             -1.
+    UFBR02    KFBR02              1.   KFBR03             -1.
+    URPR02    KRPR02              1.   KRPR03             -1.
+    UECM02    KECM02              1.   KECM03             -1.
+    UWCM02    KWCM02              1.   KWCM03             -1.
+    UCLQ02    KCLQ02              1.   KCLQ03             -1.
+    UREF02    KREF02              1.   KREF03             -1.
+    UOSE02    KOSE02              1.   KOSE03             -1.
+    UCFP02    KCFP02              1.   KCFP03             -1.
+    UOFP02    KOFP02              1.   KOFP03             -1.
+    UGFP02    KGFP02              1.   KGFP03             -1.
+    UCGL02    KCGL02              1.   KCGL03             -1.
+    UCGH02    KCGH02              1.   KCGH03             -1.
+    UHYD02    KHYD02              1.   KHYD03             -1.
+    UGEO02    KGEO02              1.   KGEO03             -1.
+    UAGR02    KAGR02              1.   KAGR03             -.8
+    UMNG02    KMNG02              1.   KMNG03             -.8
+    UEIM02    KEIM02              1.   KEIM03             -.8
+    UENM02    KENM02              1.   KENM03             -.8
+    UTAW02    KTAW02              1.   KTAW03             -.8
+    UTRD02    KTRD02              1.   KTRD03             -.8
+    UMAC02    KMAC02              1.   KMAC03             -.8
+    WLWR02    MURF03       -9.838104   MURF04      -39.352417
+    WLWR02    ECAP02      -33.585495   CEEA02       33.585495
+    WLWR02    ETDE02      -23.509842   KLWR03             -1.
+    WLWR02    KLWR04             -4.
+    WLWP02    MURN03       -8.921747   MPLU03        -.276048
+    WLWP02    MURN04      -35.686981   MPLU04       -1.104192
+    WLWP02    ECAP02      -34.432404   CEEA02       34.432404
+    WLWP02    ETDE02      -24.102676   KLWP03             -1.
+    WLWP02    KLWP04             -4.
+    WMMC02    ECAP02        -.032029   CEEA02         .032029
+    WMMC02    KMMC03             -3.   KMMC04             -2.
+    WMMC02    KMMC07              3.   KMMC08              2.
+    WENR02    ECAP02        -.224371   CEEA02         .224371
+    WENR02    KENR04             -4.   KENR05             -1.
+    WFBR02    MPLU03        -.465639   MTLN03       -5.033102
+    WFBR02    MPLU04       -1.862556   MTLN04      -20.132416
+    WFBR02    ECAP02      -44.428299   CEEA02       44.428299
+    WFBR02    ETDE02      -31.099808   KFBR03             -1.
+    WFBR02    KFBR04             -4.
+    WRPR02    ECAP02       -2.096846   CEEA02        2.096846
+    WRPR02    KRPR04             -4.   KRPR05             -1.
+    WECM02    ECAP02        -.014564   CEEA02         .014564
+    WECM02    KECM03             -4.   KECM04             -1.
+    WECM02    KECM07              4.   KECM08              1.
+    WWCM02    ECAP02        -.005172   CEEA02         .005172
+    WWCM02    KWCM03             -5.   KWCM07              5.
+    WCLQ02    ECAP02       -6.160605   CEEA02        6.160605
+    WCLQ02    KCLQ03             -5.
+    WREF02    ECAP02        -.481851   CEEA02         .481851
+    WREF02    KREF03             -5.
+    WOSE02    ECAP02       -1.682063   CEEA02        1.682063
+    WOSE02    KOSE03             -5.
+    WCFP02    ECAP02      -23.936646   CEEA02       23.936646
+    WCFP02    ETDE02      -16.755646   KCFP03             -3.
+    WCFP02    KCFP04             -2.
+    WOFP02    ECAP02      -17.952484   CEEA02       17.952484
+    WOFP02    ETDE02      -12.566738   KOFP03             -4.
+    WOFP02    KOFP04             -1.
+    WGFP02    ECAP02      -10.970949   CEEA02       10.970949
+    WGFP02    ETDE02       -7.679664   KGFP03             -4.
+    WGFP02    KGFP04             -1.
+    WCGL02    ECAP02      -75.702805   CEEA02       75.702805
+    WCGL02    ETDE02      -52.991959   KCGL03             -5.
+    WCGH02    ECAP02       -6.383089   CEEA02        6.383089
+    WCGH02    KCGH03             -5.
+    WHYD02    ECAP02      -33.710693   CEEA02       33.710693
+    WHYD02    ETDE02      -23.597473   KHYD03             -5.
+    WGEO02    ECAP02      -47.873169   CEEA02       47.873169
+    WGEO02    ETDE02      -33.511215   KGEO03             -5.
+    WTDE02    ECAP02             -1.   CEEA02              1.
+    WTDE02    ETDE02              1.
+    WAGR02    ECAP02        -1.14185   CNEA02         1.14185
+    WAGR02    KAGR02             -1.   KAGR03             -4.
+    WMNG02    ECAP02        -.290702   CNEA02         .290702
+    WMNG02    KMNG02             -1.   KMNG03             -4.
+    WEIM02    ECAP02         -.64485   CNEA02          .64485
+    WEIM02    KEIM02             -1.   KEIM03             -4.
+    WENM02    ECAP02        -.403625   CNEA02         .403625
+    WENM02    KENM02             -1.   KENM03             -4.
+    WTAW02    ECAP02        -1.41581   CNEA02         1.41581
+    WTAW02    KTAW02             -1.   KTAW03             -4.
+    WTRD02    ECAP02        -1.08414   CNEA02         1.08414
+    WTRD02    KTRD02             -1.   KTRD03             -4.
+    WMAC02    ECAP02        -.362214   CNEA02         .362214
+    WMAC02    KMAC02             -1.   KMAC03             -4.
+    KEEA03    TEEA03            -1.8   TEEA04              .8
+    KEEA03    TEEA02              1.   CEEA03             -1.
+    KNEA03    TNEA03            -1.8   TNEA04              .8
+    KNEA03    TNEA02              1.   CNEA03             -1.
+    PLWU03    DELE03             -1.   BELE03              .9
+    PLWU03    MURE03      -20.867584   MSPF03       20.867584
+    PLWU03    KLWR03        1.538461   KLWR04       -1.538461
+    PLWU03    NRGP03         -10.355   PELE03             -1.
+    PLWP03    DELE03             -1.   BELE03              .9
+    PLWP03    MURN03      -27.914734   MPLU03       -1.529699
+    PLWP03    MSPF03       29.444443   KLWP03        1.538461
+    PLWP03    KLWP04       -1.538461   NRGP03         -10.355
+    PLWP03    PELE03             -1.
+    PNR103    BELE03          -.0027   MURN03       -9.192495
+    PNR103    MURE03          1.2595   MTLN03           7.933
+    PNR103    KENR03              1.   KENR04             -1.
+    PNR203    BELE03          -.0027   MURC03          -8.261
+    PNR203    MURE03        1.459499   MTLN03        6.801496
+    PNR203    KENR03              1.   KENR04             -1.
+    PNR303    BELE03          -.0027   MURN03         -10.793
+    PNR303    MURF03        2.112499   MTLN03        8.680496
+    PNR303    KENR03              1.   KENR04             -1.
+    PMMC03    RMMC03             -5.   BMNG03           -15.4
+    PMMC03    KMMC03              1.   KMMC04             -1.
+    PFBR03    DELE03             -1.   BELE03              .9
+    PFBR03    MPLU03         -1.3775   MTLN03      -15.662098
+    PFBR03    KFBR03       10.000003   KFBR04      -10.000003
+    PFBR03    NRGP03         -10.355   PELE03             -1.
+    PRPR03    MURC03          27.715   MPLU03            1.11
+    PRPR03    MTLN03       19.069992   MSPF03            -50.
+    PRPR03    KRPR03              1.   KRPR04             -1.
+    PECM03    DCOL03          -.0258   BCOL03           .0258
+    PECM03    KECM03              1.   KECM04             -1.
+    PECM03    NRGP03          -.0258
+    PWCM03    DCOL03           -.016   BCOL03            .016
+    PWCM03    KWCM03              1.   KWCM04             -1.
+    PWCM03    NRGP03           -.016
+    PCLQ03    DROP03             -1.   BCOL03          -1.575
+    PCLQ03    BROP03              1.   KCLQ03              1.
+    PCLQ03    KCLQ04             -1.
+    PREF03    DROP03           -.549   BCRO03             -.6
+    PREF03    BROP03            .549   KREF03              1.
+    PREF03    KREF04             -1.
+    POSE03    DCRO03             -.6   BCRO03              .6
+    POSE03    KOSE03              1.   KOSE04             -1.
+    POSE03    NRGP03             -.6
+    PCFP03    DELE03             -1.   BCOL03         -10.355
+    PCFP03    BELE03              .9   KCFP03        1.851851
+    PCFP03    KCFP04       -1.851851   PELE03              1.
+    POFP03    DELE03             -1.   BROP03         -10.355
+    POFP03    BELE03              .9   KOFP03        1.886792
+    POFP03    KOFP04       -1.886792
+    PGFP03    DELE03             -1.   BGAS03         -10.355
+    PGFP03    BELE03              .9   KGFP03        1.886792
+    PGFP03    KGFP04       -1.886792
+    PCGL03    DELE03             -1.   BCOL03         -15.986
+    PCGL03    BELE03              .9   KCGL03              1.
+    PCGL03    KCGL04             -1.
+    PCGH03    DGAS03             -1.   BCOL03          -1.826
+    PCGH03    BGAS03              1.   KCGH03              1.
+    PCGH03    KCGH04             -1.
+    PHYD03    DELE03             -1.   BELE03              .9
+    PHYD03    KHYD03        1.886792   KHYD04       -1.886792
+    PHYD03    NRGP03         -10.355
+    PGEO03    DELE03             -1.   BELE03              .9
+    PGEO03    KGEO03        1.333333   KGEO04       -1.333333
+    PGEO03    NRGP03         -10.355
+    POF103    OVXT03              1.   KODR03           1800.
+    POF103    BOIP03            78.6   KODR04          -1800.
+    POF103    BOIP04           -78.6
+    POF203    OVXT03              1.   KODR03           3600.
+    POF203    BOIP03           136.5   KODR04          -3600.
+    POF203    BOIP04          -136.5
+    POF303    OVXT03              1.   KODR03           5400.
+    POF303    BOIP03           166.7   KODR04          -5400.
+    POF303    BOIP04          -166.7
+    PODR03    KODR03             -1.   ECAP03          -.0052
+    PODR03    CEEA03           .0052
+    POIP03    BOIP03             -1.   OSRB03          .00351
+    POIP03    OTRB03          .00039   ODPL03           .0135
+    POIP03    BORS04           .3135   OSRB04          .05065
+    POIP03    OTRB04          .04056   OSRB05          .01108
+    POIP03    OTRB05          .01525
+    POF403    OVXT03              1.   KODR03           7200.
+    POF403    BOIP03           182.6   KODR04          -7200.
+    POF403    BOIP04          -182.6
+    POF503    OVXT03              1.   KODR03           9000.
+    POF503    BOIP03           190.9   KODR04          -9000.
+    POF503    BOIP04          -190.9
+    POF603    OVXT03              1.   KODR03          10800.
+    POF603    BOIP03           195.2   KODR04         -10800.
+    POF603    BOIP04          -195.2
+    POF703    OVXT03              1.   KODR03          12600.
+    POF703    BOIP03           197.5   KODR04         -12600.
+    POF703    BOIP04          -197.5
+    PPOR03    ODPL03            .094   BORS03             -1.
+    PPOR03    BORS04              1.
+    PSRN03    OSRB03             -1.   OSRB04              1.
+    PSRA03    OSRB03             -1.   ODPL03            .043
+    PSRA03    BORS04              1.   ECAP03          -.1558
+    PSRA03    CEEA03           .1558
+    PTRN03    OTRB03             -1.   OTRB04              1.
+    PTRA03    OTRB03             -1.   ODPL03            .043
+    PTRA03    BORS04              1.   ECAP03            -.25
+    PTRA03    CEEA03             .25
+    PGF103    GVXT03              1.   KGDR03           1426.
+    PGF103    BGSF03            275.   KGDR04          -1426.
+    PGF103    BGSF04           -275.
+    PGF203    GVXT03              1.   KGDR03           2000.
+    PGF203    BGSF03      366.099854   KGDR04          -2000.
+    PGF203    BGSF04     -366.099854
+    PGF303    GVXT03              1.   KGDR03           3000.
+    PGF303    BGSF03      458.799805   KGDR04          -3000.
+    PGF303    BGSF04     -458.799805
+    PGDR03    KGDR03             -1.   ECAP03          -.0052
+    PGDR03    CEEA03           .0052
+    PGRA03    BGSF03             -1.   GDPL03            .043
+    PGRA03    BGRS04              1.
+    PGF403    GVXT03              1.   KGDR03           4000.
+    PGF403    BGSF03      504.599854   KGDR04          -4000.
+    PGF403    BGSF04     -504.599854
+    PGF503    GVXT03              1.   KGDR03           5000.
+    PGF503    BGSF03           527.5   KGDR04          -5000.
+    PGF503    BGSF04          -527.5
+    PGF603    GVXT03              1.   KGDR03           6000.
+    PGF603    BGSF03      538.899902   KGDR04          -6000.
+    PGF603    BGSF04     -538.899902
+    PGF703    GVXT03              1.   KGDR03           7000.
+    PGF703    BGSF03           544.5   KGDR04          -7000.
+    PGF703    BGSF04          -544.5
+    PGF803    GVXT03              1.   KGDR03           8000.
+    PGF803    BGSF03      547.299805   KGDR04          -8000.
+    PGF803    BGSF04     -547.299805
+    PPGR03    GDPL03            .094   BGRS03             -1.
+    PPGR03    BGRS04              1.
+    PGPR03    GDPL03             -1.   BCRO03            .198
+    PGPR03    BGAS03             .85   BGRS04             -5.
+    PGPR03    DCRO03          -1.198   DGAS03             -1.
+    PGPR03    NRGP03          -1.198
+    POPR03    ODPL03           -.167   BCRO03              1.
+    POPR03    BGAS03          .15555   BORS04           -.835
+    POPR03    DCRO03          -1.183   DGAS03           -.183
+    POPR03    NRGP03          -1.183
+    PNRG03    NRGP03              1.
+    UCOL03    BCOL03             -1.
+    UCRO03    BCRO03             -1.
+    UROP03    BROP03             -1.
+    UGAS03    BGAS03             -1.
+    UELE03    BELE03             -1.
+    NURC03    MURC03             -1.   MURC04              1.
+    NURE03    MURE03             -1.   MURE04              1.
+    NURF03    MURF03             -1.   MURF04              1.
+    NPLU03    MPLU03             -1.   MPLU04              1.
+    NTLN03    MTLN03             -1.   MTLN04              1.
+    NSPF03    MSPF03             -1.   MSPF04              1.
+    UR103     MURN03      242.307831   RMMC03      242.307831
+    UR103     URXT03              1.   MURN04     -242.307831
+    UR103     RMMC04     -242.307831
+    UR203     MURN03      661.538818   RMMC03      681.538818
+    UR203     URXT03              1.   MURN04     -661.538818
+    UR203     RMMC04     -681.538818
+    UR303     MURN03     1288.462158   RMMC03     1523.077637
+    UR303     URXT03              1.   MURN04    -1288.462158
+    UR303     RMMC04    -1523.077637
+    UR403     MURN03     1950.000977   RMMC03     3084.617188
+    UR403     URXT03              1.   MURN04    -1950.000977
+    UR403     RMMC04    -3084.617188
+    UR503     MURN03     3638.463623   RMMC03     10114.62109
+    UR503     URXT03              1.   MURN04    -3638.463623
+    UR503     RMMC04    -10114.62109
+    UR603     MURN03     5438.460938   RMMC03     23614.62891
+    UR603     URXT03              1.   MURN04    -5438.460938
+    UR603     RMMC04    -23614.62891
+    ICOL03    BCOL03              1.   BIMP03          -1000.
+    ICRO03    BCRO03              1.   BIMP03    -1500.029785
+    IROP03    BROP03              1.   BIMP03    -1500.029785
+    IGAS03    BGAS03              1.   BIMP03    -1875.037109
+    IELE03    BELE03              1.   BIMP03    -15532.80469
+    JCOL03    BCOL03              1.   NRGP03             -1.
+    JCOL03    ECAP03          -3.333   CEEA03           3.333
+    JCRO03    BCRO03              1.   NRGP03             -1.
+    JCRO03    ECAP03          -3.333   CEEA03           3.333
+    JROP03    BROP03              1.   NRGP03             -1.
+    JROP03    ECAP03          -3.333   CEEA03           3.333
+    JGAS03    BGAS03              1.   NRGP03             -1.
+    JGAS03    ECAP03          -3.333   CEEA03           3.333
+    E1COL03   BCOL03             -1.   BTAW03      -85.984146
+    E1COL03   BTRD03       -3.289011   BEXP03           1000.
+    E1CRO03   BCRO03             -1.   BTAW03      -30.625748
+    E1CRO03   BEXP03     1500.029785
+    E1ROP03   BROP03             -1.   BTAW03      -70.309738
+    E1ROP03   BTRD03     -230.550491   BEXP03     1500.029785
+    E1GAS03   BGAS03             -1.   BTAW03      -76.420792
+    E1GAS03   BTRD03       -49.76236   BEXP03     1875.037109
+    E1ELE03   BELE03             -1.   BTRD03     -937.608643
+    E1ELE03   BEXP03     15532.80469
+    XCOL03    DCOL03        4.438329   BELE03        -.001258
+    XCOL03    BROP03        -.009637   BMNG03      -10.737742
+    XCOL03    BEIM03      -43.582611   BENM03      -30.318329
+    XCOL03    BTAW03       -8.842848   BTRD03     -121.652298
+    XCOL03    BMAC03      -41.056076   WRKF03         .046425
+    XCRO03    DCRO03        2.892097   BELE03        -.000506
+    XCRO03    BROP03        -.002062   BGAS03        -.007408
+    XCRO03    BMNG03      -34.323624   BEIM03      -29.450958
+    XCRO03    BENM03       -9.530361   BTAW03        -10.4619
+    XCRO03    BTRD03     -227.231018   BMAC03      -31.457352
+    XCRO03    WRKF03         .021354
+    XROP03    DROP03         .813213   BELE03         -.00034
+    XROP03    BCOL03        -.001514   BGAS03        -.025955
+    XROP03    BMNG03      -16.875412   BEIM03       -41.64917
+    XROP03    BENM03       -5.162801   BTAW03        -53.5159
+    XROP03    BTRD03      -81.333328   BMAC03       -3.506082
+    XROP03    WRKF03         .007051
+    XGAS03    DGAS03        1.380471   BELE03        -.000499
+    XGAS03    BCOL03        -.000874   BROP03        -.000706
+    XGAS03    BMNG03      -18.629242   BEIM03       -1.871531
+    XGAS03    BENM03        -.372872   BTAW03        -.243801
+    XGAS03    BTRD03      -47.828018   WRKF03         .005952
+    XELE03    DELE03         .054373   BAGR03       -1.282765
+    XELE03    BMNG03      -52.155487   BEIM03        -8.14335
+    XELE03    BENM03       -2.450525   BTAW03      -29.401871
+    XELE03    BTRD03     -148.124084   BMAC03       -3.821757
+    XELE03    WRKF03         .016189
+    XAGR03    KAGR03        1.111111   BCOL03        -.000301
+    XAGR03    BROP03        -.014851   BGAS03        -.000597
+    XAGR03    BELE03        -.000139   BAGR03      693.921387
+    XAGR03    BMNG03      -11.796776   BEIM03     -105.230377
+    XAGR03    BENM03       -8.735988   BTAW03      -19.273376
+    XAGR03    BTRD03       -132.6754   BMAC03       -6.567932
+    XAGR03    BIMP03        -.573897   KAGR04        -.888889
+    XMNG03    KMNG03        1.111111   BCOL03        -.000267
+    XMNG03    BROP03        -.015673   BGAS03        -.001536
+    XMNG03    BELE03        -.000118   BAGR03       -2.328505
+    XMNG03    BMNG03      972.447266   BEIM03     -134.663696
+    XMNG03    BENM03     -160.684525   BTAW03      -25.365646
+    XMNG03    BTRD03     -153.472351   BMAC03       -26.12706
+    XMNG03    BIMP03        -.894217   WRKF03         .038859
+    XMNG03    KMNG04        -.888889
+    XEIM03    KEIM03        1.111111   BCOL03        -.014829
+    XEIM03    BCRO03        -.000073   BROP03        -.009329
+    XEIM03    BGAS03         -.01459   BELE03        -.000512
+    XEIM03    BAGR03     -119.583542   BMNG03      -24.533279
+    XEIM03    BEIM03      731.984375   BENM03      -39.738663
+    XEIM03    BTAW03      -30.974686   BTRD03     -110.634079
+    XEIM03    BMAC03      -14.378268   BIMP03       -6.938498
+    XEIM03    WRKF03         .025369   KEIM04        -.888889
+    XENM03    KENM03        1.111111   BCOL03        -.000905
+    XENM03    BROP03        -.001873   BGAS03        -.003473
+    XENM03    BELE03        -.000301   BAGR03      -14.414824
+    XENM03    BMNG03       -5.079608   BEIM03     -159.277557
+    XENM03    BENM03       754.55127   BTAW03      -13.189252
+    XENM03    BTRD03      -99.108688   BMAC03      -34.243027
+    XENM03    BIMP03       -1.637574   WRKF03         .046102
+    XENM03    KENM04        -.888889
+    XTAW03    KTAW03        1.111111   BCOL03        -.000522
+    XTAW03    BCRO03        -.000183   BROP03        -.033085
+    XTAW03    BGAS03        -.001967   BELE03         -.00065
+    XTAW03    BAGR03        -.870055   BMNG03      -26.042328
+    XTAW03    BEIM03      -20.644028   BENM03      -10.381341
+    XTAW03    BTAW03      914.338867   BTRD03      -151.68219
+    XTAW03    BMAC03      -21.711823   BIMP03      -17.717484
+    XTAW03    WRKF03         .056178   KTAW04        -.888889
+    XTRD03    KTRD03        1.111111   BCOL03        -.001115
+    XTRD03    BCRO03        -.000095   BROP03        -.004269
+    XTRD03    BGAS03        -.004353   BELE03        -.000553
+    XTRD03    BAGR03       -5.705781   BMNG03       -18.54953
+    XTRD03    BEIM03      -23.171265   BENM03      -35.265518
+    XTRD03    BTAW03      -14.880653   BTRD03      825.474609
+    XTRD03    BMAC03       -8.531651   BIMP03       -1.058328
+    XTRD03    WRKF03         .073834   KTRD04        -.888889
+    XMAC03    KMAC03        1.111111   BCOL03        -.001057
+    XMAC03    BROP03        -.002611   BGAS03        -.002701
+    XMAC03    BELE03        -.000226   BMNG03       -8.258104
+    XMAC03    BEIM03     -132.072205   BENM03     -101.023422
+    XMAC03    BTAW03      -10.780818   BTRD03      -90.647217
+    XMAC03    BMAC03      747.764404   BIMP03        -.999022
+    XMAC03    WRKF03         .032378   KMAC04        -.888889
+    CONS03    OBJ          -1.019509   BIMP03          -19.51
+    CONS03    POPL03           1000.   DNRG03        -.016224
+    CONS03    BAGR03          -8.298   BMNG03      -66.047958
+    CONS03    BEIM03     -103.797958   BENM03     -115.218994
+    CONS03    BTAW03      -35.536987   BTRD03     -609.091797
+    CONS03    BMAC03      -41.043991
+    CNRG03    DNRG03              1.   BROP03          -.6141
+    CNRG03    BGAS03           -.251   BELE03        -.039537
+    APCC03    POPL03          -234.1   UMOB03              1.
+    APCC03    UMOB04             -1.
+    GOVT03    BCOL03        -.001458   BROP03        -.006819
+    GOVT03    BGAS03        -.005441   BELE03        -.000551
+    GOVT03    BAGR03        7.501156   BMNG03     -179.188583
+    GOVT03    BEIM03      -29.199707   BENM03        -112.426
+    GOVT03    BTAW03      -24.609955   BTRD03     -552.763428
+    GOVT03    BMAC03      -89.739853   BIMP03         -22.646
+    CAPF03    BMNG03     -345.845703   BEIM03        -.755947
+    CAPF03    BENM03     -104.722321   BTAW03        -9.79188
+    CAPF03    BTRD03      -80.591064   BMAC03     -458.292969
+    CAPF03    BIMP03          -7.772   ECAP03              1.
+    XIMP03    BIMP03              1.   BTRB03             -1.
+    XIMP03    LTAW03          -.0334
+    XEXP03    BEXP03             -1.   BTRB03              1.
+    IAGR03    BAGR03              1.   BTAW03        -.123939
+    IAGR03    BTRD03        -.097273   BIMP03             -1.
+    IMNG03    BMNG03              1.   BTAW03        -.144599
+    IMNG03    BTRD03        -.031359   BIMP03             -1.
+    IEIM03    BEIM03              1.   BTAW03        -.038321
+    IEIM03    BTRD03         -.05912   BIMP03             -1.
+    IENM03    BENM03              1.   BTAW03        -.019188
+    IENM03    BTRD03        -.084225   BIMP03             -1.
+    ITAW03    BTAW03              1.   BIMP03             -1.
+    ITAW03    LTAW03              1.
+    ITRD03    BTRD03              1.   BIMP03             -1.
+    IMAC03    BTAW03        -.015658   BTRD03        -.099167
+    IMAC03    BMAC03              1.   BIMP03             -1.
+    E1AGR03   BAGR03        -.818859   BTAW03        -.101489
+    E1AGR03   BTRD03        -.079653   BEXP03              1.
+    E1MNG03   BMNG03         -.85037   BTAW03        -.122963
+    E1MNG03   BTRD03        -.026667   BEXP03              1.
+    E1EIM03   BEIM03        -.911211   BTAW03        -.034918
+    E1EIM03   BTRD03        -.053871   BEXP03              1.
+    E1ENM03   BENM03        -.906279   BTAW03         -.01739
+    E1ENM03   BTRD03        -.076332   BEXP03              1.
+    E1TAW03   BTAW03             -1.   BEXP03              1.
+    E1TRD03   BTRD03             -1.   BEXP03              1.
+    E1MAC03   BTAW03        -.014045   BTRD03        -.088953
+    E1MAC03   BMAC03        -.897002   BEXP03              1.
+    E2AGR03   BAGR03        -.818859   BTAW03        -.101489
+    E2AGR03   BTRD03        -.079653   BEXP03         .401143
+    E2MNG03   BMNG03         -.85037   BTAW03        -.122963
+    E2MNG03   BTRD03        -.026667   BEXP03         .715021
+    E2EIM03   BEIM03        -.911211   BTAW03        -.034918
+    E2EIM03   BTRD03        -.053871   BEXP03         .604231
+    E2ENM03   BENM03        -.906279   BTAW03         -.01739
+    E2ENM03   BTRD03        -.076332   BEXP03         .515274
+    E2TAW03   BTAW03             -1.
+    E2TRD03   BTRD03             -1.
+    E2MAC03   BTAW03        -.014045   BTRD03        -.088953
+    E2MAC03   BMAC03        -.897002   BEXP03         .607638
+    ULWR03    KLWR03              1.   KLWR04             -1.
+    ULWP03    KLWP03              1.   KLWP04             -1.
+    UMMC03    KMMC03              1.   KMMC04             -1.
+    UENR03    KENR03              1.   KENR04             -1.
+    UFBR03    KFBR03              1.   KFBR04             -1.
+    URPR03    KRPR03              1.   KRPR04             -1.
+    UECM03    KECM03              1.   KECM04             -1.
+    UWCM03    KWCM03              1.   KWCM04             -1.
+    UCLQ03    KCLQ03              1.   KCLQ04             -1.
+    UREF03    KREF03              1.   KREF04             -1.
+    UOSE03    KOSE03              1.   KOSE04             -1.
+    UCFP03    KCFP03              1.   KCFP04             -1.
+    UOFP03    KOFP03              1.   KOFP04             -1.
+    UGFP03    KGFP03              1.   KGFP04             -1.
+    UCGL03    KCGL03              1.   KCGL04             -1.
+    UCGH03    KCGH03              1.   KCGH04             -1.
+    UHYD03    KHYD03              1.   KHYD04             -1.
+    UGEO03    KGEO03              1.   KGEO04             -1.
+    UAGR03    KAGR03              1.   KAGR04             -.8
+    UMNG03    KMNG03              1.   KMNG04             -.8
+    UEIM03    KEIM03              1.   KEIM04             -.8
+    UENM03    KENM03              1.   KENM04             -.8
+    UTAW03    KTAW03              1.   KTAW04             -.8
+    UTRD03    KTRD03              1.   KTRD04             -.8
+    UMAC03    KMAC03              1.   KMAC04             -.8
+    WLWR03    MURF04       -9.838104   MURF05      -39.352417
+    WLWR03    ECAP03      -33.585495   CEEA03       33.585495
+    WLWR03    ETDE03      -23.509842   KLWR04             -1.
+    WLWR03    KLWR05             -4.
+    WLWP03    MURN04       -8.921747   MPLU04        -.276048
+    WLWP03    MURN05      -35.686981   MPLU05       -1.104192
+    WLWP03    ECAP03      -34.432404   CEEA03       34.432404
+    WLWP03    ETDE03      -24.102676   KLWP04             -1.
+    WLWP03    KLWP05             -4.
+    WMMC03    ECAP03        -.032029   CEEA03         .032029
+    WMMC03    KMMC04             -3.   KMMC05             -2.
+    WMMC03    KMMC08              3.
+    WENR03    ECAP03        -.224371   CEEA03         .224371
+    WENR03    KENR05             -4.   KENR06             -1.
+    WFBR03    MPLU04        -.465639   MTLN04       -5.033102
+    WFBR03    MPLU05       -1.862556   MTLN05      -20.132416
+    WFBR03    ECAP03      -44.428299   CEEA03       44.428299
+    WFBR03    ETDE03      -31.099808   KFBR04             -1.
+    WFBR03    KFBR05             -4.
+    WRPR03    ECAP03       -2.096846   CEEA03        2.096846
+    WRPR03    KRPR05             -4.   KRPR06             -1.
+    WECM03    ECAP03        -.014564   CEEA03         .014564
+    WECM03    KECM04             -4.   KECM05             -1.
+    WECM03    KECM08              4.
+    WWCM03    ECAP03        -.005172   CEEA03         .005172
+    WWCM03    KWCM04             -5.   KWCM08              5.
+    WCLQ03    ECAP03       -6.160605   CEEA03        6.160605
+    WCLQ03    KCLQ04             -5.
+    WREF03    ECAP03        -.481851   CEEA03         .481851
+    WREF03    KREF04             -5.
+    WOSE03    ECAP03       -1.682063   CEEA03        1.682063
+    WOSE03    KOSE04             -5.
+    WCFP03    ECAP03      -23.936646   CEEA03       23.936646
+    WCFP03    ETDE03      -16.755646   KCFP04             -3.
+    WCFP03    KCFP05             -2.
+    WOFP03    ECAP03      -17.952484   CEEA03       17.952484
+    WOFP03    ETDE03      -12.566738   KOFP04             -4.
+    WOFP03    KOFP05             -1.
+    WGFP03    ECAP03      -10.970949   CEEA03       10.970949
+    WGFP03    ETDE03       -7.679664   KGFP04             -4.
+    WGFP03    KGFP05             -1.
+    WCGL03    ECAP03      -75.702805   CEEA03       75.702805
+    WCGL03    ETDE03      -52.991959   KCGL04             -5.
+    WCGH03    ECAP03       -6.383089   CEEA03        6.383089
+    WCGH03    KCGH04             -5.
+    WHYD03    ECAP03      -33.710693   CEEA03       33.710693
+    WHYD03    ETDE03      -23.597473   KHYD04             -5.
+    WGEO03    ECAP03      -47.873169   CEEA03       47.873169
+    WGEO03    ETDE03      -33.511215   KGEO04             -5.
+    WTDE03    ECAP03             -1.   CEEA03              1.
+    WTDE03    ETDE03              1.
+    WAGR03    ECAP03        -1.14185   CNEA03         1.14185
+    WAGR03    KAGR03             -1.   KAGR04             -4.
+    WMNG03    ECAP03        -.290702   CNEA03         .290702
+    WMNG03    KMNG03             -1.   KMNG04             -4.
+    WEIM03    ECAP03         -.64485   CNEA03          .64485
+    WEIM03    KEIM03             -1.   KEIM04             -4.
+    WENM03    ECAP03        -.403625   CNEA03         .403625
+    WENM03    KENM03             -1.   KENM04             -4.
+    WTAW03    ECAP03        -1.41581   CNEA03         1.41581
+    WTAW03    KTAW03             -1.   KTAW04             -4.
+    WTRD03    ECAP03        -1.08414   CNEA03         1.08414
+    WTRD03    KTRD03             -1.   KTRD04             -4.
+    WMAC03    ECAP03        -.362214   CNEA03         .362214
+    WMAC03    KMAC03             -1.   KMAC04             -4.
+    KEEA04    TEEA04            -1.8   TEEA05              .8
+    KEEA04    TEEA03              1.   CEEA04             -1.
+    KNEA04    TNEA04            -1.8   TNEA05              .8
+    KNEA04    TNEA03              1.   CNEA04             -1.
+    PLWU04    DELE04             -1.   BELE04              .9
+    PLWU04    MURE04      -20.867584   MSPF04       20.867584
+    PLWU04    KLWR04        1.538461   KLWR05       -1.538461
+    PLWU04    NRGP04         -10.355   PELE04             -1.
+    PLWP04    DELE04             -1.   BELE04              .9
+    PLWP04    MURN04      -27.914734   MPLU04       -1.529699
+    PLWP04    MSPF04       29.444443   KLWP04        1.538461
+    PLWP04    KLWP05       -1.538461   NRGP04         -10.355
+    PLWP04    PELE04             -1.
+    PNR104    BELE04          -.0027   MURN04       -9.192495
+    PNR104    MURE04          1.2595   MTLN04           7.933
+    PNR104    KENR04              1.   KENR05             -1.
+    PNR204    BELE04          -.0027   MURC04          -8.261
+    PNR204    MURE04        1.459499   MTLN04        6.801496
+    PNR204    KENR04              1.   KENR05             -1.
+    PNR304    BELE04          -.0027   MURN04         -10.793
+    PNR304    MURF04        2.112499   MTLN04        8.680496
+    PNR304    KENR04              1.   KENR05             -1.
+    PMMC04    RMMC04             -5.   BMNG04           -15.4
+    PMMC04    KMMC04              1.   KMMC05             -1.
+    PFBR04    DELE04             -1.   BELE04              .9
+    PFBR04    MPLU04         -1.3775   MTLN04      -15.662098
+    PFBR04    KFBR04        1.538461   KFBR05       -1.538461
+    PFBR04    NRGP04         -10.355   PELE04             -1.
+    PRPR04    MURC04          27.715   MPLU04            1.11
+    PRPR04    MTLN04       19.069992   MSPF04            -50.
+    PRPR04    KRPR04              1.   KRPR05             -1.
+    PECM04    DCOL04          -.0258   BCOL04           .0258
+    PECM04    KECM04              1.   KECM05             -1.
+    PECM04    NRGP04          -.0258
+    PWCM04    DCOL04           -.016   BCOL04            .016
+    PWCM04    KWCM04              1.   KWCM05             -1.
+    PWCM04    NRGP04           -.016
+    PCLQ04    DROP04             -1.   BCOL04          -1.575
+    PCLQ04    BROP04              1.   KCLQ04              1.
+    PCLQ04    KCLQ05             -1.
+    PREF04    DROP04           -.549   BCRO04             -.6
+    PREF04    BROP04            .549   KREF04              1.
+    PREF04    KREF05             -1.
+    POSE04    DCRO04             -.6   BCRO04              .6
+    POSE04    KOSE04              1.   KOSE05             -1.
+    POSE04    NRGP04             -.6
+    PCFP04    DELE04             -1.   BCOL04         -10.355
+    PCFP04    BELE04              .9   KCFP04        1.851851
+    PCFP04    KCFP05       -1.851851   PELE04              1.
+    POFP04    DELE04             -1.   BROP04         -10.355
+    POFP04    BELE04              .9   KOFP04        1.923077
+    POFP04    KOFP05       -1.923077
+    PGFP04    DELE04             -1.   BGAS04         -10.355
+    PGFP04    BELE04              .9   KGFP04        1.923077
+    PGFP04    KGFP05       -1.923077
+    PCGL04    DELE04             -1.   BCOL04         -15.986
+    PCGL04    BELE04              .9   KCGL04              1.
+    PCGL04    KCGL05             -1.
+    PCGH04    DGAS04             -1.   BCOL04          -1.826
+    PCGH04    BGAS04              1.   KCGH04              1.
+    PCGH04    KCGH05             -1.
+    PHYD04    DELE04             -1.   BELE04              .9
+    PHYD04    KHYD04        1.923077   KHYD05       -1.923077
+    PHYD04    NRGP04         -10.355
+    PGEO04    DELE04             -1.   BELE04              .9
+    PGEO04    KGEO04        1.190475   KGEO05       -1.190475
+    PGEO04    NRGP04         -10.355
+    POF104    OVXT04              1.   KODR04           1800.
+    POF104    BOIP04            78.6   KODR05          -1800.
+    POF104    BOIP05           -78.6
+    POF204    OVXT04              1.   KODR04           3600.
+    POF204    BOIP04           136.5   KODR05          -3600.
+    POF204    BOIP05          -136.5
+    POF304    OVXT04              1.   KODR04           5400.
+    POF304    BOIP04           166.7   KODR05          -5400.
+    POF304    BOIP05          -166.7
+    PODR04    KODR04             -1.   ECAP04          -.0054
+    PODR04    CEEA04           .0054
+    POIP04    BOIP04             -1.   OSRB04          .00351
+    POIP04    OTRB04          .00039   ODPL04           .0135
+    POIP04    BORS05           .3135   OSRB05          .05065
+    POIP04    OTRB05          .04056   OSRB06          .01108
+    POIP04    OTRB06          .01525
+    POF404    OVXT04              1.   KODR04           7200.
+    POF404    BOIP04           182.6   KODR05          -7200.
+    POF404    BOIP05          -182.6
+    POF504    OVXT04              1.   KODR04           9000.
+    POF504    BOIP04           190.9   KODR05          -9000.
+    POF504    BOIP05          -190.9
+    POF604    OVXT04              1.   KODR04          10800.
+    POF604    BOIP04           195.2   KODR05         -10800.
+    POF604    BOIP05          -195.2
+    POF704    OVXT04              1.   KODR04          12600.
+    POF704    BOIP04           197.5   KODR05         -12600.
+    POF704    BOIP05          -197.5
+    PPOR04    ODPL04            .094   BORS04             -1.
+    PPOR04    BORS05              1.
+    PSRN04    OSRB04             -1.   OSRB05              1.
+    PSRA04    OSRB04             -1.   ODPL04            .043
+    PSRA04    BORS05              1.   ECAP04           -.173
+    PSRA04    CEEA04            .173
+    PTRN04    OTRB04             -1.   OTRB05              1.
+    PTRA04    OTRB04             -1.   ODPL04            .043
+    PTRA04    BORS05              1.   ECAP04           -.302
+    PTRA04    CEEA04            .302
+    PGF104    GVXT04              1.   KGDR04           1426.
+    PGF104    BGSF04            275.   KGDR05          -1426.
+    PGF104    BGSF05           -275.
+    PGF204    GVXT04              1.   KGDR04           2000.
+    PGF204    BGSF04      366.099854   KGDR05          -2000.
+    PGF204    BGSF05     -366.099854
+    PGF304    GVXT04              1.   KGDR04           3000.
+    PGF304    BGSF04      458.799805   KGDR05          -3000.
+    PGF304    BGSF05     -458.799805
+    PGDR04    KGDR04             -1.   ECAP04          -.0054
+    PGDR04    CEEA04           .0054
+    PGRA04    BGSF04             -1.   GDPL04            .043
+    PGRA04    BGRS05              1.
+    PGF404    GVXT04              1.   KGDR04           4000.
+    PGF404    BGSF04      504.599854   KGDR05          -4000.
+    PGF404    BGSF05     -504.599854
+    PGF504    GVXT04              1.   KGDR04           5000.
+    PGF504    BGSF04           527.5   KGDR05          -5000.
+    PGF504    BGSF05          -527.5
+    PGF604    GVXT04              1.   KGDR04           6000.
+    PGF604    BGSF04      538.899902   KGDR05          -6000.
+    PGF604    BGSF05     -538.899902
+    PGF704    GVXT04              1.   KGDR04           7000.
+    PGF704    BGSF04           544.5   KGDR05          -7000.
+    PGF704    BGSF05          -544.5
+    PGF804    GVXT04              1.   KGDR04           8000.
+    PGF804    BGSF04      547.299805   KGDR05          -8000.
+    PGF804    BGSF05     -547.299805
+    PPGR04    GDPL04            .094   BGRS04             -1.
+    PPGR04    BGRS05              1.
+    PGPR04    GDPL04             -1.   BCRO04            .198
+    PGPR04    BGAS04             .85   BGRS05             -5.
+    PGPR04    DCRO04          -1.198   DGAS04             -1.
+    PGPR04    NRGP04          -1.198
+    POPR04    ODPL04           -.167   BCRO04              1.
+    POPR04    BGAS04          .15555   BORS05           -.835
+    POPR04    DCRO04          -1.183   DGAS04           -.183
+    POPR04    NRGP04          -1.183
+    PNRG04    NRGP04              1.
+    UCOL04    BCOL04             -1.
+    UCRO04    BCRO04             -1.
+    UROP04    BROP04             -1.
+    UGAS04    BGAS04             -1.
+    UELE04    BELE04             -1.
+    NURC04    MURC04             -1.   MURC05              1.
+    NURE04    MURE04             -1.   MURE05              1.
+    NURF04    MURF04             -1.   MURF05              1.
+    NPLU04    MPLU04             -1.   MPLU05              1.
+    NTLN04    MTLN04             -1.   MTLN05              1.
+    NSPF04    MSPF04             -1.   MSPF05              1.
+    UR104     MURN04      242.307831   RMMC04      242.307831
+    UR104     URXT04              1.   MURN05     -242.307831
+    UR104     RMMC05     -242.307831
+    UR204     MURN04      661.538818   RMMC04      681.538818
+    UR204     URXT04              1.   MURN05     -661.538818
+    UR204     RMMC05     -681.538818
+    UR304     MURN04     1288.462158   RMMC04     1523.077637
+    UR304     URXT04              1.   MURN05    -1288.462158
+    UR304     RMMC05    -1523.077637
+    UR404     MURN04     1950.000977   RMMC04     3084.617188
+    UR404     URXT04              1.   MURN05    -1950.000977
+    UR404     RMMC05    -3084.617188
+    UR504     MURN04     3638.463623   RMMC04     10114.62109
+    UR504     URXT04              1.   MURN05    -3638.463623
+    UR504     RMMC05    -10114.62109
+    UR604     MURN04     5438.460938   RMMC04     23614.62891
+    UR604     URXT04              1.   MURN05    -5438.460938
+    UR604     RMMC05    -23614.62891
+    ICOL04    BCOL04              1.   BIMP04          -1000.
+    ICRO04    BCRO04              1.   BIMP04    -1500.029785
+    IROP04    BROP04              1.   BIMP04    -1500.029785
+    IGAS04    BGAS04              1.   BIMP04    -1875.037109
+    IELE04    BELE04              1.   BIMP04    -15532.80469
+    JCOL04    BCOL04              1.   NRGP04             -1.
+    JCOL04    ECAP04          -3.333   CEEA04           3.333
+    JCRO04    BCRO04              1.   NRGP04             -1.
+    JCRO04    ECAP04          -3.333   CEEA04           3.333
+    JROP04    BROP04              1.   NRGP04             -1.
+    JROP04    ECAP04          -3.333   CEEA04           3.333
+    JGAS04    BGAS04              1.   NRGP04             -1.
+    JGAS04    ECAP04          -3.333   CEEA04           3.333
+    E1COL04   BCOL04             -1.   BTAW04      -85.984146
+    E1COL04   BTRD04       -3.289011   BEXP04           1000.
+    E1CRO04   BCRO04             -1.   BTAW04      -30.625748
+    E1CRO04   BEXP04     1500.029785
+    E1ROP04   BROP04             -1.   BTAW04      -70.309738
+    E1ROP04   BTRD04     -230.550491   BEXP04     1500.029785
+    E1GAS04   BGAS04             -1.   BTAW04      -76.420792
+    E1GAS04   BTRD04       -49.76236   BEXP04     1875.037109
+    E1ELE04   BELE04             -1.   BTRD04     -937.608643
+    E1ELE04   BEXP04     15532.80469
+    XCOL04    DCOL04        4.438329   BELE04        -.001258
+    XCOL04    BROP04        -.009637   BMNG04      -10.737742
+    XCOL04    BEIM04      -43.582611   BENM04      -30.318329
+    XCOL04    BTAW04       -8.842848   BTRD04     -121.652298
+    XCOL04    BMAC04      -41.056076   WRKF04         .046425
+    XCRO04    DCRO04        2.892097   BELE04        -.000506
+    XCRO04    BROP04        -.002062   BGAS04        -.007408
+    XCRO04    BMNG04      -34.323624   BEIM04      -29.450958
+    XCRO04    BENM04       -9.530361   BTAW04        -10.4619
+    XCRO04    BTRD04     -227.231018   BMAC04      -31.457352
+    XCRO04    WRKF04         .021354
+    XROP04    DROP04         .813213   BELE04         -.00034
+    XROP04    BCOL04        -.001514   BGAS04        -.025955
+    XROP04    BMNG04      -16.875412   BEIM04       -41.64917
+    XROP04    BENM04       -5.162801   BTAW04        -53.5159
+    XROP04    BTRD04      -81.333328   BMAC04       -3.506082
+    XROP04    WRKF04         .007051
+    XGAS04    DGAS04        1.380471   BELE04        -.000499
+    XGAS04    BCOL04        -.000874   BROP04        -.000706
+    XGAS04    BMNG04      -18.629242   BEIM04       -1.871531
+    XGAS04    BENM04        -.372872   BTAW04        -.243801
+    XGAS04    BTRD04      -47.828018   WRKF04         .005952
+    XELE04    DELE04         .054373   BAGR04       -1.282765
+    XELE04    BMNG04      -52.155487   BEIM04        -8.14335
+    XELE04    BENM04       -2.450525   BTAW04      -29.401871
+    XELE04    BTRD04     -148.124084   BMAC04       -3.821757
+    XELE04    WRKF04         .016189
+    XAGR04    KAGR04        1.111111   BCOL04         -.00029
+    XAGR04    BROP04         -.01431   BGAS04        -.000575
+    XAGR04    BELE04        -.000134   BAGR04      693.921387
+    XAGR04    BMNG04      -11.796776   BEIM04     -105.230377
+    XAGR04    BENM04       -8.735988   BTAW04      -19.273376
+    XAGR04    BTRD04       -132.6754   BMAC04       -6.567932
+    XAGR04    BIMP04        -.573897   KAGR05        -.888889
+    XMNG04    KMNG04        1.111111   BCOL04        -.000257
+    XMNG04    BROP04        -.015102   BGAS04         -.00148
+    XMNG04    BELE04        -.000113   BAGR04       -2.328505
+    XMNG04    BMNG04      972.447266   BEIM04     -134.663696
+    XMNG04    BENM04     -160.684525   BTAW04      -25.365646
+    XMNG04    BTRD04     -153.472351   BMAC04       -26.12706
+    XMNG04    BIMP04        -.894217   WRKF04         .038859
+    XMNG04    KMNG05        -.888889
+    XEIM04    KEIM04        1.111111   BCOL04        -.014288
+    XEIM04    BCRO04         -.00007   BROP04        -.008988
+    XEIM04    BGAS04        -.014058   BELE04        -.000493
+    XEIM04    BAGR04     -119.583542   BMNG04      -24.533279
+    XEIM04    BEIM04      731.984375   BENM04      -39.738663
+    XEIM04    BTAW04      -30.974686   BTRD04     -110.634079
+    XEIM04    BMAC04      -14.378268   BIMP04       -6.938498
+    XEIM04    WRKF04         .025369   KEIM05        -.888889
+    XENM04    KENM04        1.111111   BCOL04        -.000872
+    XENM04    BROP04        -.001804   BGAS04        -.003347
+    XENM04    BELE04         -.00029   BAGR04      -14.414824
+    XENM04    BMNG04       -5.079608   BEIM04     -159.277557
+    XENM04    BENM04       754.55127   BTAW04      -13.189252
+    XENM04    BTRD04      -99.108688   BMAC04      -34.243027
+    XENM04    BIMP04       -1.637574   WRKF04         .046102
+    XENM04    KENM05        -.888889
+    XTAW04    KTAW04        1.111111   BCOL04        -.000503
+    XTAW04    BCRO04        -.000176   BROP04        -.031879
+    XTAW04    BGAS04        -.001895   BELE04        -.000626
+    XTAW04    BAGR04        -.870055   BMNG04      -26.042328
+    XTAW04    BEIM04      -20.644028   BENM04      -10.381341
+    XTAW04    BTAW04      914.338867   BTRD04      -151.68219
+    XTAW04    BMAC04      -21.711823   BIMP04      -17.717484
+    XTAW04    WRKF04         .056178   KTAW05        -.888889
+    XTRD04    KTRD04        1.111111   BCOL04        -.001074
+    XTRD04    BCRO04        -.000091   BROP04        -.004113
+    XTRD04    BGAS04        -.004194   BELE04        -.000533
+    XTRD04    BAGR04       -5.705781   BMNG04       -18.54953
+    XTRD04    BEIM04      -23.171265   BENM04      -35.265518
+    XTRD04    BTAW04      -14.880653   BTRD04      825.474609
+    XTRD04    BMAC04       -8.531651   BIMP04       -1.058328
+    XTRD04    WRKF04         .073834   KTRD05        -.888889
+    XMAC04    KMAC04        1.111111   BCOL04        -.001019
+    XMAC04    BROP04        -.002516   BGAS04        -.002603
+    XMAC04    BELE04        -.000217   BMNG04       -8.258104
+    XMAC04    BEIM04     -132.072205   BENM04     -101.023422
+    XMAC04    BTAW04      -10.780818   BTRD04      -90.647217
+    XMAC04    BMAC04      747.764404   BIMP04        -.999022
+    XMAC04    WRKF04         .032378   KMAC05        -.888889
+    CONS04    OBJ          -1.019509   BIMP04          -19.51
+    CONS04    POPL04           1000.   DNRG04        -.015632
+    CONS04    BAGR04          -8.298   BMNG04      -66.047958
+    CONS04    BEIM04     -103.797958   BENM04     -115.218994
+    CONS04    BTAW04      -35.536987   BTRD04     -609.091797
+    CONS04    BMAC04      -41.043991
+    CNRG04    DNRG04              1.   BROP04          -.5979
+    CNRG04    BGAS04          -.2445   BELE04         -.04619
+    APCC04    POPL04          -245.1   UMOB04              1.
+    APCC04    UMOB05             -1.
+    GOVT04    BCOL04        -.001458   BROP04        -.006819
+    GOVT04    BGAS04        -.005441   BELE04        -.000551
+    GOVT04    BAGR04        7.501156   BMNG04     -179.188583
+    GOVT04    BEIM04      -29.199707   BENM04        -112.426
+    GOVT04    BTAW04      -24.609955   BTRD04     -552.763428
+    GOVT04    BMAC04      -89.739853   BIMP04         -22.646
+    CAPF04    BMNG04     -345.845703   BEIM04        -.755947
+    CAPF04    BENM04     -104.722321   BTAW04        -9.79188
+    CAPF04    BTRD04      -80.591064   BMAC04     -458.292969
+    CAPF04    BIMP04          -7.772   ECAP04              1.
+    XIMP04    BIMP04              1.   BTRB04             -1.
+    XIMP04    LTAW04          -.0334
+    XEXP04    BEXP04             -1.   BTRB04              1.
+    IAGR04    BAGR04              1.   BTAW04        -.123939
+    IAGR04    BTRD04        -.097273   BIMP04             -1.
+    IMNG04    BMNG04              1.   BTAW04        -.144599
+    IMNG04    BTRD04        -.031359   BIMP04             -1.
+    IEIM04    BEIM04              1.   BTAW04        -.038321
+    IEIM04    BTRD04         -.05912   BIMP04             -1.
+    IENM04    BENM04              1.   BTAW04        -.019188
+    IENM04    BTRD04        -.084225   BIMP04             -1.
+    ITAW04    BTAW04              1.   BIMP04             -1.
+    ITAW04    LTAW04              1.
+    ITRD04    BTRD04              1.   BIMP04             -1.
+    IMAC04    BTAW04        -.015658   BTRD04        -.099167
+    IMAC04    BMAC04              1.   BIMP04             -1.
+    E1AGR04   BAGR04        -.818859   BTAW04        -.101489
+    E1AGR04   BTRD04        -.079653   BEXP04              1.
+    E1MNG04   BMNG04         -.85037   BTAW04        -.122963
+    E1MNG04   BTRD04        -.026667   BEXP04              1.
+    E1EIM04   BEIM04        -.911211   BTAW04        -.034918
+    E1EIM04   BTRD04        -.053871   BEXP04              1.
+    E1ENM04   BENM04        -.906279   BTAW04         -.01739
+    E1ENM04   BTRD04        -.076332   BEXP04              1.
+    E1TAW04   BTAW04             -1.   BEXP04              1.
+    E1TRD04   BTRD04             -1.   BEXP04              1.
+    E1MAC04   BTAW04        -.014045   BTRD04        -.088953
+    E1MAC04   BMAC04        -.897002   BEXP04              1.
+    E2AGR04   BAGR04        -.818859   BTAW04        -.101489
+    E2AGR04   BTRD04        -.079653   BEXP04         .401143
+    E2MNG04   BMNG04         -.85037   BTAW04        -.122963
+    E2MNG04   BTRD04        -.026667   BEXP04         .715021
+    E2EIM04   BEIM04        -.911211   BTAW04        -.034918
+    E2EIM04   BTRD04        -.053871   BEXP04         .604231
+    E2ENM04   BENM04        -.906279   BTAW04         -.01739
+    E2ENM04   BTRD04        -.076332   BEXP04         .515274
+    E2TAW04   BTAW04             -1.
+    E2TRD04   BTRD04             -1.
+    E2MAC04   BTAW04        -.014045   BTRD04        -.088953
+    E2MAC04   BMAC04        -.897002   BEXP04         .607638
+    ULWR04    KLWR04              1.   KLWR05             -1.
+    ULWP04    KLWP04              1.   KLWP05             -1.
+    UMMC04    KMMC04              1.   KMMC05             -1.
+    UENR04    KENR04              1.   KENR05             -1.
+    UFBR04    KFBR04              1.   KFBR05             -1.
+    URPR04    KRPR04              1.   KRPR05             -1.
+    UECM04    KECM04              1.   KECM05             -1.
+    UWCM04    KWCM04              1.   KWCM05             -1.
+    UCLQ04    KCLQ04              1.   KCLQ05             -1.
+    UREF04    KREF04              1.   KREF05             -1.
+    UOSE04    KOSE04              1.   KOSE05             -1.
+    UCFP04    KCFP04              1.   KCFP05             -1.
+    UOFP04    KOFP04              1.   KOFP05             -1.
+    UGFP04    KGFP04              1.   KGFP05             -1.
+    UCGL04    KCGL04              1.   KCGL05             -1.
+    UCGH04    KCGH04              1.   KCGH05             -1.
+    UHYD04    KHYD04              1.   KHYD05             -1.
+    UGEO04    KGEO04              1.   KGEO05             -1.
+    UAGR04    KAGR04              1.   KAGR05             -.8
+    UMNG04    KMNG04              1.   KMNG05             -.8
+    UEIM04    KEIM04              1.   KEIM05             -.8
+    UENM04    KENM04              1.   KENM05             -.8
+    UTAW04    KTAW04              1.   KTAW05             -.8
+    UTRD04    KTRD04              1.   KTRD05             -.8
+    UMAC04    KMAC04              1.   KMAC05             -.8
+    WLWR04    MURF05       -9.838104   MURF06      -39.352417
+    WLWR04    ECAP04      -33.585495   CEEA04       33.585495
+    WLWR04    ETDE04      -23.509842   KLWR05             -1.
+    WLWR04    KLWR06             -4.
+    WLWP04    MURN05       -8.921747   MPLU05        -.276048
+    WLWP04    MURN06      -35.686981   MPLU06       -1.104192
+    WLWP04    ECAP04      -34.432404   CEEA04       34.432404
+    WLWP04    ETDE04      -24.102676   KLWP05             -1.
+    WLWP04    KLWP06             -4.
+    WMMC04    ECAP04        -.032029   CEEA04         .032029
+    WMMC04    KMMC05             -3.   KMMC06             -2.
+    WENR04    ECAP04        -.224371   CEEA04         .224371
+    WENR04    KENR06             -4.   KENR07             -1.
+    WFBR04    MPLU05        -.465639   MTLN05       -5.033102
+    WFBR04    MPLU06       -1.862556   MTLN06      -20.132416
+    WFBR04    ECAP04      -44.428299   CEEA04       44.428299
+    WFBR04    ETDE04      -31.099808   KFBR05             -1.
+    WFBR04    KFBR06             -4.
+    WRPR04    ECAP04       -2.096846   CEEA04        2.096846
+    WRPR04    KRPR06             -4.   KRPR07             -1.
+    WECM04    ECAP04        -.014564   CEEA04         .014564
+    WECM04    KECM05             -4.   KECM06             -1.
+    WWCM04    ECAP04        -.005172   CEEA04         .005172
+    WWCM04    KWCM05             -5.
+    WCLQ04    ECAP04       -6.160605   CEEA04        6.160605
+    WCLQ04    KCLQ05             -5.
+    WREF04    ECAP04        -.481851   CEEA04         .481851
+    WREF04    KREF05             -5.
+    WOSE04    ECAP04       -1.682063   CEEA04        1.682063
+    WOSE04    KOSE05             -5.
+    WCFP04    ECAP04      -23.936646   CEEA04       23.936646
+    WCFP04    ETDE04      -16.755646   KCFP05             -3.
+    WCFP04    KCFP06             -2.
+    WOFP04    ECAP04      -17.952484   CEEA04       17.952484
+    WOFP04    ETDE04      -12.566738   KOFP05             -4.
+    WOFP04    KOFP06             -1.
+    WGFP04    ECAP04      -10.970949   CEEA04       10.970949
+    WGFP04    ETDE04       -7.679664   KGFP05             -4.
+    WGFP04    KGFP06             -1.
+    WCGL04    ECAP04      -75.702805   CEEA04       75.702805
+    WCGL04    ETDE04      -52.991959   KCGL05             -5.
+    WCGH04    ECAP04       -6.383089   CEEA04        6.383089
+    WCGH04    KCGH05             -5.
+    WHYD04    ECAP04      -33.710693   CEEA04       33.710693
+    WHYD04    ETDE04      -23.597473   KHYD05             -5.
+    WGEO04    ECAP04      -47.873169   CEEA04       47.873169
+    WGEO04    ETDE04      -33.511215   KGEO05             -5.
+    WTDE04    ECAP04             -1.   CEEA04              1.
+    WTDE04    ETDE04              1.
+    WAGR04    ECAP04        -1.14185   CNEA04         1.14185
+    WAGR04    KAGR04             -1.   KAGR05             -4.
+    WMNG04    ECAP04        -.290702   CNEA04         .290702
+    WMNG04    KMNG04             -1.   KMNG05             -4.
+    WEIM04    ECAP04         -.64485   CNEA04          .64485
+    WEIM04    KEIM04             -1.   KEIM05             -4.
+    WENM04    ECAP04        -.403625   CNEA04         .403625
+    WENM04    KENM04             -1.   KENM05             -4.
+    WTAW04    ECAP04        -1.41581   CNEA04         1.41581
+    WTAW04    KTAW04             -1.   KTAW05             -4.
+    WTRD04    ECAP04        -1.08414   CNEA04         1.08414
+    WTRD04    KTRD04             -1.   KTRD05             -4.
+    WMAC04    ECAP04        -.362214   CNEA04         .362214
+    WMAC04    KMAC04             -1.   KMAC05             -4.
+    KEEA05    TEEA05            -1.8   TEEA06              .8
+    KEEA05    TEEA04              1.   CEEA05             -1.
+    KNEA05    TNEA05            -1.8   TNEA06              .8
+    KNEA05    TNEA04              1.   CNEA05             -1.
+    PLWU05    DELE05             -1.   BELE05              .9
+    PLWU05    MURE05      -20.867584   MSPF05       20.867584
+    PLWU05    KLWR05        1.538461   KLWR06       -1.538461
+    PLWU05    NRGP05         -10.355   PELE05             -1.
+    PLWP05    DELE05             -1.   BELE05              .9
+    PLWP05    MURN05      -27.914734   MPLU05       -1.529699
+    PLWP05    MSPF05       29.444443   KLWP05        1.538461
+    PLWP05    KLWP06       -1.538461   NRGP05         -10.355
+    PLWP05    PELE05             -1.
+    PNR105    BELE05          -.0027   MURN05       -9.192495
+    PNR105    MURE05          1.2595   MTLN05           7.933
+    PNR105    KENR05              1.   KENR06             -1.
+    PNR205    BELE05          -.0027   MURC05          -8.261
+    PNR205    MURE05        1.459499   MTLN05        6.801496
+    PNR205    KENR05              1.   KENR06             -1.
+    PNR305    BELE05          -.0027   MURN05         -10.793
+    PNR305    MURF05        2.112499   MTLN05        8.680496
+    PNR305    KENR05              1.   KENR06             -1.
+    PMMC05    RMMC05             -5.   BMNG05           -15.4
+    PMMC05    KMMC05              1.   KMMC06             -1.
+    PFBR05    DELE05             -1.   BELE05              .9
+    PFBR05    MPLU05         -1.3775   MTLN05      -15.662098
+    PFBR05    KFBR05        1.538461   KFBR06       -1.538461
+    PFBR05    NRGP05         -10.355   PELE05             -1.
+    PRPR05    MURC05          27.715   MPLU05            1.11
+    PRPR05    MTLN05       19.069992   MSPF05            -50.
+    PRPR05    KRPR05              1.   KRPR06             -1.
+    PECM05    DCOL05          -.0258   BCOL05           .0258
+    PECM05    KECM05              1.   KECM06             -1.
+    PECM05    NRGP05          -.0258
+    PWCM05    DCOL05           -.016   BCOL05            .016
+    PWCM05    KWCM05              1.   KWCM06             -1.
+    PWCM05    NRGP05           -.016
+    PCLQ05    DROP05             -1.   BCOL05          -1.575
+    PCLQ05    BROP05              1.   KCLQ05              1.
+    PCLQ05    KCLQ06             -1.
+    PREF05    DROP05           -.549   BCRO05             -.6
+    PREF05    BROP05            .549   KREF05              1.
+    PREF05    KREF06             -1.
+    POSE05    DCRO05             -.6   BCRO05              .6
+    POSE05    KOSE05              1.   KOSE06             -1.
+    POSE05    NRGP05             -.6
+    PCFP05    DELE05             -1.   BCOL05         -10.355
+    PCFP05    BELE05              .9   KCFP05        1.851851
+    PCFP05    KCFP06       -1.851851   PELE05              1.
+    POFP05    DELE05             -1.   BROP05         -10.355
+    POFP05    BELE05              .9   KOFP05              2.
+    POFP05    KOFP06             -2.
+    PGFP05    DELE05             -1.   BGAS05         -10.355
+    PGFP05    BELE05              .9   KGFP05              2.
+    PGFP05    KGFP06             -2.
+    PCGL05    DELE05             -1.   BCOL05         -15.986
+    PCGL05    BELE05              .9   KCGL05              1.
+    PCGL05    KCGL06             -1.
+    PCGH05    DGAS05             -1.   BCOL05          -1.826
+    PCGH05    BGAS05              1.   KCGH05              1.
+    PCGH05    KCGH06             -1.
+    PHYD05    DELE05             -1.   BELE05              .9
+    PHYD05    KHYD05        1.923077   KHYD06       -1.923077
+    PHYD05    NRGP05         -10.355
+    PGEO05    DELE05             -1.   BELE05              .9
+    PGEO05    KGEO05         1.17647   KGEO06        -1.17647
+    PGEO05    NRGP05         -10.355
+    POF105    OVXT05              1.   KODR05           1800.
+    POF105    BOIP05            78.6   KODR06          -1800.
+    POF105    BOIP06           -78.6
+    POF205    OVXT05              1.   KODR05           3600.
+    POF205    BOIP05           136.5   KODR06          -3600.
+    POF205    BOIP06          -136.5
+    POF305    OVXT05              1.   KODR05           5400.
+    POF305    BOIP05           166.7   KODR06          -5400.
+    POF305    BOIP06          -166.7
+    PODR05    KODR05             -1.   ECAP05          -.0058
+    PODR05    CEEA05           .0058
+    POIP05    BOIP05             -1.   OSRB05          .00351
+    POIP05    OTRB05          .00039   ODPL05           .0135
+    POIP05    BORS06           .3135   OSRB06          .05065
+    POIP05    OTRB06          .04056   OSRB07          .01108
+    POIP05    OTRB07          .01525
+    POF405    OVXT05              1.   KODR05           7200.
+    POF405    BOIP05           182.6   KODR06          -7200.
+    POF405    BOIP06          -182.6
+    POF505    OVXT05              1.   KODR05           9000.
+    POF505    BOIP05           190.9   KODR06          -9000.
+    POF505    BOIP06          -190.9
+    POF605    OVXT05              1.   KODR05          10800.
+    POF605    BOIP05           195.2   KODR06         -10800.
+    POF605    BOIP06          -195.2
+    POF705    OVXT05              1.   KODR05          12600.
+    POF705    BOIP05           197.5   KODR06         -12600.
+    POF705    BOIP06          -197.5
+    PPOR05    ODPL05            .094   BORS05             -1.
+    PPOR05    BORS06              1.
+    PSRN05    OSRB05             -1.   OSRB06              1.
+    PSRA05    OSRB05             -1.   ODPL05            .043
+    PSRA05    BORS06              1.   ECAP05          -.1938
+    PSRA05    CEEA05           .1938
+    PTRN05    OTRB05             -1.   OTRB06              1.
+    PTRA05    OTRB05             -1.   ODPL05            .043
+    PTRA05    BORS06              1.   ECAP05           -.354
+    PTRA05    CEEA05            .354
+    PGF105    GVXT05              1.   KGDR05           1426.
+    PGF105    BGSF05            275.   KGDR06          -1426.
+    PGF105    BGSF06           -275.
+    PGF205    GVXT05              1.   KGDR05           2000.
+    PGF205    BGSF05      366.099854   KGDR06          -2000.
+    PGF205    BGSF06     -366.099854
+    PGF305    GVXT05              1.   KGDR05           3000.
+    PGF305    BGSF05      458.799805   KGDR06          -3000.
+    PGF305    BGSF06     -458.799805
+    PGDR05    KGDR05             -1.   ECAP05          -.0058
+    PGDR05    CEEA05           .0058
+    PGRA05    BGSF05             -1.   GDPL05            .043
+    PGRA05    BGRS06              1.
+    PGF405    GVXT05              1.   KGDR05           4000.
+    PGF405    BGSF05      504.599854   KGDR06          -4000.
+    PGF405    BGSF06     -504.599854
+    PGF505    GVXT05              1.   KGDR05           5000.
+    PGF505    BGSF05           527.5   KGDR06          -5000.
+    PGF505    BGSF06          -527.5
+    PGF605    GVXT05              1.   KGDR05           6000.
+    PGF605    BGSF05      538.899902   KGDR06          -6000.
+    PGF605    BGSF06     -538.899902
+    PGF705    GVXT05              1.   KGDR05           7000.
+    PGF705    BGSF05           544.5   KGDR06          -7000.
+    PGF705    BGSF06          -544.5
+    PGF805    GVXT05              1.   KGDR05           8000.
+    PGF805    BGSF05      547.299805   KGDR06          -8000.
+    PGF805    BGSF06     -547.299805
+    PPGR05    GDPL05            .094   BGRS05             -1.
+    PPGR05    BGRS06              1.
+    PGPR05    GDPL05             -1.   BCRO05            .198
+    PGPR05    BGAS05             .85   BGRS06             -5.
+    PGPR05    DCRO05          -1.198   DGAS05             -1.
+    PGPR05    NRGP05          -1.198
+    POPR05    ODPL05           -.167   BCRO05              1.
+    POPR05    BGAS05          .15555   BORS06           -.835
+    POPR05    DCRO05          -1.183   DGAS05           -.183
+    POPR05    NRGP05          -1.183
+    PNRG05    NRGP05              1.
+    UCOL05    BCOL05             -1.
+    UCRO05    BCRO05             -1.
+    UROP05    BROP05             -1.
+    UGAS05    BGAS05             -1.
+    UELE05    BELE05             -1.
+    NURC05    MURC05             -1.   MURC06              1.
+    NURE05    MURE05             -1.   MURE06              1.
+    NURF05    MURF05             -1.   MURF06              1.
+    NPLU05    MPLU05             -1.   MPLU06              1.
+    NTLN05    MTLN05             -1.   MTLN06              1.
+    NSPF05    MSPF05             -1.   MSPF06              1.
+    UR105     MURN05      242.307831   RMMC05      242.307831
+    UR105     URXT05              1.   MURN06     -242.307831
+    UR105     RMMC06     -242.307831
+    UR205     MURN05      661.538818   RMMC05      681.538818
+    UR205     URXT05              1.   MURN06     -661.538818
+    UR205     RMMC06     -681.538818
+    UR305     MURN05     1288.462158   RMMC05     1523.077637
+    UR305     URXT05              1.   MURN06    -1288.462158
+    UR305     RMMC06    -1523.077637
+    UR405     MURN05     1950.000977   RMMC05     3084.617188
+    UR405     URXT05              1.   MURN06    -1950.000977
+    UR405     RMMC06    -3084.617188
+    UR505     MURN05     3638.463623   RMMC05     10114.62109
+    UR505     URXT05              1.   MURN06    -3638.463623
+    UR505     RMMC06    -10114.62109
+    UR605     MURN05     5438.460938   RMMC05     23614.62891
+    UR605     URXT05              1.   MURN06    -5438.460938
+    UR605     RMMC06    -23614.62891
+    ICOL05    BCOL05              1.   BIMP05          -1000.
+    ICRO05    BCRO05              1.   BIMP05    -1500.029785
+    IROP05    BROP05              1.   BIMP05    -1500.029785
+    IGAS05    BGAS05              1.   BIMP05    -1875.037109
+    IELE05    BELE05              1.   BIMP05    -15532.80469
+    JCOL05    BCOL05              1.   NRGP05             -1.
+    JCOL05    ECAP05          -3.333   CEEA05           3.333
+    JCRO05    BCRO05              1.   NRGP05             -1.
+    JCRO05    ECAP05          -3.333   CEEA05           3.333
+    JROP05    BROP05              1.   NRGP05             -1.
+    JROP05    ECAP05          -3.333   CEEA05           3.333
+    JGAS05    BGAS05              1.   NRGP05             -1.
+    JGAS05    ECAP05          -3.333   CEEA05           3.333
+    E1COL05   BCOL05             -1.   BTAW05      -85.984146
+    E1COL05   BTRD05       -3.289011   BEXP05           1000.
+    E1CRO05   BCRO05             -1.   BTAW05      -30.625748
+    E1CRO05   BEXP05     1500.029785
+    E1ROP05   BROP05             -1.   BTAW05      -70.309738
+    E1ROP05   BTRD05     -230.550491   BEXP05     1500.029785
+    E1GAS05   BGAS05             -1.   BTAW05      -76.420792
+    E1GAS05   BTRD05       -49.76236   BEXP05     1875.037109
+    E1ELE05   BELE05             -1.   BTRD05     -937.608643
+    E1ELE05   BEXP05     15532.80469
+    XCOL05    DCOL05        4.438329   BELE05        -.001258
+    XCOL05    BROP05        -.009637   BMNG05      -10.737742
+    XCOL05    BEIM05      -43.582611   BENM05      -30.318329
+    XCOL05    BTAW05       -8.842848   BTRD05     -121.652298
+    XCOL05    BMAC05      -41.056076   WRKF05         .046425
+    XCRO05    DCRO05        2.892097   BELE05        -.000506
+    XCRO05    BROP05        -.002062   BGAS05        -.007408
+    XCRO05    BMNG05      -34.323624   BEIM05      -29.450958
+    XCRO05    BENM05       -9.530361   BTAW05        -10.4619
+    XCRO05    BTRD05     -227.231018   BMAC05      -31.457352
+    XCRO05    WRKF05         .021354
+    XROP05    DROP05         .813213   BELE05         -.00034
+    XROP05    BCOL05        -.001514   BGAS05        -.025955
+    XROP05    BMNG05      -16.875412   BEIM05       -41.64917
+    XROP05    BENM05       -5.162801   BTAW05        -53.5159
+    XROP05    BTRD05      -81.333328   BMAC05       -3.506082
+    XROP05    WRKF05         .007051
+    XGAS05    DGAS05        1.380471   BELE05        -.000499
+    XGAS05    BCOL05        -.000874   BROP05        -.000706
+    XGAS05    BMNG05      -18.629242   BEIM05       -1.871531
+    XGAS05    BENM05        -.372872   BTAW05        -.243801
+    XGAS05    BTRD05      -47.828018   WRKF05         .005952
+    XELE05    DELE05         .054373   BAGR05       -1.282765
+    XELE05    BMNG05      -52.155487   BEIM05        -8.14335
+    XELE05    BENM05       -2.450525   BTAW05      -29.401871
+    XELE05    BTRD05     -148.124084   BMAC05       -3.821757
+    XELE05    WRKF05         .016189
+    XAGR05    KAGR05        1.111111   BCOL05        -.000272
+    XAGR05    BROP05        -.013459   BGAS05        -.000541
+    XAGR05    BELE05        -.000126   BAGR05      693.921387
+    XAGR05    BMNG05      -11.796776   BEIM05     -105.230377
+    XAGR05    BENM05       -8.735988   BTAW05      -19.273376
+    XAGR05    BTRD05       -132.6754   BMAC05       -6.567932
+    XAGR05    BIMP05        -.573897   KAGR06        -.888889
+    XMNG05    KMNG05        1.111111   BCOL05        -.000242
+    XMNG05    BROP05        -.014204   BGAS05        -.001392
+    XMNG05    BELE05        -.000107   BAGR05       -2.328505
+    XMNG05    BMNG05      972.447266   BEIM05     -134.663696
+    XMNG05    BENM05     -160.684525   BTAW05      -25.365646
+    XMNG05    BTRD05     -153.472351   BMAC05       -26.12706
+    XMNG05    BIMP05        -.894217   WRKF05         .038859
+    XMNG05    KMNG06        -.888889
+    XEIM05    KEIM05        1.111111   BCOL05        -.013438
+    XEIM05    BCRO05        -.000066   BROP05        -.008454
+    XEIM05    BGAS05        -.013222   BELE05        -.000464
+    XEIM05    BAGR05     -119.583542   BMNG05      -24.533279
+    XEIM05    BEIM05      731.984375   BENM05      -39.738663
+    XEIM05    BTAW05      -30.974686   BTRD05     -110.634079
+    XEIM05    BMAC05      -14.378268   BIMP05       -6.938498
+    XEIM05    WRKF05         .025369   KEIM06        -.888889
+    XENM05    KENM05        1.111111   BCOL05         -.00082
+    XENM05    BROP05        -.001697   BGAS05        -.003148
+    XENM05    BELE05        -.000273   BAGR05      -14.414824
+    XENM05    BMNG05       -5.079608   BEIM05     -159.277557
+    XENM05    BENM05       754.55127   BTAW05      -13.189252
+    XENM05    BTRD05      -99.108688   BMAC05      -34.243027
+    XENM05    BIMP05       -1.637574   WRKF05         .046102
+    XENM05    KENM06        -.888889
+    XTAW05    KTAW05        1.111111   BCOL05        -.000473
+    XTAW05    BCRO05        -.000166   BROP05        -.029984
+    XTAW05    BGAS05        -.001783   BELE05        -.000589
+    XTAW05    BAGR05        -.870055   BMNG05      -26.042328
+    XTAW05    BEIM05      -20.644028   BENM05      -10.381341
+    XTAW05    BTAW05      914.338867   BTRD05      -151.68219
+    XTAW05    BMAC05      -21.711823   BIMP05      -17.717484
+    XTAW05    WRKF05         .056178   KTAW06        -.888889
+    XTRD05    KTRD05        1.111111   BCOL05         -.00101
+    XTRD05    BCRO05        -.000086   BROP05        -.003869
+    XTRD05    BGAS05        -.003945   BELE05        -.000501
+    XTRD05    BAGR05       -5.705781   BMNG05       -18.54953
+    XTRD05    BEIM05      -23.171265   BENM05      -35.265518
+    XTRD05    BTAW05      -14.880653   BTRD05      825.474609
+    XTRD05    BMAC05       -8.531651   BIMP05       -1.058328
+    XTRD05    WRKF05         .073834   KTRD06        -.888889
+    XMAC05    KMAC05        1.111111   BCOL05        -.000958
+    XMAC05    BROP05        -.002366   BGAS05        -.002448
+    XMAC05    BELE05        -.000204   BMNG05       -8.258104
+    XMAC05    BEIM05     -132.072205   BENM05     -101.023422
+    XMAC05    BTAW05      -10.780818   BTRD05      -90.647217
+    XMAC05    BMAC05      747.764404   BIMP05        -.999022
+    XMAC05    WRKF05         .032378   KMAC06        -.888889
+    CONS05    OBJ          -1.019509   BIMP05          -19.51
+    CONS05    POPL05           1000.   DNRG05        -.014703
+    CONS05    BAGR05          -8.298   BMNG05      -66.047958
+    CONS05    BEIM05     -103.797958   BENM05     -115.218994
+    CONS05    BTAW05      -35.536987   BTRD05     -609.091797
+    CONS05    BMAC05      -41.043991
+    CNRG05    DNRG05              1.   BROP05          -.5806
+    CNRG05    BGAS05          -.2377   BELE05        -.053253
+    APCC05    POPL05          -254.5   UMOB05              1.
+    APCC05    UMOB06             -1.
+    GOVT05    BCOL05        -.001458   BROP05        -.006819
+    GOVT05    BGAS05        -.005441   BELE05        -.000551
+    GOVT05    BAGR05        7.501156   BMNG05     -179.188583
+    GOVT05    BEIM05      -29.199707   BENM05        -112.426
+    GOVT05    BTAW05      -24.609955   BTRD05     -552.763428
+    GOVT05    BMAC05      -89.739853   BIMP05         -22.646
+    CAPF05    BMNG05     -345.845703   BEIM05        -.755947
+    CAPF05    BENM05     -104.722321   BTAW05        -9.79188
+    CAPF05    BTRD05      -80.591064   BMAC05     -458.292969
+    CAPF05    BIMP05          -7.772   ECAP05              1.
+    XIMP05    BIMP05              1.   BTRB05             -1.
+    XIMP05    LTAW05          -.0334
+    XEXP05    BEXP05             -1.   BTRB05              1.
+    IAGR05    BAGR05              1.   BTAW05        -.123939
+    IAGR05    BTRD05        -.097273   BIMP05             -1.
+    IMNG05    BMNG05              1.   BTAW05        -.144599
+    IMNG05    BTRD05        -.031359   BIMP05             -1.
+    IEIM05    BEIM05              1.   BTAW05        -.038321
+    IEIM05    BTRD05         -.05912   BIMP05             -1.
+    IENM05    BENM05              1.   BTAW05        -.019188
+    IENM05    BTRD05        -.084225   BIMP05             -1.
+    ITAW05    BTAW05              1.   BIMP05             -1.
+    ITAW05    LTAW05              1.
+    ITRD05    BTRD05              1.   BIMP05             -1.
+    IMAC05    BTAW05        -.015658   BTRD05        -.099167
+    IMAC05    BMAC05              1.   BIMP05             -1.
+    E1AGR05   BAGR05        -.818859   BTAW05        -.101489
+    E1AGR05   BTRD05        -.079653   BEXP05              1.
+    E1MNG05   BMNG05         -.85037   BTAW05        -.122963
+    E1MNG05   BTRD05        -.026667   BEXP05              1.
+    E1EIM05   BEIM05        -.911211   BTAW05        -.034918
+    E1EIM05   BTRD05        -.053871   BEXP05              1.
+    E1ENM05   BENM05        -.906279   BTAW05         -.01739
+    E1ENM05   BTRD05        -.076332   BEXP05              1.
+    E1TAW05   BTAW05             -1.   BEXP05              1.
+    E1TRD05   BTRD05             -1.   BEXP05              1.
+    E1MAC05   BTAW05        -.014045   BTRD05        -.088953
+    E1MAC05   BMAC05        -.897002   BEXP05              1.
+    E2AGR05   BAGR05        -.818859   BTAW05        -.101489
+    E2AGR05   BTRD05        -.079653   BEXP05         .401143
+    E2MNG05   BMNG05         -.85037   BTAW05        -.122963
+    E2MNG05   BTRD05        -.026667   BEXP05         .715021
+    E2EIM05   BEIM05        -.911211   BTAW05        -.034918
+    E2EIM05   BTRD05        -.053871   BEXP05         .604231
+    E2ENM05   BENM05        -.906279   BTAW05         -.01739
+    E2ENM05   BTRD05        -.076332   BEXP05         .515274
+    E2TAW05   BTAW05             -1.
+    E2TRD05   BTRD05             -1.
+    E2MAC05   BTAW05        -.014045   BTRD05        -.088953
+    E2MAC05   BMAC05        -.897002   BEXP05         .607638
+    ULWR05    KLWR05              1.   KLWR06             -1.
+    ULWP05    KLWP05              1.   KLWP06             -1.
+    UMMC05    KMMC05              1.   KMMC06             -1.
+    UENR05    KENR05              1.   KENR06             -1.
+    UFBR05    KFBR05              1.   KFBR06             -1.
+    URPR05    KRPR05              1.   KRPR06             -1.
+    UECM05    KECM05              1.   KECM06             -1.
+    UWCM05    KWCM05              1.   KWCM06             -1.
+    UCLQ05    KCLQ05              1.   KCLQ06             -1.
+    UREF05    KREF05              1.   KREF06             -1.
+    UOSE05    KOSE05              1.   KOSE06             -1.
+    UCFP05    KCFP05              1.   KCFP06             -1.
+    UOFP05    KOFP05              1.   KOFP06             -1.
+    UGFP05    KGFP05              1.   KGFP06             -1.
+    UCGL05    KCGL05              1.   KCGL06             -1.
+    UCGH05    KCGH05              1.   KCGH06             -1.
+    UHYD05    KHYD05              1.   KHYD06             -1.
+    UGEO05    KGEO05              1.   KGEO06             -1.
+    UAGR05    KAGR05              1.   KAGR06             -.8
+    UMNG05    KMNG05              1.   KMNG06             -.8
+    UEIM05    KEIM05              1.   KEIM06             -.8
+    UENM05    KENM05              1.   KENM06             -.8
+    UTAW05    KTAW05              1.   KTAW06             -.8
+    UTRD05    KTRD05              1.   KTRD06             -.8
+    UMAC05    KMAC05              1.   KMAC06             -.8
+    WLWR05    MURF06       -9.838104   MURF07      -39.352417
+    WLWR05    ECAP05      -33.585495   CEEA05       33.585495
+    WLWR05    ETDE05      -23.509842   KLWR06             -1.
+    WLWR05    KLWR07             -4.
+    WLWP05    MURN06       -8.921747   MPLU06        -.276048
+    WLWP05    MURN07      -35.686981   MPLU07       -1.104192
+    WLWP05    ECAP05      -34.432404   CEEA05       34.432404
+    WLWP05    ETDE05      -24.102676   KLWP06             -1.
+    WLWP05    KLWP07             -4.
+    WMMC05    ECAP05        -.032029   CEEA05         .032029
+    WMMC05    KMMC06             -3.   KMMC07             -2.
+    WENR05    ECAP05        -.224371   CEEA05         .224371
+    WENR05    KENR07             -4.   KENR08             -1.
+    WFBR05    MPLU06        -.465639   MTLN06       -5.033102
+    WFBR05    MPLU07       -1.862556   MTLN07      -20.132416
+    WFBR05    ECAP05      -44.428299   CEEA05       44.428299
+    WFBR05    ETDE05      -31.099808   KFBR06             -1.
+    WFBR05    KFBR07             -4.
+    WRPR05    ECAP05       -2.096846   CEEA05        2.096846
+    WRPR05    KRPR07             -4.   KRPR08             -1.
+    WECM05    ECAP05        -.014564   CEEA05         .014564
+    WECM05    KECM06             -4.   KECM07             -1.
+    WWCM05    ECAP05        -.005172   CEEA05         .005172
+    WWCM05    KWCM06             -5.
+    WCLQ05    ECAP05       -6.160605   CEEA05        6.160605
+    WCLQ05    KCLQ06             -5.
+    WREF05    ECAP05        -.481851   CEEA05         .481851
+    WREF05    KREF06             -5.
+    WOSE05    ECAP05       -1.682063   CEEA05        1.682063
+    WOSE05    KOSE06             -5.
+    WCFP05    ECAP05      -23.936646   CEEA05       23.936646
+    WCFP05    ETDE05      -16.755646   KCFP06             -3.
+    WCFP05    KCFP07             -2.
+    WOFP05    ECAP05      -17.952484   CEEA05       17.952484
+    WOFP05    ETDE05      -12.566738   KOFP06             -4.
+    WOFP05    KOFP07             -1.
+    WGFP05    ECAP05      -10.970949   CEEA05       10.970949
+    WGFP05    ETDE05       -7.679664   KGFP06             -4.
+    WGFP05    KGFP07             -1.
+    WCGL05    ECAP05      -75.702805   CEEA05       75.702805
+    WCGL05    ETDE05      -52.991959   KCGL06             -5.
+    WCGH05    ECAP05       -6.383089   CEEA05        6.383089
+    WCGH05    KCGH06             -5.
+    WHYD05    ECAP05      -33.710693   CEEA05       33.710693
+    WHYD05    ETDE05      -23.597473   KHYD06             -5.
+    WGEO05    ECAP05      -47.873169   CEEA05       47.873169
+    WGEO05    ETDE05      -33.511215   KGEO06             -5.
+    WTDE05    ECAP05             -1.   CEEA05              1.
+    WTDE05    ETDE05              1.
+    WAGR05    ECAP05        -1.14185   CNEA05         1.14185
+    WAGR05    KAGR05             -1.   KAGR06             -4.
+    WMNG05    ECAP05        -.290702   CNEA05         .290702
+    WMNG05    KMNG05             -1.   KMNG06             -4.
+    WEIM05    ECAP05         -.64485   CNEA05          .64485
+    WEIM05    KEIM05             -1.   KEIM06             -4.
+    WENM05    ECAP05        -.403625   CNEA05         .403625
+    WENM05    KENM05             -1.   KENM06             -4.
+    WTAW05    ECAP05        -1.41581   CNEA05         1.41581
+    WTAW05    KTAW05             -1.   KTAW06             -4.
+    WTRD05    ECAP05        -1.08414   CNEA05         1.08414
+    WTRD05    KTRD05             -1.   KTRD06             -4.
+    WMAC05    ECAP05        -.362214   CNEA05         .362214
+    WMAC05    KMAC05             -1.   KMAC06             -4.
+    KEEA06    TEEA06            -1.8   TEEA07              .8
+    KEEA06    TEEA05              1.   CEEA06             -1.
+    KNEA06    TNEA06            -1.8   TNEA07              .8
+    KNEA06    TNEA05              1.   CNEA06             -1.
+    PLWU06    DELE06             -1.   BELE06              .9
+    PLWU06    MURE06      -20.867584   MSPF06       20.867584
+    PLWU06    KLWR06        1.538461   KLWR07       -1.538461
+    PLWU06    NRGP06         -10.355   PELE06             -1.
+    PLWP06    DELE06             -1.   BELE06              .9
+    PLWP06    MURN06      -27.914734   MPLU06       -1.529699
+    PLWP06    MSPF06       29.444443   KLWP06        1.538461
+    PLWP06    KLWP07       -1.538461   NRGP06         -10.355
+    PLWP06    PELE06             -1.
+    PNR106    BELE06          -.0027   MURN06       -9.192495
+    PNR106    MURE06          1.2595   MTLN06           7.933
+    PNR106    KENR06              1.   KENR07             -1.
+    PNR206    BELE06          -.0027   MURC06          -8.261
+    PNR206    MURE06        1.459499   MTLN06        6.801496
+    PNR206    KENR06              1.   KENR07             -1.
+    PNR306    BELE06          -.0027   MURN06         -10.793
+    PNR306    MURF06        2.112499   MTLN06        8.680496
+    PNR306    KENR06              1.   KENR07             -1.
+    PMMC06    RMMC06             -5.   BMNG06           -15.4
+    PMMC06    KMMC06              1.   KMMC07             -1.
+    PFBR06    DELE06             -1.   BELE06              .9
+    PFBR06    MPLU06         -1.3775   MTLN06      -15.662098
+    PFBR06    KFBR06        1.538461   KFBR07       -1.538461
+    PFBR06    NRGP06         -10.355   PELE06             -1.
+    PRPR06    MURC06          27.715   MPLU06            1.11
+    PRPR06    MTLN06       19.069992   MSPF06            -50.
+    PRPR06    KRPR06              1.   KRPR07             -1.
+    PECM06    DCOL06          -.0258   BCOL06           .0258
+    PECM06    KECM06              1.   KECM07             -1.
+    PECM06    NRGP06          -.0258
+    PWCM06    DCOL06           -.016   BCOL06            .016
+    PWCM06    KWCM06              1.   KWCM07             -1.
+    PWCM06    NRGP06           -.016
+    PCLQ06    DROP06             -1.   BCOL06          -1.575
+    PCLQ06    BROP06              1.   KCLQ06              1.
+    PCLQ06    KCLQ07             -1.
+    PREF06    DROP06           -.549   BCRO06             -.6
+    PREF06    BROP06            .549   KREF06              1.
+    PREF06    KREF07             -1.
+    POSE06    DCRO06             -.6   BCRO06              .6
+    POSE06    KOSE06              1.   KOSE07             -1.
+    POSE06    NRGP06             -.6
+    PCFP06    DELE06             -1.   BCOL06         -10.355
+    PCFP06    BELE06              .9   KCFP06        1.851851
+    PCFP06    KCFP07       -1.851851   PELE06              1.
+    POFP06    DELE06             -1.   BROP06         -10.355
+    POFP06    BELE06              .9   KOFP06              2.
+    POFP06    KOFP07             -2.
+    PGFP06    DELE06             -1.   BGAS06         -10.355
+    PGFP06    BELE06              .9   KGFP06              2.
+    PGFP06    KGFP07             -2.
+    PCGL06    DELE06             -1.   BCOL06         -15.986
+    PCGL06    BELE06              .9   KCGL06              1.
+    PCGL06    KCGL07             -1.
+    PCGH06    DGAS06             -1.   BCOL06          -1.826
+    PCGH06    BGAS06              1.   KCGH06              1.
+    PCGH06    KCGH07             -1.
+    PHYD06    DELE06             -1.   BELE06              .9
+    PHYD06    KHYD06        1.960784   KHYD07       -1.960784
+    PHYD06    NRGP06         -10.355
+    PGEO06    DELE06             -1.   BELE06              .9
+    PGEO06    KGEO06         1.17647   KGEO07        -1.17647
+    PGEO06    NRGP06         -10.355
+    POF106    OVXT06              1.   KODR06           1800.
+    POF106    BOIP06            78.6   KODR07          -1800.
+    POF106    BOIP07           -78.6
+    POF206    OVXT06              1.   KODR06           3600.
+    POF206    BOIP06           136.5   KODR07          -3600.
+    POF206    BOIP07          -136.5
+    POF306    OVXT06              1.   KODR06           5400.
+    POF306    BOIP06           166.7   KODR07          -5400.
+    POF306    BOIP07          -166.7
+    PODR06    KODR06             -1.   ECAP06          -.0058
+    PODR06    CEEA06           .0058
+    POIP06    BOIP06             -1.   OSRB06          .00351
+    POIP06    OTRB06          .00039   ODPL06           .0135
+    POIP06    BORS07           .3135   OSRB07          .05065
+    POIP06    OTRB07          .04056   OSRB08          .01108
+    POIP06    OTRB08          .01525
+    POF406    OVXT06              1.   KODR06           7200.
+    POF406    BOIP06           182.6   KODR07          -7200.
+    POF406    BOIP07          -182.6
+    POF506    OVXT06              1.   KODR06           9000.
+    POF506    BOIP06           190.9   KODR07          -9000.
+    POF506    BOIP07          -190.9
+    POF606    OVXT06              1.   KODR06          10800.
+    POF606    BOIP06           195.2   KODR07         -10800.
+    POF606    BOIP07          -195.2
+    POF706    OVXT06              1.   KODR06          12600.
+    POF706    BOIP06           197.5   KODR07         -12600.
+    POF706    BOIP07          -197.5
+    PPOR06    ODPL06            .094   BORS06             -1.
+    PPOR06    BORS07              1.
+    PSRN06    OSRB06             -1.   OSRB07              1.
+    PSRA06    OSRB06             -1.   ODPL06            .043
+    PSRA06    BORS07              1.   ECAP06           -.212
+    PSRA06    CEEA06            .212
+    PTRN06    OTRB06             -1.   OTRB07              1.
+    PTRA06    OTRB06             -1.   ODPL06            .043
+    PTRA06    BORS07              1.   ECAP06           -.398
+    PTRA06    CEEA06            .398
+    PGF106    GVXT06              1.   KGDR06           1426.
+    PGF106    BGSF06            275.   KGDR07          -1426.
+    PGF106    BGSF07           -275.
+    PGF206    GVXT06              1.   KGDR06           2000.
+    PGF206    BGSF06      366.099854   KGDR07          -2000.
+    PGF206    BGSF07     -366.099854
+    PGF306    GVXT06              1.   KGDR06           3000.
+    PGF306    BGSF06      458.799805   KGDR07          -3000.
+    PGF306    BGSF07     -458.799805
+    PGDR06    KGDR06             -1.   ECAP06          -.0058
+    PGDR06    CEEA06           .0058
+    PGRA06    BGSF06             -1.   GDPL06            .043
+    PGRA06    BGRS07              1.
+    PGF406    GVXT06              1.   KGDR06           4000.
+    PGF406    BGSF06      504.599854   KGDR07          -4000.
+    PGF406    BGSF07     -504.599854
+    PGF506    GVXT06              1.   KGDR06           5000.
+    PGF506    BGSF06           527.5   KGDR07          -5000.
+    PGF506    BGSF07          -527.5
+    PGF606    GVXT06              1.   KGDR06           6000.
+    PGF606    BGSF06      538.899902   KGDR07          -6000.
+    PGF606    BGSF07     -538.899902
+    PGF706    GVXT06              1.   KGDR06           7000.
+    PGF706    BGSF06           544.5   KGDR07          -7000.
+    PGF706    BGSF07          -544.5
+    PGF806    GVXT06              1.   KGDR06           8000.
+    PGF806    BGSF06      547.299805   KGDR07          -8000.
+    PGF806    BGSF07     -547.299805
+    PPGR06    GDPL06            .094   BGRS06             -1.
+    PPGR06    BGRS07              1.
+    PGPR06    GDPL06             -1.   BCRO06            .198
+    PGPR06    BGAS06             .85   BGRS07             -5.
+    PGPR06    DCRO06          -1.198   DGAS06             -1.
+    PGPR06    NRGP06          -1.198
+    POPR06    ODPL06           -.167   BCRO06              1.
+    POPR06    BGAS06          .15555   BORS07           -.835
+    POPR06    DCRO06          -1.183   DGAS06           -.183
+    POPR06    NRGP06          -1.183
+    PNRG06    NRGP06              1.
+    UCOL06    BCOL06             -1.
+    UCRO06    BCRO06             -1.
+    UROP06    BROP06             -1.
+    UGAS06    BGAS06             -1.
+    UELE06    BELE06             -1.
+    NURC06    MURC06             -1.   MURC07              1.
+    NURE06    MURE06             -1.   MURE07              1.
+    NURF06    MURF06             -1.   MURF07              1.
+    NPLU06    MPLU06             -1.   MPLU07              1.
+    NTLN06    MTLN06             -1.   MTLN07              1.
+    NSPF06    MSPF06             -1.   MSPF07              1.
+    UR106     MURN06      242.307831   RMMC06      242.307831
+    UR106     URXT06              1.   MURN07     -242.307831
+    UR106     RMMC07     -242.307831
+    UR206     MURN06      661.538818   RMMC06      681.538818
+    UR206     URXT06              1.   MURN07     -661.538818
+    UR206     RMMC07     -681.538818
+    UR306     MURN06     1288.462158   RMMC06     1523.077637
+    UR306     URXT06              1.   MURN07    -1288.462158
+    UR306     RMMC07    -1523.077637
+    UR406     MURN06     1950.000977   RMMC06     3084.617188
+    UR406     URXT06              1.   MURN07    -1950.000977
+    UR406     RMMC07    -3084.617188
+    UR506     MURN06     3638.463623   RMMC06     10114.62109
+    UR506     URXT06              1.   MURN07    -3638.463623
+    UR506     RMMC07    -10114.62109
+    UR606     MURN06     5438.460938   RMMC06     23614.62891
+    UR606     URXT06              1.   MURN07    -5438.460938
+    UR606     RMMC07    -23614.62891
+    ICOL06    BCOL06              1.   BIMP06          -1000.
+    ICRO06    BCRO06              1.   BIMP06    -1500.029785
+    IROP06    BROP06              1.   BIMP06    -1500.029785
+    IGAS06    BGAS06              1.   BIMP06    -1875.037109
+    IELE06    BELE06              1.   BIMP06    -15532.80469
+    JCOL06    BCOL06              1.   NRGP06             -1.
+    JCOL06    ECAP06          -3.333   CEEA06           3.333
+    JCRO06    BCRO06              1.   NRGP06             -1.
+    JCRO06    ECAP06          -3.333   CEEA06           3.333
+    JROP06    BROP06              1.   NRGP06             -1.
+    JROP06    ECAP06          -3.333   CEEA06           3.333
+    JGAS06    BGAS06              1.   NRGP06             -1.
+    JGAS06    ECAP06          -3.333   CEEA06           3.333
+    E1COL06   BCOL06             -1.   BTAW06      -85.984146
+    E1COL06   BTRD06       -3.289011   BEXP06           1000.
+    E1CRO06   BCRO06             -1.   BTAW06      -30.625748
+    E1CRO06   BEXP06     1500.029785
+    E1ROP06   BROP06             -1.   BTAW06      -70.309738
+    E1ROP06   BTRD06     -230.550491   BEXP06     1500.029785
+    E1GAS06   BGAS06             -1.   BTAW06      -76.420792
+    E1GAS06   BTRD06       -49.76236   BEXP06     1875.037109
+    E1ELE06   BELE06             -1.   BTRD06     -937.608643
+    E1ELE06   BEXP06     15532.80469
+    XCOL06    DCOL06        4.438329   BELE06        -.001258
+    XCOL06    BROP06        -.009637   BMNG06      -10.737742
+    XCOL06    BEIM06      -43.582611   BENM06      -30.318329
+    XCOL06    BTAW06       -8.842848   BTRD06     -121.652298
+    XCOL06    BMAC06      -41.056076   WRKF06         .046425
+    XCRO06    DCRO06        2.892097   BELE06        -.000506
+    XCRO06    BROP06        -.002062   BGAS06        -.007408
+    XCRO06    BMNG06      -34.323624   BEIM06      -29.450958
+    XCRO06    BENM06       -9.530361   BTAW06        -10.4619
+    XCRO06    BTRD06     -227.231018   BMAC06      -31.457352
+    XCRO06    WRKF06         .021354
+    XROP06    DROP06         .813213   BELE06         -.00034
+    XROP06    BCOL06        -.001514   BGAS06        -.025955
+    XROP06    BMNG06      -16.875412   BEIM06       -41.64917
+    XROP06    BENM06       -5.162801   BTAW06        -53.5159
+    XROP06    BTRD06      -81.333328   BMAC06       -3.506082
+    XROP06    WRKF06         .007051
+    XGAS06    DGAS06        1.380471   BELE06        -.000499
+    XGAS06    BCOL06        -.000874   BROP06        -.000706
+    XGAS06    BMNG06      -18.629242   BEIM06       -1.871531
+    XGAS06    BENM06        -.372872   BTAW06        -.243801
+    XGAS06    BTRD06      -47.828018   WRKF06         .005952
+    XELE06    DELE06         .054373   BAGR06       -1.282765
+    XELE06    BMNG06      -52.155487   BEIM06        -8.14335
+    XELE06    BENM06       -2.450525   BTAW06      -29.401871
+    XELE06    BTRD06     -148.124084   BMAC06       -3.821757
+    XELE06    WRKF06         .016189
+    XAGR06    KAGR06        1.111111   BCOL06        -.000251
+    XAGR06    BROP06        -.012376   BGAS06        -.000497
+    XAGR06    BELE06        -.000116   BAGR06      693.921387
+    XAGR06    BMNG06      -11.796776   BEIM06     -105.230377
+    XAGR06    BENM06       -8.735988   BTAW06      -19.273376
+    XAGR06    BTRD06       -132.6754   BMAC06       -6.567932
+    XAGR06    BIMP06        -.573897   KAGR07        -.888889
+    XMNG06    KMNG06        1.111111   BCOL06        -.000223
+    XMNG06    BROP06        -.013061   BGAS06         -.00128
+    XMNG06    BELE06        -.000098   BAGR06       -2.328505
+    XMNG06    BMNG06      972.447266   BEIM06     -134.663696
+    XMNG06    BENM06     -160.684525   BTAW06      -25.365646
+    XMNG06    BTRD06     -153.472351   BMAC06       -26.12706
+    XMNG06    BIMP06        -.894217   WRKF06         .038859
+    XMNG06    KMNG07        -.888889
+    XEIM06    KEIM06        1.111111   BCOL06        -.012357
+    XEIM06    BCRO06        -.000061   BROP06        -.007774
+    XEIM06    BGAS06        -.012158   BELE06        -.000427
+    XEIM06    BAGR06     -119.583542   BMNG06      -24.533279
+    XEIM06    BEIM06      731.984375   BENM06      -39.738663
+    XEIM06    BTAW06      -30.974686   BTRD06     -110.634079
+    XEIM06    BMAC06      -14.378268   BIMP06       -6.938498
+    XEIM06    WRKF06         .025369   KEIM07        -.888889
+    XENM06    KENM06        1.111111   BCOL06        -.000754
+    XENM06    BROP06        -.001561   BGAS06        -.002894
+    XENM06    BELE06        -.000251   BAGR06      -14.414824
+    XENM06    BMNG06       -5.079608   BEIM06     -159.277557
+    XENM06    BENM06       754.55127   BTAW06      -13.189252
+    XENM06    BTRD06      -99.108688   BMAC06      -34.243027
+    XENM06    BIMP06       -1.637574   WRKF06         .046102
+    XENM06    KENM07        -.888889
+    XTAW06    KTAW06        1.111111   BCOL06        -.000435
+    XTAW06    BCRO06        -.000152   BROP06        -.027571
+    XTAW06    BGAS06        -.001639   BELE06        -.000541
+    XTAW06    BAGR06        -.870055   BMNG06      -26.042328
+    XTAW06    BEIM06      -20.644028   BENM06      -10.381341
+    XTAW06    BTAW06      914.338867   BTRD06      -151.68219
+    XTAW06    BMAC06      -21.711823   BIMP06      -17.717484
+    XTAW06    WRKF06         .056178   KTAW07        -.888889
+    XTRD06    KTRD06        1.111111   BCOL06        -.000929
+    XTRD06    BCRO06        -.000079   BROP06        -.003558
+    XTRD06    BGAS06        -.003628   BELE06        -.000461
+    XTRD06    BAGR06       -5.705781   BMNG06       -18.54953
+    XTRD06    BEIM06      -23.171265   BENM06      -35.265518
+    XTRD06    BTAW06      -14.880653   BTRD06      825.474609
+    XTRD06    BMAC06       -8.531651   BIMP06       -1.058328
+    XTRD06    WRKF06         .073834   KTRD07        -.888889
+    XMAC06    KMAC06        1.111111   BCOL06        -.000881
+    XMAC06    BROP06        -.002176   BGAS06        -.002251
+    XMAC06    BELE06        -.000188   BMNG06       -8.258104
+    XMAC06    BEIM06     -132.072205   BENM06     -101.023422
+    XMAC06    BTAW06      -10.780818   BTRD06      -90.647217
+    XMAC06    BMAC06      747.764404   BIMP06        -.999022
+    XMAC06    WRKF06         .032378   KMAC07        -.888889
+    CONS06    OBJ          -1.019509   BIMP06          -19.51
+    CONS06    POPL06           1000.   DNRG06         -.01352
+    CONS06    BAGR06          -8.298   BMNG06      -66.047958
+    CONS06    BEIM06     -103.797958   BENM06     -115.218994
+    CONS06    BTAW06      -35.536987   BTRD06     -609.091797
+    CONS06    BMAC06      -41.043991
+    CNRG06    DNRG06              1.   BROP06          -.5626
+    CNRG06    BGAS06          -.2306   BELE06         -.06061
+    APCC06    POPL06          -262.5   UMOB06              1.
+    APCC06    UMOB07             -1.
+    GOVT06    BCOL06        -.001458   BROP06        -.006819
+    GOVT06    BGAS06        -.005441   BELE06        -.000551
+    GOVT06    BAGR06        7.501156   BMNG06     -179.188583
+    GOVT06    BEIM06      -29.199707   BENM06        -112.426
+    GOVT06    BTAW06      -24.609955   BTRD06     -552.763428
+    GOVT06    BMAC06      -89.739853   BIMP06         -22.646
+    CAPF06    BMNG06     -345.845703   BEIM06        -.755947
+    CAPF06    BENM06     -104.722321   BTAW06        -9.79188
+    CAPF06    BTRD06      -80.591064   BMAC06     -458.292969
+    CAPF06    BIMP06          -7.772   ECAP06              1.
+    XIMP06    BIMP06              1.   BTRB06             -1.
+    XIMP06    LTAW06          -.0334
+    XEXP06    BEXP06             -1.   BTRB06              1.
+    IAGR06    BAGR06              1.   BTAW06        -.123939
+    IAGR06    BTRD06        -.097273   BIMP06             -1.
+    IMNG06    BMNG06              1.   BTAW06        -.144599
+    IMNG06    BTRD06        -.031359   BIMP06             -1.
+    IEIM06    BEIM06              1.   BTAW06        -.038321
+    IEIM06    BTRD06         -.05912   BIMP06             -1.
+    IENM06    BENM06              1.   BTAW06        -.019188
+    IENM06    BTRD06        -.084225   BIMP06             -1.
+    ITAW06    BTAW06              1.   BIMP06             -1.
+    ITAW06    LTAW06              1.
+    ITRD06    BTRD06              1.   BIMP06             -1.
+    IMAC06    BTAW06        -.015658   BTRD06        -.099167
+    IMAC06    BMAC06              1.   BIMP06             -1.
+    E1AGR06   BAGR06        -.818859   BTAW06        -.101489
+    E1AGR06   BTRD06        -.079653   BEXP06              1.
+    E1MNG06   BMNG06         -.85037   BTAW06        -.122963
+    E1MNG06   BTRD06        -.026667   BEXP06              1.
+    E1EIM06   BEIM06        -.911211   BTAW06        -.034918
+    E1EIM06   BTRD06        -.053871   BEXP06              1.
+    E1ENM06   BENM06        -.906279   BTAW06         -.01739
+    E1ENM06   BTRD06        -.076332   BEXP06              1.
+    E1TAW06   BTAW06             -1.   BEXP06              1.
+    E1TRD06   BTRD06             -1.   BEXP06              1.
+    E1MAC06   BTAW06        -.014045   BTRD06        -.088953
+    E1MAC06   BMAC06        -.897002   BEXP06              1.
+    E2AGR06   BAGR06        -.818859   BTAW06        -.101489
+    E2AGR06   BTRD06        -.079653   BEXP06         .401143
+    E2MNG06   BMNG06         -.85037   BTAW06        -.122963
+    E2MNG06   BTRD06        -.026667   BEXP06         .715021
+    E2EIM06   BEIM06        -.911211   BTAW06        -.034918
+    E2EIM06   BTRD06        -.053871   BEXP06         .604231
+    E2ENM06   BENM06        -.906279   BTAW06         -.01739
+    E2ENM06   BTRD06        -.076332   BEXP06         .515274
+    E2TAW06   BTAW06             -1.
+    E2TRD06   BTRD06             -1.
+    E2MAC06   BTAW06        -.014045   BTRD06        -.088953
+    E2MAC06   BMAC06        -.897002   BEXP06         .607638
+    ULWR06    KLWR06              1.   KLWR07             -1.
+    ULWP06    KLWP06              1.   KLWP07             -1.
+    UMMC06    KMMC06              1.   KMMC07             -1.
+    UENR06    KENR06              1.   KENR07             -1.
+    UFBR06    KFBR06              1.   KFBR07             -1.
+    URPR06    KRPR06              1.   KRPR07             -1.
+    UECM06    KECM06              1.   KECM07             -1.
+    UWCM06    KWCM06              1.   KWCM07             -1.
+    UCLQ06    KCLQ06              1.   KCLQ07             -1.
+    UREF06    KREF06              1.   KREF07             -1.
+    UOSE06    KOSE06              1.   KOSE07             -1.
+    UCFP06    KCFP06              1.   KCFP07             -1.
+    UOFP06    KOFP06              1.   KOFP07             -1.
+    UGFP06    KGFP06              1.   KGFP07             -1.
+    UCGL06    KCGL06              1.   KCGL07             -1.
+    UCGH06    KCGH06              1.   KCGH07             -1.
+    UHYD06    KHYD06              1.   KHYD07             -1.
+    UGEO06    KGEO06              1.   KGEO07             -1.
+    UAGR06    KAGR06              1.   KAGR07             -.8
+    UMNG06    KMNG06              1.   KMNG07             -.8
+    UEIM06    KEIM06              1.   KEIM07             -.8
+    UENM06    KENM06              1.   KENM07             -.8
+    UTAW06    KTAW06              1.   KTAW07             -.8
+    UTRD06    KTRD06              1.   KTRD07             -.8
+    UMAC06    KMAC06              1.   KMAC07             -.8
+    WLWR06    MURF07       -9.838104   MURF08      -39.352417
+    WLWR06    ECAP06      -33.585495   CEEA06       33.585495
+    WLWR06    ETDE06      -23.509842   KLWR07             -1.
+    WLWR06    KLWR08             -4.
+    WLWP06    MURN07       -8.921747   MPLU07        -.276048
+    WLWP06    MURN08      -35.686981   MPLU08       -1.104192
+    WLWP06    ECAP06      -34.432404   CEEA06       34.432404
+    WLWP06    ETDE06      -24.102676   KLWP07             -1.
+    WLWP06    KLWP08             -4.
+    WMMC06    ECAP06        -.032029   CEEA06         .032029
+    WMMC06    KMMC07             -3.   KMMC08             -2.
+    WENR06    ECAP06        -.224371   CEEA06         .224371
+    WENR06    KENR08             -4.
+    WFBR06    MPLU07        -.465639   MTLN07       -5.033102
+    WFBR06    MPLU08       -1.862556   MTLN08      -20.132416
+    WFBR06    ECAP06      -44.428299   CEEA06       44.428299
+    WFBR06    ETDE06      -31.099808   KFBR07             -1.
+    WFBR06    KFBR08             -4.
+    WRPR06    ECAP06       -2.096846   CEEA06        2.096846
+    WRPR06    KRPR08             -4.
+    WECM06    ECAP06        -.014564   CEEA06         .014564
+    WECM06    KECM07             -4.   KECM08             -1.
+    WWCM06    ECAP06        -.005172   CEEA06         .005172
+    WWCM06    KWCM07             -5.
+    WCLQ06    ECAP06       -6.160605   CEEA06        6.160605
+    WCLQ06    KCLQ07             -5.
+    WREF06    ECAP06        -.481851   CEEA06         .481851
+    WREF06    KREF07             -5.
+    WOSE06    ECAP06       -1.682063   CEEA06        1.682063
+    WOSE06    KOSE07             -5.
+    WCFP06    ECAP06      -23.936646   CEEA06       23.936646
+    WCFP06    ETDE06      -16.755646   KCFP07             -3.
+    WCFP06    KCFP08             -2.
+    WOFP06    ECAP06      -17.952484   CEEA06       17.952484
+    WOFP06    ETDE06      -12.566738   KOFP07             -4.
+    WOFP06    KOFP08             -1.
+    WGFP06    ECAP06      -10.970949   CEEA06       10.970949
+    WGFP06    ETDE06       -7.679664   KGFP07             -4.
+    WGFP06    KGFP08             -1.
+    WCGL06    ECAP06      -75.702805   CEEA06       75.702805
+    WCGL06    ETDE06      -52.991959   KCGL07             -5.
+    WCGH06    ECAP06       -6.383089   CEEA06        6.383089
+    WCGH06    KCGH07             -5.
+    WHYD06    ECAP06      -33.710693   CEEA06       33.710693
+    WHYD06    ETDE06      -23.597473   KHYD07             -5.
+    WGEO06    ECAP06      -47.873169   CEEA06       47.873169
+    WGEO06    ETDE06      -33.511215   KGEO07             -5.
+    WTDE06    ECAP06             -1.   CEEA06              1.
+    WTDE06    ETDE06              1.
+    WAGR06    ECAP06        -1.14185   CNEA06         1.14185
+    WAGR06    KAGR06             -1.   KAGR07             -4.
+    WMNG06    ECAP06        -.290702   CNEA06         .290702
+    WMNG06    KMNG06             -1.   KMNG07             -4.
+    WEIM06    ECAP06         -.64485   CNEA06          .64485
+    WEIM06    KEIM06             -1.   KEIM07             -4.
+    WENM06    ECAP06        -.403625   CNEA06         .403625
+    WENM06    KENM06             -1.   KENM07             -4.
+    WTAW06    ECAP06        -1.41581   CNEA06         1.41581
+    WTAW06    KTAW06             -1.   KTAW07             -4.
+    WTRD06    ECAP06        -1.08414   CNEA06         1.08414
+    WTRD06    KTRD06             -1.   KTRD07             -4.
+    WMAC06    ECAP06        -.362214   CNEA06         .362214
+    WMAC06    KMAC06             -1.   KMAC07             -4.
+    KEEA07    TEEA07            -1.8   TEEA06              1.
+    KEEA07    CEEA07             -1.
+    KNEA07    TNEA07            -1.8   TNEA06              1.
+    KNEA07    CNEA07             -1.
+    PLWU07    DELE07             -1.   BELE07              .9
+    PLWU07    MURE07      -20.867584   MSPF07       20.867584
+    PLWU07    KLWR07        1.538461   KLWR08       -1.538461
+    PLWU07    NRGP07         -10.355   PELE07             -1.
+    PLWP07    DELE07             -1.   BELE07              .9
+    PLWP07    MURN07      -27.914734   MPLU07       -1.529699
+    PLWP07    MSPF07       29.444443   KLWP07        1.538461
+    PLWP07    KLWP08       -1.538461   NRGP07         -10.355
+    PLWP07    PELE07             -1.
+    PNR107    BELE07          -.0027   MURN07       -9.192495
+    PNR107    MURE07          1.2595   MTLN07           7.933
+    PNR107    KENR07              1.   KENR08             -1.
+    PNR207    BELE07          -.0027   MURC07          -8.261
+    PNR207    MURE07        1.459499   MTLN07        6.801496
+    PNR207    KENR07              1.   KENR08             -1.
+    PNR307    BELE07          -.0027   MURN07         -10.793
+    PNR307    MURF07        2.112499   MTLN07        8.680496
+    PNR307    KENR07              1.   KENR08             -1.
+    PMMC07    RMMC07             -5.   BMNG07           -15.4
+    PMMC07    KMMC07              1.   KMMC08             -1.
+    PFBR07    DELE07             -1.   BELE07              .9
+    PFBR07    MPLU07         -1.3775   MTLN07      -15.662098
+    PFBR07    KFBR07        1.538461   KFBR08       -1.538461
+    PFBR07    NRGP07         -10.355   PELE07             -1.
+    PRPR07    MURC07          27.715   MPLU07            1.11
+    PRPR07    MTLN07       19.069992   MSPF07            -50.
+    PRPR07    KRPR07              1.   KRPR08             -1.
+    PECM07    DCOL07          -.0258   BCOL07           .0258
+    PECM07    KECM07              1.   KECM08             -1.
+    PECM07    NRGP07          -.0258
+    PWCM07    DCOL07           -.016   BCOL07            .016
+    PWCM07    KWCM07              1.   KWCM08             -1.
+    PWCM07    NRGP07           -.016
+    PCLQ07    DROP07             -1.   BCOL07          -1.575
+    PCLQ07    BROP07              1.   KCLQ07              1.
+    PCLQ07    KCLQ08             -1.
+    PREF07    DROP07           -.549   BCRO07             -.6
+    PREF07    BROP07            .549   KREF07              1.
+    PREF07    KREF08             -1.
+    POSE07    DCRO07             -.6   BCRO07              .6
+    POSE07    KOSE07              1.   KOSE08             -1.
+    POSE07    NRGP07             -.6
+    PCFP07    DELE07             -1.   BCOL07         -10.355
+    PCFP07    BELE07              .9   KCFP07        1.851851
+    PCFP07    KCFP08       -1.851851   PELE07              1.
+    POFP07    DELE07             -1.   BROP07         -10.355
+    POFP07    BELE07              .9   KOFP07              2.
+    POFP07    KOFP08             -2.
+    PGFP07    DELE07             -1.   BGAS07         -10.355
+    PGFP07    BELE07              .9   KGFP07              2.
+    PGFP07    KGFP08             -2.
+    PCGL07    DELE07             -1.   BCOL07         -15.986
+    PCGL07    BELE07              .9   KCGL07              1.
+    PCGL07    KCGL08             -1.
+    PCGH07    DGAS07             -1.   BCOL07          -1.826
+    PCGH07    BGAS07              1.   KCGH07              1.
+    PCGH07    KCGH08             -1.
+    PHYD07    DELE07             -1.   BELE07              .9
+    PHYD07    KHYD07        1.960784   KHYD08       -1.960784
+    PHYD07    NRGP07         -10.355
+    PGEO07    DELE07             -1.   BELE07              .9
+    PGEO07    KGEO07         1.17647   KGEO08        -1.17647
+    PGEO07    NRGP07         -10.355
+    POF107    OVXT07              1.   KODR07           1800.
+    POF107    BOIP07            78.6   KODR08          -1800.
+    POF107    BOIP08           -78.6
+    POF207    OVXT07              1.   KODR07           3600.
+    POF207    BOIP07           136.5   KODR08          -3600.
+    POF207    BOIP08          -136.5
+    POF307    OVXT07              1.   KODR07           5400.
+    POF307    BOIP07           166.7   KODR08          -5400.
+    POF307    BOIP08          -166.7
+    PODR07    KODR07             -1.   ECAP07           -.006
+    PODR07    CEEA07            .006
+    POIP07    BOIP07             -1.   OSRB07          .00351
+    POIP07    OTRB07          .00039   ODPL07           .0135
+    POIP07    BORS08           .3135   OSRB08          .05065
+    POIP07    OTRB08          .04056
+    POF407    OVXT07              1.   KODR07           7200.
+    POF407    BOIP07           182.6   KODR08          -7200.
+    POF407    BOIP08          -182.6
+    POF507    OVXT07              1.   KODR07           9000.
+    POF507    BOIP07           190.9   KODR08          -9000.
+    POF507    BOIP08          -190.9
+    POF607    OVXT07              1.   KODR07          10800.
+    POF607    BOIP07           195.2   KODR08         -10800.
+    POF607    BOIP08          -195.2
+    POF707    OVXT07              1.   KODR07          12600.
+    POF707    BOIP07           197.5   KODR08         -12600.
+    POF707    BOIP08          -197.5
+    PPOR07    ODPL07            .094   BORS07             -1.
+    PPOR07    BORS08              1.
+    PSRN07    OSRB07             -1.   OSRB08              1.
+    PSRA07    OSRB07             -1.   ODPL07            .043
+    PSRA07    BORS08              1.   ECAP07           -.228
+    PSRA07    CEEA07            .228
+    PTRN07    OTRB07             -1.   OTRB08              1.
+    PTRA07    OTRB07             -1.   ODPL07            .043
+    PTRA07    BORS08              1.   ECAP07           -.442
+    PTRA07    CEEA07            .442
+    PGF107    GVXT07              1.   KGDR07           1426.
+    PGF107    BGSF07            275.   KGDR08          -1426.
+    PGF107    BGSF08           -275.
+    PGF207    GVXT07              1.   KGDR07           2000.
+    PGF207    BGSF07      366.099854   KGDR08          -2000.
+    PGF207    BGSF08     -366.099854
+    PGF307    GVXT07              1.   KGDR07           3000.
+    PGF307    BGSF07      458.799805   KGDR08          -3000.
+    PGF307    BGSF08     -458.799805
+    PGDR07    KGDR07             -1.   ECAP07           -.006
+    PGDR07    CEEA07            .006
+    PGRA07    BGSF07             -1.   GDPL07            .043
+    PGRA07    BGRS08              1.
+    PGF407    GVXT07              1.   KGDR07           4000.
+    PGF407    BGSF07      504.599854   KGDR08          -4000.
+    PGF407    BGSF08     -504.599854
+    PGF507    GVXT07              1.   KGDR07           5000.
+    PGF507    BGSF07           527.5   KGDR08          -5000.
+    PGF507    BGSF08          -527.5
+    PGF607    GVXT07              1.   KGDR07           6000.
+    PGF607    BGSF07      538.899902   KGDR08          -6000.
+    PGF607    BGSF08     -538.899902
+    PGF707    GVXT07              1.   KGDR07           7000.
+    PGF707    BGSF07           544.5   KGDR08          -7000.
+    PGF707    BGSF08          -544.5
+    PGF807    GVXT07              1.   KGDR07           8000.
+    PGF807    BGSF07      547.299805   KGDR08          -8000.
+    PGF807    BGSF08     -547.299805
+    PPGR07    GDPL07            .094   BGRS07             -1.
+    PPGR07    BGRS08              1.
+    PGPR07    GDPL07             -1.   BCRO07            .198
+    PGPR07    BGAS07             .85   BGRS08             -5.
+    PGPR07    DCRO07          -1.198   DGAS07             -1.
+    PGPR07    NRGP07          -1.198
+    POPR07    ODPL07           -.167   BCRO07              1.
+    POPR07    BGAS07          .15555   BORS08           -.835
+    POPR07    DCRO07          -1.183   DGAS07           -.183
+    POPR07    NRGP07          -1.183
+    PNRG07    NRGP07              1.
+    UCOL07    BCOL07             -1.
+    UCRO07    BCRO07             -1.
+    UROP07    BROP07             -1.
+    UGAS07    BGAS07             -1.
+    UELE07    BELE07             -1.
+    NURC07    MURC07             -1.   MURC08              1.
+    NURE07    MURE07             -1.   MURE08              1.
+    NURF07    MURF07             -1.   MURF08              1.
+    NPLU07    MPLU07             -1.   MPLU08              1.
+    NTLN07    MTLN07             -1.   MTLN08              1.
+    NSPF07    MSPF07             -1.   MSPF08              1.
+    UR107     MURN07      242.307831   RMMC07      242.307831
+    UR107     URXT07              1.   MURN08     -242.307831
+    UR107     RMMC08     -242.307831
+    UR207     MURN07      661.538818   RMMC07      681.538818
+    UR207     URXT07              1.   MURN08     -661.538818
+    UR207     RMMC08     -681.538818
+    UR307     MURN07     1288.462158   RMMC07     1523.077637
+    UR307     URXT07              1.   MURN08    -1288.462158
+    UR307     RMMC08    -1523.077637
+    UR407     MURN07     1950.000977   RMMC07     3084.617188
+    UR407     URXT07              1.   MURN08    -1950.000977
+    UR407     RMMC08    -3084.617188
+    UR507     MURN07     3638.463623   RMMC07     10114.62109
+    UR507     URXT07              1.   MURN08    -3638.463623
+    UR507     RMMC08    -10114.62109
+    UR607     MURN07     5438.460938   RMMC07     23614.62891
+    UR607     URXT07              1.   MURN08    -5438.460938
+    UR607     RMMC08    -23614.62891
+    ICOL07    BCOL07              1.   BIMP07          -1000.
+    ICRO07    BCRO07              1.   BIMP07    -1500.029785
+    IROP07    BROP07              1.   BIMP07    -1500.029785
+    IGAS07    BGAS07              1.   BIMP07    -1875.037109
+    IELE07    BELE07              1.   BIMP07    -15532.80469
+    JCOL07    BCOL07              1.   NRGP07             -1.
+    JCOL07    ECAP07          -3.333   CEEA07           3.333
+    JCRO07    BCRO07              1.   NRGP07             -1.
+    JCRO07    ECAP07          -3.333   CEEA07           3.333
+    JROP07    BROP07              1.   NRGP07             -1.
+    JROP07    ECAP07          -3.333   CEEA07           3.333
+    JGAS07    BGAS07              1.   NRGP07             -1.
+    JGAS07    ECAP07          -3.333   CEEA07           3.333
+    E1COL07   BCOL07             -1.   BTAW07      -85.984146
+    E1COL07   BTRD07       -3.289011   BEXP07           1000.
+    E1CRO07   BCRO07             -1.   BTAW07      -30.625748
+    E1CRO07   BEXP07     1500.029785
+    E1ROP07   BROP07             -1.   BTAW07      -70.309738
+    E1ROP07   BTRD07     -230.550491   BEXP07     1500.029785
+    E1GAS07   BGAS07             -1.   BTAW07      -76.420792
+    E1GAS07   BTRD07       -49.76236   BEXP07     1875.037109
+    E1ELE07   BELE07             -1.   BTRD07     -937.608643
+    E1ELE07   BEXP07     15532.80469
+    XCOL07    DCOL07        4.438329   BELE07        -.001258
+    XCOL07    BROP07        -.009637   BMNG07      -10.737742
+    XCOL07    BEIM07      -43.582611   BENM07      -30.318329
+    XCOL07    BTAW07       -8.842848   BTRD07     -121.652298
+    XCOL07    BMAC07      -41.056076   WRKF07         .046425
+    XCRO07    DCRO07        2.892097   BELE07        -.000506
+    XCRO07    BROP07        -.002062   BGAS07        -.007408
+    XCRO07    BMNG07      -34.323624   BEIM07      -29.450958
+    XCRO07    BENM07       -9.530361   BTAW07        -10.4619
+    XCRO07    BTRD07     -227.231018   BMAC07      -31.457352
+    XCRO07    WRKF07         .021354
+    XROP07    DROP07         .813213   BELE07         -.00034
+    XROP07    BCOL07        -.001514   BGAS07        -.025955
+    XROP07    BMNG07      -16.875412   BEIM07       -41.64917
+    XROP07    BENM07       -5.162801   BTAW07        -53.5159
+    XROP07    BTRD07      -81.333328   BMAC07       -3.506082
+    XROP07    WRKF07         .007051
+    XGAS07    DGAS07        1.380471   BELE07        -.000499
+    XGAS07    BCOL07        -.000874   BROP07        -.000706
+    XGAS07    BMNG07      -18.629242   BEIM07       -1.871531
+    XGAS07    BENM07        -.372872   BTAW07        -.243801
+    XGAS07    BTRD07      -47.828018   WRKF07         .005952
+    XELE07    DELE07         .054373   BAGR07       -1.282765
+    XELE07    BMNG07      -52.155487   BEIM07        -8.14335
+    XELE07    BENM07       -2.450525   BTAW07      -29.401871
+    XELE07    BTRD07     -148.124084   BMAC07       -3.821757
+    XELE07    WRKF07         .016189
+    XAGR07    KAGR07        1.111111   BCOL07        -.000232
+    XAGR07    BROP07        -.011448   BGAS07         -.00046
+    XAGR07    BELE07        -.000107   BAGR07      693.921387
+    XAGR07    BMNG07      -11.796776   BEIM07     -105.230377
+    XAGR07    BENM07       -8.735988   BTAW07      -19.273376
+    XAGR07    BTRD07       -132.6754   BMAC07       -6.567932
+    XAGR07    BIMP07        -.573897   KAGR08        -.888889
+    XMNG07    KMNG07        1.111111   BCOL07        -.000206
+    XMNG07    BROP07        -.012082   BGAS07        -.001184
+    XMNG07    BELE07        -.000091   BAGR07       -2.328505
+    XMNG07    BMNG07      972.447266   BEIM07     -134.663696
+    XMNG07    BENM07     -160.684525   BTAW07      -25.365646
+    XMNG07    BTRD07     -153.472351   BMAC07       -26.12706
+    XMNG07    BIMP07        -.894217   WRKF07         .038859
+    XMNG07    KMNG08        -.888889
+    XEIM07    KEIM07        1.111111   BCOL07         -.01143
+    XEIM07    BCRO07        -.000056   BROP07        -.007191
+    XEIM07    BGAS07        -.011246   BELE07        -.000395
+    XEIM07    BAGR07     -119.583542   BMNG07      -24.533279
+    XEIM07    BEIM07      731.984375   BENM07      -39.738663
+    XEIM07    BTAW07      -30.974686   BTRD07     -110.634079
+    XEIM07    BMAC07      -14.378268   BIMP07       -6.938498
+    XEIM07    WRKF07         .025369   KEIM08        -.888889
+    XENM07    KENM07        1.111111   BCOL07        -.000698
+    XENM07    BROP07        -.001444   BGAS07        -.002677
+    XENM07    BELE07        -.000232   BAGR07      -14.414824
+    XENM07    BMNG07       -5.079608   BEIM07     -159.277557
+    XENM07    BENM07       754.55127   BTAW07      -13.189252
+    XENM07    BTRD07      -99.108688   BMAC07      -34.243027
+    XENM07    BIMP07       -1.637574   WRKF07         .046102
+    XENM07    KENM08        -.888889
+    XTAW07    KTAW07        1.111111   BCOL07        -.000403
+    XTAW07    BCRO07        -.000141   BROP07        -.025503
+    XTAW07    BGAS07        -.001516   BELE07        -.000501
+    XTAW07    BAGR07        -.870055   BMNG07      -26.042328
+    XTAW07    BEIM07      -20.644028   BENM07      -10.381341
+    XTAW07    BTAW07      914.338867   BTRD07      -151.68219
+    XTAW07    BMAC07      -21.711823   BIMP07      -17.717484
+    XTAW07    WRKF07         .056178   KTAW08        -.888889
+    XTRD07    KTRD07        1.111111   BCOL07        -.000859
+    XTRD07    BCRO07        -.000073   BROP07        -.003291
+    XTRD07    BGAS07        -.003356   BELE07        -.000427
+    XTRD07    BAGR07       -5.705781   BMNG07       -18.54953
+    XTRD07    BEIM07      -23.171265   BENM07      -35.265518
+    XTRD07    BTAW07      -14.880653   BTRD07      825.474609
+    XTRD07    BMAC07       -8.531651   BIMP07       -1.058328
+    XTRD07    WRKF07         .073834   KTRD08        -.888889
+    XMAC07    KMAC07        1.111111   BCOL07        -.000815
+    XMAC07    BROP07        -.002013   BGAS07        -.002082
+    XMAC07    BELE07        -.000174   BMNG07       -8.258104
+    XMAC07    BEIM07     -132.072205   BENM07     -101.023422
+    XMAC07    BTAW07      -10.780818   BTRD07      -90.647217
+    XMAC07    BMAC07      747.764404   BIMP07        -.999022
+    XMAC07    WRKF07         .032378   KMAC08        -.888889
+    CONS07    OBJ          -1.019509   BIMP07          -19.51
+    CONS07    POPL07           1000.   DNRG07        -.012506
+    CONS07    BAGR07          -8.298   BMNG07      -66.047958
+    CONS07    BEIM07     -103.797958   BENM07     -115.218994
+    CONS07    BTAW07      -35.536987   BTRD07     -609.091797
+    CONS07    BMAC07      -41.043991
+    CNRG07    DNRG07              1.   BROP07          -.5443
+    CNRG07    BGAS07          -.2233   BELE07        -.068112
+    APCC07    POPL07     -270.399902   UMOB07              1.
+    APCC07    UMOB08             -1.
+    GOVT07    BCOL07        -.001458   BROP07        -.006819
+    GOVT07    BGAS07        -.005441   BELE07        -.000551
+    GOVT07    BAGR07        7.501156   BMNG07     -179.188583
+    GOVT07    BEIM07      -29.199707   BENM07        -112.426
+    GOVT07    BTAW07      -24.609955   BTRD07     -552.763428
+    GOVT07    BMAC07      -89.739853   BIMP07         -22.646
+    CAPF07    BMNG07     -345.845703   BEIM07        -.755947
+    CAPF07    BENM07     -104.722321   BTAW07        -9.79188
+    CAPF07    BTRD07      -80.591064   BMAC07     -458.292969
+    CAPF07    BIMP07          -7.772   ECAP07              1.
+    XIMP07    BIMP07              1.   BTRB07             -1.
+    XIMP07    LTAW07          -.0334
+    XEXP07    BEXP07             -1.   BTRB07              1.
+    IAGR07    BAGR07              1.   BTAW07        -.123939
+    IAGR07    BTRD07        -.097273   BIMP07             -1.
+    IMNG07    BMNG07              1.   BTAW07        -.144599
+    IMNG07    BTRD07        -.031359   BIMP07             -1.
+    IEIM07    BEIM07              1.   BTAW07        -.038321
+    IEIM07    BTRD07         -.05912   BIMP07             -1.
+    IENM07    BENM07              1.   BTAW07        -.019188
+    IENM07    BTRD07        -.084225   BIMP07             -1.
+    ITAW07    BTAW07              1.   BIMP07             -1.
+    ITAW07    LTAW07              1.
+    ITRD07    BTRD07              1.   BIMP07             -1.
+    IMAC07    BTAW07        -.015658   BTRD07        -.099167
+    IMAC07    BMAC07              1.   BIMP07             -1.
+    E1AGR07   BAGR07        -.818859   BTAW07        -.101489
+    E1AGR07   BTRD07        -.079653   BEXP07              1.
+    E1MNG07   BMNG07         -.85037   BTAW07        -.122963
+    E1MNG07   BTRD07        -.026667   BEXP07              1.
+    E1EIM07   BEIM07        -.911211   BTAW07        -.034918
+    E1EIM07   BTRD07        -.053871   BEXP07              1.
+    E1ENM07   BENM07        -.906279   BTAW07         -.01739
+    E1ENM07   BTRD07        -.076332   BEXP07              1.
+    E1TAW07   BTAW07             -1.   BEXP07              1.
+    E1TRD07   BTRD07             -1.   BEXP07              1.
+    E1MAC07   BTAW07        -.014045   BTRD07        -.088953
+    E1MAC07   BMAC07        -.897002   BEXP07              1.
+    E2AGR07   BAGR07        -.818859   BTAW07        -.101489
+    E2AGR07   BTRD07        -.079653   BEXP07         .401143
+    E2MNG07   BMNG07         -.85037   BTAW07        -.122963
+    E2MNG07   BTRD07        -.026667   BEXP07         .715021
+    E2EIM07   BEIM07        -.911211   BTAW07        -.034918
+    E2EIM07   BTRD07        -.053871   BEXP07         .604231
+    E2ENM07   BENM07        -.906279   BTAW07         -.01739
+    E2ENM07   BTRD07        -.076332   BEXP07         .515274
+    E2TAW07   BTAW07             -1.
+    E2TRD07   BTRD07             -1.
+    E2MAC07   BTAW07        -.014045   BTRD07        -.088953
+    E2MAC07   BMAC07        -.897002   BEXP07         .607638
+    ULWR07    KLWR07              1.   KLWR08             -1.
+    ULWP07    KLWP07              1.   KLWP08             -1.
+    UMMC07    KMMC07              1.   KMMC08             -1.
+    UENR07    KENR07              1.   KENR08             -1.
+    UFBR07    KFBR07              1.   KFBR08             -1.
+    URPR07    KRPR07              1.   KRPR08             -1.
+    UECM07    KECM07              1.   KECM08             -1.
+    UWCM07    KWCM07              1.   KWCM08             -1.
+    UCLQ07    KCLQ07              1.   KCLQ08             -1.
+    UREF07    KREF07              1.   KREF08             -1.
+    UOSE07    KOSE07              1.   KOSE08             -1.
+    UCFP07    KCFP07              1.   KCFP08             -1.
+    UOFP07    KOFP07              1.   KOFP08             -1.
+    UGFP07    KGFP07              1.   KGFP08             -1.
+    UCGL07    KCGL07              1.   KCGL08             -1.
+    UCGH07    KCGH07              1.   KCGH08             -1.
+    UHYD07    KHYD07              1.   KHYD08             -1.
+    UGEO07    KGEO07              1.   KGEO08             -1.
+    UAGR07    KAGR07              1.   KAGR08             -.8
+    UMNG07    KMNG07              1.   KMNG08             -.8
+    UEIM07    KEIM07              1.   KEIM08             -.8
+    UENM07    KENM07              1.   KENM08             -.8
+    UTAW07    KTAW07              1.   KTAW08             -.8
+    UTRD07    KTRD07              1.   KTRD08             -.8
+    UMAC07    KMAC07              1.   KMAC08             -.8
+    WLWR07    MURF08       -9.838104   ECAP07      -33.585495
+    WLWR07    CEEA07       33.585495   ETDE07      -23.509842
+    WLWR07    KLWR08             -1.
+    WLWP07    MURN08       -8.921747   MPLU08        -.276048
+    WLWP07    ECAP07      -34.432404   CEEA07       34.432404
+    WLWP07    ETDE07      -24.102676   KLWP08             -1.
+    WMMC07    ECAP07        -.032029   CEEA07         .032029
+    WMMC07    KMMC08             -3.
+    WENR07    ECAP07        -.224371   CEEA07         .224371
+    WFBR07    MPLU08        -.465639   MTLN08       -5.033102
+    WFBR07    ECAP07      -44.428299   CEEA07       44.428299
+    WFBR07    ETDE07      -31.099808   KFBR08             -1.
+    WRPR07    ECAP07       -2.096846   CEEA07        2.096846
+    WECM07    ECAP07        -.014564   CEEA07         .014564
+    WECM07    KECM08             -4.
+    WWCM07    ECAP07        -.005172   CEEA07         .005172
+    WWCM07    KWCM08             -5.
+    WCLQ07    ECAP07       -6.160605   CEEA07        6.160605
+    WCLQ07    KCLQ08             -5.
+    WREF07    ECAP07        -.481851   CEEA07         .481851
+    WREF07    KREF08             -5.
+    WOSE07    ECAP07       -1.682063   CEEA07        1.682063
+    WOSE07    KOSE08             -5.
+    WCFP07    ECAP07      -23.936646   CEEA07       23.936646
+    WCFP07    ETDE07      -16.755646   KCFP08             -3.
+    WOFP07    ECAP07      -17.952484   CEEA07       17.952484
+    WOFP07    ETDE07      -12.566738   KOFP08             -4.
+    WGFP07    ECAP07      -10.970949   CEEA07       10.970949
+    WGFP07    ETDE07       -7.679664   KGFP08             -4.
+    WCGL07    ECAP07      -75.702805   CEEA07       75.702805
+    WCGL07    ETDE07      -52.991959   KCGL08             -5.
+    WCGH07    ECAP07       -6.383089   CEEA07        6.383089
+    WCGH07    KCGH08             -5.
+    WHYD07    ECAP07      -33.710693   CEEA07       33.710693
+    WHYD07    ETDE07      -23.597473   KHYD08             -5.
+    WGEO07    ECAP07      -47.873169   CEEA07       47.873169
+    WGEO07    ETDE07      -33.511215   KGEO08             -5.
+    WTDE07    ECAP07             -1.   CEEA07              1.
+    WTDE07    ETDE07              1.
+    WAGR07    ECAP07        -1.14185   CNEA07         1.14185
+    WAGR07    KAGR07             -1.   KAGR08             -4.
+    WMNG07    ECAP07        -.290702   CNEA07         .290702
+    WMNG07    KMNG07             -1.   KMNG08             -4.
+    WEIM07    ECAP07         -.64485   CNEA07          .64485
+    WEIM07    KEIM07             -1.   KEIM08             -4.
+    WENM07    ECAP07        -.403625   CNEA07         .403625
+    WENM07    KENM07             -1.   KENM08             -4.
+    WTAW07    ECAP07        -1.41581   CNEA07         1.41581
+    WTAW07    KTAW07             -1.   KTAW08             -4.
+    WTRD07    ECAP07        -1.08414   CNEA07         1.08414
+    WTRD07    KTRD07             -1.   KTRD08             -4.
+    WMAC07    ECAP07        -.362214   CNEA07         .362214
+    WMAC07    KMAC07             -1.   KMAC08             -4.
+    KEEA08    TEEA07              1.   CEEA08             -1.
+    KNEA08    TNEA07              1.   CNEA08             -1.
+    PLWU08    DELE08             -1.   BELE08              .9
+    PLWU08    MURE08      -20.867584   MSPF08       20.867584
+    PLWU08    KLWR08        1.538461   NRGP08         -10.355
+    PLWU08    PELE08             -1.
+    PLWP08    DELE08             -1.   BELE08              .9
+    PLWP08    MURN08      -27.914734   MPLU08       -1.529699
+    PLWP08    MSPF08       29.444443   KLWP08        1.538461
+    PLWP08    NRGP08         -10.355   PELE08             -1.
+    PNR108    BELE08          -.0027   MURN08       -9.192495
+    PNR108    MURE08          1.2595   MTLN08           7.933
+    PNR108    KENR08              1.
+    PNR208    BELE08          -.0027   MURC08          -8.261
+    PNR208    MURE08        1.459499   MTLN08        6.801496
+    PNR208    KENR08              1.
+    PNR308    BELE08          -.0027   MURN08         -10.793
+    PNR308    MURF08        2.112499   MTLN08        8.680496
+    PNR308    KENR08              1.
+    PMMC08    RMMC08             -5.   BMNG08           -15.4
+    PMMC08    KMMC08              1.
+    PFBR08    DELE08             -1.   BELE08              .9
+    PFBR08    MPLU08         -1.3775   MTLN08      -15.662098
+    PFBR08    KFBR08        1.538461   NRGP08         -10.355
+    PFBR08    PELE08             -1.
+    PRPR08    MURC08          27.715   MPLU08            1.11
+    PRPR08    MTLN08       19.069992   MSPF08            -50.
+    PRPR08    KRPR08              1.
+    PECM08    DCOL08          -.0258   BCOL08           .0258
+    PECM08    KECM08              1.   NRGP08          -.0258
+    PWCM08    DCOL08           -.016   BCOL08            .016
+    PWCM08    KWCM08              1.   NRGP08           -.016
+    PCLQ08    DROP08             -1.   BCOL08          -1.575
+    PCLQ08    BROP08              1.   KCLQ08              1.
+    PREF08    DROP08           -.549   BCRO08             -.6
+    PREF08    BROP08            .549   KREF08              1.
+    POSE08    DCRO08             -.6   BCRO08              .6
+    POSE08    KOSE08              1.   NRGP08             -.6
+    PCFP08    DELE08             -1.   BCOL08         -10.355
+    PCFP08    BELE08              .9   KCFP08        1.851851
+    PCFP08    PELE08              1.
+    POFP08    DELE08             -1.   BROP08         -10.355
+    POFP08    BELE08              .9   KOFP08              2.
+    PGFP08    DELE08             -1.   BGAS08         -10.355
+    PGFP08    BELE08              .9   KGFP08              2.
+    PCGL08    DELE08             -1.   BCOL08         -15.986
+    PCGL08    BELE08              .9   KCGL08              1.
+    PCGH08    DGAS08             -1.   BCOL08          -1.826
+    PCGH08    BGAS08              1.   KCGH08              1.
+    PHYD08    DELE08             -1.   BELE08              .9
+    PHYD08    KHYD08        1.960784   NRGP08         -10.355
+    PGEO08    DELE08             -1.   BELE08              .9
+    PGEO08    KGEO08         1.17647   NRGP08         -10.355
+    POF108    OVXT08              1.   KODR08           1800.
+    POF108    BOIP08            78.6
+    POF208    OVXT08              1.   KODR08           3600.
+    POF208    BOIP08           136.5
+    POF308    OVXT08              1.   KODR08           5400.
+    POF308    BOIP08           166.7
+    PODR08    KODR08             -1.   ECAP08          -.0062
+    PODR08    CEEA08           .0062
+    POIP08    BOIP08             -1.   OSRB08          .00351
+    POIP08    OTRB08          .00039   ODPL08           .0135
+    POF408    OVXT08              1.   KODR08           7200.
+    POF408    BOIP08           182.6
+    POF508    OVXT08              1.   KODR08           9000.
+    POF508    BOIP08           190.9
+    POF608    OVXT08              1.   KODR08          10800.
+    POF608    BOIP08           195.2
+    POF708    OVXT08              1.   KODR08          12600.
+    POF708    BOIP08           197.5
+    PPOR08    ODPL08            .094   BORS08             -1.
+    PSRN08    OSRB08             -1.
+    PSRA08    OSRB08             -1.   ODPL08            .043
+    PSRA08    ECAP08           -.246   CEEA08            .246
+    PTRN08    OTRB08             -1.
+    PTRA08    OTRB08             -1.   ODPL08            .043
+    PTRA08    ECAP08           -.484   CEEA08            .484
+    PGF108    GVXT08              1.   KGDR08           1426.
+    PGF108    BGSF08            275.
+    PGF208    GVXT08              1.   KGDR08           2000.
+    PGF208    BGSF08      366.099854
+    PGF308    GVXT08              1.   KGDR08           3000.
+    PGF308    BGSF08      458.799805
+    PGDR08    KGDR08             -1.   ECAP08          -.0062
+    PGDR08    CEEA08           .0062
+    PGRA08    BGSF08             -1.   GDPL08            .043
+    PGF408    GVXT08              1.   KGDR08           4000.
+    PGF408    BGSF08      504.599854
+    PGF508    GVXT08              1.   KGDR08           5000.
+    PGF508    BGSF08           527.5
+    PGF608    GVXT08              1.   KGDR08           6000.
+    PGF608    BGSF08      538.899902
+    PGF708    GVXT08              1.   KGDR08           7000.
+    PGF708    BGSF08           544.5
+    PGF808    GVXT08              1.   KGDR08           8000.
+    PGF808    BGSF08      547.299805
+    PPGR08    GDPL08            .094   BGRS08             -1.
+    PGPR08    GDPL08             -1.   BCRO08            .198
+    PGPR08    BGAS08             .85   DCRO08          -1.198
+    PGPR08    DGAS08             -1.   NRGP08          -1.198
+    POPR08    ODPL08           -.167   BCRO08              1.
+    POPR08    BGAS08          .15555   DCRO08          -1.183
+    POPR08    DGAS08           -.183   NRGP08          -1.183
+    PNRG08    NRGP08              1.
+    UCOL08    BCOL08             -1.
+    UCRO08    BCRO08             -1.
+    UROP08    BROP08             -1.
+    UGAS08    BGAS08             -1.
+    UELE08    BELE08             -1.
+    NURC08    MURC08             -1.
+    NURE08    MURE08             -1.
+    NURF08    MURF08             -1.
+    NPLU08    MPLU08             -1.
+    NTLN08    MTLN08             -1.
+    NSPF08    MSPF08             -1.
+    UR108     MURN08      242.307831   RMMC08      242.307831
+    UR108     URXT08              1.
+    UR208     MURN08      661.538818   RMMC08      681.538818
+    UR208     URXT08              1.
+    UR308     MURN08     1288.462158   RMMC08     1523.077637
+    UR308     URXT08              1.
+    UR408     MURN08     1950.000977   RMMC08     3084.617188
+    UR408     URXT08              1.
+    UR508     MURN08     3638.463623   RMMC08     10114.62109
+    UR508     URXT08              1.
+    UR608     MURN08     5438.460938   RMMC08     23614.62891
+    UR608     URXT08              1.
+    ICOL08    BCOL08              1.   BIMP08          -1000.
+    ICRO08    BCRO08              1.   BIMP08    -1500.029785
+    IROP08    BROP08              1.   BIMP08    -1500.029785
+    IGAS08    BGAS08              1.   BIMP08    -1875.037109
+    IELE08    BELE08              1.   BIMP08    -15532.80469
+    JCOL08    BCOL08              1.   NRGP08             -1.
+    JCOL08    ECAP08          -3.333   CEEA08           3.333
+    JCRO08    BCRO08              1.   NRGP08             -1.
+    JCRO08    ECAP08          -3.333   CEEA08           3.333
+    JROP08    BROP08              1.   NRGP08             -1.
+    JROP08    ECAP08          -3.333   CEEA08           3.333
+    JGAS08    BGAS08              1.   NRGP08             -1.
+    JGAS08    ECAP08          -3.333   CEEA08           3.333
+    E1COL08   BCOL08             -1.   BTAW08      -85.984146
+    E1COL08   BTRD08       -3.289011   BEXP08           1000.
+    E1CRO08   BCRO08             -1.   BTAW08      -30.625748
+    E1CRO08   BEXP08     1500.029785
+    E1ROP08   BROP08             -1.   BTAW08      -70.309738
+    E1ROP08   BTRD08     -230.550491   BEXP08     1500.029785
+    E1GAS08   BGAS08             -1.   BTAW08      -76.420792
+    E1GAS08   BTRD08       -49.76236   BEXP08     1875.037109
+    E1ELE08   BELE08             -1.   BTRD08     -937.608643
+    E1ELE08   BEXP08     15532.80469
+    XCOL08    DCOL08        4.438329   BELE08        -.001258
+    XCOL08    BROP08        -.009637   BMNG08      -10.737742
+    XCOL08    BEIM08      -43.582611   BENM08      -30.318329
+    XCOL08    BTAW08       -8.842848   BTRD08     -121.652298
+    XCOL08    BMAC08      -41.056076   WRKF08         .046425
+    XCRO08    DCRO08        2.892097   BELE08        -.000506
+    XCRO08    BROP08        -.002062   BGAS08        -.007408
+    XCRO08    BMNG08      -34.323624   BEIM08      -29.450958
+    XCRO08    BENM08       -9.530361   BTAW08        -10.4619
+    XCRO08    BTRD08     -227.231018   BMAC08      -31.457352
+    XCRO08    WRKF08         .021354
+    XROP08    DROP08         .813213   BELE08         -.00034
+    XROP08    BCOL08        -.001514   BGAS08        -.025955
+    XROP08    BMNG08      -16.875412   BEIM08       -41.64917
+    XROP08    BENM08       -5.162801   BTAW08        -53.5159
+    XROP08    BTRD08      -81.333328   BMAC08       -3.506082
+    XROP08    WRKF08         .007051
+    XGAS08    DGAS08        1.380471   BELE08        -.000499
+    XGAS08    BCOL08        -.000874   BROP08        -.000706
+    XGAS08    BMNG08      -18.629242   BEIM08       -1.871531
+    XGAS08    BENM08        -.372872   BTAW08        -.243801
+    XGAS08    BTRD08      -47.828018   WRKF08         .005952
+    XELE08    DELE08         .054373   BAGR08       -1.282765
+    XELE08    BMNG08      -52.155487   BEIM08        -8.14335
+    XELE08    BENM08       -2.450525   BTAW08      -29.401871
+    XELE08    BTRD08     -148.124084   BMAC08       -3.821757
+    XELE08    WRKF08         .016189
+    XAGR08    KAGR08        1.111111   BCOL08        -.000219
+    XAGR08    BROP08        -.010829   BGAS08        -.000435
+    XAGR08    BELE08        -.000101   BAGR08      693.921387
+    XAGR08    BMNG08      -11.796776   BEIM08     -105.230377
+    XAGR08    BENM08       -8.735988   BTAW08      -19.273376
+    XAGR08    BTRD08       -132.6754   BMAC08       -6.567932
+    XAGR08    BIMP08        -.573897
+    XMNG08    KMNG08        1.111111   BCOL08        -.000195
+    XMNG08    BROP08        -.011428   BGAS08         -.00112
+    XMNG08    BELE08        -.000086   BAGR08       -2.328505
+    XMNG08    BMNG08      972.447266   BEIM08     -134.663696
+    XMNG08    BENM08     -160.684525   BTAW08      -25.365646
+    XMNG08    BTRD08     -153.472351   BMAC08       -26.12706
+    XMNG08    BIMP08        -.894217   WRKF08         .038859
+    XEIM08    KEIM08        1.111111   BCOL08        -.010813
+    XEIM08    BCRO08        -.000053   BROP08        -.006802
+    XEIM08    BGAS08        -.010639   BELE08        -.000373
+    XEIM08    BAGR08     -119.583542   BMNG08      -24.533279
+    XEIM08    BEIM08      731.984375   BENM08      -39.738663
+    XEIM08    BTAW08      -30.974686   BTRD08     -110.634079
+    XEIM08    BMAC08      -14.378268   BIMP08       -6.938498
+    XEIM08    WRKF08         .025369
+    XENM08    KENM08        1.111111   BCOL08         -.00066
+    XENM08    BROP08        -.001365   BGAS08        -.002533
+    XENM08    BELE08        -.000219   BAGR08      -14.414824
+    XENM08    BMNG08       -5.079608   BEIM08     -159.277557
+    XENM08    BENM08       754.55127   BTAW08      -13.189252
+    XENM08    BTRD08      -99.108688   BMAC08      -34.243027
+    XENM08    BIMP08       -1.637574   WRKF08         .046102
+    XTAW08    KTAW08        1.111111   BCOL08        -.000381
+    XTAW08    BCRO08        -.000133   BROP08        -.024125
+    XTAW08    BGAS08        -.001434   BELE08        -.000474
+    XTAW08    BAGR08        -.870055   BMNG08      -26.042328
+    XTAW08    BEIM08      -20.644028   BENM08      -10.381341
+    XTAW08    BTAW08      914.338867   BTRD08      -151.68219
+    XTAW08    BMAC08      -21.711823   BIMP08      -17.717484
+    XTAW08    WRKF08         .056178
+    XTRD08    KTRD08        1.111111   BCOL08        -.000813
+    XTRD08    BCRO08        -.000069   BROP08        -.003113
+    XTRD08    BGAS08        -.003174   BELE08        -.000403
+    XTRD08    BAGR08       -5.705781   BMNG08       -18.54953
+    XTRD08    BEIM08      -23.171265   BENM08      -35.265518
+    XTRD08    BTAW08      -14.880653   BTRD08      825.474609
+    XTRD08    BMAC08       -8.531651   BIMP08       -1.058328
+    XTRD08    WRKF08         .073834
+    XMAC08    KMAC08        1.111111   BCOL08        -.000771
+    XMAC08    BROP08        -.001904   BGAS08         -.00197
+    XMAC08    BELE08        -.000165   BMNG08       -8.258104
+    XMAC08    BEIM08     -132.072205   BENM08     -101.023422
+    XMAC08    BTAW08      -10.780818   BTRD08      -90.647217
+    XMAC08    BMAC08      747.764404   BIMP08        -.999022
+    XMAC08    WRKF08         .032378
+    CONS08    OBJ          -1.019509   BIMP08          -19.51
+    CONS08    POPL08           1000.   DNRG08         -.01183
+    CONS08    BAGR08          -8.298   BMNG08      -66.047958
+    CONS08    BEIM08     -103.797958   BENM08     -115.218994
+    CONS08    BTAW08      -35.536987   BTRD08     -609.091797
+    CONS08    BMAC08      -41.043991
+    CNRG08    DNRG08              1.   BROP08          -.5254
+    CNRG08    BGAS08          -.2158   BELE08         -.07585
+    APCC08    POPL08     -278.799805   UMOB08              1.
+    GOVT08    BCOL08        -.001458   BROP08        -.006819
+    GOVT08    BGAS08        -.005441   BELE08        -.000551
+    GOVT08    BAGR08        7.501156   BMNG08     -179.188583
+    GOVT08    BEIM08      -29.199707   BENM08        -112.426
+    GOVT08    BTAW08      -24.609955   BTRD08     -552.763428
+    GOVT08    BMAC08      -89.739853   BIMP08         -22.646
+    CAPF08    BMNG08     -345.845703   BEIM08        -.755947
+    CAPF08    BENM08     -104.722321   BTAW08        -9.79188
+    CAPF08    BTRD08      -80.591064   BMAC08     -458.292969
+    CAPF08    BIMP08          -7.772   ECAP08              1.
+    XIMP08    BIMP08              1.   BTRB08             -1.
+    XIMP08    LTAW08          -.0334
+    XEXP08    BEXP08             -1.   BTRB08              1.
+    IAGR08    BAGR08              1.   BTAW08        -.123939
+    IAGR08    BTRD08        -.097273   BIMP08             -1.
+    IMNG08    BMNG08              1.   BTAW08        -.144599
+    IMNG08    BTRD08        -.031359   BIMP08             -1.
+    IEIM08    BEIM08              1.   BTAW08        -.038321
+    IEIM08    BTRD08         -.05912   BIMP08             -1.
+    IENM08    BENM08              1.   BTAW08        -.019188
+    IENM08    BTRD08        -.084225   BIMP08             -1.
+    ITAW08    BTAW08              1.   BIMP08             -1.
+    ITAW08    LTAW08              1.
+    ITRD08    BTRD08              1.   BIMP08             -1.
+    IMAC08    BTAW08        -.015658   BTRD08        -.099167
+    IMAC08    BMAC08              1.   BIMP08             -1.
+    E1AGR08   BAGR08        -.818859   BTAW08        -.101489
+    E1AGR08   BTRD08        -.079653   BEXP08              1.
+    E1MNG08   BMNG08         -.85037   BTAW08        -.122963
+    E1MNG08   BTRD08        -.026667   BEXP08              1.
+    E1EIM08   BEIM08        -.911211   BTAW08        -.034918
+    E1EIM08   BTRD08        -.053871   BEXP08              1.
+    E1ENM08   BENM08        -.906279   BTAW08         -.01739
+    E1ENM08   BTRD08        -.076332   BEXP08              1.
+    E1TAW08   BTAW08             -1.   BEXP08              1.
+    E1TRD08   BTRD08             -1.   BEXP08              1.
+    E1MAC08   BTAW08        -.014045   BTRD08        -.088953
+    E1MAC08   BMAC08        -.897002   BEXP08              1.
+    E2AGR08   BAGR08        -.818859   BTAW08        -.101489
+    E2AGR08   BTRD08        -.079653   BEXP08         .401143
+    E2MNG08   BMNG08         -.85037   BTAW08        -.122963
+    E2MNG08   BTRD08        -.026667   BEXP08         .715021
+    E2EIM08   BEIM08        -.911211   BTAW08        -.034918
+    E2EIM08   BTRD08        -.053871   BEXP08         .604231
+    E2ENM08   BENM08        -.906279   BTAW08         -.01739
+    E2ENM08   BTRD08        -.076332   BEXP08         .515274
+    E2TAW08   BTAW08             -1.
+    E2TRD08   BTRD08             -1.
+    E2MAC08   BTAW08        -.014045   BTRD08        -.088953
+    E2MAC08   BMAC08        -.897002   BEXP08         .607638
+    ULWR08    KLWR08              1.
+    ULWP08    KLWP08              1.
+    UMMC08    KMMC08              1.
+    UENR08    KENR08              1.
+    UFBR08    KFBR08              1.
+    URPR08    KRPR08              1.
+    UECM08    KECM08              1.
+    UWCM08    KWCM08              1.
+    UCLQ08    KCLQ08              1.
+    UREF08    KREF08              1.
+    UOSE08    KOSE08              1.
+    UCFP08    KCFP08              1.
+    UOFP08    KOFP08              1.
+    UGFP08    KGFP08              1.
+    UCGL08    KCGL08              1.
+    UCGH08    KCGH08              1.
+    UHYD08    KHYD08              1.
+    UGEO08    KGEO08              1.
+    UAGR08    KAGR08              1.
+    UMNG08    KMNG08              1.
+    UEIM08    KEIM08              1.
+    UENM08    KENM08              1.
+    UTAW08    KTAW08              1.
+    UTRD08    KTRD08              1.
+    UMAC08    KMAC08              1.
+    WLWR08    ECAP08      -33.585495   CEEA08       33.585495
+    WLWP08    ECAP08      -34.432404   CEEA08       34.432404
+    WMMC08    ECAP08        -.032029   CEEA08         .032029
+    WENR08    ECAP08        -.224371   CEEA08         .224371
+    WFBR08    ECAP08      -44.428299   CEEA08       44.428299
+    WRPR08    ECAP08       -2.096846   CEEA08        2.096846
+    WECM08    ECAP08        -.014564   CEEA08         .014564
+    WWCM08    ECAP08        -.005172   CEEA08         .005172
+    WCLQ08    ECAP08       -6.160605   CEEA08        6.160605
+    WREF08    ECAP08        -.481851   CEEA08         .481851
+    WOSE08    ECAP08       -1.682063   CEEA08        1.682063
+    WCFP08    ECAP08      -23.936646   CEEA08       23.936646
+    WOFP08    ECAP08      -17.952484   CEEA08       17.952484
+    WGFP08    ECAP08      -10.970949   CEEA08       10.970949
+    WCGL08    ECAP08      -75.702805   CEEA08       75.702805
+    WCGH08    ECAP08       -6.383089   CEEA08        6.383089
+    WHYD08    ECAP08      -33.710693   CEEA08       33.710693
+    WGEO08    ECAP08      -47.873169   CEEA08       47.873169
+    WTDE08    ECAP08             -1.   CEEA08              1.
+    WAGR08    ECAP08        -1.14185   CNEA08         1.14185
+    WAGR08    KAGR08             -1.
+    WMNG08    ECAP08        -.290702   CNEA08         .290702
+    WMNG08    KMNG08             -1.
+    WEIM08    ECAP08         -.64485   CNEA08          .64485
+    WEIM08    KEIM08             -1.
+    WENM08    ECAP08        -.403625   CNEA08         .403625
+    WENM08    KENM08             -1.
+    WTAW08    ECAP08        -1.41581   CNEA08         1.41581
+    WTAW08    KTAW08             -1.
+    WTRD08    ECAP08        -1.08414   CNEA08         1.08414
+    WTRD08    KTRD08             -1.
+    WMAC08    ECAP08        -.362214   CNEA08         .362214
+    WMAC08    KMAC08             -1.
+RHS
+    RHSIDE    BORS01            -24.   BGRS01           -164.
+    RHSIDE    KLWR01             .32   KMMC01             13.
+    RHSIDE    KENR01            17.1   KECM01           544.5
+    RHSIDE    KWCM01            50.6   KREF01           48.75
+    RHSIDE    KCFP01           1.612   KOFP01            .482
+    RHSIDE    KGFP01            .622   KHYD01            .526
+    RHSIDE    KLWR02           .1401   KLWR08          -.1401
+    RHSIDE    KLWR07            -.32   KENR07           -17.1
+    RHSIDE    KHYD07           -.526   KAGR01       86.155991
+    RHSIDE    KMNG01         156.674   KEIM01      335.392822
+    RHSIDE    KENM01      258.721924   KTAW01       69.455994
+    RHSIDE    KTRD01       848.98999   KMAC01      187.846985
+    RHSIDE    BTRB01          18140.   URXT01              1.
+    RHSIDE    OVXT01              1.   GVXT01              1.
+    RHSIDE    OSRB01            -5.9   OTRB01            -2.9
+    RHSIDE    BCOL01        1.318118   DNRG01        8.264796
+    RHSIDE    BAGR01     2106.790039   BMNG01    -7839.503906
+    RHSIDE    BEIM01     28167.26563   BENM01    -11460.67578
+    RHSIDE    BTAW01    -7404.175781   BTRD01    -14054.91406
+    RHSIDE    BMAC01    -2262.672852   WRKF01       98.599777
+    RHSIDE    ECAP01           12.93   CEEA01            -.93
+    RHSIDE    CNEA01            -12.   URXT02              1.
+    RHSIDE    OVXT02              1.   GVXT02              1.
+    RHSIDE    OSRB02            -4.8   OTRB02            -4.2
+    RHSIDE    BCOL02        1.375535   DNRG02        8.495433
+    RHSIDE    BAGR02     2198.561035   BMNG02    -8180.988281
+    RHSIDE    BEIM02     29394.22266   BENM02    -11959.89844
+    RHSIDE    BTAW02    -7726.699219   BTRD02    -14667.14453
+    RHSIDE    BMAC02    -2361.234131   BCRO02           -3.72
+    RHSIDE    KMMC02          -2.158   KECM02      -90.386963
+    RHSIDE    KWCM02       -8.399595   KREF02       -8.092497
+    RHSIDE    KCFP02        -.267592   KOFP02        -.080012
+    RHSIDE    KGFP02        -.103252   WRKF02      117.370331
+    RHSIDE    ECAP02       16.069992   CEEA02           -1.07
+    RHSIDE    CNEA02            -15.   NRGP02            3.72
+    RHSIDE    URXT03              1.   OVXT03              1.
+    RHSIDE    GVXT03              1.   OSRB03            -3.7
+    RHSIDE    OTRB03            -5.2   BCOL03        1.445299
+    RHSIDE    DNRG03         8.69975   BAGR03     2310.068115
+    RHSIDE    BMNG03    -8595.914063   BEIM03     30885.04297
+    RHSIDE    BENM03    -12566.48438   BTAW03    -8118.585938
+    RHSIDE    BTRD03    -15411.03125   BMAC03    -2480.991455
+    RHSIDE    BCRO03           -5.91   KMMC03          -2.158
+    RHSIDE    KECM03      -90.386963   KWCM03       -8.399595
+    RHSIDE    KREF03       -8.092497   KCFP03        -.267592
+    RHSIDE    KOFP03        -.080012   KGFP03        -.103252
+    RHSIDE    WRKF03      139.570831   ECAP03            15.4
+    RHSIDE    CEEA03             -.4   CNEA03            -15.
+    RHSIDE    NRGP03            5.91   URXT04              1.
+    RHSIDE    OVXT04              1.   GVXT04              1.
+    RHSIDE    OSRB04            -2.6   OTRB04            -5.9
+    RHSIDE    BCOL04         1.51321   DNRG04        8.776457
+    RHSIDE    BAGR04     2418.614502   BMNG04    -8999.824219
+    RHSIDE    BEIM04     32336.28516   BENM04    -13156.96484
+    RHSIDE    BTAW04      -8500.0625   BTRD04    -16135.17578
+    RHSIDE    BMAC04     -2597.56958   BCRO04           -5.48
+    RHSIDE    KMMC04          -2.171   KECM04      -90.931488
+    RHSIDE    KWCM04       -8.450198   KREF04        -8.14125
+    RHSIDE    KCFP04        -.269204   KOFP04        -.080494
+    RHSIDE    KGFP04        -.103874   WRKF04      163.447586
+    RHSIDE    ECAP04           15.17   CEEA04            -.17
+    RHSIDE    CNEA04            -15.   NRGP04            5.48
+    RHSIDE    URXT05              1.   OVXT05              1.
+    RHSIDE    GVXT05              1.   OSRB05            -2.1
+    RHSIDE    OTRB05            -6.4   BCOL05        1.571246
+    RHSIDE    DNRG05        8.571191   BAGR05     2511.372559
+    RHSIDE    BMNG05    -9344.980469   BEIM05      33576.4375
+    RHSIDE    BENM05    -13661.55469   BTAW05    -8826.054688
+    RHSIDE    BTRD05    -16753.98438   BMAC05    -2697.190674
+    RHSIDE    BCRO05           -2.63   KMMC05          -2.171
+    RHSIDE    KECM05      -90.931488   KWCM05       -8.450198
+    RHSIDE    KREF05        -8.14125   KCFP05        -.269204
+    RHSIDE    KOFP05        -.080494   KGFP05        -.103874
+    RHSIDE    WRKF05      187.192795   ECAP05             15.
+    RHSIDE    CNEA05            -15.   NRGP05            2.63
+    RHSIDE    URXT06              1.   OVXT06              1.
+    RHSIDE    GVXT06              1.   OSRB06            -1.1
+    RHSIDE    OTRB06             -4.   BCOL06        1.620637
+    RHSIDE    DNRG06        8.129308   BAGR06     2590.315674
+    RHSIDE    BMNG06    -9638.734375   BEIM06     34631.88672
+    RHSIDE    BENM06    -14090.99609   BTAW06    -9103.496094
+    RHSIDE    BTRD06    -17280.63281   BMAC06    -2781.974854
+    RHSIDE    BCRO06            -1.1   KMMC06          -2.171
+    RHSIDE    KECM06      -90.931488   KWCM06       -8.450198
+    RHSIDE    KREF06        -8.14125   KCFP06        -.269204
+    RHSIDE    KOFP06        -.080494   KGFP06        -.103874
+    RHSIDE    WRKF06      213.084091   ECAP06             15.
+    RHSIDE    CNEA06            -15.   NRGP06             1.1
+    RHSIDE    URXT07              1.   OVXT07              1.
+    RHSIDE    GVXT07              1.   BCOL07        1.669409
+    RHSIDE    DNRG07         7.74591   BAGR07     2668.270752
+    RHSIDE    BMNG07    -9928.808594   BEIM07     35674.12891
+    RHSIDE    BENM07     -14515.0625   BTAW07    -9377.464844
+    RHSIDE    BTRD07    -17800.69141   BMAC07       -2865.698
+    RHSIDE    BCRO07            -.44   KMMC07          -2.171
+    RHSIDE    KECM07      -90.931488   KWCM07       -8.450198
+    RHSIDE    KREF07        -8.14125   KCFP07        -.269204
+    RHSIDE    KOFP07        -.080494   KGFP07        -.103874
+    RHSIDE    WRKF07      242.291962   ECAP07             15.
+    RHSIDE    CNEA07            -15.   NRGP07             .44
+    RHSIDE    URXT08              1.   OVXT08              1.
+    RHSIDE    GVXT08              1.   BCOL08        1.721269
+    RHSIDE    DNRG08        7.554828   BAGR08     2751.159912
+    RHSIDE    BMNG08    -10237.24609   BEIM08     36782.33594
+    RHSIDE    BENM08    -14965.96875   BTAW08    -9668.773438
+    RHSIDE    BTRD08    -18353.66797   BMAC08    -2954.719971
+    RHSIDE    WRKF08      275.604492   ECAP08             15.
+    RHSIDE    CNEA08            -15.
+BOUNDS
+ FX BOUND     CONS01      621.209961
+ FX BOUND     CAPF01       111.12999
+ FX BOUND     GOVT01          210.48
+ FX BOUND     WLWP01              0.
+ FX BOUND     WFBR01              0.
+ FX BOUND     WRPR01              0.
+ FX BOUND     WENR01              0.
+ FX BOUND     WLWR01           .0797
+ FX BOUND     ICOL01              0.
+ UP BOUND     IROP01              7.
+ UP BOUND     IGAS01              2.
+ FX BOUND     IELE01              0.
+ UP BOUND     E1COL01       2.915768
+ UP BOUND     E1ROP01        .837864
+ UP BOUND     E1GAS01        .154173
+ FX BOUND     E1CRO01             0.
+ FX BOUND     E1ELE01             0.
+ FX BOUND     ITRD01              0.
+ UP BOUND     IAGR01     2136.041992
+ UP BOUND     IMNG01     2331.932617
+ UP BOUND     IEIM01     15573.30859
+ UP BOUND     IENM01     8239.910156
+ UP BOUND     ITAW01     2840.414795
+ UP BOUND     IMAC01     5359.902344
+ UP BOUND     E1AGR01    5521.097656
+ UP BOUND     E1MNG01     924.749756
+ UP BOUND     E1EIM01    11927.21875
+ UP BOUND     E1ENM01    7484.308594
+ UP BOUND     E1TAW01    3575.699463
+ UP BOUND     E1MAC01    15216.58594
+ FX BOUND     E1TRD01             0.
+ UP BOUND     XCOL01        3.469773
+ FR BOUND     XCRO01
+ FR BOUND     XROP01
+ FR BOUND     XGAS01
+ FR BOUND     XELE01
+ FR BOUND     XAGR01
+ FR BOUND     XMNG01
+ FR BOUND     XEIM01
+ FR BOUND     XENM01
+ FR BOUND     XTAW01
+ FR BOUND     XTRD01
+ FR BOUND     XMAC01
+ UP BOUND     E2AGR01    1105.481445
+ UP BOUND     E2MNG01     496.057617
+ UP BOUND     E2EIM01    4025.814209
+ UP BOUND     E2ENM01    1947.390381
+ UP BOUND     E2MAC01    5203.980469
+ FX BOUND     E2TRD01             0.
+ UP BOUND     PHYD01          .28404
+ UP BOUND     PGEO01         .000007
+ UP BOUND     PODR01            400.
+ UP BOUND     PGDR01            300.
+ UP BOUND     PCGL01          .00001
+ UP BOUND     PCGH01          .00001
+ UP BOUND     PFBR01          .00001
+ UP BOUND     POSE01          .00001
+ UP BOUND     WWCM01             30.
+ UP BOUND     WMMC01           2.333
+ FX BOUND     ICOL02              0.
+ UP BOUND     IROP02              7.
+ UP BOUND     IGAS02              2.
+ FX BOUND     IELE02              0.
+ LO BOUND     GOVT02      234.799988
+ UP BOUND     E1COL02       3.554255
+ UP BOUND     E1ROP02       1.021337
+ UP BOUND     E1GAS02        .187933
+ FX BOUND     E1CRO02             0.
+ FX BOUND     E1ELE02             0.
+ FX BOUND     ITRD02              0.
+ UP BOUND     IAGR02     2229.086914
+ UP BOUND     IMNG02     2433.510498
+ UP BOUND     IEIM02     16251.67188
+ UP BOUND     IENM02     8598.835938
+ UP BOUND     ITAW02     2964.142334
+ UP BOUND     IMAC02        5593.375
+ UP BOUND     E1AGR02     6730.09375
+ UP BOUND     E1MNG02    1127.249268
+ UP BOUND     E1EIM02    14539.01172
+ UP BOUND     E1ENM02    9123.203125
+ UP BOUND     E1TAW02    4358.695313
+ UP BOUND     E1MAC02    18548.67969
+ FX BOUND     E1TRD02             0.
+ UP BOUND     XCOL02        5.137062
+ FR BOUND     XCRO02
+ FR BOUND     XROP02
+ FR BOUND     XGAS02
+ FR BOUND     XELE02
+ FR BOUND     XAGR02
+ FR BOUND     XMNG02
+ FR BOUND     XEIM02
+ FR BOUND     XENM02
+ FR BOUND     XTAW02
+ FR BOUND     XTRD02
+ FR BOUND     XMAC02
+ UP BOUND     E2AGR02    1347.557129
+ UP BOUND     E2MNG02     604.683105
+ UP BOUND     E2EIM02       4907.375
+ UP BOUND     E2ENM02    2373.825439
+ UP BOUND     E2MAC02    6343.535156
+ FX BOUND     E2TRD02             0.
+ UP BOUND     PHYD02          .31104
+ UP BOUND     PGEO02          .00675
+ UP BOUND     PODR02            588.
+ UP BOUND     PGDR02            441.
+ UP BOUND     PCLQ02              .5
+ UP BOUND     PCGL02           .0342
+ UP BOUND     PCGH02              .5
+ UP BOUND     PFBR02          .00001
+ UP BOUND     POSE02          .00001
+ UP BOUND     WWCM02             30.
+ UP BOUND     WMMC02           2.759
+ FX BOUND     ICOL03              0.
+ UP BOUND     IROP03              7.
+ UP BOUND     IGAS03              2.
+ FX BOUND     IELE03              0.
+ LO BOUND     GOVT03            309.
+ UP BOUND     E1COL03       4.320444
+ UP BOUND     E1ROP03       1.241506
+ UP BOUND     E1GAS03        .228446
+ FX BOUND     E1CRO03             0.
+ FX BOUND     E1ELE03             0.
+ FX BOUND     ITRD03              0.
+ UP BOUND     IAGR03      2342.14209
+ UP BOUND     IMNG03     2556.933838
+ UP BOUND     IEIM03     17075.92969
+ UP BOUND     IENM03     9034.953125
+ UP BOUND     ITAW03     3114.478027
+ UP BOUND     IMAC03     5877.058594
+ UP BOUND     E1AGR03    8180.898438
+ UP BOUND     E1MNG03    1370.249756
+ UP BOUND     E1EIM03    17673.17578
+ UP BOUND     E1ENM03    11089.88672
+ UP BOUND     E1TAW03    5298.296875
+ UP BOUND     E1MAC03    22547.20703
+ FX BOUND     E1TRD03             0.
+ UP BOUND     XCOL03        7.345101
+ FR BOUND     XCRO03
+ FR BOUND     XROP03
+ FR BOUND     XGAS03
+ FR BOUND     XELE03
+ FR BOUND     XAGR03
+ FR BOUND     XMNG03
+ FR BOUND     XEIM03
+ FR BOUND     XENM03
+ FR BOUND     XTAW03
+ FR BOUND     XTRD03
+ FR BOUND     XMAC03
+ UP BOUND     E2AGR03    1638.049072
+ UP BOUND     E2MNG03      735.03418
+ UP BOUND     E2EIM03    5965.253906
+ UP BOUND     E2ENM03    2885.549316
+ UP BOUND     E2MAC03    7711.007813
+ FX BOUND     E2TRD03             0.
+ UP BOUND     PHYD03          .33867
+ UP BOUND     PGEO03          .02625
+ UP BOUND     PODR03            864.
+ UP BOUND     PGDR03            648.
+ UP BOUND     PCLQ03            2.69
+ UP BOUND     PCGL03            .184
+ UP BOUND     PCGH03            2.69
+ UP BOUND     PFBR03          .00001
+ UP BOUND     POSE03             .33
+ UP BOUND     WWCM03             30.
+ UP BOUND     WMMC03           4.615
+ FX BOUND     ICOL04              0.
+ UP BOUND     IROP04              7.
+ UP BOUND     IGAS04              2.
+ FX BOUND     IELE04              0.
+ LO BOUND     GOVT04      402.699951
+ UP BOUND     E1COL04       5.235612
+ UP BOUND     E1ROP04       1.504484
+ UP BOUND     E1GAS04        .276835
+ FX BOUND     E1CRO04             0.
+ FX BOUND     E1ELE04             0.
+ FX BOUND     ITRD04              0.
+ UP BOUND     IAGR04     2452.195801
+ UP BOUND     IMNG04     2677.080322
+ UP BOUND     IEIM04     17878.30078
+ UP BOUND     IENM04     9459.492188
+ UP BOUND     ITAW04     3260.822754
+ UP BOUND     IMAC04     6153.214844
+ UP BOUND     E1AGR04    9913.792969
+ UP BOUND     E1MNG04    1660.499268
+ UP BOUND     E1EIM04       21416.75
+ UP BOUND     E1ENM04    13438.97266
+ UP BOUND     E1TAW04     6420.59375
+ UP BOUND     E1MAC04    27323.20703
+ FX BOUND     E1TRD04             0.
+ UP BOUND     XCOL04       10.003761
+ FR BOUND     XCRO04
+ FR BOUND     XROP04
+ FR BOUND     XGAS04
+ FR BOUND     XELE04
+ FR BOUND     XAGR04
+ FR BOUND     XMNG04
+ FR BOUND     XEIM04
+ FR BOUND     XENM04
+ FR BOUND     XTAW04
+ FR BOUND     XTRD04
+ FR BOUND     XMAC04
+ UP BOUND     E2AGR04    1985.024658
+ UP BOUND     E2MNG04     890.730957
+ UP BOUND     E2EIM04    7228.832031
+ UP BOUND     E2ENM04    3496.773193
+ UP BOUND     E2MAC04    9344.371094
+ FX BOUND     E2TRD04             0.
+ UP BOUND     PHYD04           .3484
+ UP BOUND     PGEO04          .04452
+ UP BOUND     PODR04           1269.
+ UP BOUND     PGDR04            952.
+ UP BOUND     PCLQ04            9.98
+ UP BOUND     PCGL04            .683
+ UP BOUND     PCGH04            9.98
+ UP BOUND     PFBR04          .00001
+ UP BOUND     POSE04            1.33
+ UP BOUND     WWCM04             30.
+ FX BOUND     ICOL05              0.
+ UP BOUND     IROP05              7.
+ UP BOUND     IGAS05              2.
+ FX BOUND     IELE05              0.
+ LO BOUND     GOVT05            451.
+ UP BOUND     E1COL05       6.384896
+ UP BOUND     E1ROP05       1.834738
+ UP BOUND     E1GAS05        .337604
+ FX BOUND     E1CRO05             0.
+ FX BOUND     E1ELE05             0.
+ FX BOUND     ITRD05              0.
+ UP BOUND     IAGR05     2546.241943
+ UP BOUND     IMNG05     2779.750977
+ UP BOUND     IEIM05     18563.96484
+ UP BOUND     IENM05      9822.28125
+ UP BOUND     ITAW05     3385.880859
+ UP BOUND     IMAC05     6389.203125
+ UP BOUND     E1AGR05         12090.
+ UP BOUND     E1MNG05          2025.
+ UP BOUND     E1EIM05         26118.
+ UP BOUND     E1ENM05         16389.
+ UP BOUND     E1TAW05          7830.
+ UP BOUND     E1MAC05         33321.
+ FX BOUND     E1TRD05             0.
+ UP BOUND     XCOL05       12.910257
+ FR BOUND     XCRO05
+ FR BOUND     XROP05
+ FR BOUND     XGAS05
+ FR BOUND     XELE05
+ FR BOUND     XAGR05
+ FR BOUND     XMNG05
+ FR BOUND     XEIM05
+ FR BOUND     XENM05
+ FR BOUND     XTAW05
+ FR BOUND     XTRD05
+ FR BOUND     XMAC05
+ UP BOUND     E2AGR05    2420.762695
+ UP BOUND     E2MNG05    1086.257813
+ UP BOUND     E2EIM05    8815.652344
+ UP BOUND     E2ENM05    4264.359375
+ UP BOUND     E2MAC05    11395.58203
+ FX BOUND     E2TRD05             0.
+ UP BOUND     PHYD05           .3692
+ UP BOUND     PGEO05          .05525
+ UP BOUND     PODR05           1864.
+ UP BOUND     PGDR05           1398.
+ UP BOUND     PCLQ05           24.84
+ UP BOUND     PCGL05             1.7
+ UP BOUND     PCGH05           24.84
+ UP BOUND     PFBR05          .00001
+ UP BOUND     POSE05            2.33
+ UP BOUND     WWCM05             30.
+ FX BOUND     ICOL06              0.
+ UP BOUND     IROP06              7.
+ UP BOUND     IGAS06              2.
+ FX BOUND     IELE06              0.
+ LO BOUND     GOVT06      506.199951
+ UP BOUND     E1COL06       7.768289
+ UP BOUND     E1ROP06       2.232265
+ UP BOUND     E1GAS06        .410752
+ FX BOUND     E1CRO06             0.
+ FX BOUND     E1ELE06             0.
+ FX BOUND     ITRD06              0.
+ UP BOUND     IAGR06     2626.281006
+ UP BOUND     IMNG06     2867.130371
+ UP BOUND     IEIM06     19147.50781
+ UP BOUND     IENM06     10131.03906
+ UP BOUND     ITAW06     3492.313232
+ UP BOUND     IMAC06     6590.042969
+ UP BOUND     E1AGR06    14709.49609
+ UP BOUND     E1MNG06    2463.749512
+ UP BOUND     E1EIM06    31776.89453
+ UP BOUND     E1ENM06    19939.94531
+ UP BOUND     E1TAW06    9526.496094
+ UP BOUND     E1MAC06    40540.54297
+ FX BOUND     E1TRD06             0.
+ UP BOUND     XCOL06       15.771699
+ FR BOUND     XCRO06
+ FR BOUND     XROP06
+ FR BOUND     XGAS06
+ FR BOUND     XELE06
+ FR BOUND     XAGR06
+ FR BOUND     XMNG06
+ FR BOUND     XEIM06
+ FR BOUND     XENM06
+ FR BOUND     XTAW06
+ FR BOUND     XTRD06
+ FR BOUND     XMAC06
+ UP BOUND     E2AGR06    2945.260742
+ UP BOUND     E2MNG06    1321.613525
+ UP BOUND     E2EIM06    10725.70703
+ UP BOUND     E2ENM06    5188.300781
+ UP BOUND     E2MAC06    13864.62109
+ FX BOUND     E2TRD06             0.
+ UP BOUND     PHYD06           .3876
+ UP BOUND     PGEO06          .06715
+ UP BOUND     PODR06           2739.
+ UP BOUND     PGDR06           2055.
+ UP BOUND     PCLQ06             40.
+ UP BOUND     PCGL06           2.737
+ UP BOUND     PCGH06             40.
+ UP BOUND     PFBR06           .0342
+ UP BOUND     POSE06            3.33
+ UP BOUND     WWCM06             30.
+ FX BOUND     ICOL07              0.
+ UP BOUND     IROP07              7.
+ UP BOUND     IGAS07              2.
+ FX BOUND     IELE07              0.
+ LO BOUND     GOVT07            588.
+ UP BOUND     E1COL07       9.449645
+ UP BOUND     E1ROP07       2.715411
+ UP BOUND     E1GAS07        .499654
+ FX BOUND     E1CRO07             0.
+ FX BOUND     E1ELE07             0.
+ FX BOUND     ITRD07              0.
+ UP BOUND     IAGR07     2705.318359
+ UP BOUND     IMNG07     2953.416016
+ UP BOUND     IEIM07     19723.74609
+ UP BOUND     IENM07     10435.92969
+ UP BOUND     ITAW07     3597.414063
+ UP BOUND     IMAC07     6788.367188
+ UP BOUND     E1AGR07    17893.19531
+ UP BOUND     E1MNG07    2996.999512
+ UP BOUND     E1EIM07    38654.63281
+ UP BOUND     E1ENM07    24255.71484
+ UP BOUND     E1TAW07    11588.39844
+ UP BOUND     E1MAC07    49315.07422
+ FX BOUND     E1TRD07             0.
+ UP BOUND     XCOL07       18.295166
+ FR BOUND     XCRO07
+ FR BOUND     XROP07
+ FR BOUND     XGAS07
+ FR BOUND     XELE07
+ FR BOUND     XAGR07
+ FR BOUND     XMNG07
+ FR BOUND     XEIM07
+ FR BOUND     XENM07
+ FR BOUND     XTAW07
+ FR BOUND     XTRD07
+ FR BOUND     XMAC07
+ UP BOUND     E2AGR07    3582.728271
+ UP BOUND     E2MNG07    1607.661377
+ UP BOUND     E2EIM07    13047.16406
+ UP BOUND     E2ENM07        6311.25
+ UP BOUND     E2MAC07    16865.45703
+ FX BOUND     E2TRD07             0.
+ UP BOUND     PHYD07            .408
+ UP BOUND     PGEO07           .0816
+ UP BOUND     PODR07           4025.
+ UP BOUND     PGDR07           3018.
+ UP BOUND     PCLQ07            64.4
+ UP BOUND     PCGL07           4.408
+ UP BOUND     PCGH07            64.4
+ UP BOUND     PFBR07            .184
+ UP BOUND     POSE07              6.
+ UP BOUND     WWCM07             30.
+ FX BOUND     ICOL08              0.
+ UP BOUND     IROP08              7.
+ UP BOUND     IGAS08              2.
+ FX BOUND     IELE08              0.
+ LO BOUND     GOVT08      656.199951
+ UP BOUND     E1COL08      11.492811
+ UP BOUND     E1ROP08       3.302526
+ UP BOUND     E1GAS08        .607688
+ FX BOUND     E1CRO08             0.
+ FX BOUND     E1ELE08             0.
+ FX BOUND     ITRD08              0.
+ UP BOUND     IAGR08     2789.358398
+ UP BOUND     IMNG08     3045.163086
+ UP BOUND     IEIM08     20336.46094
+ UP BOUND     IENM08     10760.11719
+ UP BOUND     ITAW08     3709.166748
+ UP BOUND     IMAC08     6999.246094
+ UP BOUND     E1AGR08    21761.99609
+ UP BOUND     E1MNG08    3644.999512
+ UP BOUND     E1EIM08    47012.39453
+ UP BOUND     E1ENM08    29500.19531
+ UP BOUND     E1TAW08    14093.99609
+ UP BOUND     E1MAC08    59977.79297
+ FX BOUND     E1TRD08             0.
+ UP BOUND     XCOL08       20.300415
+ FR BOUND     XCRO08
+ FR BOUND     XROP08
+ FR BOUND     XGAS08
+ FR BOUND     XELE08
+ FR BOUND     XAGR08
+ FR BOUND     XMNG08
+ FR BOUND     XEIM08
+ FR BOUND     XENM08
+ FR BOUND     XTAW08
+ FR BOUND     XTRD08
+ FR BOUND     XMAC08
+ UP BOUND     E2AGR08    4357.371094
+ UP BOUND     E2MNG08    1955.263916
+ UP BOUND     E2EIM08    15868.17188
+ UP BOUND     E2ENM08     7675.84375
+ UP BOUND     E2MAC08    20512.04297
+ FX BOUND     E2TRD08             0.
+ UP BOUND     PHYD08           .4284
+ UP BOUND     PGEO08           .1003
+ UP BOUND     PODR08           5914.
+ UP BOUND     PGDR08           4436.
+ UP BOUND     PCLQ08           103.7
+ UP BOUND     PCGL08           7.099
+ UP BOUND     PCGH08           103.7
+ UP BOUND     PFBR08            .682
+ UP BOUND     POSE08             10.
+ UP BOUND     WWCM08             30.
+ENDATA

--- a/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
@@ -182,9 +182,11 @@ Int FactorHiGHSSolver::setup() {
   if (Int status = setNla()) return status;
   setParallel();
 
-  std::stringstream log_stream;
-  log_stream << textline("Analyse time:") << fix(clock.stop(), 0, 2) << '\n';
-  logger_.print(log_stream.str().c_str());
+  if (!options_.timeless_log) {
+    std::stringstream log_stream;
+    log_stream << textline("Analyse time:") << fix(clock.stop(), 0, 2) << '\n';
+    logger_.print(log_stream.str().c_str());
+  }
 
   S_.print(logger_, logger_.debug(1));
 

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -423,8 +423,7 @@ void Model::adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
     if (is_free_[i]) {
       if (x[i] < lower_[i] * kFreeVarsCloseRatio) {
         // getting close to lower bound
-        const double new_lower = std::min(lower_[i] * kFreeVarsIncreaseBound,
-                                          x[i] / kFreeVarsCloseRatio);
+        const double new_lower = x[i] / kFreeVarsCloseRatio;
         logger.printDetailed(
             "Free var %d is at %.1e with lb %.1e, lb changed to %.1e\n", i,
             x[i], lower_[i], new_lower);
@@ -433,8 +432,7 @@ void Model::adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
       }
       if (x[i] > upper_[i] * kFreeVarsCloseRatio) {
         // getting close to upper bound
-        const double new_upper = std::max(upper_[i] * kFreeVarsIncreaseBound,
-                                          x[i] / kFreeVarsCloseRatio);
+        const double new_upper = x[i] / kFreeVarsCloseRatio;
         logger.printDetailed(
             "Free var %d is at %.1e with ub %.1e, ub changed to %.1e\n", i,
             x[i], upper_[i], new_upper);

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -419,26 +419,24 @@ void Model::printDense() const {
 
 void Model::adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
                            std::vector<double>& xu, const Logger& logger) {
-  for (Int i = 0; i < n_; ++i) {
-    if (is_free_[i]) {
-      if (x[i] < lower_[i] * kFreeVarsCloseRatio) {
-        // getting close to lower bound
-        const double new_lower = x[i] / kFreeVarsCloseRatio;
-        logger.printDetailed(
-            "Free var %d is at %.1e with lb %.1e, lb changed to %.1e\n", i,
-            x[i], lower_[i], new_lower);
-        lower_[i] = new_lower;
-        xl[i] = x[i] - lower_[i];
-      }
-      if (x[i] > upper_[i] * kFreeVarsCloseRatio) {
-        // getting close to upper bound
-        const double new_upper = x[i] / kFreeVarsCloseRatio;
-        logger.printDetailed(
-            "Free var %d is at %.1e with ub %.1e, ub changed to %.1e\n", i,
-            x[i], upper_[i], new_upper);
-        upper_[i] = new_upper;
-        xu[i] = upper_[i] - x[i];
-      }
+  for (Int i : free_variables_) {
+    if (x[i] < lower_[i] * kFreeVarsCloseRatio) {
+      // getting close to lower bound
+      const double new_lower = x[i] / kFreeVarsCloseRatio;
+      logger.printDetailed(
+          "Free var %5d is at %8.1e with lb %8.1e, lb changed to %8.1e\n", i, x[i],
+          lower_[i], new_lower);
+      lower_[i] = new_lower;
+      xl[i] = x[i] - lower_[i];
+    }
+    if (x[i] > upper_[i] * kFreeVarsCloseRatio) {
+      // getting close to upper bound
+      const double new_upper = x[i] / kFreeVarsCloseRatio;
+      logger.printDetailed(
+          "Free var %5d is at %8.1e with ub %8.1e, ub changed to %8.1e\n", i, x[i],
+          upper_[i], new_upper);
+      upper_[i] = new_upper;
+      xu[i] = upper_[i] - x[i];
     }
   }
 }

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -277,15 +277,12 @@ void Model::print(const Logger& logger) const {
   // compute max and min for bounds intervals
   double boundmin = kHighsInf;
   double boundmax = 0.0;
-  Int free_vars = 0;
   for (Int i = 0; i < n_; ++i) {
     if (std::isfinite(lower_[i]) && std::isfinite(upper_[i])) {
       const double diff = std::abs(upper_[i] - lower_[i]);
       boundmin = std::min(boundmin, diff);
       boundmax = std::max(boundmax, diff);
     }
-
-    if (!std::isfinite(lower_[i]) && !std::isfinite(upper_[i])) free_vars++;
   }
   if (std::isinf(boundmin)) boundmin = 0.0;
 
@@ -345,7 +342,6 @@ void Model::print(const Logger& logger) const {
 
   if (logger.debug(1)) {
     preprocessor_.print(log_stream);
-    log_stream << textline("Free variables:") << integer(free_vars) << '\n';
 
     log_stream << "Expected nnz: ";
     log_stream << "AS " << sci(AS_nz_, 0, 1) << "; ";
@@ -419,6 +415,34 @@ void Model::printDense() const {
     printf("\n");
   }
   printf("offset %6.2f\n", offset_);
+}
+
+void Model::adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
+                           std::vector<double>& xu, const Logger& logger) {
+  for (Int i = 0; i < n_; ++i) {
+    if (is_free_[i]) {
+      if (x[i] < lower_[i] * kFreeVarsCloseRatio) {
+        // getting close to lower bound
+        const double new_lower = std::min(lower_[i] * kFreeVarsIncreaseBound,
+                                          x[i] / kFreeVarsCloseRatio);
+        logger.printDetailed(
+            "Free var %d is at %.1e with lb %.1e, lb changed to %.1e\n", i,
+            x[i], lower_[i], new_lower);
+        lower_[i] = new_lower;
+        xl[i] = x[i] - lower_[i];
+      }
+      if (x[i] > upper_[i] * kFreeVarsCloseRatio) {
+        // getting close to upper bound
+        const double new_upper = std::max(upper_[i] * kFreeVarsIncreaseBound,
+                                          x[i] / kFreeVarsCloseRatio);
+        logger.printDetailed(
+            "Free var %d is at %.1e with ub %.1e, ub changed to %.1e\n", i,
+            x[i], upper_[i], new_upper);
+        upper_[i] = new_upper;
+        xu[i] = upper_[i] - x[i];
+      }
+    }
+  }
 }
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Model.h
+++ b/highs/ipm/hipo/ipm/Model.h
@@ -5,9 +5,9 @@
 #include <string>
 #include <vector>
 
-#include "ipm/hipo/auxiliary/Logger.h"
 #include "PreProcess.h"
 #include "ipm/hipo/auxiliary/IntConfig.h"
+#include "ipm/hipo/auxiliary/Logger.h"
 #include "ipm/ipx/lp_solver.h"
 #include "lp_data/HighsLp.h"
 #include "model/HighsHessian.h"
@@ -65,6 +65,8 @@ class Model {
   std::vector<double> one_norm_cols_, one_norm_rows_, inf_norm_cols_,
       inf_norm_rows_;
 
+  std::vector<bool> is_free_;
+
   void preprocess();
   Int checkData() const;
   void computeNorms();
@@ -89,6 +91,9 @@ class Model {
   double normUnscaledRhs() const { return norm_unscaled_rhs_; }
 
   void nzBounds();
+
+  void adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
+                      std::vector<double>& xu, const Logger& logger);
 
   // Check if variable has finite lower/upper bound
   bool hasLb(Int j) const { return std::isfinite(lower_[j]); }
@@ -123,6 +128,7 @@ class Model {
   Int64 nzAS() const { return AS_nz_; }
   Int64 nzNElb() const { return NE_nz_lb_; }
   Int64 nzNEub() const { return NE_nz_ub_; }
+  bool free(Int i) const { return is_free_[i]; }
 
   Int loadIntoIpx(ipx::LpSolver& lps) const;
 
@@ -131,6 +137,7 @@ class Model {
   friend struct PreprocessFixedVars;
   friend struct PreprocessScaling;
   friend struct PreprocessFormulation;
+  friend struct PreprocessFreeVars;
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Model.h
+++ b/highs/ipm/hipo/ipm/Model.h
@@ -128,7 +128,7 @@ class Model {
   Int64 nzAS() const { return AS_nz_; }
   Int64 nzNElb() const { return NE_nz_lb_; }
   Int64 nzNEub() const { return NE_nz_ub_; }
-  bool free(Int i) const { return is_free_[i]; }
+  bool isFree(Int i) const { return is_free_[i]; }
 
   Int loadIntoIpx(ipx::LpSolver& lps) const;
 

--- a/highs/ipm/hipo/ipm/Model.h
+++ b/highs/ipm/hipo/ipm/Model.h
@@ -65,7 +65,7 @@ class Model {
   std::vector<double> one_norm_cols_, one_norm_rows_, inf_norm_cols_,
       inf_norm_rows_;
 
-  std::vector<bool> is_free_;
+  std::vector<Int> free_variables_;
 
   void preprocess();
   Int checkData() const;
@@ -128,7 +128,7 @@ class Model {
   Int64 nzAS() const { return AS_nz_; }
   Int64 nzNElb() const { return NE_nz_lb_; }
   Int64 nzNEub() const { return NE_nz_ub_; }
-  bool isFree(Int i) const { return is_free_[i]; }
+  const std::vector<Int>& freeVars() const { return free_variables_; }
 
   Int loadIntoIpx(ipx::LpSolver& lps) const;
 

--- a/highs/ipm/hipo/ipm/Parameters.h
+++ b/highs/ipm/hipo/ipm/Parameters.h
@@ -54,7 +54,6 @@ const double kSmallBoundDiff = 1e-3;
 // parameters for free variables
 const double kFreeVarsInitialBound = 1e4;
 const double kFreeVarsCloseRatio = 0.5;
-const double kFreeVarsIncreaseBound = 10.0;
 
 // static regularisation
 struct Regularisation {

--- a/highs/ipm/hipo/ipm/Parameters.h
+++ b/highs/ipm/hipo/ipm/Parameters.h
@@ -51,6 +51,11 @@ const double kSmallScalingCoeff = 1e-4;
 const double kLargeScalingCoeff = 1e4;
 const double kSmallBoundDiff = 1e-3;
 
+// parameters for free variables
+const double kFreeVarsInitialBound = 1e4;
+const double kFreeVarsCloseRatio = 0.5;
+const double kFreeVarsIncreaseBound = 10.0;
+
 // static regularisation
 struct Regularisation {
   double primal = 1e-12;

--- a/highs/ipm/hipo/ipm/PreProcess.cpp
+++ b/highs/ipm/hipo/ipm/PreProcess.cpp
@@ -619,21 +619,11 @@ void PreprocessFormulation::print(std::stringstream& stream) const {
 
 void PreprocessFreeVars::apply(Model& model) {
   Int& n = model.n_;
-  Int& m = model.m_;
-  HighsSparseMatrix& A = model.A_;
-  std::vector<double>& b = model.b_;
-  std::vector<double>& c = model.c_;
   std::vector<double>& lower = model.lower_;
   std::vector<double>& upper = model.upper_;
-  std::vector<char>& constraints = model.constraints_;
-  HighsHessian& Q = model.Q_;
   std::vector<bool>& is_free = model.is_free_;
 
-  n_pre = n;
-  m_pre = m;
-
   is_free.assign(n, false);
-
   for (Int i = 0; i < n; ++i) {
     if (!std::isfinite(lower[i]) && !std::isfinite(upper[i]) &&
         lower[i] != upper[i]) {
@@ -644,17 +634,10 @@ void PreprocessFreeVars::apply(Model& model) {
       upper[i] = kFreeVarsInitialBound;
     }
   }
-
-  n_post = n;
-  m_post = m;
 }
 
 void PreprocessFreeVars::undo(PreprocessorPoint& point, const Model& model,
-                              const Iterate& it) const {
-  point.assertConsistency(n_post, m_post);
-  //
-  point.assertConsistency(n_pre, m_pre);
-}
+                              const Iterate& it) const {}
 
 void PreprocessFreeVars::print(std::stringstream& stream) const {
   if (free_vars > 0) stream << "Found " << free_vars << " free variables\n";

--- a/highs/ipm/hipo/ipm/PreProcess.cpp
+++ b/highs/ipm/hipo/ipm/PreProcess.cpp
@@ -483,11 +483,11 @@ void PreprocessScaling::undo(PreprocessorPoint& point, const Model& model,
 
     // set variables that were ignored
     for (Int i = 0; i < n_post; ++i) {
-      if (!model.hasLb(i) || model.is_free_[i]) {
+      if (!model.hasLb(i) || model.isFree(i)) {
         point.xl[i] = kHighsInf;
         point.zl[i] = 0.0;
       }
-      if (!model.hasUb(i) || model.is_free_[i]) {
+      if (!model.hasUb(i) || model.isFree(i)) {
         point.xu[i] = kHighsInf;
         point.zu[i] = 0.0;
       }
@@ -561,11 +561,11 @@ void PreprocessFormulation::undo(PreprocessorPoint& point, const Model& model,
 
   // force unused entries to have correct value
   for (Int i = 0; i < n_pre; ++i) {
-    if (!model.hasLb(i) || model.is_free_[i]) {
+    if (!model.hasLb(i) || model.isFree(i)) {
       point.xl[i] = kHighsInf;
       point.zl[i] = 0.0;
     }
-    if (!model.hasUb(i) || model.is_free_[i]) {
+    if (!model.hasUb(i) || model.isFree(i)) {
       point.xu[i] = kHighsInf;
       point.zu[i] = 0.0;
     }

--- a/highs/ipm/hipo/ipm/PreProcess.cpp
+++ b/highs/ipm/hipo/ipm/PreProcess.cpp
@@ -483,11 +483,11 @@ void PreprocessScaling::undo(PreprocessorPoint& point, const Model& model,
 
     // set variables that were ignored
     for (Int i = 0; i < n_post; ++i) {
-      if (!model.hasLb(i)) {
+      if (!model.hasLb(i) || model.is_free_[i]) {
         point.xl[i] = kHighsInf;
         point.zl[i] = 0.0;
       }
-      if (!model.hasUb(i)) {
+      if (!model.hasUb(i) || model.is_free_[i]) {
         point.xu[i] = kHighsInf;
         point.zu[i] = 0.0;
       }
@@ -561,11 +561,11 @@ void PreprocessFormulation::undo(PreprocessorPoint& point, const Model& model,
 
   // force unused entries to have correct value
   for (Int i = 0; i < n_pre; ++i) {
-    if (!model.hasLb(i)) {
+    if (!model.hasLb(i) || model.is_free_[i]) {
       point.xl[i] = kHighsInf;
       point.zl[i] = 0.0;
     }
-    if (!model.hasUb(i)) {
+    if (!model.hasUb(i) || model.is_free_[i]) {
       point.xu[i] = kHighsInf;
       point.zu[i] = 0.0;
     }
@@ -617,6 +617,49 @@ void PreprocessFormulation::print(std::stringstream& stream) const {
   stream << "Added " << n_post - n_pre << " slacks\n";
 }
 
+void PreprocessFreeVars::apply(Model& model) {
+  Int& n = model.n_;
+  Int& m = model.m_;
+  HighsSparseMatrix& A = model.A_;
+  std::vector<double>& b = model.b_;
+  std::vector<double>& c = model.c_;
+  std::vector<double>& lower = model.lower_;
+  std::vector<double>& upper = model.upper_;
+  std::vector<char>& constraints = model.constraints_;
+  HighsHessian& Q = model.Q_;
+  std::vector<bool>& is_free = model.is_free_;
+
+  n_pre = n;
+  m_pre = m;
+
+  is_free.assign(n, false);
+
+  for (Int i = 0; i < n; ++i) {
+    if (!std::isfinite(lower[i]) && !std::isfinite(upper[i]) &&
+        lower[i] != upper[i]) {
+      // free variable
+      is_free[i] = true;
+      ++free_vars;
+      lower[i] = -kFreeVarsInitialBound;
+      upper[i] = kFreeVarsInitialBound;
+    }
+  }
+
+  n_post = n;
+  m_post = m;
+}
+
+void PreprocessFreeVars::undo(PreprocessorPoint& point, const Model& model,
+                              const Iterate& it) const {
+  point.assertConsistency(n_post, m_post);
+  //
+  point.assertConsistency(n_pre, m_pre);
+}
+
+void PreprocessFreeVars::print(std::stringstream& stream) const {
+  if (free_vars > 0) stream << "Found " << free_vars << " free variables\n";
+}
+
 #define APPLY_ACTION(T)                                      \
   stack.push_back(std::unique_ptr<PreprocessAction>(new T)); \
   stack.back()->apply(model);
@@ -629,6 +672,7 @@ void Preprocessor::apply(Model& model) {
   APPLY_ACTION(PreprocessEmptyRows);
   APPLY_ACTION(PreprocessScaling);
   APPLY_ACTION(PreprocessFormulation);
+  APPLY_ACTION(PreprocessFreeVars);
 }
 void Preprocessor::undo(PreprocessorPoint& point, const Model& model,
                         const Iterate& it) const {

--- a/highs/ipm/hipo/ipm/PreProcess.cpp
+++ b/highs/ipm/hipo/ipm/PreProcess.cpp
@@ -483,14 +483,20 @@ void PreprocessScaling::undo(PreprocessorPoint& point, const Model& model,
 
     // set variables that were ignored
     for (Int i = 0; i < n_post; ++i) {
-      if (!model.hasLb(i) || model.isFree(i)) {
+      if (!model.hasLb(i)) {
         point.xl[i] = kHighsInf;
         point.zl[i] = 0.0;
       }
-      if (!model.hasUb(i) || model.isFree(i)) {
+      if (!model.hasUb(i)) {
         point.xu[i] = kHighsInf;
         point.zu[i] = 0.0;
       }
+    }
+    for (Int i : model.freeVars()) {
+      point.xl[i] = kHighsInf;
+      point.zl[i] = 0.0;
+      point.xu[i] = kHighsInf;
+      point.zu[i] = 0.0;
     }
   }
   point.assertConsistency(n_pre, m_pre);
@@ -561,14 +567,20 @@ void PreprocessFormulation::undo(PreprocessorPoint& point, const Model& model,
 
   // force unused entries to have correct value
   for (Int i = 0; i < n_pre; ++i) {
-    if (!model.hasLb(i) || model.isFree(i)) {
+    if (!model.hasLb(i)) {
       point.xl[i] = kHighsInf;
       point.zl[i] = 0.0;
     }
-    if (!model.hasUb(i) || model.isFree(i)) {
+    if (!model.hasUb(i)) {
       point.xu[i] = kHighsInf;
       point.zu[i] = 0.0;
     }
+  }
+  for (Int i : model.freeVars()) {
+    point.xl[i] = kHighsInf;
+    point.zl[i] = 0.0;
+    point.xu[i] = kHighsInf;
+    point.zu[i] = 0.0;
   }
 
   // For the Lagrange multipliers, use slacks from zl and zu, to get correct
@@ -621,15 +633,15 @@ void PreprocessFreeVars::apply(Model& model) {
   Int& n = model.n_;
   std::vector<double>& lower = model.lower_;
   std::vector<double>& upper = model.upper_;
-  std::vector<bool>& is_free = model.is_free_;
+  std::vector<Int>& free_variables = model.free_variables_;
 
-  is_free.assign(n, false);
+  free_variables.clear();
   for (Int i = 0; i < n; ++i) {
     if (!std::isfinite(lower[i]) && !std::isfinite(upper[i]) &&
         lower[i] != upper[i]) {
       // free variable
-      is_free[i] = true;
-      ++free_vars;
+      free_variables.push_back(i);
+      ++free_vars_count;
       lower[i] = -kFreeVarsInitialBound;
       upper[i] = kFreeVarsInitialBound;
     }
@@ -640,7 +652,8 @@ void PreprocessFreeVars::undo(PreprocessorPoint& point, const Model& model,
                               const Iterate& it) const {}
 
 void PreprocessFreeVars::print(std::stringstream& stream) const {
-  if (free_vars > 0) stream << "Found " << free_vars << " free variables\n";
+  if (free_vars_count > 0)
+    stream << "Found " << free_vars_count << " free variables\n";
 }
 
 #define APPLY_ACTION(T)                                      \

--- a/highs/ipm/hipo/ipm/PreProcess.h
+++ b/highs/ipm/hipo/ipm/PreProcess.h
@@ -80,6 +80,15 @@ struct PreprocessFormulation : public PreprocessAction {
   void print(std::stringstream& stream) const override;
 };
 
+struct PreprocessFreeVars : public PreprocessAction {
+  Int free_vars{};
+
+  void apply(Model& model) override;
+  void undo(PreprocessorPoint& point, const Model& model,
+            const Iterate& it) const override;
+  void print(std::stringstream& stream) const override;
+};
+
 struct Preprocessor {
   std::vector<std::unique_ptr<PreprocessAction>> stack;
 

--- a/highs/ipm/hipo/ipm/PreProcess.h
+++ b/highs/ipm/hipo/ipm/PreProcess.h
@@ -81,7 +81,7 @@ struct PreprocessFormulation : public PreprocessAction {
 };
 
 struct PreprocessFreeVars : public PreprocessAction {
-  Int free_vars{};
+  Int free_vars_count{};
 
   void apply(Model& model) override;
   void undo(PreprocessorPoint& point, const Model& model,

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -191,6 +191,8 @@ bool Solver::prepareIter() {
 
   ++iter_;
 
+  model_.adjustFreeVars(it_->x, it_->xl, it_->xu, logger_);
+
   // Clear Newton direction
   it_->clearDir();
 


### PR DESCRIPTION
Free variables now receive an artificial upper and lower bound. If the variable gets too close to the bound during the IPM iterations, the bound is moved. This improve robustness on some problems. I added the instance ``perold`` from Netlib, which has a large number of free variables, and a unit test.