### PR TITLE
workflows and pyproject update: cibuildwheel 4.0.0

### DIFF
--- a/.github/workflows/build-meson.yml
+++ b/.github/workflows/build-meson.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           environment-name: highsdev
           create-args: >-
-            python==3.8
+            python==3.9
             meson
             pkgconfig
             ninja

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v4.0.0
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v4.0.0
         with:
           package-dir: ./highspy-extras
         env:

--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -48,7 +48,7 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
     steps:
       - uses: actions/checkout@v6
       - name: Build wheels
@@ -79,7 +79,7 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]
-        python: ["cp38", "cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/sanitizers-meson.yml
+++ b/.github/workflows/sanitizers-meson.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           environment-name: highsdev
           create-args: >-
-            python==3.8
+            python==3.9
             meson
             pkgconfig
             ninja

--- a/docs/src/interfaces/python/hipo-in-python.md
+++ b/docs/src/interfaces/python/hipo-in-python.md
@@ -53,7 +53,7 @@ print(highspy_extras.get_library_version())
 
 To install locally, you will need
 
-- Python >= 3.8
+- Python >= 3.9
 - BLAS library (bundled or system)
 
 ## Uninstall

--- a/highspy-extras/README.md
+++ b/highspy-extras/README.md
@@ -51,7 +51,7 @@ print(highspy_extras.get_library_version())
 
 ## Requirements
 
-- Python >= 3.8
+- Python >= 3.9
 
 - BLAS library
 The highspy-extras wheels on PyPI and conda-forge ship with a bundled OpenBLAS.

--- a/highspy-extras/pyproject.toml
+++ b/highspy-extras/pyproject.toml
@@ -17,11 +17,10 @@ license-files = [
   "THIRD_PARTY_NOTICES.md",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,12 @@ license-files = [
   "THIRD_PARTY_NOTICES.md",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["numpy", "typing_extensions; python_version < '3.10'"]
 
 classifiers = [
   # "Development Status :: 4 - Beta",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,9 +116,6 @@ norecursedirs = ["check", ".git", "build", "dist", "*.egg-info"]
 build = "*"
 archs = ["auto64", "auto32"]
 
-# Enable free-threaded support
-enable = ["cpython-freethreading"]
-
 # highspy does not need vcpkg dependencies (avoid unnecessary compile)
 environment = { VCPKG_ROOT = "", VCPKG_INSTALLATION_ROOT = "" }
 


### PR DESCRIPTION
Updated cibw to 4.0.0 (new version on runners) 
Updated pyproject accordingly

Dropped python 3.8 (end of life 2024-10-07)
No longer supported by cibw

Closes https://github.com/ERGO-Code/HiGHS/issues/3064