### PR TITLE
GPU support for local Python pip install

### DIFF
--- a/highspy/CMakeLists.txt
+++ b/highspy/CMakeLists.txt
@@ -54,25 +54,37 @@ if (NOT MSVC)
   target_compile_options(_core PRIVATE "-ftemplate-depth=2048")
 endif()
 
+if(CUPDLP_GPU)
+  target_link_libraries(_core PRIVATE cudalin ${CUDA_LIBRARY})
+endif()
+
 # The install directory is the output (wheel) directory
 install(TARGETS _core
         RUNTIME DESTINATION highspy
         LIBRARY DESTINATION highspy
         COMPONENT python)
 
-# Only needed if the wheel is built with a shared library, but can be left in for static linking as well.
-# Include highs library (but ignore .lib file)
-install(TARGETS highs
-        RUNTIME DESTINATION highspy
-        LIBRARY DESTINATION highspy
-        NAMELINK_SKIP
-        COMPONENT python)
-
-# When GPU support is enabled, cudalin is built as a separate shared library
-# that highs.dll depends on at runtime — bundle it with the wheel.
-if (CUPDLP_GPU AND NOT HIGHS_GPU_LIB)
-  install(TARGETS cudalin
-          RUNTIME DESTINATION highspy
+# install(TARGETS highs/cudalin ...) is silently ignored in CMake 4.x when the
+# target is owned by a different directory, and also when BUILD_SHARED_LIBS is
+# OFF in this scope (reset above). Use install(FILES $<TARGET_FILE:...>) which
+# resolves the actual DLL path at install time with no directory restrictions.
+if (CUPDLP_GPU)
+  # Use install(FILES) to avoid CMake 4.x cross-directory install(TARGETS)
+  # restrictions (silently ignored for targets owned by other directories).
+  # $<TARGET_SONAME_FILE:highs> gives the SONAME file on Linux (libhighs.so.1.14)
+  # or the DLL on Windows — the exact file the extension's linker records.
+  install(FILES $<TARGET_SONAME_FILE:highs>
+          DESTINATION highspy
+          COMPONENT python)
+  if (NOT HIGHS_GPU_LIB)
+    install(FILES $<TARGET_FILE:cudalin>
+            DESTINATION highspy
+            COMPONENT python)
+  endif()
+else()
+  # Non-GPU: on Unix highs is shared by default; LIBRARY+NAMELINK_SKIP installs
+  # the SONAME file that the extension's RPATH resolves.
+  install(TARGETS highs
           LIBRARY DESTINATION highspy
           NAMELINK_SKIP
           COMPONENT python)

--- a/highspy/CMakeLists.txt
+++ b/highspy/CMakeLists.txt
@@ -64,10 +64,6 @@ install(TARGETS _core
         LIBRARY DESTINATION highspy
         COMPONENT python)
 
-# install(TARGETS highs/cudalin ...) is silently ignored in CMake 4.x when the
-# target is owned by a different directory, and also when BUILD_SHARED_LIBS is
-# OFF in this scope (reset above). Use install(FILES $<TARGET_FILE:...>) which
-# resolves the actual DLL path at install time with no directory restrictions.
 if (CUPDLP_GPU)
   # Use install(FILES) to avoid CMake 4.x cross-directory install(TARGETS)
   # restrictions (silently ignored for targets owned by other directories).
@@ -82,9 +78,8 @@ if (CUPDLP_GPU)
             COMPONENT python)
   endif()
 else()
-  # Non-GPU: on Unix highs is shared by default; LIBRARY+NAMELINK_SKIP installs
-  # the SONAME file that the extension's RPATH resolves.
   install(TARGETS highs
+          RUNTIME DESTINATION highspy
           LIBRARY DESTINATION highspy
           NAMELINK_SKIP
           COMPONENT python)

--- a/highspy/CMakeLists.txt
+++ b/highspy/CMakeLists.txt
@@ -67,11 +67,17 @@ install(TARGETS _core
 if (CUPDLP_GPU)
   # Use install(FILES) to avoid CMake 4.x cross-directory install(TARGETS)
   # restrictions (silently ignored for targets owned by other directories).
-  # $<TARGET_SONAME_FILE:highs> gives the SONAME file on Linux (libhighs.so.1.14)
-  # or the DLL on Windows — the exact file the extension's linker records.
-  install(FILES $<TARGET_SONAME_FILE:highs>
-          DESTINATION highspy
-          COMPONENT python)
+  if (WIN32)
+    install(FILES $<TARGET_FILE:highs>
+            DESTINATION highspy
+            COMPONENT python)
+  else()
+    # On Linux/macOS TARGET_SONAME_FILE gives the SONAME file (e.g.
+    # libhighs.so.1.14)
+    install(FILES $<TARGET_SONAME_FILE:highs>
+            DESTINATION highspy
+            COMPONENT python)
+  endif()
   if (NOT HIGHS_GPU_LIB)
     install(FILES $<TARGET_FILE:cudalin>
             DESTINATION highspy

--- a/highspy/CMakeLists.txt
+++ b/highspy/CMakeLists.txt
@@ -67,3 +67,13 @@ install(TARGETS highs
         LIBRARY DESTINATION highspy
         NAMELINK_SKIP
         COMPONENT python)
+
+# When GPU support is enabled, cudalin is built as a separate shared library
+# that highs.dll depends on at runtime — bundle it with the wheel.
+if (CUPDLP_GPU AND NOT HIGHS_GPU_LIB)
+  install(TARGETS cudalin
+          RUNTIME DESTINATION highspy
+          LIBRARY DESTINATION highspy
+          NAMELINK_SKIP
+          COMPONENT python)
+endif()

--- a/highspy/CMakeLists.txt
+++ b/highspy/CMakeLists.txt
@@ -72,11 +72,18 @@ if (CUPDLP_GPU)
             DESTINATION highspy
             COMPONENT python)
   else()
-    # On Linux/macOS TARGET_SONAME_FILE gives the SONAME file (e.g.
-    # libhighs.so.1.14)
-    install(FILES $<TARGET_SONAME_FILE:highs>
+    install(FILES $<TARGET_FILE:highs>
             DESTINATION highspy
+            RENAME $<TARGET_SONAME_FILE_NAME:highs>
             COMPONENT python)
+    # install(FILES) does not update RPATH (unlike install(TARGETS)).
+    # Without this, the embedded build-tree RPATH prevents libhighs from
+    # finding libcudalin at $ORIGIN after installation.
+    install(CODE "
+      file(RPATH_SET
+        FILE \"\${CMAKE_INSTALL_PREFIX}/highspy/$<TARGET_SONAME_FILE_NAME:highs>\"
+        NEW_RPATH \"\$ORIGIN\")
+    " COMPONENT python)
   endif()
   if (NOT HIGHS_GPU_LIB)
     install(FILES $<TARGET_FILE:cudalin>

--- a/highspy/highspy/__init__.py
+++ b/highspy/highspy/__init__.py
@@ -1,3 +1,18 @@
+import os as _os
+import sys as _sys
+
+if _sys.platform == "win32" and _os.path.exists(_os.path.join(_os.path.dirname(__file__), "cudalin.dll")):
+    # Python 3.8+ no longer searches PATH when loading extension DLLs.
+    # cudalin.dll is present only in GPU builds; register the CUDA bin directory
+    # so cudart64_12.dll etc. are found when _core is loaded.
+    _cuda_path = _os.environ.get("CUDA_PATH") or _os.environ.get("CUDA_HOME")
+    if _cuda_path:
+        _cuda_bin = _os.path.join(_cuda_path, "bin")
+        if _os.path.isdir(_cuda_bin):
+            _os.add_dll_directory(_cuda_bin)
+    del _cuda_path
+del _os, _sys
+
 from ._core import (
     ObjSense,
     MatrixFormat,

--- a/highspy/highspy/__init__.py
+++ b/highspy/highspy/__init__.py
@@ -4,7 +4,7 @@ import sys as _sys
 if _sys.platform == "win32" and _os.path.exists(_os.path.join(_os.path.dirname(__file__), "cudalin.dll")):
     # Python 3.8+ no longer searches PATH when loading extension DLLs.
     # cudalin.dll is present only in GPU builds; register the CUDA bin directory
-    # so cudart64_12.dll etc. are found when _core is loaded.
+    # so cuda*.dll etc. are found when _core is loaded.
     _cuda_path = _os.environ.get("CUDA_PATH") or _os.environ.get("CUDA_HOME")
     if _cuda_path:
         _cuda_bin = _os.path.join(_cuda_path, "bin")


### PR DESCRIPTION
NVidia GPUs now supported locally from Python via 

pip install . --config-settings=cmake.define.CUPDLP_GPU=ON

Tested locally on Windows and Linux with NVIDIA GeForce RTX 4050

Closes https://github.com/ERGO-Code/HiGHS/issues/2906 and https://github.com/ERGO-Code/HiGHS/issues/3008

Will likely be updated later for dynamic loading, like in highspy_extras