### PR TITLE
Csharp msvc stl static link and win32 installation fix

### DIFF
--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -93,8 +93,8 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: win-x32
-          path: ${{github.workspace}}/build32/dotnet/Highs.Native/runtimes/win-x64/
+          name: win-x86
+          path: ${{github.workspace}}/build32/dotnet/Highs.Native/runtimes/win-x86/
 
   build_linux:
     runs-on: ubuntu-latest
@@ -178,11 +178,11 @@ jobs:
           name: macos-arm64
           path: ${{github.workspace}}/build/dotnet/Highs.Native/runtimes
 
-      - name: Download runtimes win-x32
+      - name: Download runtimes win-x86
         uses: actions/download-artifact@v8
         with:
-          name: win-x32
-          path: ${{github.workspace}}/build/dotnet/Highs.Native/runtimes/win-x32
+          name: win-x86
+          path: ${{github.workspace}}/build/dotnet/Highs.Native/runtimes/win-x86
 
       - name: Download runtimes
         uses: actions/download-artifact@v8

--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -220,7 +220,7 @@ jobs:
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
 
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.push_package == 'true')
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.push_package)
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -2,6 +2,15 @@ name: build-nuget-package
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Package version (e.g. 1.14.0-preview.1)'
+        required: true
+        default: '1.14.0-preview.1'
+      push_package:
+        description: 'Push package to NuGet.org'
+        type: boolean
+        default: false
   pull_request:
   release:
     types:
@@ -196,7 +205,7 @@ jobs:
 
       - name: Dotnet pack
         working-directory: ${{github.workspace}}/build/dotnet/Highs.Native
-        run: dotnet pack -c Release /p:Version=1.14.0
+        run: dotnet pack -c Release /p:Version=${{ inputs.version || '1.14.0' }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -211,7 +220,7 @@ jobs:
     permissions:
       id-token: write  # enable GitHub OIDC token issuance for this job
 
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.push_package == 'true')
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v5

--- a/.github/workflows/build-nuget-package.yml
+++ b/.github/workflows/build-nuget-package.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Configure CMake win32
         shell: bash
         working-directory: ${{github.workspace}}/build32
-        run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON -A Win32
+        run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON -A Win32 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
 
       - name: Build win32
         shell: bash
@@ -145,7 +145,7 @@ jobs:
       - name: Configure CMake
         working-directory: ${{github.workspace}}/build
         shell: bash
-        run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON
+        run: cmake $GITHUB_WORKSPACE -DCSHARP=ON -DBUILD_DOTNET=ON -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ dotnet add package Highs.Native --version 1.14.0
 The nuget package contains runtime libraries for
 
 * `win-x64`
-* `win-x32`
+* `win-x86`
 * `linux-x64`
 * `linux-arm64`
 * `macos-x64`

--- a/cmake/dotnet.cmake
+++ b/cmake/dotnet.cmake
@@ -13,7 +13,7 @@ set(DOTNET_PACKAGES_DIR "${PROJECT_BINARY_DIR}/dotnet")
 # see: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
   set(DOTNET_PLATFORM arm64)
-elseif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+elseif(WIN32 AND (CMAKE_GENERATOR_PLATFORM STREQUAL "Win32" OR CMAKE_SIZEOF_VOID_P EQUAL 4))
   set(DOTNET_PLATFORM x86)
 else()
   set(DOTNET_PLATFORM x64)

--- a/cmake/dotnet.cmake
+++ b/cmake/dotnet.cmake
@@ -13,6 +13,8 @@ set(DOTNET_PACKAGES_DIR "${PROJECT_BINARY_DIR}/dotnet")
 # see: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
   set(DOTNET_PLATFORM arm64)
+elseif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+  set(DOTNET_PLATFORM x86)
 else()
   set(DOTNET_PLATFORM x64)
 endif()

--- a/docs/src/interfaces/csharp.md
+++ b/docs/src/interfaces/csharp.md
@@ -23,7 +23,7 @@ dotnet add package Highs.Native --version 1.14.0
 The nuget package contains runtime libraries for
 
 * `win-x64`
-* `win-x32`
+* `win-x86`
 * `linux-x64`
 * `linux-arm64`
 * `macos-x64`

--- a/highs/CMakeLists.txt
+++ b/highs/CMakeLists.txt
@@ -377,7 +377,7 @@ else()
       # see: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
       if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
         set(DOTNET_PLATFORM arm64)
-      elseif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+      elseif(WIN32 AND (CMAKE_GENERATOR_PLATFORM STREQUAL "Win32" OR CMAKE_SIZEOF_VOID_P EQUAL 4))
         set(DOTNET_PLATFORM x86)
       else()
         set(DOTNET_PLATFORM x64)

--- a/highs/CMakeLists.txt
+++ b/highs/CMakeLists.txt
@@ -377,6 +377,8 @@ else()
       # see: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
       if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
         set(DOTNET_PLATFORM arm64)
+      elseif(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(DOTNET_PLATFORM x86)
       else()
         set(DOTNET_PLATFORM x64)
       endif()

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -13,7 +13,7 @@ dotnet add package Highs.Native --version 1.14.0
 The nuget package contains runtime libraries for
 
 * `win-x64`
-* `win-x32`
+* `win-x86`
 * `linux-x64`
 * `linux-arm64`
 * `macos-x64`

--- a/nuget/build_windows.ps1
+++ b/nuget/build_windows.ps1
@@ -17,6 +17,7 @@ try {
 	# $flags = "/arch:AVX512 /Ox /Ot /Oi /O2" - Intel stopped supporting AVX-512 on some CPUs, me might run into compatibility issues
 	$flags = "/Ox /Ot /Oi /O2"
 	$arguments += "-DCMAKE_CXX_FLAGS='$flags'"
+	$arguments += "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded"
 		
 	# Pass the argument list to cmake
 	& cmake $arguments ../.. 


### PR DESCRIPTION
Closes https://github.com/ERGO-Code/HiGHS/issues/2968 and https://github.com/ERGO-Code/HiGHS/issues/2967

Also used to test the new NuGet Trusted Publishing: seems to work with a published pre-release version Highs.Native --version 1.14.0-preview.1
