### PR TITLE
Check BLAS used in HiPO at runtime

### DIFF
--- a/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
@@ -598,7 +598,7 @@ void FactorHiGHSSolver::setParallel() {
       assert(1 == 0);
 
   } else if (options_.parallel == kHighsChooseString) {
-    if (strstr(HighsExtras::blas::getInfo()->provider, "apple")) {
+    if (strstr(HighsExtras::blas::getInfo()->provider, "Apple")) {
       // Blas on Apple do not work well with parallel_node, but parallel_tree
       // seems to always be beneficial.
       parallel_node = false;

--- a/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
@@ -598,8 +598,7 @@ void FactorHiGHSSolver::setParallel() {
       assert(1 == 0);
 
   } else if (options_.parallel == kHighsChooseString) {
-    if (strcmp(HighsExtras::blas::getInfo()->provider, "Apple Accelerate") ==
-        0) {
+    if (strstr(HighsExtras::blas::getInfo()->provider, "apple")) {
       // Blas on Apple do not work well with parallel_node, but parallel_tree
       // seems to always be beneficial.
       parallel_node = false;

--- a/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
@@ -1,5 +1,6 @@
 #include "FactorHiGHSSolver.h"
 
+#include <cstring>
 #include <limits>
 
 #include "HighsExternalApi.h"
@@ -597,35 +598,36 @@ void FactorHiGHSSolver::setParallel() {
       assert(1 == 0);
 
   } else if (options_.parallel == kHighsChooseString) {
-#ifdef HIPO_USES_APPLE_BLAS
-    // Blas on Apple do not work well with parallel_node, but parallel_tree
-    // seems to always be beneficial.
-    parallel_node = false;
-    parallel_tree = true;
-#else
-    // Otherwise, parallel_node is active because it is triggered only if the
-    // frontal matrix is large enough anyway.
-    parallel_node = true;
-
-    // parallel_tree instead is chosen with a heuristic
-
-    double tree_speedup = S_.flops() / S_.critops();
-    double sn_size = (double)S_.size() / S_.sn();
-
-    bool enough_sn = S_.sn() > kMinNumberSn;
-    bool enough_flops = S_.flops() > kLargeFlopsThresh;
-    bool speedup_is_large = tree_speedup > kLargeSpeedupThresh;
-    bool sn_are_large = sn_size > kLargeSnThresh;
-    bool sn_are_not_small = sn_size > kSmallSnThresh;
-
-    // parallel_tree is active if the supernodes are large, or if there is a
-    // large expected speedup and the supernodes are not too small, provided
-    // that the number of flops and supernodes is not too small.
-    if (enough_sn && enough_flops &&
-        (sn_are_large || (speedup_is_large && sn_are_not_small))) {
+    if (strcmp(HighsExtras::blas::getInfo()->provider, "Apple Accelerate") ==
+        0) {
+      // Blas on Apple do not work well with parallel_node, but parallel_tree
+      // seems to always be beneficial.
+      parallel_node = false;
       parallel_tree = true;
+    } else {
+      // Otherwise, parallel_node is active because it is triggered only if the
+      // frontal matrix is large enough anyway.
+      parallel_node = true;
+
+      // parallel_tree instead is chosen with a heuristic
+
+      double tree_speedup = S_.flops() / S_.critops();
+      double sn_size = (double)S_.size() / S_.sn();
+
+      bool enough_sn = S_.sn() > kMinNumberSn;
+      bool enough_flops = S_.flops() > kLargeFlopsThresh;
+      bool speedup_is_large = tree_speedup > kLargeSpeedupThresh;
+      bool sn_are_large = sn_size > kLargeSnThresh;
+      bool sn_are_not_small = sn_size > kSmallSnThresh;
+
+      // parallel_tree is active if the supernodes are large, or if there is a
+      // large expected speedup and the supernodes are not too small, provided
+      // that the number of flops and supernodes is not too small.
+      if (enough_sn && enough_flops &&
+          (sn_are_large || (speedup_is_large && sn_are_not_small))) {
+        parallel_tree = true;
+      }
     }
-#endif
 
     // If serial memory is too large, switch off tree parallelism to avoid
     // running out of memory

--- a/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHiGHSSolver.cpp
@@ -573,6 +573,10 @@ Int FactorHiGHSSolver::setNla() {
   return kStatusOk;
 }
 
+static bool usingAppleBlas() {
+  return strstr(HighsExtras::blas::getInfo()->provider, "Apple") != nullptr;
+}
+
 void FactorHiGHSSolver::setParallel() {
   // Set parallel options
   bool parallel_tree = false;
@@ -598,7 +602,7 @@ void FactorHiGHSSolver::setParallel() {
       assert(1 == 0);
 
   } else if (options_.parallel == kHighsChooseString) {
-    if (strstr(HighsExtras::blas::getInfo()->provider, "Apple")) {
+    if (usingAppleBlas()) {
       // Blas on Apple do not work well with parallel_node, but parallel_tree
       // seems to always be beneficial.
       parallel_node = false;


### PR DESCRIPTION
HiPO was using `HIPO_USES_APPLE_BLAS` for making algorithmic choices.
However, this is not defined in `highs` anymore, but only in `highs_extras`.
The use of Apple Accelerate can be checked at runtime using the HighsExtras interface.