### PR TITLE
Add blas compile def to highs library

### DIFF
--- a/cmake/FindHipoDeps.cmake
+++ b/cmake/FindHipoDeps.cmake
@@ -372,7 +372,6 @@ function(highs_link_blas target_name)
         message(FATAL_ERROR "Ensure highs_configure_blas() called before highs_link_blas(${target_name}).")
     endif()
 
-    target_compile_definitions(${target_name} PRIVATE ${HIGHS_BLAS_COMPILE_DEFINITION})
     target_compile_definitions(${target_name} PRIVATE HIGHS_BLAS_VENDOR="${HIGHS_BLAS_VENDOR}")
     target_compile_definitions(${target_name} PRIVATE HIGHS_BLAS_VERSION="${HIGHS_BLAS_VERSION}")
     target_compile_definitions(${target_name} PRIVATE HIGHS_BLAS_LICENSE="${HIGHS_BLAS_LICENSE}")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -77,6 +77,8 @@ endif()
 
 # add optional dependencies (linker)
 if(HIPO)
+  target_compile_definitions(highs_extras PRIVATE ${HIGHS_BLAS_COMPILE_DEFINITION})
+  target_compile_definitions(highs PRIVATE ${HIGHS_BLAS_COMPILE_DEFINITION})
   highs_link_blas(highs_extras)
 endif()
 # end optional dependencies (linker)


### PR DESCRIPTION
`HIGHS_BLAS_COMPILE_DEFINITION` is defined only for the `highs_extras` library and not for the `highs` library, but it is needed in both.