### PR TITLE
Fix HiPDLP GPU initialization consistency

### DIFF
--- a/highs/pdlp/hipdlp/pdhg.cc
+++ b/highs/pdlp/hipdlp/pdhg.cc
@@ -1663,6 +1663,119 @@ double PDLPSolver::powerMethod() {
   return op_norm_sq;
 }
 
+#ifdef CUPDLP_GPU
+double PDLPSolver::powerMethodGpu() {
+  if (a_num_rows_ == 0 || a_num_cols_ == 0) return 1.0;
+
+  const int max_iter = 5000;
+  const double tolerance = 1e-4;
+  const double one = 1.0;
+  const double zero = 0.0;
+
+  double* d_eigenvector = nullptr;
+  double* d_next_eigenvector = nullptr;
+  double* d_dual_product = nullptr;
+  void* d_buffer_at = nullptr;
+  void* d_buffer_a = nullptr;
+  size_t buffer_size_at = 0;
+  size_t buffer_size_a = 0;
+
+  CUDA_CHECK(cudaMalloc(&d_eigenvector, a_num_rows_ * sizeof(double)));
+  CUDA_CHECK(cudaMalloc(&d_next_eigenvector, a_num_rows_ * sizeof(double)));
+  CUDA_CHECK(cudaMalloc(&d_dual_product, a_num_cols_ * sizeof(double)));
+
+  std::vector<double> eigenvector_h(a_num_rows_);
+  std::mt19937 engine_fixed_seed(12345);
+  std::uniform_real_distribution<double> distribution(-1.0, 1.0);
+  for (HighsInt i = 0; i < a_num_rows_; ++i) {
+    eigenvector_h[i] = distribution(engine_fixed_seed);
+  }
+
+  CUDA_CHECK(cudaMemcpy(d_eigenvector, eigenvector_h.data(),
+                        a_num_rows_ * sizeof(double), cudaMemcpyHostToDevice));
+
+  cusparseDnVecDescr_t vecEigen = nullptr;
+  cusparseDnVecDescr_t vecNextEigen = nullptr;
+  cusparseDnVecDescr_t vecDual = nullptr;
+  CUSPARSE_CHECK(cusparseCreateDnVec(&vecEigen, a_num_rows_, d_eigenvector,
+                                     CUDA_R_64F));
+  CUSPARSE_CHECK(cusparseCreateDnVec(&vecNextEigen, a_num_rows_,
+                                     d_next_eigenvector, CUDA_R_64F));
+  CUSPARSE_CHECK(cusparseCreateDnVec(&vecDual, a_num_cols_, d_dual_product,
+                                     CUDA_R_64F));
+
+  CUSPARSE_CHECK(cusparseSpMV_bufferSize(
+      cusparse_handle_, CUSPARSE_OPERATION_NON_TRANSPOSE, &one, mat_a_T_csr_,
+      vecEigen, &zero, vecDual, CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG2,
+      &buffer_size_at));
+  CUSPARSE_CHECK(cusparseSpMV_bufferSize(
+      cusparse_handle_, CUSPARSE_OPERATION_NON_TRANSPOSE, &one, mat_a_csr_,
+      vecDual, &zero, vecNextEigen, CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG2,
+      &buffer_size_a));
+
+  CUDA_CHECK(cudaMalloc(&d_buffer_at, buffer_size_at));
+  CUDA_CHECK(cudaMalloc(&d_buffer_a, buffer_size_a));
+
+  double sigma_max_sq = 1.0;
+
+  for (int iter = 0; iter < max_iter; ++iter) {
+    CUDA_CHECK(cudaMemcpy(d_next_eigenvector, d_eigenvector,
+                          a_num_rows_ * sizeof(double),
+                          cudaMemcpyDeviceToDevice));
+
+    double eigenvector_norm = 0.0;
+    CUBLAS_CHECK(cublasDnrm2(cublas_handle_, a_num_rows_, d_next_eigenvector, 1,
+                             &eigenvector_norm));
+    if (!(eigenvector_norm > 0.0) || !std::isfinite(eigenvector_norm)) break;
+
+    double inv_eigenvector_norm = 1.0 / eigenvector_norm;
+    CUBLAS_CHECK(cublasDscal(cublas_handle_, a_num_rows_, &inv_eigenvector_norm,
+                             d_next_eigenvector, 1));
+
+    CUSPARSE_CHECK(cusparseDnVecSetValues(vecNextEigen, d_next_eigenvector));
+    CUSPARSE_CHECK(cusparseDnVecSetValues(vecDual, d_dual_product));
+
+    CUSPARSE_CHECK(cusparseSpMV(cusparse_handle_,
+                                CUSPARSE_OPERATION_NON_TRANSPOSE, &one,
+                                mat_a_T_csr_, vecNextEigen, &zero, vecDual,
+                                CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG2,
+                                d_buffer_at));
+
+    CUSPARSE_CHECK(cusparseDnVecSetValues(vecEigen, d_eigenvector));
+    CUSPARSE_CHECK(cusparseSpMV(cusparse_handle_,
+                                CUSPARSE_OPERATION_NON_TRANSPOSE, &one,
+                                mat_a_csr_, vecDual, &zero, vecEigen,
+                                CUDA_R_64F, CUSPARSE_SPMV_CSR_ALG2,
+                                d_buffer_a));
+
+    CUBLAS_CHECK(cublasDdot(cublas_handle_, a_num_rows_, d_next_eigenvector, 1,
+                            d_eigenvector, 1, &sigma_max_sq));
+
+    double neg_sigma_sq = -sigma_max_sq;
+    CUBLAS_CHECK(cublasDscal(cublas_handle_, a_num_rows_, &neg_sigma_sq,
+                             d_next_eigenvector, 1));
+    CUBLAS_CHECK(cublasDaxpy(cublas_handle_, a_num_rows_, &one, d_eigenvector,
+                             1, d_next_eigenvector, 1));
+
+    double residual_norm = 0.0;
+    CUBLAS_CHECK(cublasDnrm2(cublas_handle_, a_num_rows_, d_next_eigenvector, 1,
+                             &residual_norm));
+    if (residual_norm < tolerance) break;
+  }
+
+  CUDA_CHECK(cudaFree(d_buffer_at));
+  CUDA_CHECK(cudaFree(d_buffer_a));
+  CUSPARSE_CHECK(cusparseDestroyDnVec(vecEigen));
+  CUSPARSE_CHECK(cusparseDestroyDnVec(vecNextEigen));
+  CUSPARSE_CHECK(cusparseDestroyDnVec(vecDual));
+  CUDA_CHECK(cudaFree(d_eigenvector));
+  CUDA_CHECK(cudaFree(d_next_eigenvector));
+  CUDA_CHECK(cudaFree(d_dual_product));
+
+  return sigma_max_sq;
+}
+#endif
+
 void PDLPSolver::setup(const HighsOptions& options, HighsTimer& timer) {
   logger_.initialise(options.log_dev_level, options.log_options, &timer);
   logger_.printHeader();
@@ -1825,18 +1938,10 @@ void AdaptiveLinesearchParams::initialise() {
 // =============================================================================
 
 void PDLPSolver::initializeStepSizes() {
-  double cost_norm_sq = linalg::vectorNormSquared(lp_.col_cost_);
-  double rhs_norm_sq = linalg::vectorNormSquared(lp_.row_lower_);
-
-  if (std::min(cost_norm_sq, rhs_norm_sq) > 1e-6) {
-    stepsize_.beta = cost_norm_sq / rhs_norm_sq;
-  } else {
-    stepsize_.beta = 1.0;
-  }
-
-  // Match initial primal weight calculation from cuPDLPx
-  params_.omega = (unscaled_c_norm_ + 1.0) / (unscaled_rhs_norm_ + 1.0);
   primal_weight_ = 1.0;
+  best_primal_weight_ = primal_weight_;
+  stepsize_.beta = primal_weight_ * primal_weight_;
+  params_.omega = primal_weight_;
 
   if (params_.step_size_strategy != StepSizeStrategy::FIXED &&
       params_.step_size_strategy != StepSizeStrategy::PID) {
@@ -1845,8 +1950,11 @@ void PDLPSolver::initializeStepSizes() {
     params_.step_size_strategy = StepSizeStrategy::FIXED;
   }
 
-  // Use power method for fixed/PID step size initialization.
+#ifdef CUPDLP_GPU
+  double op_norm_sq = powerMethodGpu();
+#else
   double op_norm_sq = powerMethod();
+#endif
 
   stepsize_.power_method_lambda = op_norm_sq;
 

--- a/highs/pdlp/hipdlp/pdhg.cc
+++ b/highs/pdlp/hipdlp/pdhg.cc
@@ -513,12 +513,30 @@ void PDLPSolver::solve(std::vector<double>& x, std::vector<double>& y) {
   // Copy initial input x,y to internal state
   x_current_ = x;
   y_current_ = y;
+  linalg::projectBounds(lp_, x_current_);
 
   if (params_.use_halpern_restart) {
     x_anchor_ = x_current_;
     y_anchor_ = y_current_;
     halpern_iteration_ = 0;
 #ifdef CUPDLP_GPU
+<<<<<<< HEAD
+=======
+  if (!params_.use_halpern_restart) {
+    CUDA_CHECK(cudaMemset(d_x_sum_, 0, lp_.num_col_ * sizeof(double)));
+    CUDA_CHECK(cudaMemset(d_y_sum_, 0, lp_.num_row_ * sizeof(double)));
+    CUDA_CHECK(cudaMemset(d_x_avg_, 0, lp_.num_col_ * sizeof(double)));
+    CUDA_CHECK(cudaMemset(d_y_avg_, 0, lp_.num_row_ * sizeof(double)));
+  }
+  sum_weights_gpu_ = 0.0;
+  CUDA_CHECK(cudaMemcpy(d_x_current_, x_current_.data(),
+                        lp_.num_col_ * sizeof(double),
+                        cudaMemcpyHostToDevice));
+  CUDA_CHECK(cudaMemcpy(d_y_current_, y_current_.data(),
+                        lp_.num_row_ * sizeof(double),
+                        cudaMemcpyHostToDevice));
+  if (params_.use_halpern_restart) {
+>>>>>>> dbcb7bc627 (Fix HiPDLP false convergence at iteration 0)
     CUDA_CHECK(cudaMemcpy(d_x_anchor_, d_x_current_,
                           lp_.num_col_ * sizeof(double),
                           cudaMemcpyDeviceToDevice));
@@ -542,7 +560,6 @@ void PDLPSolver::solve(std::vector<double>& x, std::vector<double>& y) {
   linalgGpuAx(d_x_current_, d_ax_current_);
   linalgGpuATy(d_y_current_, d_aty_current_);
 #else
-  linalg::projectBounds(lp_, x_current_);
   linalg::ax(lp_, x_current_, Ax_cache_);
   linalg::aTy(lp_, y_current_, ATy_cache_);
 #endif
@@ -827,9 +844,12 @@ bool PDLPSolver::runConvergenceCheck(size_t iter, std::vector<double>& output_x,
         iter, x_current_, y_current_, Ax_cache_, ATy_cache_, params_.tolerance,
         current_results, "[L]", dSlackPos_, dSlackNeg_);
   }
-  average_converged = checkConvergence(iter, x_avg_, y_avg_, Ax_avg_, ATy_avg_,
-                                       params_.tolerance, average_results,
-                                       "[A]", dSlackPosAvg_, dSlackNegAvg_);
+  if (!params_.use_halpern_restart) {
+    average_converged =
+        checkConvergence(iter, x_avg_, y_avg_, Ax_avg_, ATy_avg_,
+                         params_.tolerance, average_results, "[A]",
+                         dSlackPosAvg_, dSlackNegAvg_);
+  }
 #endif
 
   // 3. Handle Convergence Success

--- a/highs/pdlp/hipdlp/pdhg.cc
+++ b/highs/pdlp/hipdlp/pdhg.cc
@@ -519,9 +519,9 @@ void PDLPSolver::solve(std::vector<double>& x, std::vector<double>& y) {
     x_anchor_ = x_current_;
     y_anchor_ = y_current_;
     halpern_iteration_ = 0;
-#ifdef CUPDLP_GPU
-<<<<<<< HEAD
-=======
+  }
+
+  #ifdef CUPDLP_GPU
   if (!params_.use_halpern_restart) {
     CUDA_CHECK(cudaMemset(d_x_sum_, 0, lp_.num_col_ * sizeof(double)));
     CUDA_CHECK(cudaMemset(d_y_sum_, 0, lp_.num_row_ * sizeof(double)));
@@ -529,40 +529,29 @@ void PDLPSolver::solve(std::vector<double>& x, std::vector<double>& y) {
     CUDA_CHECK(cudaMemset(d_y_avg_, 0, lp_.num_row_ * sizeof(double)));
   }
   sum_weights_gpu_ = 0.0;
+
   CUDA_CHECK(cudaMemcpy(d_x_current_, x_current_.data(),
                         lp_.num_col_ * sizeof(double),
                         cudaMemcpyHostToDevice));
   CUDA_CHECK(cudaMemcpy(d_y_current_, y_current_.data(),
                         lp_.num_row_ * sizeof(double),
                         cudaMemcpyHostToDevice));
+
   if (params_.use_halpern_restart) {
->>>>>>> dbcb7bc627 (Fix HiPDLP false convergence at iteration 0)
     CUDA_CHECK(cudaMemcpy(d_x_anchor_, d_x_current_,
                           lp_.num_col_ * sizeof(double),
                           cudaMemcpyDeviceToDevice));
     CUDA_CHECK(cudaMemcpy(d_y_anchor_, d_y_current_,
                           lp_.num_row_ * sizeof(double),
                           cudaMemcpyDeviceToDevice));
-#endif
   }
 
-  // Pre-calculate ax and aTy for current iterate
-#ifdef CUPDLP_GPU
-  CUDA_CHECK(cudaMemset(d_x_sum_, 0, lp_.num_col_ * sizeof(double)));
-  CUDA_CHECK(cudaMemset(d_y_sum_, 0, lp_.num_row_ * sizeof(double)));
-  CUDA_CHECK(cudaMemset(d_x_avg_, 0, lp_.num_col_ * sizeof(double)));
-  CUDA_CHECK(cudaMemset(d_y_avg_, 0, lp_.num_row_ * sizeof(double)));
-  sum_weights_gpu_ = 0.0;
-  CUDA_CHECK(cudaMemcpy(d_x_current_, x.data(), lp_.num_col_ * sizeof(double),
-                        cudaMemcpyHostToDevice));
-  CUDA_CHECK(cudaMemcpy(d_y_current_, y.data(), lp_.num_row_ * sizeof(double),
-                        cudaMemcpyHostToDevice));
   linalgGpuAx(d_x_current_, d_ax_current_);
   linalgGpuATy(d_y_current_, d_aty_current_);
-#else
+  #else
   linalg::ax(lp_, x_current_, Ax_cache_);
   linalg::aTy(lp_, y_current_, ATy_cache_);
-#endif
+  #endif
 
   TerminationStatus termination_status = TerminationStatus::NOTSET;
   bool do_restart = false;

--- a/highs/pdlp/hipdlp/pdhg.cc
+++ b/highs/pdlp/hipdlp/pdhg.cc
@@ -1947,10 +1947,10 @@ void AdaptiveLinesearchParams::initialise() {
 // =============================================================================
 
 void PDLPSolver::initializeStepSizes() {
-  primal_weight_ = 1.0;
+  params_.omega = (unscaled_c_norm_ + 1.0) / (unscaled_rhs_norm_ + 1.0);
+  primal_weight_ = params_.omega;
   best_primal_weight_ = primal_weight_;
   stepsize_.beta = primal_weight_ * primal_weight_;
-  params_.omega = primal_weight_;
 
   if (params_.step_size_strategy != StepSizeStrategy::FIXED &&
       params_.step_size_strategy != StepSizeStrategy::PID) {

--- a/highs/pdlp/hipdlp/pdhg.hpp
+++ b/highs/pdlp/hipdlp/pdhg.hpp
@@ -126,6 +126,9 @@ class PDLPSolver {
 
   // --- Convergence & Math Helpers ---
   double powerMethod();
+#ifdef CUPDLP_GPU
+  double powerMethodGpu();
+#endif
   void initializeStepSizes();
 
   // Convergence checks


### PR DESCRIPTION
This PR fixes HiPDLP GPU startup consistency.

Changes:
- keep `params_.omega`, `primal_weight_`, and `stepsize_.beta` consistent as cupdlp-C style
- use `powerMethodGpu()` for GPU step-size initialization
- project the initial primal vector before copying it to GPU state
- initialize Halpern anchors from the projected device current vector

This avoids inconsistent startup behavior where step sizes used one primal-dual weight while restart/PID bookkeeping used another.

Benchmarks at `1e-8` show mixed performance, so this PR should be treated as a correctness/stability fix rather than a performance optimization.