### PR TITLE
Fix suboptimal MIP from singleton column stuffing on mixed-integer rows

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1404,3 +1404,51 @@ TEST_CASE("issue-2173", "[highs_test_mip_solver]") {
   const double optimal_objective = -26770.8075489;
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
 }
+
+TEST_CASE("MIP-singleton-col-stuffing-mixed-integer",
+          "[highs_test_mip_solver]") {
+  // Regression test for a singleton-column-stuffing presolve bug that returns a
+  // suboptimal MIP solution (reported as cvxpy #3368).
+  //
+  // Minimal model:
+  //   min  -100 x + 0.01 t
+  //   s.t.        x - t <= 0          (i.e. t >= x)
+  //        1 <= x <= 3,  x integer
+  //        1 <= t <= 3,  t continuous
+  //
+  // x and t are both singleton columns of the single row. The optimum is
+  // x = 3, t = 3 with objective -299.97. Singleton column stuffing collapsed
+  // the integer singleton x onto its lower bound while computing the row
+  // activity, then dropped x from the candidate set (mixed integer/continuous
+  // row) and, on the stale activity, fixed t to its lower bound 1. That forced
+  // x <= 1, giving the suboptimal x = 1, t = 1, objective -99.99.
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.setOptionValue("mip_rel_gap", 0);
+  highs.setOptionValue("mip_abs_gap", 0);
+
+  HighsLp lp;
+  lp.num_col_ = 2;
+  lp.num_row_ = 1;
+  lp.col_cost_ = {-100, 0.01};
+  lp.col_lower_ = {1, 1};
+  lp.col_upper_ = {3, 3};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kContinuous};
+  lp.row_lower_ = {-kHighsInf};
+  lp.row_upper_ = {0};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.num_col_ = 2;
+  lp.a_matrix_.num_row_ = 1;
+  lp.a_matrix_.start_ = {0, 1, 2};
+  lp.a_matrix_.index_ = {0, 0};
+  lp.a_matrix_.value_ = {1, -1};
+
+  const HighsModelStatus require_model_status = HighsModelStatus::kOptimal;
+  const double optimal_objective = -299.97;
+  // Solve with presolve on (the default) and off: both must reach the optimum.
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  solve(highs, kHighsOnString, require_model_status, optimal_objective);
+  solve(highs, kHighsOffString, require_model_status, optimal_objective);
+
+  highs.resetGlobalScheduler(true);
+}

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5082,7 +5082,18 @@ HPresolve::Result HPresolve::singletonColStuffing(
     if (allInteger && minWeight != maxWeight) return Result::kOk;
 
     // remove integer columns if there are also continuous ones
-    if (!allInteger)
+    if (!allInteger) {
+      // The activity bounds (sumLower / sumUpper) accumulated above treat every
+      // singleton *candidate* as collapsed onto a single bound (the bound it would
+      // be stuffed to) rather than ranging over [lower, upper]. That collapse is
+      // only sound for candidates that are actually stuffed. Dropping the integer
+      // candidates here (because the row mixes integer and continuous singletons)
+      // leaves the activity bounds artificially tight, so a subsequent fix of a
+      // surviving continuous candidate can cut off the true optimum. Skip stuffing
+      // on such mixed rows rather than fix on stale activity bounds.
+      for (const auto& p : candidates)
+        if (model->integrality_[std::get<0>(p)] == HighsVarType::kInteger)
+          return Result::kOk;
       candidates.erase(
           std::remove_if(candidates.begin(), candidates.end(),
                          [&](const candidate& p) {
@@ -5090,6 +5101,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
                                   HighsVarType::kInteger;
                          }),
           candidates.end());
+    }
 
     // sort candidates
     sortCols(candidates);


### PR DESCRIPTION
## Summary

`singletonColStuffing` can return a **suboptimal MIP solution while reporting status `Optimal`** when a row mixes integer and continuous singleton columns. This was reported downstream as [cvxpy/cvxpy#3368](https://github.com/cvxpy/cvxpy/issues/3368). It is a regression introduced in v1.14.0 by commit `5e58bf7` ("Also handle integer variables in stuffing"); v1.12 and v1.13.x are unaffected.

## Minimal reproducer

```
min  -100 x + 0.01 t
s.t.        x - t <= 0          (t >= x)
     1 <= x <= 3,  x integer
     1 <= t <= 3,  t continuous
```

The optimum is `x = 3, t = 3` with objective **-299.97**.

| presolve | result |
|----------|--------|
| on (default) | `x = 1, t = 1`, objective **-99.99**  ❌ (status reported `Optimal`, 0 nodes) |
| off          | `x = 3, t = 3`, objective **-299.97** ✅ |

## Root cause

In `checkRow`, the row activity bounds (`sumLower` / `sumUpper`) are accumulated with every singleton **candidate** collapsed onto a single bound — the bound it would be stuffed to — instead of ranging over `[lower, upper]`. That collapse is only sound for candidates that actually get stuffed.

When the row mixes integer and continuous singletons, the `!allInteger` branch drops the integer candidates from `candidates`. But their collapse has already biased `sumLower`/`sumUpper`. In the reproducer the integer singleton `x` (coefficient `+1`, negative cost) is collapsed onto its *lower* bound `1` while computing `sumUpper`, then removed. The surviving continuous candidate `t` is then evaluated against that stale, artificially tight `sumUpper` and fixed to its lower bound `1` — which forces `x <= 1` and cuts off the true optimum.

Before v1.14.0 the rule (`isContSingleton`) only collapsed *continuous* singletons and treated integer singletons as ordinary full-range row entries, so this case was handled correctly.

## Fix

Skip singleton column stuffing on rows that mix integer and continuous singleton candidates, rather than fixing on stale activity bounds. Pure-integer and pure-continuous rows are unaffected, and pure-LP models never reach this branch — so existing reductions are preserved.

A less conservative alternative would be to restore the pre-v1.14.0 behavior for mixed rows (treat the dropped integer singletons as full-range when accumulating the activity bounds); happy to take that route instead if you'd prefer to keep stuffing active on mixed rows.

## Testing

- New regression test `MIP-singleton-col-stuffing-mixed-integer` in `check/TestMipSolver.cpp` (the 2-variable / 1-constraint model above), checked with presolve both on and off.
- Full `unit_tests` suite passes (307 test cases), including all `[highs_test_mip_solver]` and `[highs_test_presolve]` cases.
