### PR TITLE
Add explicit -fexceptions copts to Bazel config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,6 +81,7 @@ cc_library(
     copts = select({
         "@rules_cc//cc/compiler:msvc-cl": [],
         "//conditions:default": [
+            "-fexceptions",
             "-Wno-unused-variable",
             "-Wno-unused-but-set-variable",
         ],
@@ -232,6 +233,7 @@ TEST_NAMES = [
     copts = ["-Iextern"] + select({
         "@rules_cc//cc/compiler:msvc-cl": [],
         "//conditions:default": [
+            "-fexceptions",
             "-Wno-unused-variable",
             "-Wno-unused-but-set-variable",
         ],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You can raise an [issue](https://github.com/ERGO-Code/HiGHS/issues) with HiGHS i
 
 HiGHS is open source for distribution rather than contribution. This applies particularly to the core C++ code of the solvers. However, there is definitely scope for external contribution to interfaces and documentation. If you want to contribute in this way, please open an issue before making a pull request, since pull requests to the HiGHS solvers will not normally be accepted. 
 
-Please note that any pull requests to HiGHS must be made to the `latest` branch, so that full testing can take place befor updating `master`. This ensures that `master` is always good to be downloaded by users.
+Please note that any pull requests to HiGHS must be made to the `latest` branch, so that full testing can take place befor updating `master`. This ensures that `master` is always good to be downloaded by users. As a consequence, any changes should be developed as a branch of `latest` to reduce the chance of merge conflicts.
 
 Note that, under the terms of the MIT license, by contributing to HiGHS you assign away your rights to the content of your contribution.
 


### PR DESCRIPTION
This allows users to build with -fno-exceptions, and smoothly turns exceptions into crashes at the boundary.