### PR TITLE
Prevent parallel simplex when solving MIPs

### DIFF
--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -438,9 +438,7 @@ struct HighsOptionsStruct {
   HighsInt presolve_rule_off;
   bool presolve_rule_logging;
   bool presolve_remove_slacks;
-  bool simplex_initial_condition_check;
   bool no_unnecessary_rebuild_refactor;
-  double simplex_initial_condition_tolerance;
   double rebuild_refactor_solution_error_tolerance;
   double dual_steepest_edge_weight_error_tolerance;
   double dual_steepest_edge_weight_log_error_threshold;
@@ -605,9 +603,7 @@ struct HighsOptionsStruct {
         presolve_rule_off(0),
         presolve_rule_logging(false),
         presolve_remove_slacks(false),
-        simplex_initial_condition_check(false),
         no_unnecessary_rebuild_refactor(false),
-        simplex_initial_condition_tolerance(0.0),
         rebuild_refactor_solution_error_tolerance(0.0),
         dual_steepest_edge_weight_error_tolerance(0.0),
         dual_steepest_edge_weight_log_error_threshold(0.0),
@@ -1523,23 +1519,11 @@ class HighsOptions : public HighsOptionsStruct {
                             kSimplexUnscaledSolutionStrategyMax);
     records.push_back(record_int);
 
-    record_bool =
-        new OptionRecordBool("simplex_initial_condition_check",
-                             "Perform initial basis condition check in simplex",
-                             advanced, &simplex_initial_condition_check, true);
-    records.push_back(record_bool);
-
     record_bool = new OptionRecordBool(
         "no_unnecessary_rebuild_refactor",
         "No unnecessary refactorization on simplex rebuild", advanced,
         &no_unnecessary_rebuild_refactor, true);
     records.push_back(record_bool);
-
-    record_double = new OptionRecordDouble(
-        "simplex_initial_condition_tolerance",
-        "Tolerance on initial basis condition in simplex", advanced,
-        &simplex_initial_condition_tolerance, 1.0, 1e14, kHighsInf);
-    records.push_back(record_double);
 
     record_double = new OptionRecordDouble(
         "rebuild_refactor_solution_error_tolerance",

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -940,9 +940,6 @@ void HighsMipSolverData::runSetup() {
   domain.clearChangedCols();
 
   lp.getLpSolver().setOptionValue("presolve", kHighsOffString);
-  // lp.getLpSolver().setOptionValue("dual_simplex_cost_perturbation_multiplier",
-  // 0.0); lp.getLpSolver().setOptionValue("parallel", kHighsOnString);
-  lp.getLpSolver().setOptionValue("simplex_initial_condition_check", false);
 
   checkObjIntegrality();
   rootlpsol.clear();

--- a/highs/simplex/HEkk.cpp
+++ b/highs/simplex/HEkk.cpp
@@ -1723,13 +1723,18 @@ void HEkk::chooseSimplexStrategyThreads(const HighsOptions& options,
   const HighsInt simplex_max_concurrency = options.simplex_max_concurrency;
   HighsInt max_threads = highs::parallel::num_threads();
 
-  if (options.parallel == kHighsOnString &&
-      simplex_strategy == kSimplexStrategyDual) {
-    // The parallel strategy is on and the simplex strategy is dual so use
-    // PAMI if there are enough threads
-    if (max_threads >= kDualMultiMinConcurrency)
-      simplex_strategy = kSimplexStrategyDualMulti;
-  }
+  // Don't allow the parallel option to switch from
+  // kSimplexStrategyDual to kSimplexStrategyDualMulti so the MIP
+  // solver only ever uses serial simplex
+  //
+  //  if (options.parallel == kHighsOnString &&
+  //      simplex_strategy == kSimplexStrategyDual) {
+  //    // The parallel strategy is on and the simplex strategy is dual so use
+  //    // PAMI if there are enough threads
+  //    if (max_threads >= kDualMultiMinConcurrency)
+  //      simplex_strategy = kSimplexStrategyDualMulti;
+  //  }
+
   //
   // If parallel strategies are used, the minimum concurrency will be
   // set to be at least the minimum required for the strategy


### PR DESCRIPTION
If  the `parallel` option is set "on" by a user in an attempt to run the parallel MIP solver, don't allow this to cause a switch from `kSimplexStrategyDual` to `kSimplexStrategyDualMulti` (in `HEkk::chooseSimplexStrategyThreads`) otherwise the MIP solver may use parallel dual simplex - which is less robust.

A couple of un-used options have been deleted