### PR TITLE
Model pic

### DIFF
--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -611,3 +611,23 @@ TEST_CASE("efficient-add-row", "[highs_filereader]") {
     printf("Added %d rows together     in %.2gs\n", int(lp.num_row_), tt);
   }
 }
+
+TEST_CASE("matrix-hessian-image", "[highs_filereader]") {
+   const std::string test_name = Catch::getResultCapture().getCurrentTestName();
+  std::string filename;
+  filename = std::string(HIGHS_DIR) + "/check/instances/primal1.mps";
+
+  Highs h;
+  h.setOptionValue("output_flag", dev_run);
+  h.setOptionValue("write_matrix_image", true);
+  h.setOptionValue("write_hessian_image", true);
+  REQUIRE(h.readModel(filename) == HighsStatus::kOk);
+
+  std::string matrix_image_filename = test_name + "_matrix.pbm";
+  std::string hessian_image_filename = test_name + "_hessian.pbm";
+
+  h.matrixImage(matrix_image_filename, hessian_image_filename);
+
+  std::remove(matrix_image_filename.c_str());
+  std::remove(hessian_image_filename.c_str());
+}

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -613,7 +613,7 @@ TEST_CASE("efficient-add-row", "[highs_filereader]") {
 }
 
 TEST_CASE("matrix-hessian-image", "[highs_filereader]") {
-   const std::string test_name = Catch::getResultCapture().getCurrentTestName();
+  const std::string test_name = Catch::getResultCapture().getCurrentTestName();
   std::string filename;
   filename = std::string(HIGHS_DIR) + "/check/instances/primal1.mps";
 
@@ -623,11 +623,17 @@ TEST_CASE("matrix-hessian-image", "[highs_filereader]") {
   h.setOptionValue("write_hessian_image", true);
   REQUIRE(h.readModel(filename) == HighsStatus::kOk);
 
-  std::string matrix_image_filename = test_name + "_matrix.pbm";
-  std::string hessian_image_filename = test_name + "_hessian.pbm";
+  std::string matrix_image_filename = test_name + "_matrix";
+  std::string hessian_image_filename = test_name + "_hessian";
 
   h.matrixImage(matrix_image_filename, hessian_image_filename);
 
-  std::remove(matrix_image_filename.c_str());
-  std::remove(hessian_image_filename.c_str());
+  std::string matrix_image_filename_and_extension =
+      matrix_image_filename + ".pbm";
+  std::string hessian_image_filename_and_extension =
+      hessian_image_filename + ".pbm";
+  std::remove(matrix_image_filename_and_extension.c_str());
+  std::remove(hessian_image_filename_and_extension.c_str());
+  std::remove("LpMatrix.pbm");
+  std::remove("Hessian.pbm");
 }

--- a/check/TestFilereader.cpp
+++ b/check/TestFilereader.cpp
@@ -626,7 +626,8 @@ TEST_CASE("matrix-hessian-image", "[highs_filereader]") {
   std::string matrix_image_filename = test_name + "_matrix";
   std::string hessian_image_filename = test_name + "_hessian";
 
-  h.matrixImage(matrix_image_filename, hessian_image_filename);
+  REQUIRE(h.matrixImage(matrix_image_filename, hessian_image_filename) ==
+          HighsStatus::kOk);
 
   std::string matrix_image_filename_and_extension =
       matrix_image_filename + ".pbm";

--- a/highs/Highs.h
+++ b/highs/Highs.h
@@ -211,11 +211,12 @@ class Highs {
   HighsStatus readBasis(const std::string& filename);
 
   /**
-   * @brief Generate an image of the matrix nonzeros, and possibly
-   * Hessian nonzeros
+   * @brief Generate a PBM image of the matrix nonzeros, and possibly
+   * Hessian nonzeros. Note that the .pbm extnesion will be added to
+   * the fime names passed
    */
   HighsStatus matrixImage(const std::string& matrix_image_filename,
-			  const std::string& hessian_image_filename = "") const;
+                          const std::string& hessian_image_filename = "") const;
 
   /**
    * @brief Presolve the incumbent model, allowing the presolved model

--- a/highs/Highs.h
+++ b/highs/Highs.h
@@ -211,6 +211,13 @@ class Highs {
   HighsStatus readBasis(const std::string& filename);
 
   /**
+   * @brief Generate an image of the matrix nonzeros, and possibly
+   * Hessian nonzeros
+   */
+  HighsStatus matrixImage(const std::string& matrix_image_filename,
+			  const std::string& hessian_image_filename = "") const;
+
+  /**
    * @brief Presolve the incumbent model, allowing the presolved model
    * to be extracted. Subsequent solution of the incumbent model will
    * only use presolve if there is no valid basis

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -380,7 +380,7 @@ HighsStatus Highs::passModel(HighsModel model) {
   // Ensure that any non-zero Hessian of dimension less than the
   // number of columns in the model is completed
   if (hessian.dim_) completeHessian(this->model_.lp_.num_col_, hessian);
-  // Possibly write
+  // Possibly create image files of the constraint matrix and Hessian
   if (options_.write_matrix_image)
     writeLpMatrixPicToFile(options_, "LpMatrix", model_.lp_);
   if (options_.write_hessian_image)
@@ -701,11 +701,16 @@ HighsStatus Highs::readModel(const std::string& filename) {
 HighsStatus Highs::matrixImage(
     const std::string& matrix_image_filename,
     const std::string& hessian_image_filename) const {
-  if (matrix_image_filename != "")
-    writeLpMatrixPicToFile(options_, matrix_image_filename, model_.lp_);
+  HighsStatus status = HighsStatus::kOk;
+  if (matrix_image_filename != "") {
+    status =
+        writeLpMatrixPicToFile(options_, matrix_image_filename, model_.lp_);
+    if (status != HighsStatus::kOk) return status;
+  }
   if (hessian_image_filename != "")
-    writeHessianPicToFile(options_, hessian_image_filename, model_.hessian_);
-  return HighsStatus::kOk;
+    status = writeHessianPicToFile(options_, hessian_image_filename,
+                                   model_.hessian_);
+  return status;
 }
 
 HighsStatus Highs::readBasis(const std::string& filename) {

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -380,8 +380,11 @@ HighsStatus Highs::passModel(HighsModel model) {
   // Ensure that any non-zero Hessian of dimension less than the
   // number of columns in the model is completed
   if (hessian.dim_) completeHessian(this->model_.lp_.num_col_, hessian);
-  // if (model_.lp_.num_row_>0 && model_.lp_.num_col_>0)
-  //    writeLpMatrixPicToFile(options_, "LpMatrix", model_.lp_);
+  // Possibly write 
+  if (options_.write_matrix_image) 
+    writeLpMatrixPicToFile(options_, "LpMatrix", model_.lp_);
+  if (options_.write_hessian_image) 
+    writeLpMatrixPicToFile(options_, "Hessian", model_.lp_);
 
   // Clear solver status, solution, basis and info associated with any
   // previous model; clear any HiGHS model object; create a HiGHS
@@ -694,6 +697,16 @@ HighsStatus Highs::readModel(const std::string& filename) {
                           return_status, "passModel");
   return returnFromHighs(return_status);
 }
+
+HighsStatus Highs::matrixImage(const std::string& matrix_image_filename,
+			       const std::string& hessian_image_filename) const {
+  if (matrix_image_filename != "")
+    writeLpMatrixPicToFile(options_, "LpMatrix", model_.lp_);
+  if (hessian_image_filename != "")
+    writeLpMatrixPicToFile(options_, "Hessian", model_.lp_);
+  return HighsStatus::kOk;
+}
+
 
 HighsStatus Highs::readBasis(const std::string& filename) {
   this->logHeader();

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -380,11 +380,11 @@ HighsStatus Highs::passModel(HighsModel model) {
   // Ensure that any non-zero Hessian of dimension less than the
   // number of columns in the model is completed
   if (hessian.dim_) completeHessian(this->model_.lp_.num_col_, hessian);
-  // Possibly write 
-  if (options_.write_matrix_image) 
+  // Possibly write
+  if (options_.write_matrix_image)
     writeLpMatrixPicToFile(options_, "LpMatrix", model_.lp_);
-  if (options_.write_hessian_image) 
-    writeLpMatrixPicToFile(options_, "Hessian", model_.lp_);
+  if (options_.write_hessian_image)
+    writeHessianPicToFile(options_, "Hessian", model_.hessian_);
 
   // Clear solver status, solution, basis and info associated with any
   // previous model; clear any HiGHS model object; create a HiGHS
@@ -698,15 +698,15 @@ HighsStatus Highs::readModel(const std::string& filename) {
   return returnFromHighs(return_status);
 }
 
-HighsStatus Highs::matrixImage(const std::string& matrix_image_filename,
-			       const std::string& hessian_image_filename) const {
+HighsStatus Highs::matrixImage(
+    const std::string& matrix_image_filename,
+    const std::string& hessian_image_filename) const {
   if (matrix_image_filename != "")
-    writeLpMatrixPicToFile(options_, "LpMatrix", model_.lp_);
+    writeLpMatrixPicToFile(options_, matrix_image_filename, model_.lp_);
   if (hessian_image_filename != "")
-    writeLpMatrixPicToFile(options_, "Hessian", model_.lp_);
+    writeHessianPicToFile(options_, hessian_image_filename, model_.hessian_);
   return HighsStatus::kOk;
 }
-
 
 HighsStatus Highs::readBasis(const std::string& filename) {
   this->logHeader();

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -421,6 +421,8 @@ struct HighsOptionsStruct {
   bool lp_presolve_requires_basis_postsolve;
   bool mps_parser_type_free;
   bool use_warm_start;
+  bool write_matrix_image;
+  bool write_hessian_image;
   HighsInt keep_n_rows;
   HighsInt cost_scale_factor;
   HighsInt allowed_matrix_scale_factor;
@@ -586,6 +588,8 @@ struct HighsOptionsStruct {
         lp_presolve_requires_basis_postsolve(false),
         mps_parser_type_free(false),
         use_warm_start(true),
+        write_matrix_image(false),
+        write_hessian_image(false),
         keep_n_rows(0),
         cost_scale_factor(0),
         allowed_matrix_scale_factor(0),
@@ -1446,6 +1450,16 @@ class HighsOptions : public HighsOptionsStruct {
     record_bool = new OptionRecordBool("use_warm_start",
                                        "Use any warm start that is available",
                                        advanced, &use_warm_start, true);
+    records.push_back(record_bool);
+
+    record_bool = new OptionRecordBool("write_matrix_image",
+                                       "Write an image of the constraint matrix to a file",
+                                       advanced, &write_matrix_image, false);
+    records.push_back(record_bool);
+
+    record_bool = new OptionRecordBool("write_hessian_image",
+                                       "Write an image of the Hessian to a file",
+                                       advanced, &write_hessian_image, false);
     records.push_back(record_bool);
 
     record_int =

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -1452,14 +1452,15 @@ class HighsOptions : public HighsOptionsStruct {
                                        advanced, &use_warm_start, true);
     records.push_back(record_bool);
 
-    record_bool = new OptionRecordBool("write_matrix_image",
-                                       "Write an image of the constraint matrix to a file",
-                                       advanced, &write_matrix_image, false);
+    record_bool = new OptionRecordBool(
+        "write_matrix_image",
+        "Write an image of the constraint matrix to a file", advanced,
+        &write_matrix_image, false);
     records.push_back(record_bool);
 
-    record_bool = new OptionRecordBool("write_hessian_image",
-                                       "Write an image of the Hessian to a file",
-                                       advanced, &write_hessian_image, false);
+    record_bool = new OptionRecordBool(
+        "write_hessian_image", "Write an image of the Hessian to a file",
+        advanced, &write_hessian_image, false);
     records.push_back(record_bool);
 
     record_int =

--- a/highs/util/HighsMatrixPic.cpp
+++ b/highs/util/HighsMatrixPic.cpp
@@ -23,16 +23,28 @@ HighsStatus writeLpMatrixPicToFile(const HighsOptions& options,
                               lp.a_matrix_.start_, lp.a_matrix_.index_);
 }
 
+HighsStatus writeHessianPicToFile(const HighsOptions& options,
+                                  const std::string& fileprefix,
+                                  const HighsHessian& hessian) {
+  return writeMatrixPicToFile(options, fileprefix, hessian.dim_, hessian.dim_,
+                              hessian.start_, hessian.index_);
+}
+
 HighsStatus writeMatrixPicToFile(const HighsOptions& options,
                                  const std::string& fileprefix,
                                  const HighsInt numRow, const HighsInt numCol,
                                  const std::vector<HighsInt>& Astart,
                                  const std::vector<HighsInt>& Aindex) {
+  if (numRow == 0 || numCol == 0) {
+    highsLogUser(options.log_options, HighsLogType::kError,
+                 "Cannot generate image of matrix with a zero dimension\n");
+    return HighsStatus::kError;
+  }
+  assert(numRow > 0);
+  assert(numCol > 0);
   std::vector<HighsInt> ARlength;
   std::vector<HighsInt> ARstart;
   std::vector<HighsInt> ARindex;
-  assert(numRow > 0);
-  assert(numCol > 0);
   const HighsInt numNz = Astart[numCol];
   ARlength.assign(numRow, 0);
   ARstart.resize(numRow + 1);
@@ -94,14 +106,13 @@ HighsStatus writeRmatrixPicToFile(const HighsOptions& options,
   assert(num_pixel_wide <= max_num_pixel_wide);
   assert(num_pixel_deep <= max_num_pixel_deep);
 
-  highsLogUser(
-      options.log_options, HighsLogType::kInfo,
-      "Representing LP constraint matrix sparsity pattern %" HIGHSINT_FORMAT
-      "x%" HIGHSINT_FORMAT
-      " .pbm file,"
-      " mapping entries in square of size %" HIGHSINT_FORMAT
-      " onto one pixel\n",
-      num_pixel_wide, num_pixel_deep, dim_per_pixel);
+  highsLogUser(options.log_options, HighsLogType::kInfo,
+               "Representing matrix sparsity pattern %" HIGHSINT_FORMAT
+               "x%" HIGHSINT_FORMAT
+               " .pbm file,"
+               " mapping entries in square of size %" HIGHSINT_FORMAT
+               " onto one pixel\n",
+               num_pixel_wide, num_pixel_deep, dim_per_pixel);
 
   std::vector<HighsInt> value;
   value.assign(num_pixel_wide, 0);

--- a/highs/util/HighsMatrixPic.h
+++ b/highs/util/HighsMatrixPic.h
@@ -17,10 +17,15 @@
 #include "HConfig.h"
 #include "lp_data/HighsLp.h"
 #include "lp_data/HighsOptions.h"
+#include "model/HighsHessian.h"
 
 HighsStatus writeLpMatrixPicToFile(const HighsOptions& options,
                                    const std::string& fileprefix,
                                    const HighsLp& lp);
+
+HighsStatus writeHessianPicToFile(const HighsOptions& options,
+                                  const std::string& fileprefix,
+                                  const HighsHessian& hessian);
 
 HighsStatus writeMatrixPicToFile(const HighsOptions& options,
                                  const std::string& fileprefix,


### PR DESCRIPTION
The facility to generate images of constraint matrices has been extended to Hessians, and is now available by setting the `write_matrix_image` or `write_hessian_image` options to be true, or by calling `Highs::matrixImage`