### PR TITLE
Significantly improve macos build times (i.e., github actions)

### DIFF
--- a/highs/CMakeLists.txt
+++ b/highs/CMakeLists.txt
@@ -132,8 +132,18 @@ else()
   # Define library in modern CMake using target_*()
   # No interfaces (apart from c); No ipx; New (short) ctest instances.
   add_library(highs)
-
   add_library(${PROJECT_NAMESPACE}::highs ALIAS highs)
+
+  if(APPLE)
+    # linker was taking ~1 hour, unity build reduces it to ~1 minute
+    set_target_properties(highs PROPERTIES
+      UNITY_BUILD ON
+      UNITY_BUILD_BATCH_SIZE 8)
+
+    if(NOT CMAKE_VERSION VERSION_LESS 3.20)
+      set_target_properties(highs PROPERTIES UNITY_BUILD_UNIQUE_ID "HIGHS_UNITY_ID")
+    endif()
+  endif()
 
   if(${BUILD_SHARED_LIBS})
     # put version information into shared library file

--- a/highs/CMakeLists.txt
+++ b/highs/CMakeLists.txt
@@ -23,6 +23,17 @@ if(NOT FAST_BUILD)
   add_library(libhighs ${sources} ${headers} ${win_version_file})
   target_include_directories(libhighs PRIVATE ${include_dirs})
 
+  if(APPLE)
+    # linker was taking ~1 hour, unity build reduces it to ~1 minute
+    set_target_properties(libhighs PROPERTIES
+      UNITY_BUILD ON
+      UNITY_BUILD_BATCH_SIZE 8)
+
+    if(NOT CMAKE_VERSION VERSION_LESS 3.20)
+      set_target_properties(libhighs PROPERTIES UNITY_BUILD_UNIQUE_ID "HIGHS_UNITY_ID")
+    endif()
+  endif()
+
   if(${BUILD_SHARED_LIBS})
     # put version information into shared library file
     set_target_properties(libhighs PROPERTIES


### PR DESCRIPTION
* I noticed that a few github actions were taking >1 hour for macos builds.  
* Most of this time was spent linking libhighs. 
* This change enables `UNITY_BUILD` on `APPLE` and build time reduces to ~1 minute.

I haven't seen any issues with using it, but I noticed that it had been previously disabled.  I'm not an Apple user, so please reject this PR if it doesn't make sense.

Note: This is PR is set to merge to my `third-party-dependencies` branch, i.e., PR #3031.  I can rewrite it to work directly with latest if preferred.