### PR TITLE
Added unit tests for highspy-extras

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Test highspy
         run: |
           python3 -m pip install pytest
-          python3 -m pytest $GITHUB_WORKSPACE
+          python3 -m pytest ./highspy
 
   build_sdist_mac:
     runs-on: macos-latest

--- a/.github/workflows/build-python-sdist.yml
+++ b/.github/workflows/build-python-sdist.yml
@@ -152,13 +152,6 @@ jobs:
           source .venv/bin/activate
           python3 -m pip install dist/*.tar.gz
 
-      - name: Debug extras loading
-        run: |
-          source .venv/bin/activate
-          python -c "import highspy._core; print(highspy._core.getExtrasLoadStatus())"
-          python -c "import highspy_extras; print(highspy_extras.__file__); print(highspy_extras._PACKAGE_DIR)"
-          python -c "import highspy_extras; highspy_extras._load_library()"
-
       - name: Test highspy
         run: |
           source .venv/bin/activate
@@ -194,12 +187,6 @@ jobs:
       - name: install highspy and highspy-extras
         run: python -m pip install (Get-ChildItem dist\*.tar.gz)
 
-      - name: Debug extras loading
-        run: |
-          python -c "import highspy._core; print(highspy._core.getExtrasLoadStatus())"
-          python -c "import highspy_extras; print(highspy_extras.__file__); print(highspy_extras._PACKAGE_DIR)"
-          python -c "import highspy_extras; highspy_extras._load_library()"
-          
       - name: Test highspy
         run: |
           python -m pip install pytest

--- a/extern/HighsExtrasApi.cpp
+++ b/extern/HighsExtrasApi.cpp
@@ -15,6 +15,8 @@
 
 using namespace HighsExtras;
 
+namespace {
+
 template <class Methods, class... Fn>
 void bind_api(HighsExtrasApi* api, const std::tuple<Fn...>& funcs) {
   static_assert(std::tuple_size<Methods>::value == sizeof...(Fn),
@@ -23,14 +25,38 @@ void bind_api(HighsExtrasApi* api, const std::tuple<Fn...>& funcs) {
       api->template as<Methods>(), funcs);
 }
 
+// Get feature name by index at runtime via template recursion
+template <size_t N>
+struct feature_name {
+  static const char* get(size_t index) {
+    return (index == N - 1) ? extras_feature<N - 1>::name()
+                            : feature_name<N - 1>::get(index);
+  }
+};
+
+template <>
+struct feature_name<0> {
+  static const char* get(size_t) { return nullptr; }
+};
+}  // namespace
+
 extern "C" {
 
 HIGHS_EXTRAS_API const char* HighsExtras_getVersion(void) {
   return HIGHS_EXTRAS_VERSION;
 }
 
+HIGHS_EXTRAS_API size_t HighsExtras_getFeatureCount(void) {
+  return feature_count<extrasAll>::value;
+}
+
+HIGHS_EXTRAS_API const char* HighsExtras_getFeatureName(size_t index) {
+  if (index >= feature_count<extrasAll>::value) return nullptr;
+  return feature_name<feature_count<extrasAll>::value>::get(index);
+}
+
 HIGHS_EXTRAS_API const HighsExtrasFeatureInfo* HighsExtras_getFeatureInfo() {
-  return extras_feature_info;
+  return extras_family::getInfo();
 }
 
 HIGHS_EXTRAS_API bool HighsExtras_getApi(HighsExtrasApi* api) {

--- a/extern/HighsExtrasApi.h
+++ b/extern/HighsExtrasApi.h
@@ -62,6 +62,8 @@ extern "C" {
 HIGHS_EXTRAS_API const char* HighsExtras_getVersion(void);
 
 // Get metadata for all features
+HIGHS_EXTRAS_API size_t HighsExtras_getFeatureCount(void);
+HIGHS_EXTRAS_API const char* HighsExtras_getFeatureName(size_t index);
 HIGHS_EXTRAS_API const HighsExtrasFeatureInfo* HighsExtras_getFeatureInfo();
 
 // Get the HighsExtrasApi, with appropriate function pointers

--- a/extern/HighsExtrasApiBinding.h
+++ b/extern/HighsExtrasApiBinding.h
@@ -11,7 +11,10 @@
 #ifndef HIGHS_EXTRAS_API_BINDING_H_
 #define HIGHS_EXTRAS_API_BINDING_H_
 
+#include <stddef.h>
+
 #include <tuple>
+
 
 // provide metadata info for each feature
 struct HighsExtrasFeatureInfo {

--- a/extern/HighsExtrasApiBinding.h
+++ b/extern/HighsExtrasApiBinding.h
@@ -34,6 +34,25 @@ namespace HighsExtras {
 template <class... Features>
 struct require {};
 
+// compile-time count of nested features in a list,
+// e.g., feature_count<require<amd, blas>, rcm>::value == 3
+template <class T>
+struct feature_count : std::integral_constant<size_t, 1> {};
+
+template <class... Fs>
+struct sum_feature_counts;
+
+template <>
+struct sum_feature_counts<> : std::integral_constant<size_t, 0> {};
+
+template <class F, class... Rest>
+struct sum_feature_counts<F, Rest...>
+    : std::integral_constant<size_t, feature_count<F>::value +
+                                         sum_feature_counts<Rest...>::value> {};
+
+template <class... Features>
+struct feature_count<require<Features...>> : sum_feature_counts<Features...> {};
+
 template <class Methods>
 struct feature_api;
 

--- a/extern/HighsExtrasExternalDeps.cpp
+++ b/extern/HighsExtrasExternalDeps.cpp
@@ -29,4 +29,8 @@ const HighsExtrasFeatureInfo extras_feature_info[] = {
     {"METIS-GKlib", "5.2.1+", "Apache-2.0", __hipo_enabled},
     {"SPARSEPAK", "unversioned+", "MIT", __hipo_enabled}};
 
+const HighsExtrasFeatureInfo* extras_family::getInfo() {
+  return extras_feature_info;
+}
+
 }  // namespace HighsExtras

--- a/extern/HighsExtrasExternalDeps.h
+++ b/extern/HighsExtrasExternalDeps.h
@@ -35,8 +35,9 @@
 // 0. Define Features
 //
 namespace HighsExtras {
-struct extras_family {};
-extern const HighsExtrasFeatureInfo extras_feature_info[];
+struct extras_family {
+  static const HighsExtrasFeatureInfo* getInfo();
+};
 
 template <>
 struct wrapper_storage<extras_family> {

--- a/highspy-extras/highspy_extras/__init__.py
+++ b/highspy-extras/highspy_extras/__init__.py
@@ -26,7 +26,7 @@ class _HighsExtrasFeatureInfoRaw(ctypes.Structure):
     ]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class HighsExtrasFeatureInfo:
     """Feature metadata for an external dependency."""
 

--- a/highspy-extras/highspy_extras/__init__.py
+++ b/highspy-extras/highspy_extras/__init__.py
@@ -4,50 +4,132 @@ from __future__ import annotations
 
 import ctypes
 import sys
+from dataclasses import dataclass
+from functools import cached_property
 from importlib.metadata import version
 from pathlib import Path
 
-__all__ = ["__version__", "get_library_version"]
+__all__ = ["__version__", "HighsExtrasFeatureInfo", "library"]
 
 __version__ = version("highspy-extras")
-
 _PACKAGE_DIR = Path(__file__).resolve().parent
-_library_handle: ctypes.CDLL | None = None
 
 
-def _load_library() -> ctypes.CDLL:
-    global _library_handle
+class _HighsExtrasFeatureInfoRaw(ctypes.Structure):
+    """Raw feature info layout exposed by the shared library."""
 
-    if _library_handle is not None:
-        return _library_handle
+    _fields_ = [
+        ("provider", ctypes.c_char_p),
+        ("version", ctypes.c_char_p),
+        ("license", ctypes.c_char_p),
+        ("enabled", ctypes.c_bool),
+    ]
 
-    if sys.platform == "win32":
-        library_name = "highs_extras.dll"
-    elif sys.platform == "darwin":
-        library_name = "libhighs_extras.dylib"
-    else:
-        library_name = "libhighs_extras.so"
 
-    library_path = _PACKAGE_DIR / library_name
-    if not library_path.is_file():
-        raise FileNotFoundError(
-            f"Could not find the highs_extras shared library at {library_path}"
+@dataclass(frozen=True, slots=True)
+class HighsExtrasFeatureInfo:
+    """Feature metadata for an external dependency."""
+
+    provider: str
+    version: str
+    license: str
+    enabled: bool
+
+    @classmethod
+    def from_raw(cls, raw: _HighsExtrasFeatureInfoRaw) -> HighsExtrasFeatureInfo:
+        return cls(
+            provider=raw.provider.decode("utf-8"),
+            version=raw.version.decode("utf-8"),
+            license=raw.license.decode("utf-8"),
+            enabled=bool(raw.enabled),
         )
 
-    _library_handle = ctypes.CDLL(str(library_path))
-    return _library_handle
+
+class HighsExtrasLibrary:
+    """Wrapper around the highs_extras shared library."""
+
+    @cached_property
+    def handle(self) -> ctypes.CDLL:
+        if sys.platform == "win32":
+            library_name = "highs_extras.dll"
+        elif sys.platform == "darwin":
+            library_name = "libhighs_extras.dylib"
+        else:
+            library_name = "libhighs_extras.so"
+
+        library_path = _PACKAGE_DIR / library_name
+        if not library_path.is_file():
+            raise FileNotFoundError(f"Could not find the shared library at {library_path}")
+
+        handle = ctypes.CDLL(str(library_path))
+
+        handle.HighsExtras_getVersion.argtypes = []
+        handle.HighsExtras_getVersion.restype = ctypes.c_char_p
+
+        handle.HighsExtras_getFeatureCount.argtypes = []
+        handle.HighsExtras_getFeatureCount.restype = ctypes.c_size_t
+
+        handle.HighsExtras_getFeatureName.argtypes = [ctypes.c_size_t]
+        handle.HighsExtras_getFeatureName.restype = ctypes.c_char_p
+
+        handle.HighsExtras_getFeatureInfo.argtypes = []
+        handle.HighsExtras_getFeatureInfo.restype = ctypes.POINTER(_HighsExtrasFeatureInfoRaw)
+
+        return handle
+
+    @property
+    def version(self) -> str:
+        version_bytes = self.handle.HighsExtras_getVersion()
+        if version_bytes is None:
+            raise RuntimeError("HighsExtras_getVersion() returned NULL")
+        return version_bytes.decode("utf-8")
+
+    def _feature_name(self, index: int) -> str:
+        name_bytes = self.handle.HighsExtras_getFeatureName(index)
+        if name_bytes is None:
+            raise RuntimeError(f"HighsExtras_getFeatureName({index}) returned NULL")
+        return name_bytes.decode("utf-8")
+
+    @cached_property
+    def features(self) -> dict[str, HighsExtrasFeatureInfo]:
+        info_ptr = self.handle.HighsExtras_getFeatureInfo()
+        if not info_ptr:
+            raise RuntimeError("HighsExtras_getFeatureInfo() returned NULL")
+
+        count = int(self.handle.HighsExtras_getFeatureCount())
+        return {self._feature_name(index): HighsExtrasFeatureInfo.from_raw(info_ptr[index]) for index in range(count)}
+
+    def __getitem__(self, name: str) -> HighsExtrasFeatureInfo:
+        return self.features[name]
+
+    @cached_property
+    def feature_table(self) -> str:
+        """Return a human-readable table describing the external dependency features."""
+
+        headers = ("key", "name", "version", "license", "enabled")
+        rows = [
+            (
+                name,
+                info.provider,
+                info.version,
+                info.license,
+                "yes" if info.enabled else "no",
+            )
+            for name, info in self.features.items()
+        ]
+
+        widths = [max(len(headers[i]), *(len(row[i]) for row in rows)) if rows else len(headers[i]) for i in range(len(headers))]
+
+        def _fmt(row: tuple[str, ...]) -> str:
+            return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row))
+
+        separator = "  ".join("-" * w for w in widths)
+        lines = [_fmt(headers), separator]
+        lines.extend(_fmt(row) for row in rows)
+        return "\n".join(lines)
+
+    def __str__(self) -> str:
+        return self.feature_table
 
 
-def get_library_version() -> str:
-    """Return the ABI version string exported by the highs_extras library."""
-
-    get_version = _load_library().highs_extras_get_version
-    get_version.argtypes = []
-    get_version.restype = ctypes.c_char_p
-
-    version_bytes = get_version()
-    if version_bytes is None:
-        raise RuntimeError("highs_extras_get_version() returned NULL")
-
-    return version_bytes.decode("utf-8")
-
+library = HighsExtrasLibrary()

--- a/highspy-extras/pyproject.toml
+++ b/highspy-extras/pyproject.toml
@@ -30,6 +30,9 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [project.urls]
 "Source Code" = "https://github.com/ERGO-Code/HiGHS"
 "Bug Tracker" = "https://github.com/ERGO-Code/HiGHS/issues"
@@ -46,7 +49,8 @@ sdist.include = [
   "extern",
   "cmake",
   "Version.txt",
-  "highs/HConfig.h.in"
+  "highs/HConfig.h.in",
+  "tests/test_highspy_extras.py"
 ]
 
 sdist.exclude = [
@@ -76,10 +80,22 @@ sdist.exclude = [
 ]
 
 [tool.scikit-build.cmake.define]
+#HIGHS_VCPKG="ON"
 BUILD_OPENBLAS = "ON"
 HIPO = "ON"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
+xfail_strict = true
+log_cli_level = "INFO"
+filterwarnings = ["error"]
+testpaths = ["tests"]
+norecursedirs = ["check", ".git", "build", "dist", "*.egg-info"]
 
 [tool.cibuildwheel]
 build = "*"
 archs = ["auto64", "auto32"]
 build-verbosity = 1
+test-command = "pytest {project}/highspy-extras/tests"
+test-extras = ["test"]

--- a/highspy-extras/tests/test_highspy_extras.py
+++ b/highspy-extras/tests/test_highspy_extras.py
@@ -1,0 +1,41 @@
+import re
+import unittest
+
+import highspy_extras
+
+
+class TestHighsPyExtras(unittest.TestCase):
+    def test_version(self):
+        # Ensure the library version matches the release part of the package version,
+        # e.g., "1.14.0.dev1" -> "1.14.0"
+        package_release = re.match(r"\d+(?:\.\d+)*", highspy_extras.__version__)
+        if package_release is None:
+            self.fail(f"Could not parse a release version from {highspy_extras.__version__!r}")
+        self.assertEqual(highspy_extras.library.version, package_release.group(0))
+
+    def test_features(self):
+        # Ensure the library has non-zero features available
+        features = highspy_extras.library.features
+        self.assertIsInstance(features, dict)
+        self.assertGreater(len(features), 0)
+
+    def test_blas_enabled(self):
+        # Ensure BLAS feature is present and enabled in this build
+        self.assertIn("blas", highspy_extras.library.features)
+        blas_feature = highspy_extras.library["blas"]
+        self.assertTrue(blas_feature.enabled)
+
+    def test_getitem_matches_features_mapping(self):
+        # Ensure __getitem__ and features[] are the same
+        self.assertIs(
+            highspy_extras.library["blas"],
+            highspy_extras.library.features["blas"],
+        )
+
+    def test_feature_table(self):
+        # Basic sanity check for the feature table
+        table = highspy_extras.library.feature_table
+        self.assertIsInstance(table, str)
+        self.assertIn("key", table)
+        self.assertIn("version", table)
+        self.assertIn("blas", table)


### PR DESCRIPTION
Added unit tests for `highspy-extras` and cleaned up API for better usability.  For example,

```python
import highspy_extras

highspy_extras.library.version  # e.g., "1.14.0"
highspy_extras.library.features # dict[str, HighsExtrasFeatureInfo] 
highspy_extras.library["blas"]  # HighsExtrasFeatureInfo with BLAS details

# available features in a table
print(highspy_extras.library.feature_table)
print(highspy_extras.library)
```

```
key    name             version       license       enabled
-----  ---------------  ------------  ------------  -------
amd    SuiteSparse AMD  7.12.1+       BSD-3-Clause  yes
blas   OpenBLAS         0.3.29        BSD-3-Clause  yes
metis  METIS-GKlib      5.2.1+        Apache-2.0    yes
rcm    SPARSEPAK        unversioned+  MIT           yes
```

**I don't expect users to ever need these helper functions, but they can help for debugging.**