### PR TITLE
Fix column stuffing

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -225,6 +225,7 @@ TEST_NAMES = [
     "TestLpValidation",
     "TestMipSolver",
     "TestPresolve",
+    "TestPresolveRules",
     "TestQpSolver",
     "TestRanging",
     "TestRays",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -228,6 +228,7 @@ TEST_NAMES = [
     "TestPresolveRules",
     "TestQpSolver",
     "TestRanging",
+    "TestRunData",
     "TestRays",
     "TestSemiVariables",
     "TestSetup",

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -71,6 +71,7 @@ if ((NOT FAST_BUILD OR ALL_TESTS) AND NOT (BUILD_EXTRA_UNIT_ONLY))
       TestPdlp.cpp
       TestPdlpHi.cpp
       TestPresolve.cpp
+      TestPresolveRules.cpp
       TestQpSolver.cpp
       TestRanging.cpp
       TestRays.cpp

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -75,6 +75,7 @@ if ((NOT FAST_BUILD OR ALL_TESTS) AND NOT (BUILD_EXTRA_UNIT_ONLY))
       TestQpSolver.cpp
       TestRanging.cpp
       TestRays.cpp
+      TestRunData.cpp
       TestSemiVariables.cpp
       TestSetup.cpp
       TestSort.cpp

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -8,27 +8,82 @@ const bool dev_run = false;
 
 TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   HighsLp lp;
-  lp.num_col_ = 3;
+
+  Highs h;
+  //  h.setOptionValue("output_flag", dev_run);
+  const HighsLp& presolved_lp = h.getPresolvedLp();
+  h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
+  const bool lp0 = false;
+  const bool lp1 = false;
+  const bool lp1a = true;
+  const bool lp1b = false;
+
+  if (lp0) {
+    lp.num_col_ = 3;
+    lp.num_row_ = 1;
+    lp.sense_ = ObjSense::kMaximize;
+    lp.col_cost_ = {1.8, 0.9, 1};
+    lp.col_lower_.assign(lp.num_col_, 0);
+    lp.col_upper_.assign(lp.num_col_, 1);
+    lp.row_lower_ = {-kHighsInf};
+    lp.row_upper_ = {4};
+    lp.a_matrix_.format_ = MatrixFormat::kRowwise;
+    lp.a_matrix_.start_ = {0, lp.num_col_};
+    lp.a_matrix_.index_.resize( lp.num_col_);
+    std::iota(lp.a_matrix_.index_.begin(), lp.a_matrix_.index_.end(), 0);
+    lp.a_matrix_.value_ = {3, 2, 2};
+
+    for (int k = 0; k < 2; k++) {
+      printf("\n3-variable knapsack: %s\n", k == 0 ? "LP" : "IP");
+      REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+      h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
+      h.run();
+      h.writeSolution("", 1);
+      lp.integrality_.assign(lp.num_col_, HighsVarType::kInteger);
+    }
+    lp.clear();
+  }
+
+  auto presolveOffOn = [&] (const std::string& message) {
+    h.setOptionValue(kPresolveString, kHighsOffString);
+    for (int k = 0; k < 2; k++) {
+      printf("\n============\n%s: presolve = %s\n============\n\n", message.c_str(), k == 0 ? "off" : "on");
+      REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+      h.run();
+      h.writeSolution("", 1);
+      if (k == 1)
+	REQUIRE(h.getInfo().simplex_iteration_count == 0);
+      h.setOptionValue(kPresolveString, kHighsOnString);
+    }
+  };
+
+  lp.num_col_ = 2;
   lp.num_row_ = 1;
-  lp.sense_ = ObjSense::kMaximize;
-  lp.col_cost_ = {1.8, 0.9, 1};
+  lp.sense_ = ObjSense::kMinimize;
   lp.col_lower_.assign(lp.num_col_, 0);
   lp.col_upper_.assign(lp.num_col_, 1);
-  //  lp.integrality_.assign(lp.num_col_, HighsVarType::kInteger);
-  lp.row_lower_ = {-kHighsInf};
-  lp.row_upper_ = {4};
+  lp.row_lower_ = {2.0};
+  lp.row_upper_ = {kHighsInf};
   lp.a_matrix_.format_ = MatrixFormat::kRowwise;
   lp.a_matrix_.start_ = {0, lp.num_col_};
   lp.a_matrix_.index_.resize( lp.num_col_);
   std::iota(lp.a_matrix_.index_.begin(), lp.a_matrix_.index_.end(), 0);
-  lp.a_matrix_.value_ = {3, 2, 2};
-
-  Highs h;
-  //  h.setOptionValue("output_flag", dev_run);
-  REQUIRE(h.passModel(lp) == HighsStatus::kOk);
-  h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
-  h.run();
-  h.writeSolution("", 1);
+  if (lp1) {
+    lp.col_cost_.assign(lp.num_col_, 1);
+    lp.a_matrix_.value_.assign(lp.num_col_, 1);
+    presolveOffOn("Capturing neos-787933 issue");
+  }
+  if (lp1a) {
+    lp.col_cost_ = {2, 1};
+    lp.a_matrix_.value_.assign(lp.num_col_, 1);
+    presolveOffOn("Variant A neos-787933 issue");
+  }
+  if (lp1b) {
+    lp.col_cost_ = {-2, -1};
+    lp.a_matrix_.value_.assign(lp.num_col_, 1);
+    presolveOffOn("Variant B neos-787933 issue");
+  }
+  lp.clear();
 
   h.resetGlobalScheduler(true);
   

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -1,0 +1,35 @@
+#include "HCheckConfig.h"
+#include "Highs.h"
+#include "catch.hpp"
+
+#include <numeric>
+
+const bool dev_run = false;
+
+TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
+  HighsLp lp;
+  lp.num_col_ = 3;
+  lp.num_row_ = 1;
+  lp.sense_ = ObjSense::kMaximize;
+  lp.col_cost_ = {1.8, 0.9, 1};
+  lp.col_lower_.assign(lp.num_col_, 0);
+  lp.col_upper_.assign(lp.num_col_, 1);
+  //  lp.integrality_.assign(lp.num_col_, HighsVarType::kInteger);
+  lp.row_lower_ = {-kHighsInf};
+  lp.row_upper_ = {4};
+  lp.a_matrix_.format_ = MatrixFormat::kRowwise;
+  lp.a_matrix_.start_ = {0, lp.num_col_};
+  lp.a_matrix_.index_.resize( lp.num_col_);
+  std::iota(lp.a_matrix_.index_.begin(), lp.a_matrix_.index_.end(), 0);
+  lp.a_matrix_.value_ = {3, 2, 2};
+
+  Highs h;
+  //  h.setOptionValue("output_flag", dev_run);
+  REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+  h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
+  h.run();
+  h.writeSolution("", 1);
+
+  h.resetGlobalScheduler(true);
+  
+}

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -4,14 +4,51 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = false;
+const bool dev_run = true;
+
+void presolveOffOn(const std::string& message, const HighsLp& lp, Highs& h) {
+  const HighsRunData& run_data = h.getRunData();
+  bool presolve_on = false;
+  for (int k = 0; k < 4; k++) {
+    std::string solver = kSimplexString;
+    if (k == 0) {
+      // Presolve off - to get the optimal solution to debug
+      // presolve
+      presolve_on = false;
+    } else {
+      presolve_on = true;
+      if (k == 1) {
+        solver = kSimplexString;
+      } else if (k == 2) {
+        solver = kHipoString;
+      } else {
+        solver = kHiPdlpString;
+      }
+    }
+    std::string presolve = presolve_on ? kHighsOnString : kHighsOffString;
+    h.setOptionValue(kPresolveString, presolve);
+    h.setOptionValue(kSolverString, solver);
+    if (dev_run)
+      printf("\n============\n%s: presolve = %s; solver = %s\n============\n\n",
+             message.c_str(), presolve.c_str(), solver.c_str());
+    REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+    h.run();
+    if (dev_run) h.writeSolution("", 1);
+    if (presolve_on) {
+      REQUIRE(h.getInfo().simplex_iteration_count == 0);
+      REQUIRE(run_data.presolved_model_num_col == 0);
+      REQUIRE(run_data.presolved_model_num_row == 0);
+      REQUIRE(run_data.presolved_model_num_nz == 0);
+      REQUIRE(run_data.num_simplex_iterations_after_postsolve == 0);
+    }
+  }
+}
 
 TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   HighsLp lp;
 
   Highs h;
   //  h.setOptionValue("output_flag", dev_run);
-  const HighsRunData& run_data = h.getRunData();
   h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
   const bool lp0 = false;
   const bool lp1 = false;
@@ -34,51 +71,15 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
     lp.a_matrix_.value_ = {3, 2, 2};
 
     for (int k = 0; k < 2; k++) {
-      printf("\n3-variable knapsack: %s\n", k == 0 ? "LP" : "IP");
+      if (dev_run) printf("\n3-variable knapsack: %s\n", k == 0 ? "LP" : "IP");
       REQUIRE(h.passModel(lp) == HighsStatus::kOk);
       h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
       h.run();
-      h.writeSolution("", 1);
+      if (dev_run) h.writeSolution("", 1);
       lp.integrality_.assign(lp.num_col_, HighsVarType::kInteger);
     }
     lp.clear();
   }
-
-  auto presolveOffOn = [&](const std::string& message) {
-    bool presolve_on = false;
-    for (int k = 0; k < 4; k++) {
-      std::string solver = kSimplexString;
-      if (k == 0) {
-	// Presolve off - to get the optimal solution to debug
-	// presolve
-	presolve_on = false;
-      } else {
-	presolve_on = true;
-	if (k == 1) {
-	  solver = kSimplexString;
-	} else if (k == 2) {
-	  solver = kHipoString;
-	} else {
-	  solver = kHiPdlpString;
-	}
-      }
-      std::string presolve = presolve_on ? kHighsOnString : kHighsOffString;
-      h.setOptionValue(kPresolveString, presolve);
-      h.setOptionValue(kSolverString, solver);
-      printf("\n============\n%s: presolve = %s; solver = %s\n============\n\n",
-             message.c_str(), presolve.c_str(), solver.c_str());
-      REQUIRE(h.passModel(lp) == HighsStatus::kOk);
-      h.run();
-      h.writeSolution("", 1);
-      if (presolve_on) {
-	REQUIRE(h.getInfo().simplex_iteration_count == 0);
-	REQUIRE(run_data.presolved_model_num_col == 0);
-	REQUIRE(run_data.presolved_model_num_row == 0);
-	REQUIRE(run_data.presolved_model_num_nz == 0);
-	REQUIRE(run_data.num_simplex_iterations_after_postsolve == 0);
-      }
-    }
-  };
 
   lp.num_col_ = 2;
   lp.num_row_ = 1;
@@ -94,17 +95,17 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   if (lp1) {
     lp.col_cost_.assign(lp.num_col_, 1);
     lp.a_matrix_.value_.assign(lp.num_col_, 1);
-    presolveOffOn("Capturing neos-787933 issue");
+    presolveOffOn("Capturing neos-787933 issue", lp, h);
   }
   if (lp1a) {
     lp.col_cost_ = {2, 1};
     lp.a_matrix_.value_.assign(lp.num_col_, 1);
-    presolveOffOn("Variant A neos-787933 issue");
+    presolveOffOn("Variant A neos-787933 issue", lp, h);
   }
   if (lp1b) {
     lp.col_cost_ = {-2, -1};
     lp.a_matrix_.value_.assign(lp.num_col_, 1);
-    presolveOffOn("Variant B neos-787933 issue");
+    presolveOffOn("Variant B neos-787933 issue", lp, h);
   }
   lp.clear();
 

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -11,7 +11,7 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
 
   Highs h;
   //  h.setOptionValue("output_flag", dev_run);
-  const HighsLp& presolved_lp = h.getPresolvedLp();
+  const HighsRunData& run_data = h.getRunData();
   h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
   const bool lp0 = false;
   const bool lp1 = false;
@@ -45,15 +45,38 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   }
 
   auto presolveOffOn = [&](const std::string& message) {
-    h.setOptionValue(kPresolveString, kHighsOffString);
-    for (int k = 0; k < 2; k++) {
-      printf("\n============\n%s: presolve = %s\n============\n\n",
-             message.c_str(), k == 0 ? "off" : "on");
+    bool presolve_on = false;
+    for (int k = 0; k < 4; k++) {
+      std::string solver = kSimplexString;
+      if (k == 0) {
+	// Presolve off - to get the optimal solution to debug
+	// presolve
+	presolve_on = false;
+      } else {
+	presolve_on = true;
+	if (k == 1) {
+	  solver = kSimplexString;
+	} else if (k == 2) {
+	  solver = kHipoString;
+	} else {
+	  solver = kHiPdlpString;
+	}
+      }
+      std::string presolve = presolve_on ? kHighsOnString : kHighsOffString;
+      h.setOptionValue(kPresolveString, presolve);
+      h.setOptionValue(kSolverString, solver);
+      printf("\n============\n%s: presolve = %s; solver = %s\n============\n\n",
+             message.c_str(), presolve.c_str(), solver.c_str());
       REQUIRE(h.passModel(lp) == HighsStatus::kOk);
       h.run();
       h.writeSolution("", 1);
-      if (k == 1) REQUIRE(h.getInfo().simplex_iteration_count == 0);
-      h.setOptionValue(kPresolveString, kHighsOnString);
+      if (presolve_on) {
+	REQUIRE(h.getInfo().simplex_iteration_count == 0);
+	REQUIRE(run_data.presolved_model_num_col == 0);
+	REQUIRE(run_data.presolved_model_num_row == 0);
+	REQUIRE(run_data.presolved_model_num_nz == 0);
+	REQUIRE(run_data.num_simplex_iterations_after_postsolve == 0);
+      }
     }
   };
 

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -1,8 +1,8 @@
+#include <numeric>
+
 #include "HCheckConfig.h"
 #include "Highs.h"
 #include "catch.hpp"
-
-#include <numeric>
 
 const bool dev_run = false;
 
@@ -29,7 +29,7 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
     lp.row_upper_ = {4};
     lp.a_matrix_.format_ = MatrixFormat::kRowwise;
     lp.a_matrix_.start_ = {0, lp.num_col_};
-    lp.a_matrix_.index_.resize( lp.num_col_);
+    lp.a_matrix_.index_.resize(lp.num_col_);
     std::iota(lp.a_matrix_.index_.begin(), lp.a_matrix_.index_.end(), 0);
     lp.a_matrix_.value_ = {3, 2, 2};
 
@@ -44,15 +44,15 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
     lp.clear();
   }
 
-  auto presolveOffOn = [&] (const std::string& message) {
+  auto presolveOffOn = [&](const std::string& message) {
     h.setOptionValue(kPresolveString, kHighsOffString);
     for (int k = 0; k < 2; k++) {
-      printf("\n============\n%s: presolve = %s\n============\n\n", message.c_str(), k == 0 ? "off" : "on");
+      printf("\n============\n%s: presolve = %s\n============\n\n",
+             message.c_str(), k == 0 ? "off" : "on");
       REQUIRE(h.passModel(lp) == HighsStatus::kOk);
       h.run();
       h.writeSolution("", 1);
-      if (k == 1)
-	REQUIRE(h.getInfo().simplex_iteration_count == 0);
+      if (k == 1) REQUIRE(h.getInfo().simplex_iteration_count == 0);
       h.setOptionValue(kPresolveString, kHighsOnString);
     }
   };
@@ -66,7 +66,7 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   lp.row_upper_ = {kHighsInf};
   lp.a_matrix_.format_ = MatrixFormat::kRowwise;
   lp.a_matrix_.start_ = {0, lp.num_col_};
-  lp.a_matrix_.index_.resize( lp.num_col_);
+  lp.a_matrix_.index_.resize(lp.num_col_);
   std::iota(lp.a_matrix_.index_.begin(), lp.a_matrix_.index_.end(), 0);
   if (lp1) {
     lp.col_cost_.assign(lp.num_col_, 1);
@@ -86,5 +86,4 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   lp.clear();
 
   h.resetGlobalScheduler(true);
-  
 }

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -6,43 +6,10 @@
 
 const bool dev_run = true;
 
-void presolveOffOn(const std::string& message, const HighsLp& lp, Highs& h) {
-  const HighsRunData& run_data = h.getRunData();
-  bool presolve_on = false;
-  for (int k = 0; k < 4; k++) {
-    std::string solver = kSimplexString;
-    if (k == 0) {
-      // Presolve off - to get the optimal solution to debug
-      // presolve
-      presolve_on = false;
-    } else {
-      presolve_on = true;
-      if (k == 1) {
-        solver = kSimplexString;
-      } else if (k == 2) {
-        solver = kHipoString;
-      } else {
-        solver = kHiPdlpString;
-      }
-    }
-    std::string presolve = presolve_on ? kHighsOnString : kHighsOffString;
-    h.setOptionValue(kPresolveString, presolve);
-    h.setOptionValue(kSolverString, solver);
-    if (dev_run)
-      printf("\n============\n%s: presolve = %s; solver = %s\n============\n\n",
-             message.c_str(), presolve.c_str(), solver.c_str());
-    REQUIRE(h.passModel(lp) == HighsStatus::kOk);
-    h.run();
-    if (dev_run) h.writeSolution("", 1);
-    if (presolve_on) {
-      REQUIRE(h.getInfo().simplex_iteration_count == 0);
-      REQUIRE(run_data.presolved_model_num_col == 0);
-      REQUIRE(run_data.presolved_model_num_row == 0);
-      REQUIRE(run_data.presolved_model_num_nz == 0);
-      REQUIRE(run_data.num_simplex_iterations_after_postsolve == 0);
-    }
-  }
-}
+void presolveOffOn(const std::string& message, const HighsLp& lp, Highs& h,
+                   const HighsInt require_presolved_model_num_col = 0,
+                   const HighsInt require_presolved_model_num_row = 0,
+                   const HighsInt require_presolved_model_num_nz = 0);
 
 TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   HighsLp lp;
@@ -110,4 +77,71 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   lp.clear();
 
   h.resetGlobalScheduler(true);
+}
+
+void presolveOffOn(const std::string& message, const HighsLp& lp, Highs& h,
+                   const HighsInt require_presolved_model_num_col,
+                   const HighsInt require_presolved_model_num_row,
+                   const HighsInt require_presolved_model_num_nz) {
+  const HighsRunData& run_data = h.getRunData();
+  bool presolve_on = false;
+  // If the model reduces to empty, then the output from different
+  // solvers cannot be tested
+  const bool reduce_to_empty = require_presolved_model_num_col == 0 &&
+                               require_presolved_model_num_row == 0;
+  const HighsInt to_k = reduce_to_empty ? 2 : 5;
+  for (int k = 0; k < to_k; k++) {
+    std::string solver = kSimplexString;
+    std::string run_crossover = kHighsOnString;
+    bool basis_postsolve = true;
+    if (k == 0) {
+      // Presolve off - to get the optimal solution to debug
+      // presolve
+      presolve_on = false;
+    } else {
+      presolve_on = true;
+      if (k == 1) {
+        solver = kSimplexString;
+      } else if (k == 2) {
+        solver = kIpmString;
+      } else if (k == 3) {
+        solver = kIpmString;
+        run_crossover = kHighsOffString;
+        basis_postsolve = false;
+      } else {
+        solver = kHiPdlpString;
+        basis_postsolve = false;
+      }
+    }
+    std::string presolve = presolve_on ? kHighsOnString : kHighsOffString;
+    h.setOptionValue(kPresolveString, presolve);
+    h.setOptionValue(kRunCrossoverString, run_crossover);
+    h.setOptionValue(kSolverString, solver);
+    if (dev_run)
+      printf(
+          "\n============\n%s: presolve = %s; solver = %s%s\n============\n\n",
+          message.c_str(), presolve.c_str(), solver.c_str(),
+          solver == kIpmString ? ("; run_crossover = " + run_crossover).c_str()
+                               : "");
+    REQUIRE(h.passModel(lp) == HighsStatus::kOk);
+    h.run();
+    if (dev_run) h.writeSolution("", 1);
+    if (presolve_on) {
+      // Ensure that the model is reduced to empty
+      REQUIRE(run_data.presolved_model_num_col ==
+              require_presolved_model_num_col);
+      REQUIRE(run_data.presolved_model_num_row ==
+              require_presolved_model_num_row);
+      REQUIRE(run_data.presolved_model_num_nz ==
+              require_presolved_model_num_nz);
+      // Ensure that dual postsolve is correct
+      REQUIRE(h.getModelStatus() == HighsModelStatus::kOptimal);
+      REQUIRE(h.getInfo().num_primal_infeasibilities == 0);
+      REQUIRE(h.getInfo().num_dual_infeasibilities == 0);
+      REQUIRE(h.getInfo().simplex_iteration_count == 0);
+      // Ensure that any basis postsolve is correct
+      if (basis_postsolve)
+        REQUIRE(run_data.num_simplex_iterations_after_postsolve == 0);
+    }
+  }
 }

--- a/check/TestPresolveRules.cpp
+++ b/check/TestPresolveRules.cpp
@@ -4,7 +4,7 @@
 #include "Highs.h"
 #include "catch.hpp"
 
-const bool dev_run = true;
+const bool dev_run = false;
 
 void presolveOffOn(const std::string& message, const HighsLp& lp, Highs& h,
                    const HighsInt require_presolved_model_num_col = 0,
@@ -15,12 +15,12 @@ TEST_CASE("test-col-stuffing", "[highs_test_presolve_rules]") {
   HighsLp lp;
 
   Highs h;
-  //  h.setOptionValue("output_flag", dev_run);
+  h.setOptionValue("output_flag", dev_run);
   h.setOptionValue("presolve_rule_test", kPresolveRuleColStuffing);
-  const bool lp0 = false;
-  const bool lp1 = false;
+  const bool lp0 = true;
+  const bool lp1 = true;
   const bool lp1a = true;
-  const bool lp1b = false;
+  const bool lp1b = true;
 
   if (lp0) {
     lp.num_col_ = 3;

--- a/check/TestRunData.cpp
+++ b/check/TestRunData.cpp
@@ -1,0 +1,137 @@
+#include <cstdio>
+
+#include "HCheckConfig.h"
+#include "Highs.h"
+#include "catch.hpp"
+#include "io/HMPSIO.h"
+
+const bool dev_run = false;
+
+TEST_CASE("run-data-md", "[highs_run_data]") {
+  Highs h;
+  h.setOptionValue("output_flag", dev_run);
+  // Use this name so that it can be copied to docs and provides code
+  // coverage
+  const std::string run_data_file = "HighsRunData.md";
+  REQUIRE(h.writeRunData(run_data_file) == HighsStatus::kOk);
+  if (!dev_run) std::remove(run_data_file.c_str());
+}
+
+TEST_CASE("highs-run-data", "[highs_run_data]") {
+  const std::string test_name = Catch::getResultCapture().getCurrentTestName();
+  const std::string highs_run_data_file = test_name + ".run_data";
+
+  Highs h;
+  if (!dev_run) h.setOptionValue("output_flag", false);
+  const HighsRunData& highs_run_data = h.getRunData();
+
+  auto testRunData = [&](const std::string& filename) {
+    HighsStatus return_status = h.readModel(filename);
+    REQUIRE(return_status == HighsStatus::kOk);
+
+    // Cannot write run_data since not valid before run()
+    return_status = h.writeRunData("");
+    REQUIRE(return_status == HighsStatus::kWarning);
+
+    HighsRunDataType highs_run_data_type;
+    return_status = h.getRunDataType("presolved_num_col", highs_run_data_type);
+    REQUIRE(return_status == HighsStatus::kError);
+    return_status =
+        h.getRunDataType("presolved_model_num_col", highs_run_data_type);
+    REQUIRE(return_status == HighsStatus::kOk);
+    REQUIRE(highs_run_data_type == HighsRunDataType::kInt);
+
+    return_status = h.getRunDataType("presolving_time", highs_run_data_type);
+    REQUIRE(return_status == HighsStatus::kError);
+    return_status = h.getRunDataType("presolve_time", highs_run_data_type);
+    REQUIRE(return_status == HighsStatus::kOk);
+    REQUIRE(highs_run_data_type == HighsRunDataType::kDouble);
+
+    // Run data not valid before run()
+    HighsInt presolved_model_num_col;
+    return_status =
+        h.getRunDataValue("presolved_model_num_col", presolved_model_num_col);
+    REQUIRE(return_status == HighsStatus::kWarning);
+
+    return_status = h.run();
+    REQUIRE(return_status == HighsStatus::kOk);
+
+    if (dev_run) {
+      return_status = h.writeRunData("");
+      REQUIRE(return_status == HighsStatus::kOk);
+    }
+
+    return_status = h.writeRunData(highs_run_data_file);
+    REQUIRE(return_status == HighsStatus::kOk);
+
+    // Wrong name for objective
+    return_status =
+        h.getRunDataValue("presolved_num_col", presolved_model_num_col);
+    REQUIRE(return_status == HighsStatus::kError);
+
+    // Right name for objective
+    return_status =
+        h.getRunDataValue("presolved_model_num_col", presolved_model_num_col);
+    REQUIRE(return_status == HighsStatus::kOk);
+
+    if (dev_run)
+      printf("From getRunDataValue: presolved_model_num_col = %d\n",
+             int(presolved_model_num_col));
+
+    double presolve_time;
+    // Wrong name for simplex iteration count
+    return_status = h.getRunDataValue("presolving_time", presolve_time);
+    REQUIRE(return_status == HighsStatus::kError);
+
+    // Right name for presolve time
+    return_status = h.getRunDataValue("presolve_time", presolve_time);
+    REQUIRE(return_status == HighsStatus::kOk);
+
+    const HighsModelStatus model_status = h.getModelStatus();
+    if (dev_run) {
+      printf("From getModelStatus: model_status = %s\n",
+             h.modelStatusToString(model_status).c_str());
+      printf("From getRunData: presolved_model_num_col = %d\n",
+             int(highs_run_data.presolved_model_num_col));
+      printf("From getRunData: presolved_model_num_row = %d\n",
+             int(highs_run_data.presolved_model_num_row));
+      printf("From getRunData: presolved_model_num_nz  = %d\n",
+             int(highs_run_data.presolved_model_num_nz));
+      if (!h.getLp().isMip())
+        printf(
+            "From getRunData: num_simplex_iterations_after_postsolve  = %d\n",
+            int(highs_run_data.num_simplex_iterations_after_postsolve));
+      printf("From getRunData:  presolve_time = %g\n",
+             highs_run_data.presolve_time);
+      printf("From getRunData:     solve_time = %g\n",
+             highs_run_data.solve_time);
+      printf("From getRunData: postsolve_time = %g\n",
+             highs_run_data.postsolve_time);
+    }
+    REQUIRE(highs_run_data.presolved_model_num_col >= 0);
+    REQUIRE(highs_run_data.presolved_model_num_row >= 0);
+    REQUIRE(highs_run_data.presolved_model_num_nz >= 0);
+    if (!h.getLp().isMip())
+      REQUIRE(highs_run_data.num_simplex_iterations_after_postsolve == 0);
+    REQUIRE(highs_run_data.presolve_time >= 0);
+    REQUIRE(highs_run_data.solve_time >= 0);
+    REQUIRE(highs_run_data.postsolve_time >= 0);
+  };
+
+  std::string filename;
+  filename = std::string(HIGHS_DIR) + "/check/instances/adlittle.mps";
+  testRunData(filename);
+
+  filename = std::string(HIGHS_DIR) + "/check/instances/egout-ac.mps";
+  testRunData(filename);
+
+  // Doesn't work for MIPs yet, but wait until profiling is merged in
+  // to avoid conflicts
+  //
+  //  filename = std::string(HIGHS_DIR) + "/check/instances/flugpl.mps";
+  //  testRunData(filename);
+
+  if (!dev_run) std::remove(highs_run_data_file.c_str());
+
+  h.resetGlobalScheduler(true);
+}

--- a/check/meson.build
+++ b/check/meson.build
@@ -55,6 +55,7 @@ test_array = [
   ['test_TestOptions', 'TestOptions.cpp'],
   ['test_TestPdlp', 'TestPdlp.cpp'],
   ['test_TestPresolve', 'TestPresolve.cpp'],
+  ['test_TestPresolveRules', 'TestPresolveRules.cpp'],
   ['test_TestQpSolver', 'TestQpSolver.cpp'],
   ['test_TestRanging', 'TestRanging.cpp'],
   ['test_TestRays', 'TestRays.cpp'],

--- a/check/meson.build
+++ b/check/meson.build
@@ -59,6 +59,7 @@ test_array = [
   ['test_TestQpSolver', 'TestQpSolver.cpp'],
   ['test_TestRanging', 'TestRanging.cpp'],
   ['test_TestRays', 'TestRays.cpp'],
+  ['test_TestRunData', 'TestRunData.cpp'],
   ['test_TestSemiVariables', 'TestSemiVariables.cpp'],
   ['test_TestSetup', 'TestSetup.cpp'],
   ['test_TestSort', 'TestSort.cpp'],

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -410,6 +410,7 @@ set(highs_sources
     presolve/HighsSymmetry.cpp
     presolve/HPresolve.cpp
     presolve/HPresolveAnalysis.cpp
+    presolve/HPresolveTest.cpp
     presolve/ICrash.cpp
     presolve/ICrashUtil.cpp
     presolve/ICrashX.cpp

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -364,6 +364,7 @@ set(highs_sources
     lp_data/HighsModelUtils.cpp
     lp_data/HighsOptions.cpp
     lp_data/HighsRanging.cpp
+    lp_data/HighsRunData.cpp
     lp_data/HighsSolution.cpp
     lp_data/HighsSolutionDebug.cpp
     lp_data/HighsSolve.cpp
@@ -493,6 +494,7 @@ set(highs_headers
     lp_data/HighsModelUtils.h
     lp_data/HighsOptions.h
     lp_data/HighsRanging.h
+    lp_data/HighsRunData.h
     lp_data/HighsSolution.h
     lp_data/HighsSolutionDebug.h
     lp_data/HighsSolve.h

--- a/highs/Highs.h
+++ b/highs/Highs.h
@@ -17,6 +17,7 @@
 #include "lp_data/HighsIis.h"
 #include "lp_data/HighsLpUtils.h"
 #include "lp_data/HighsRanging.h"
+#include "lp_data/HighsRunData.h"
 #include "lp_data/HighsSolutionDebug.h"
 #include "model/HighsModel.h"
 #include "presolve/ICrash.h"
@@ -398,8 +399,12 @@ class Highs {
                                     std::string* default_value = nullptr) const;
 
   /**
-   * @brief Get a const reference to the internal info values
-   * type.
+   * @brief Get a const reference to the internal run data values.
+   */
+  const HighsRunData& getRunData() const { return run_data_; }
+
+  /**
+   * @brief Get a const reference to the internal info values.
    */
   const HighsInfo& getInfo() const { return info_; }
 
@@ -1553,6 +1558,7 @@ class Highs {
   HighsCallback callback_;
   HighsOptions options_;
   HighsInfo info_;
+  HighsRunData run_data_;
   HighsRanging ranging_;
   HighsIis iis_;
   std::vector<HighsObjectiveSolution> saved_objective_and_solution_;

--- a/highs/Highs.h
+++ b/highs/Highs.h
@@ -404,6 +404,31 @@ class Highs {
   const HighsRunData& getRunData() const { return run_data_; }
 
   /**
+   * @brief Get an run_data value as HighsInt/int64_t/double, and only if
+   * it's of the correct type.
+   */
+
+  HighsStatus getRunDataValue(const std::string& run_data,
+                              HighsInt& value) const;
+
+#ifndef HIGHSINT64
+  HighsStatus getRunDataValue(const std::string& run_data,
+                              int64_t& value) const;
+#endif
+
+  HighsStatus getRunDataValue(const std::string& run_data, double& value) const;
+
+  HighsStatus getRunDataType(const std::string& run_data,
+                             HighsRunDataType& type) const;
+
+  /**
+   * @brief Write run data values to a file, with the extension ".html"
+   * producing HTML, otherwise using the standard format used to read
+   * options from a file.
+   */
+  HighsStatus writeRunData(const std::string& filename = "") const;
+
+  /**
    * @brief Get a const reference to the internal info values.
    */
   const HighsInfo& getInfo() const { return info_; }
@@ -1643,8 +1668,8 @@ class Highs {
   //
   // Invalidates all solver data in Highs class members by calling
   // invalidateModelStatus(), invalidateSolution(), invalidateBasis(),
-  // invalidateRanging(), invalidateInfo(), invalidateEkk() and
-  // clearIis()
+  // invalidateRanging(), invalidateInfo(), invalidateRunData(),
+  // invalidateEkk() and clearIis()
   void invalidateSolverData();
 
   // Invalidates all solver dual data in Highs class members by calling
@@ -1670,6 +1695,9 @@ class Highs {
   //
   // Invalidates info_ and resets the values of its members
   void invalidateInfo();
+  //
+  // Invalidates run_data_ and resets the values of its members
+  void invalidateRunData();
   //
   // Invalidates ranging_
   void invalidateRanging();

--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -364,7 +364,7 @@ const HighsInt kHighsIllegalErrorIndex = -1;
 const double kHighsIllegalComplementarityViolation = kHighsInf;
 const HighsInt kHighsIllegalComplementarityCount = -1;
 
-const double kHighsIllegalDoubleMeasure = kHighsInf;
+const double kHighsIllegalDoubleMeasure = -kHighsInf;
 const HighsInt kHighsIllegalIntMeasure = -1;
 
 // Maximum upper bound on semi-variables

--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -110,6 +110,8 @@ enum class HighsOptionType { kBool = 0, kInt, kDouble, kString };
 
 enum class HighsInfoType { kInt64 = -1, kInt = 1, kDouble };
 
+enum class HighsRunDataType { kInt64 = -1, kInt = 1, kDouble };
+
 enum OptionOffChooseOn {
   kHighsOptionOff = -1,
   kHighsOptionChoose,
@@ -361,6 +363,9 @@ const HighsInt kHighsIllegalErrorIndex = -1;
 // values aren't known
 const double kHighsIllegalComplementarityViolation = kHighsInf;
 const HighsInt kHighsIllegalComplementarityCount = -1;
+
+const double kHighsIllegalDoubleMeasure = kHighsInf;
+const HighsInt kHighsIllegalIntMeasure = -1;
 
 // Maximum upper bound on semi-variables
 const double kMaxSemiVariableUpper = 1e5;

--- a/highs/lp_data/HConst.h
+++ b/highs/lp_data/HConst.h
@@ -88,12 +88,14 @@ enum HighsAnalysisLevel {
   kHighsAnalysisLevelNlaTime = 32,
   kHighsAnalysisLevelMipData = 64,
   kHighsAnalysisLevelMipTime = 128,
+  kHighsAnalysisLevelPresolveTime = 256,
   kHighsAnalysisLevelMin = kHighsAnalysisLevelNone,
   kHighsAnalysisLevelMax =
       kHighsAnalysisLevelModelData + kHighsAnalysisLevelSolverSummaryData +
       kHighsAnalysisLevelSolverRuntimeData + kHighsAnalysisLevelSolverTime +
       kHighsAnalysisLevelNlaData + kHighsAnalysisLevelNlaTime +
-      kHighsAnalysisLevelMipData + kHighsAnalysisLevelMipTime
+      kHighsAnalysisLevelMipData + kHighsAnalysisLevelMipTime +
+      kHighsAnalysisLevelPresolveTime
 };
 
 enum class HighsVarType : uint8_t {
@@ -275,7 +277,10 @@ enum PresolveRuleType : int {
   kPresolveRuleSparsify,
   kPresolveRuleProbing,
   kPresolveRuleEnumeration,
-  kPresolveRuleMax = kPresolveRuleEnumeration,
+  kPresolveRuleDualFixing,
+  kPresolveRuleColStuffing,
+  kPresolveRuleInitialSweep,
+  kPresolveRuleMax = kPresolveRuleInitialSweep,
   kPresolveRuleLastAllowOff = kPresolveRuleMax,
   kPresolveRuleCount
 };

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -234,6 +234,79 @@ HighsStatus Highs::getStringOptionValues(const std::string& option,
   return HighsStatus::kOk;
 }
 
+HighsStatus Highs::getRunDataValue(const std::string& run_data,
+                                   HighsInt& value) const {
+  RunDataStatus status =
+      getLocalRunDataValue(options_.log_options, run_data, run_data_.valid,
+                           run_data_.records, value);
+  if (status == RunDataStatus::kOk) {
+    return HighsStatus::kOk;
+  } else if (status == RunDataStatus::kUnavailable) {
+    return HighsStatus::kWarning;
+  } else {
+    return HighsStatus::kError;
+  }
+}
+
+#ifndef HIGHSINT64
+HighsStatus Highs::getRunDataValue(const std::string& run_data,
+                                   int64_t& value) const {
+  RunDataStatus status =
+      getLocalRunDataValue(options_.log_options, run_data, run_data_.valid,
+                           run_data_.records, value);
+  if (status == RunDataStatus::kOk) {
+    return HighsStatus::kOk;
+  } else if (status == RunDataStatus::kUnavailable) {
+    return HighsStatus::kWarning;
+  } else {
+    return HighsStatus::kError;
+  }
+}
+#endif
+
+HighsStatus Highs::getRunDataType(const std::string& run_data,
+                                  HighsRunDataType& type) const {
+  if (getLocalRunDataType(options_.log_options, run_data, run_data_.records,
+                          type) == RunDataStatus::kOk)
+    return HighsStatus::kOk;
+  return HighsStatus::kError;
+}
+
+HighsStatus Highs::getRunDataValue(const std::string& run_data,
+                                   double& value) const {
+  RunDataStatus status =
+      getLocalRunDataValue(options_.log_options, run_data, run_data_.valid,
+                           run_data_.records, value);
+  if (status == RunDataStatus::kOk) {
+    return HighsStatus::kOk;
+  } else if (status == RunDataStatus::kUnavailable) {
+    return HighsStatus::kWarning;
+  } else {
+    return HighsStatus::kError;
+  }
+}
+
+HighsStatus Highs::writeRunData(const std::string& filename) const {
+  HighsStatus return_status = HighsStatus::kOk;
+  FILE* file;
+  HighsFileType file_type;
+  return_status = interpretCallStatus(
+      options_.log_options,
+      openWriteFile(filename, "writeRunData", file, file_type), return_status,
+      "openWriteFile");
+  if (return_status == HighsStatus::kError) return return_status;
+  // Report to user that options are being written to a file
+  if (filename != "")
+    highsLogUser(options_.log_options, HighsLogType::kInfo,
+                 "Writing the run_data values to %s\n", filename.c_str());
+  return_status = interpretCallStatus(
+      options_.log_options,
+      writeRunDataToFile(file, run_data_.valid, run_data_.records, file_type),
+      return_status, "writeRunDataToFile");
+  if (file != stdout) fclose(file);
+  return return_status;
+}
+
 HighsStatus Highs::getInfoValue(const std::string& info,
                                 HighsInt& value) const {
   InfoStatus status = getLocalInfoValue(options_.log_options, info, info_.valid,
@@ -962,7 +1035,6 @@ HighsStatus Highs::presolve() {
 
 HighsStatus Highs::run() {
   // Level 0 of Highs::run()
-  //
   // Action the file operations associated with running HiGHS, and
   // call Highs::runFromUserScaling()
   HighsStatus status = HighsStatus::kOk;
@@ -991,6 +1063,9 @@ HighsStatus Highs::run() {
   // Optimize the model in the Highs instance
   status = optimizeHighs();
   if (status == HighsStatus::kError) return status;
+
+  // Assume that run data are valid
+  this->run_data_.valid = true;
 
   // Undo any user objective and bound scaling
   if (this->userUnscale(user_scale_data) == HighsStatus::kError)
@@ -1162,8 +1237,9 @@ HighsStatus Highs::calledOptimizeModel() {
   HighsStatus call_status;
   // Initialise the HiGHS model status
   model_status_ = HighsModelStatus::kNotset;
-  // Clear the run info
+  // Clear the run info and data
   invalidateInfo();
+  invalidateRunData();
   // Zero the iteration counts
   zeroIterationCounts();
   // Start the HiGHS run clock
@@ -1461,6 +1537,7 @@ HighsStatus Highs::calledOptimizeModel() {
     const double to_presolve_time = timer_.read(timer_.presolve_clock);
     this_presolve_time += to_presolve_time;
     presolve_.info_.presolve_time = this_presolve_time;
+    this->run_data_.presolve_time = this_presolve_time;
     // Recover any modified options
     options_.lp_presolve_requires_basis_postsolve =
         lp_presolve_requires_basis_postsolve;
@@ -1480,6 +1557,12 @@ HighsStatus Highs::calledOptimizeModel() {
     // Log the presolve reductions
     reportPresolveReductions(log_options, model_presolve_status_, incumbent_lp,
                              presolve_.getReducedProblem());
+    this->run_data_.presolved_model_num_col =
+        presolve_.getReducedProblem().num_col_;
+    this->run_data_.presolved_model_num_row =
+        presolve_.getReducedProblem().num_row_;
+    this->run_data_.presolved_model_num_nz =
+        presolve_.getReducedProblem().a_matrix_.numNz();
     switch (model_presolve_status_) {
       case HighsPresolveStatus::kNotPresolved: {
         ekk_instance_.lp_name_ = "Original LP";
@@ -1543,6 +1626,7 @@ HighsStatus Highs::calledOptimizeModel() {
         options_.objective_bound = kHighsInf;
         solveLp(reduced_lp, "Solving the presolved LP",
                 this_solve_presolved_lp_time);
+        this->run_data_.solve_time = this_solve_presolved_lp_time;
         if (ekk_instance_.status_.initialised_for_solve) {
           // Record the pivot threshold resulting from solving the presolved LP
           // with simplex
@@ -1586,6 +1670,7 @@ HighsStatus Highs::calledOptimizeModel() {
         // Optimality will not be spotted if there's no basis
         // postsolve
         model_status_ = HighsModelStatus::kOptimal;
+        this->run_data_.solve_time = 0;
         break;
       }
       case HighsPresolveStatus::kInfeasible: {
@@ -1710,6 +1795,7 @@ HighsStatus Highs::calledOptimizeModel() {
       timer_.stop(timer_.postsolve_clock);
       this_postsolve_time += timer_.read(timer_.postsolve_clock);
       presolve_.info_.postsolve_time = this_postsolve_time;
+      this->run_data_.postsolve_time = this_postsolve_time;
 
       if (postsolve_status == HighsPostsolveStatus::kSolutionRecovered) {
         // Indicate that nontrivial postsolve has been performed
@@ -1792,6 +1878,8 @@ HighsStatus Highs::calledOptimizeModel() {
           options_ = save_options;
           if (return_status == HighsStatus::kError)
             return returnFromOptimizeModel(return_status, undo_mods);
+          this->run_data_.num_simplex_iterations_after_postsolve =
+              postsolve_iteration_count;
           if (postsolve_iteration_count > 0)
             highsLogUser(options_.log_options, HighsLogType::kInfo,
                          "Required %d simplex iterations after postsolve\n",
@@ -1804,6 +1892,8 @@ HighsStatus Highs::calledOptimizeModel() {
             HighsModelStatus::kPostsolveError);
         return returnFromOptimizeModel(HighsStatus::kError, undo_mods);
       }
+    } else {
+      this->run_data_.postsolve_time = 0;
     }
     // Final chance to resolve model_status_ ==
     // HighsModelStatus::kUnknown after solver that doesn't yield a
@@ -3776,6 +3866,7 @@ void Highs::invalidateSolverDualData() {
   invalidateModelStatus();
   invalidateRanging();
   invalidateInfo();
+  invalidateRunData();
 }
 
 void Highs::invalidateModelStatusSolutionAndInfo() {
@@ -3787,6 +3878,7 @@ void Highs::invalidateModelStatusAndInfo() {
   invalidateModelStatus();
   invalidateRanging();
   invalidateInfo();
+  invalidateRunData();
   clearIis();
 }
 
@@ -3812,6 +3904,8 @@ void Highs::invalidateBasis() {
 }
 
 void Highs::invalidateInfo() { info_.invalidate(); }
+
+void Highs::invalidateRunData() { run_data_.invalidate(); }
 
 void Highs::invalidateRanging() { ranging_.invalidate(); }
 
@@ -4347,7 +4441,7 @@ HighsStatus Highs::callRunPostsolve(const HighsSolution& solution,
     if (postsolve_status == HighsPostsolveStatus::kSolutionRecovered) {
       this->solution_ = presolve_.data_.recovered_solution_;
       this->model_status_ = HighsModelStatus::kUnknown;
-      this->info_.invalidate();
+      invalidateInfo();
       HighsLp& lp = this->model_.lp_;
       this->info_.objective_function_value =
           computeObjectiveValue(lp, this->solution_);
@@ -4660,6 +4754,7 @@ HighsStatus Highs::returnFromOptimizeModel(const HighsStatus run_return_status,
       // Don't clear the model status!
       //      invalidateSolverData();
       invalidateInfo();
+      invalidateRunData();
       invalidateSolution();
       invalidateBasis();
       assert(return_status == HighsStatus::kError);
@@ -4668,6 +4763,7 @@ HighsStatus Highs::returnFromOptimizeModel(const HighsStatus run_return_status,
       // Then consider the OK returns
     case HighsModelStatus::kModelEmpty:
       invalidateInfo();
+      invalidateRunData();
       invalidateSolution();
       invalidateBasis();
       assert(return_status == HighsStatus::kOk);

--- a/highs/lp_data/HighsModelUtils.cpp
+++ b/highs/lp_data/HighsModelUtils.cpp
@@ -1515,6 +1515,12 @@ std::string utilPresolveRuleTypeToString(const HighsInt rule_type) {
     return "Probing";
   } else if (rule_type == kPresolveRuleEnumeration) {
     return "Enumeration";
+  } else if (rule_type == kPresolveRuleDualFixing) {
+    return "Dual fixing";
+  } else if (rule_type == kPresolveRuleColStuffing) {
+    return "Col stuffing";
+  } else if (rule_type == kPresolveRuleInitialSweep) {
+    return "Initial sweep";
   }
   assert(1 == 0);
   return "????";

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -1609,8 +1609,8 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(
-        "presolve_rule_test", "Presolve rule to test - DEV only!",
-        advanced, &presolve_rule_test, 0, 0, kPresolveRuleMax);
+        "presolve_rule_test", "Presolve rule to test - DEV only!", advanced,
+        &presolve_rule_test, 0, 0, kPresolveRuleMax);
     records.push_back(record_int);
 
     record_bool = new OptionRecordBool(

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -438,6 +438,7 @@ struct HighsOptionsStruct {
   HighsInt restart_presolve_reduction_limit;
   HighsInt presolve_substitution_maxfillin;
   HighsInt presolve_rule_off;
+  HighsInt presolve_rule_test;
   bool presolve_rule_logging;
   bool presolve_remove_slacks;
   bool no_unnecessary_rebuild_refactor;
@@ -605,6 +606,7 @@ struct HighsOptionsStruct {
         restart_presolve_reduction_limit(0),
         presolve_substitution_maxfillin(0),
         presolve_rule_off(0),
+        presolve_rule_test(0),
         presolve_rule_logging(false),
         presolve_remove_slacks(false),
         no_unnecessary_rebuild_refactor(false),
@@ -1604,6 +1606,11 @@ class HighsOptions : public HighsOptionsStruct {
     record_int = new OptionRecordInt(
         "presolve_rule_off", "Bit mask of presolve rules that are not allowed",
         advanced, &presolve_rule_off, 0, 0, kHighsIInf);
+    records.push_back(record_int);
+
+    record_int = new OptionRecordInt(
+        "presolve_rule_test", "Presolve rule to test - DEV only!",
+        advanced, &presolve_rule_test, 0, 0, kPresolveRuleMax);
     records.push_back(record_int);
 
     record_bool = new OptionRecordBool(

--- a/highs/lp_data/HighsRunData.cpp
+++ b/highs/lp_data/HighsRunData.cpp
@@ -1,0 +1,230 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/*    This file is part of the HiGHS linear optimization suite           */
+/*                                                                       */
+/*    Available as open-source under the MIT License                     */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/**@file lp_data/HighsRunData.cpp
+ * @brief
+ */
+#include "lp_data/HighsRunData.h"
+
+#include <cassert>
+
+#include "lp_data/HighsOptions.h"
+
+void HighsRunData::invalidate() {
+  valid = false;
+  presolved_model_num_col = kHighsIllegalIntMeasure;
+  presolved_model_num_row = kHighsIllegalIntMeasure;
+  presolved_model_num_nz = kHighsIllegalIntMeasure;
+  num_simplex_iterations_after_postsolve = kHighsIllegalIntMeasure;
+  presolve_time = kHighsIllegalDoubleMeasure;
+  solve_time = kHighsIllegalDoubleMeasure;
+  postsolve_time = kHighsIllegalDoubleMeasure;
+}
+
+bool HighsRunData::equal(const HighsRunData& run_data_) const {
+  if (run_data_.valid != this->valid) return false;
+
+  if (run_data_.presolved_model_num_col != this->presolved_model_num_col) return false;
+  if (run_data_.presolved_model_num_row != this->presolved_model_num_row) return false;
+  if (run_data_.presolved_model_num_nz != this->presolved_model_num_nz) return false;
+  if (run_data_.num_simplex_iterations_after_postsolve != this->num_simplex_iterations_after_postsolve) return false;
+  if (run_data_.presolve_time != this->presolve_time) return false;
+  if (run_data_.solve_time != this->solve_time) return false;
+  if (run_data_.postsolve_time != this->postsolve_time) return false;
+  return true;
+}
+
+static std::string run_dataEntryTypeToString(const HighsRunDataType type) {
+  if (type == HighsRunDataType::kInt64) {
+    return "int64_t";
+  } else if (type == HighsRunDataType::kInt) {
+    return "HighsInt";
+  } else {
+    return "double";
+  }
+}
+
+RunDataStatus getRunDataIndex(const HighsLogOptions& report_log_options,
+                        const std::string& name,
+                        const std::vector<RunDataRecord*>& run_data_records,
+                        HighsInt& index) {
+  HighsInt num_run_data = run_data_records.size();
+  for (index = 0; index < num_run_data; index++)
+    if (run_data_records[index]->name == name) return RunDataStatus::kOk;
+  highsLogUser(report_log_options, HighsLogType::kError,
+               "getRunDataIndex: Run data \"%s\" is unknown\n", name.c_str());
+  return RunDataStatus::kUnknownRunData;
+}
+
+#ifndef HIGHSINT64
+RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
+                             const std::string& name, const bool valid,
+                             const std::vector<RunDataRecord*>& run_data_records,
+                             int64_t& value) {
+  HighsInt index;
+  RunDataStatus status =
+      getRunDataIndex(report_log_options, name, run_data_records, index);
+  if (status != RunDataStatus::kOk) return status;
+  if (!valid) return RunDataStatus::kUnavailable;
+  HighsRunDataType type = run_data_records[index]->type;
+  if (type != HighsRunDataType::kInt64) {
+    highsLogUser(
+        report_log_options, HighsLogType::kError,
+        "getRunDataValue: RunData \"%s\" requires value of type %s, not int64_t\n",
+        name.c_str(), run_dataEntryTypeToString(type).c_str());
+    return RunDataStatus::kIllegalValue;
+  }
+  RunDataRecordInt64 run_data = ((RunDataRecordInt64*)run_data_records[index])[0];
+  value = *run_data.value;
+  return RunDataStatus::kOk;
+}
+#endif
+
+RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
+                             const std::string& name, const bool valid,
+                             const std::vector<RunDataRecord*>& run_data_records,
+                             HighsInt& value) {
+  HighsInt index;
+  RunDataStatus status =
+      getRunDataIndex(report_log_options, name, run_data_records, index);
+  if (status != RunDataStatus::kOk) return status;
+  if (!valid) return RunDataStatus::kUnavailable;
+  HighsRunDataType type = run_data_records[index]->type;
+  bool type_ok = type == HighsRunDataType::kInt;
+  // When HIGHSINT64 is "on", value is int64_t and this method is used
+  // get HighsRunData values of type HighsRunDataType::kInt64
+#ifdef HIGHSINT64
+  type_ok = type_ok || type == HighsRunDataType::kInt64;
+#endif
+  if (!type_ok) {
+    std::string illegal_type = "HighsInt";
+#ifdef HIGHSINT64
+    illegal_type += " or int64_t";
+#endif
+    highsLogUser(
+        report_log_options, HighsLogType::kError,
+        "getRunDataValue: RunData \"%s\" requires value of type %s, not %s\n",
+        name.c_str(), run_dataEntryTypeToString(type).c_str(),
+        illegal_type.c_str());
+    return RunDataStatus::kIllegalValue;
+  }
+  if (type == HighsRunDataType::kInt) {
+    RunDataRecordInt run_data = ((RunDataRecordInt*)run_data_records[index])[0];
+    value = *run_data.value;
+  } else {
+    assert(type == HighsRunDataType::kInt64);
+    RunDataRecordInt64 run_data = ((RunDataRecordInt64*)run_data_records[index])[0];
+    value = *run_data.value;
+  }
+  return RunDataStatus::kOk;
+}
+
+RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
+                             const std::string& name, const bool valid,
+                             const std::vector<RunDataRecord*>& run_data_records,
+                             double& value) {
+  HighsInt index;
+  RunDataStatus status =
+      getRunDataIndex(report_log_options, name, run_data_records, index);
+  if (status != RunDataStatus::kOk) return status;
+  if (!valid) return RunDataStatus::kUnavailable;
+  HighsRunDataType type = run_data_records[index]->type;
+  if (type != HighsRunDataType::kDouble) {
+    highsLogUser(
+        report_log_options, HighsLogType::kError,
+        "getRunDataValue: RunData \"%s\" requires value of type %s, not double\n",
+        name.c_str(), run_dataEntryTypeToString(type).c_str());
+    return RunDataStatus::kIllegalValue;
+  }
+  RunDataRecordDouble run_data = ((RunDataRecordDouble*)run_data_records[index])[0];
+  value = *run_data.value;
+  return RunDataStatus::kOk;
+}
+
+RunDataStatus getLocalRunDataType(const HighsLogOptions& report_log_options,
+                            const std::string& name,
+                            const std::vector<RunDataRecord*>& run_data_records,
+                            HighsRunDataType& type) {
+  HighsInt index;
+  RunDataStatus status =
+      getRunDataIndex(report_log_options, name, run_data_records, index);
+  if (status != RunDataStatus::kOk) return status;
+  type = run_data_records[index]->type;
+  return RunDataStatus::kOk;
+}
+
+HighsStatus writeRunDataToFile(FILE* file, const bool valid, const HighsRunData& run_data,
+                            const HighsFileType file_type) {
+  return writeRunDataToFile(file, valid, run_data.records, file_type);
+}
+
+HighsStatus writeRunDataToFile(FILE* file, const bool valid,
+                            const std::vector<RunDataRecord*>& run_data_records,
+                            const HighsFileType file_type) {
+  const bool documentation_file = file_type == HighsFileType::kMd;
+  if (!documentation_file && !valid) return HighsStatus::kWarning;
+  if (documentation_file || valid) reportRunData(file, run_data_records, file_type);
+  return HighsStatus::kOk;
+}
+
+void reportRunData(FILE* file, const std::vector<RunDataRecord*>& run_data_records,
+                const HighsFileType file_type) {
+  HighsInt num_run_data = run_data_records.size();
+  for (HighsInt index = 0; index < num_run_data; index++) {
+    HighsRunDataType type = run_data_records[index]->type;
+    if (type == HighsRunDataType::kInt64) {
+      reportRunData(file, ((RunDataRecordInt64*)run_data_records[index])[0], file_type);
+    } else if (type == HighsRunDataType::kInt) {
+      reportRunData(file, ((RunDataRecordInt*)run_data_records[index])[0], file_type);
+    } else {
+      reportRunData(file, ((RunDataRecordDouble*)run_data_records[index])[0], file_type);
+    }
+  }
+}
+
+void reportRunData(FILE* file, const RunDataRecordInt64& run_data,
+                const HighsFileType file_type) {
+  if (file_type == HighsFileType::kMd) {
+    fprintf(file, "## %s\n- %s\n- Type: long integer\n\n",
+            highsInsertMdEscapes(run_data.name).c_str(),
+            highsInsertMdEscapes(run_data.description).c_str());
+  } else if (file_type == HighsFileType::kFull) {
+    fprintf(file, "\n# %s\n# [type: int64_t]\n%s = %" PRId64 "\n",
+            run_data.description.c_str(), run_data.name.c_str(), *run_data.value);
+  } else {
+    fprintf(file, "%-30s = %" PRId64 "\n", run_data.name.c_str(), *run_data.value);
+  }
+}
+
+void reportRunData(FILE* file, const RunDataRecordInt& run_data,
+                const HighsFileType file_type) {
+  if (file_type == HighsFileType::kMd) {
+    fprintf(file, "## %s\n- %s\n- Type: integer\n\n",
+            highsInsertMdEscapes(run_data.name).c_str(),
+            highsInsertMdEscapes(run_data.description).c_str());
+  } else if (file_type == HighsFileType::kFull) {
+    fprintf(file, "\n# %s\n# [type: HighsInt]\n%s = %" HIGHSINT_FORMAT "\n",
+            run_data.description.c_str(), run_data.name.c_str(), *run_data.value);
+  } else {
+    fprintf(file, "%-30s = %" HIGHSINT_FORMAT "\n", run_data.name.c_str(),
+            *run_data.value);
+  }
+}
+
+void reportRunData(FILE* file, const RunDataRecordDouble& run_data,
+                const HighsFileType file_type) {
+  if (file_type == HighsFileType::kMd) {
+    fprintf(file, "## %s\n- %s\n- Type: double\n\n",
+            highsInsertMdEscapes(run_data.name).c_str(),
+            highsInsertMdEscapes(run_data.description).c_str());
+  } else if (file_type == HighsFileType::kFull) {
+    fprintf(file, "\n# %s\n# [type: double]\n%s = %g\n",
+            run_data.description.c_str(), run_data.name.c_str(), *run_data.value);
+  } else {
+    fprintf(file, "%-30s = %g\n", run_data.name.c_str(), *run_data.value);
+  }
+}

--- a/highs/lp_data/HighsRunData.cpp
+++ b/highs/lp_data/HighsRunData.cpp
@@ -28,10 +28,15 @@ void HighsRunData::invalidate() {
 bool HighsRunData::equal(const HighsRunData& run_data_) const {
   if (run_data_.valid != this->valid) return false;
 
-  if (run_data_.presolved_model_num_col != this->presolved_model_num_col) return false;
-  if (run_data_.presolved_model_num_row != this->presolved_model_num_row) return false;
-  if (run_data_.presolved_model_num_nz != this->presolved_model_num_nz) return false;
-  if (run_data_.num_simplex_iterations_after_postsolve != this->num_simplex_iterations_after_postsolve) return false;
+  if (run_data_.presolved_model_num_col != this->presolved_model_num_col)
+    return false;
+  if (run_data_.presolved_model_num_row != this->presolved_model_num_row)
+    return false;
+  if (run_data_.presolved_model_num_nz != this->presolved_model_num_nz)
+    return false;
+  if (run_data_.num_simplex_iterations_after_postsolve !=
+      this->num_simplex_iterations_after_postsolve)
+    return false;
   if (run_data_.presolve_time != this->presolve_time) return false;
   if (run_data_.solve_time != this->solve_time) return false;
   if (run_data_.postsolve_time != this->postsolve_time) return false;
@@ -48,10 +53,9 @@ static std::string run_dataEntryTypeToString(const HighsRunDataType type) {
   }
 }
 
-RunDataStatus getRunDataIndex(const HighsLogOptions& report_log_options,
-                        const std::string& name,
-                        const std::vector<RunDataRecord*>& run_data_records,
-                        HighsInt& index) {
+RunDataStatus getRunDataIndex(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const std::vector<RunDataRecord*>& run_data_records, HighsInt& index) {
   HighsInt num_run_data = run_data_records.size();
   for (index = 0; index < num_run_data; index++)
     if (run_data_records[index]->name == name) return RunDataStatus::kOk;
@@ -61,10 +65,10 @@ RunDataStatus getRunDataIndex(const HighsLogOptions& report_log_options,
 }
 
 #ifndef HIGHSINT64
-RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
-                             const std::string& name, const bool valid,
-                             const std::vector<RunDataRecord*>& run_data_records,
-                             int64_t& value) {
+RunDataStatus getLocalRunDataValue(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    int64_t& value) {
   HighsInt index;
   RunDataStatus status =
       getRunDataIndex(report_log_options, name, run_data_records, index);
@@ -72,22 +76,23 @@ RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
   if (!valid) return RunDataStatus::kUnavailable;
   HighsRunDataType type = run_data_records[index]->type;
   if (type != HighsRunDataType::kInt64) {
-    highsLogUser(
-        report_log_options, HighsLogType::kError,
-        "getRunDataValue: RunData \"%s\" requires value of type %s, not int64_t\n",
-        name.c_str(), run_dataEntryTypeToString(type).c_str());
+    highsLogUser(report_log_options, HighsLogType::kError,
+                 "getRunDataValue: RunData \"%s\" requires value of type %s, "
+                 "not int64_t\n",
+                 name.c_str(), run_dataEntryTypeToString(type).c_str());
     return RunDataStatus::kIllegalValue;
   }
-  RunDataRecordInt64 run_data = ((RunDataRecordInt64*)run_data_records[index])[0];
+  RunDataRecordInt64 run_data =
+      ((RunDataRecordInt64*)run_data_records[index])[0];
   value = *run_data.value;
   return RunDataStatus::kOk;
 }
 #endif
 
-RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
-                             const std::string& name, const bool valid,
-                             const std::vector<RunDataRecord*>& run_data_records,
-                             HighsInt& value) {
+RunDataStatus getLocalRunDataValue(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    HighsInt& value) {
   HighsInt index;
   RunDataStatus status =
       getRunDataIndex(report_log_options, name, run_data_records, index);
@@ -117,16 +122,17 @@ RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
     value = *run_data.value;
   } else {
     assert(type == HighsRunDataType::kInt64);
-    RunDataRecordInt64 run_data = ((RunDataRecordInt64*)run_data_records[index])[0];
+    RunDataRecordInt64 run_data =
+        ((RunDataRecordInt64*)run_data_records[index])[0];
     value = *run_data.value;
   }
   return RunDataStatus::kOk;
 }
 
-RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
-                             const std::string& name, const bool valid,
-                             const std::vector<RunDataRecord*>& run_data_records,
-                             double& value) {
+RunDataStatus getLocalRunDataValue(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    double& value) {
   HighsInt index;
   RunDataStatus status =
       getRunDataIndex(report_log_options, name, run_data_records, index);
@@ -134,21 +140,22 @@ RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
   if (!valid) return RunDataStatus::kUnavailable;
   HighsRunDataType type = run_data_records[index]->type;
   if (type != HighsRunDataType::kDouble) {
-    highsLogUser(
-        report_log_options, HighsLogType::kError,
-        "getRunDataValue: RunData \"%s\" requires value of type %s, not double\n",
-        name.c_str(), run_dataEntryTypeToString(type).c_str());
+    highsLogUser(report_log_options, HighsLogType::kError,
+                 "getRunDataValue: RunData \"%s\" requires value of type %s, "
+                 "not double\n",
+                 name.c_str(), run_dataEntryTypeToString(type).c_str());
     return RunDataStatus::kIllegalValue;
   }
-  RunDataRecordDouble run_data = ((RunDataRecordDouble*)run_data_records[index])[0];
+  RunDataRecordDouble run_data =
+      ((RunDataRecordDouble*)run_data_records[index])[0];
   value = *run_data.value;
   return RunDataStatus::kOk;
 }
 
-RunDataStatus getLocalRunDataType(const HighsLogOptions& report_log_options,
-                            const std::string& name,
-                            const std::vector<RunDataRecord*>& run_data_records,
-                            HighsRunDataType& type) {
+RunDataStatus getLocalRunDataType(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const std::vector<RunDataRecord*>& run_data_records,
+    HighsRunDataType& type) {
   HighsInt index;
   RunDataStatus status =
       getRunDataIndex(report_log_options, name, run_data_records, index);
@@ -157,58 +164,68 @@ RunDataStatus getLocalRunDataType(const HighsLogOptions& report_log_options,
   return RunDataStatus::kOk;
 }
 
-HighsStatus writeRunDataToFile(FILE* file, const bool valid, const HighsRunData& run_data,
-                            const HighsFileType file_type) {
+HighsStatus writeRunDataToFile(FILE* file, const bool valid,
+                               const HighsRunData& run_data,
+                               const HighsFileType file_type) {
   return writeRunDataToFile(file, valid, run_data.records, file_type);
 }
 
-HighsStatus writeRunDataToFile(FILE* file, const bool valid,
-                            const std::vector<RunDataRecord*>& run_data_records,
-                            const HighsFileType file_type) {
+HighsStatus writeRunDataToFile(
+    FILE* file, const bool valid,
+    const std::vector<RunDataRecord*>& run_data_records,
+    const HighsFileType file_type) {
   const bool documentation_file = file_type == HighsFileType::kMd;
   if (!documentation_file && !valid) return HighsStatus::kWarning;
-  if (documentation_file || valid) reportRunData(file, run_data_records, file_type);
+  if (documentation_file || valid)
+    reportRunData(file, run_data_records, file_type);
   return HighsStatus::kOk;
 }
 
-void reportRunData(FILE* file, const std::vector<RunDataRecord*>& run_data_records,
-                const HighsFileType file_type) {
+void reportRunData(FILE* file,
+                   const std::vector<RunDataRecord*>& run_data_records,
+                   const HighsFileType file_type) {
   HighsInt num_run_data = run_data_records.size();
   for (HighsInt index = 0; index < num_run_data; index++) {
     HighsRunDataType type = run_data_records[index]->type;
     if (type == HighsRunDataType::kInt64) {
-      reportRunData(file, ((RunDataRecordInt64*)run_data_records[index])[0], file_type);
+      reportRunData(file, ((RunDataRecordInt64*)run_data_records[index])[0],
+                    file_type);
     } else if (type == HighsRunDataType::kInt) {
-      reportRunData(file, ((RunDataRecordInt*)run_data_records[index])[0], file_type);
+      reportRunData(file, ((RunDataRecordInt*)run_data_records[index])[0],
+                    file_type);
     } else {
-      reportRunData(file, ((RunDataRecordDouble*)run_data_records[index])[0], file_type);
+      reportRunData(file, ((RunDataRecordDouble*)run_data_records[index])[0],
+                    file_type);
     }
   }
 }
 
 void reportRunData(FILE* file, const RunDataRecordInt64& run_data,
-                const HighsFileType file_type) {
+                   const HighsFileType file_type) {
   if (file_type == HighsFileType::kMd) {
     fprintf(file, "## %s\n- %s\n- Type: long integer\n\n",
             highsInsertMdEscapes(run_data.name).c_str(),
             highsInsertMdEscapes(run_data.description).c_str());
   } else if (file_type == HighsFileType::kFull) {
     fprintf(file, "\n# %s\n# [type: int64_t]\n%s = %" PRId64 "\n",
-            run_data.description.c_str(), run_data.name.c_str(), *run_data.value);
+            run_data.description.c_str(), run_data.name.c_str(),
+            *run_data.value);
   } else {
-    fprintf(file, "%-30s = %" PRId64 "\n", run_data.name.c_str(), *run_data.value);
+    fprintf(file, "%-30s = %" PRId64 "\n", run_data.name.c_str(),
+            *run_data.value);
   }
 }
 
 void reportRunData(FILE* file, const RunDataRecordInt& run_data,
-                const HighsFileType file_type) {
+                   const HighsFileType file_type) {
   if (file_type == HighsFileType::kMd) {
     fprintf(file, "## %s\n- %s\n- Type: integer\n\n",
             highsInsertMdEscapes(run_data.name).c_str(),
             highsInsertMdEscapes(run_data.description).c_str());
   } else if (file_type == HighsFileType::kFull) {
     fprintf(file, "\n# %s\n# [type: HighsInt]\n%s = %" HIGHSINT_FORMAT "\n",
-            run_data.description.c_str(), run_data.name.c_str(), *run_data.value);
+            run_data.description.c_str(), run_data.name.c_str(),
+            *run_data.value);
   } else {
     fprintf(file, "%-30s = %" HIGHSINT_FORMAT "\n", run_data.name.c_str(),
             *run_data.value);
@@ -216,14 +233,15 @@ void reportRunData(FILE* file, const RunDataRecordInt& run_data,
 }
 
 void reportRunData(FILE* file, const RunDataRecordDouble& run_data,
-                const HighsFileType file_type) {
+                   const HighsFileType file_type) {
   if (file_type == HighsFileType::kMd) {
     fprintf(file, "## %s\n- %s\n- Type: double\n\n",
             highsInsertMdEscapes(run_data.name).c_str(),
             highsInsertMdEscapes(run_data.description).c_str());
   } else if (file_type == HighsFileType::kFull) {
     fprintf(file, "\n# %s\n# [type: double]\n%s = %g\n",
-            run_data.description.c_str(), run_data.name.c_str(), *run_data.value);
+            run_data.description.c_str(), run_data.name.c_str(),
+            *run_data.value);
   } else {
     fprintf(file, "%-30s = %g\n", run_data.name.c_str(), *run_data.value);
   }

--- a/highs/lp_data/HighsRunData.h
+++ b/highs/lp_data/HighsRunData.h
@@ -19,7 +19,12 @@
 
 class HighsOptions;
 
-enum class RunDataStatus { kOk = 0, kUnknownRunData, kIllegalValue, kUnavailable };
+enum class RunDataStatus {
+  kOk = 0,
+  kUnknownRunData,
+  kIllegalValue,
+  kUnavailable
+};
 
 class RunDataRecord {
  public:
@@ -28,8 +33,8 @@ class RunDataRecord {
   std::string description;
   bool advanced;
 
-  RunDataRecord(HighsRunDataType Xtype, std::string Xname, std::string Xdescription,
-             bool Xadvanced) {
+  RunDataRecord(HighsRunDataType Xtype, std::string Xname,
+                std::string Xdescription, bool Xadvanced) {
     this->type = Xtype;
     this->name = Xname;
     this->description = Xdescription;
@@ -43,9 +48,11 @@ class RunDataRecordInt64 : public RunDataRecord {
  public:
   int64_t* value;
   int64_t default_value;
-  RunDataRecordInt64(std::string Xname, std::string Xdescription, bool Xadvanced,
-                  int64_t* Xvalue_pointer, int64_t Xdefault_value)
-      : RunDataRecord(HighsRunDataType::kInt64, Xname, Xdescription, Xadvanced) {
+  RunDataRecordInt64(std::string Xname, std::string Xdescription,
+                     bool Xadvanced, int64_t* Xvalue_pointer,
+                     int64_t Xdefault_value)
+      : RunDataRecord(HighsRunDataType::kInt64, Xname, Xdescription,
+                      Xadvanced) {
     value = Xvalue_pointer;
     default_value = Xdefault_value;
     *value = default_value;
@@ -59,7 +66,7 @@ class RunDataRecordInt : public RunDataRecord {
   HighsInt* value;
   HighsInt default_value;
   RunDataRecordInt(std::string Xname, std::string Xdescription, bool Xadvanced,
-                HighsInt* Xvalue_pointer, HighsInt Xdefault_value)
+                   HighsInt* Xvalue_pointer, HighsInt Xdefault_value)
       : RunDataRecord(HighsRunDataType::kInt, Xname, Xdescription, Xadvanced) {
     value = Xvalue_pointer;
     default_value = Xdefault_value;
@@ -73,9 +80,11 @@ class RunDataRecordDouble : public RunDataRecord {
  public:
   double* value;
   double default_value;
-  RunDataRecordDouble(std::string Xname, std::string Xdescription, bool Xadvanced,
-                   double* Xvalue_pointer, double Xdefault_value)
-      : RunDataRecord(HighsRunDataType::kDouble, Xname, Xdescription, Xadvanced) {
+  RunDataRecordDouble(std::string Xname, std::string Xdescription,
+                      bool Xadvanced, double* Xvalue_pointer,
+                      double Xdefault_value)
+      : RunDataRecord(HighsRunDataType::kDouble, Xname, Xdescription,
+                      Xadvanced) {
     value = Xvalue_pointer;
     default_value = Xdefault_value;
     *value = default_value;
@@ -144,40 +153,37 @@ class HighsRunData : public HighsRunDataStruct {
     const bool advanced = false;  // Not used
 
     record_int = new RunDataRecordInt("presolved_model_num_col",
-                                   "",
-                                   advanced, &presolved_model_num_col, 0);
+                                      "Number of columns in presolved model",
+                                      advanced, &presolved_model_num_col, 0);
     records.push_back(record_int);
 
     record_int = new RunDataRecordInt("presolved_model_num_row",
-                                   "",
-                                   advanced, &presolved_model_num_row, 0);
+                                      "Number of rows in presolved model",
+                                      advanced, &presolved_model_num_row, 0);
     records.push_back(record_int);
 
     record_int = new RunDataRecordInt("presolved_model_num_nz",
-                                   "",
-                                   advanced, &presolved_model_num_nz, 0);
+                                      "Number of nonzeros in presolved model",
+                                      advanced, &presolved_model_num_nz, 0);
     records.push_back(record_int);
 
-    record_int = new RunDataRecordInt("num_simplex_iterations_after_postsolve",
-                                   "",
-                                   advanced, &num_simplex_iterations_after_postsolve, 0);
+    record_int = new RunDataRecordInt(
+        "num_simplex_iterations_after_postsolve",
+        "Number of simplex iterations after postsolve", advanced,
+        &num_simplex_iterations_after_postsolve, 0);
     records.push_back(record_int);
 
-    record_double = new RunDataRecordDouble("presolve_time",
-                                         "", advanced,
-                                         &presolve_time, 0);
+    record_double = new RunDataRecordDouble("presolve_time", "Presolve time",
+                                            advanced, &presolve_time, 0);
     records.push_back(record_double);
 
-    record_double = new RunDataRecordDouble("solve_time",
-                                         "", advanced,
-                                         &solve_time, 0);
+    record_double = new RunDataRecordDouble("solve_time", "Solve time",
+                                            advanced, &solve_time, 0);
     records.push_back(record_double);
 
-    record_double = new RunDataRecordDouble("postsolve_time",
-                                         "", advanced,
-                                         &postsolve_time, 0);
+    record_double = new RunDataRecordDouble("postsolve_time", "Postsolve time",
+                                            advanced, &postsolve_time, 0);
     records.push_back(record_double);
-
   }
 
  public:
@@ -188,39 +194,40 @@ HighsStatus writeRunDataToFile(
     FILE* file, const bool valid, const HighsRunData& run_data,
     const HighsFileType file_type = HighsFileType::kFull);
 
-RunDataStatus getRunDataIndex(const HighsLogOptions& report_log_options,
-                        const std::string& name,
-                        const std::vector<RunDataRecord*>& run_data_records,
-                        HighsInt& index);
+RunDataStatus getRunDataIndex(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const std::vector<RunDataRecord*>& run_data_records, HighsInt& index);
 
-RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
-                             const std::string& name, const bool valid,
-                             const std::vector<RunDataRecord*>& run_data_records,
-                             int64_t& value);
-RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
-                             const std::string& name, const bool valid,
-                             const std::vector<RunDataRecord*>& run_data_records,
-                             HighsInt& value);
-RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
-                             const std::string& name, const bool valid,
-                             const std::vector<RunDataRecord*>& run_data_records,
-                             double& value);
+RunDataStatus getLocalRunDataValue(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    int64_t& value);
+RunDataStatus getLocalRunDataValue(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    HighsInt& value);
+RunDataStatus getLocalRunDataValue(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    double& value);
 
-RunDataStatus getLocalRunDataType(const HighsLogOptions& report_log_options,
-                            const std::string& name,
-                            const std::vector<RunDataRecord*>& run_data_records,
-                            HighsRunDataType& type);
+RunDataStatus getLocalRunDataType(
+    const HighsLogOptions& report_log_options, const std::string& name,
+    const std::vector<RunDataRecord*>& run_data_records,
+    HighsRunDataType& type);
 
 HighsStatus writeRunDataToFile(
-    FILE* file, const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    FILE* file, const bool valid,
+    const std::vector<RunDataRecord*>& run_data_records,
     const HighsFileType file_type = HighsFileType::kFull);
-void reportRunData(FILE* file, const std::vector<RunDataRecord*>& run_data_records,
-                const HighsFileType file_type = HighsFileType::kFull);
+void reportRunData(FILE* file,
+                   const std::vector<RunDataRecord*>& run_data_records,
+                   const HighsFileType file_type = HighsFileType::kFull);
 void reportRunData(FILE* file, const RunDataRecordInt64& run_data,
-                const HighsFileType file_type = HighsFileType::kFull);
+                   const HighsFileType file_type = HighsFileType::kFull);
 void reportRunData(FILE* file, const RunDataRecordInt& run_data,
-                const HighsFileType file_type = HighsFileType::kFull);
+                   const HighsFileType file_type = HighsFileType::kFull);
 void reportRunData(FILE* file, const RunDataRecordDouble& run_data,
-                const HighsFileType file_type = HighsFileType::kFull);
+                   const HighsFileType file_type = HighsFileType::kFull);
 
 #endif

--- a/highs/lp_data/HighsRunData.h
+++ b/highs/lp_data/HighsRunData.h
@@ -1,0 +1,226 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/*    This file is part of the HiGHS linear optimization suite           */
+/*                                                                       */
+/*    Available as open-source under the MIT License                     */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/**@file lp_data/HighsRunData.h
+ * @brief
+ */
+#ifndef LP_DATA_HIGHS_RUN_DATA_H_
+#define LP_DATA_HIGHS_RUN_DATA_H_
+
+#include <cstring>  // For strchr
+#include <vector>
+
+#include "lp_data/HConst.h"
+#include "lp_data/HighsStatus.h"
+
+class HighsOptions;
+
+enum class RunDataStatus { kOk = 0, kUnknownRunData, kIllegalValue, kUnavailable };
+
+class RunDataRecord {
+ public:
+  HighsRunDataType type;
+  std::string name;
+  std::string description;
+  bool advanced;
+
+  RunDataRecord(HighsRunDataType Xtype, std::string Xname, std::string Xdescription,
+             bool Xadvanced) {
+    this->type = Xtype;
+    this->name = Xname;
+    this->description = Xdescription;
+    this->advanced = Xadvanced;
+  }
+
+  virtual ~RunDataRecord() {}
+};
+
+class RunDataRecordInt64 : public RunDataRecord {
+ public:
+  int64_t* value;
+  int64_t default_value;
+  RunDataRecordInt64(std::string Xname, std::string Xdescription, bool Xadvanced,
+                  int64_t* Xvalue_pointer, int64_t Xdefault_value)
+      : RunDataRecord(HighsRunDataType::kInt64, Xname, Xdescription, Xadvanced) {
+    value = Xvalue_pointer;
+    default_value = Xdefault_value;
+    *value = default_value;
+  }
+
+  virtual ~RunDataRecordInt64() {}
+};
+
+class RunDataRecordInt : public RunDataRecord {
+ public:
+  HighsInt* value;
+  HighsInt default_value;
+  RunDataRecordInt(std::string Xname, std::string Xdescription, bool Xadvanced,
+                HighsInt* Xvalue_pointer, HighsInt Xdefault_value)
+      : RunDataRecord(HighsRunDataType::kInt, Xname, Xdescription, Xadvanced) {
+    value = Xvalue_pointer;
+    default_value = Xdefault_value;
+    *value = default_value;
+  }
+
+  virtual ~RunDataRecordInt() {}
+};
+
+class RunDataRecordDouble : public RunDataRecord {
+ public:
+  double* value;
+  double default_value;
+  RunDataRecordDouble(std::string Xname, std::string Xdescription, bool Xadvanced,
+                   double* Xvalue_pointer, double Xdefault_value)
+      : RunDataRecord(HighsRunDataType::kDouble, Xname, Xdescription, Xadvanced) {
+    value = Xvalue_pointer;
+    default_value = Xdefault_value;
+    *value = default_value;
+  }
+
+  virtual ~RunDataRecordDouble() {}
+};
+
+struct HighsRunDataStruct {
+  bool valid;
+  HighsInt presolved_model_num_col;
+  HighsInt presolved_model_num_row;
+  HighsInt presolved_model_num_nz;
+  HighsInt num_simplex_iterations_after_postsolve;
+  double presolve_time;
+  double solve_time;
+  double postsolve_time;
+};
+
+class HighsRunData : public HighsRunDataStruct {
+ public:
+  HighsRunData() { initRecords(); }
+
+  HighsRunData(const HighsRunData& run_data) {
+    initRecords();
+    HighsRunDataStruct::operator=(run_data);
+  }
+
+  HighsRunData(HighsRunData&& run_data) {
+    records = std::move(run_data.records);
+    HighsRunDataStruct::operator=(std::move(run_data));
+  }
+
+  const HighsRunData& operator=(const HighsRunData& other) {
+    if (&other != this) {
+      if ((HighsInt)records.size() == 0) initRecords();
+      HighsRunDataStruct::operator=(other);
+    }
+    return *this;
+  }
+
+  const HighsRunData& operator=(HighsRunData&& other) {
+    if (&other != this) {
+      if ((HighsInt)records.size() == 0) initRecords();
+      HighsRunDataStruct::operator=(other);
+    }
+    return *this;
+  }
+
+  virtual ~HighsRunData() {
+    if (records.size() > 0) deleteRecords();
+  }
+
+  void invalidate();
+  bool equal(const HighsRunData& run_data_) const;
+
+ private:
+  void deleteRecords() {
+    for (auto record : records) delete record;
+  }
+
+  void initRecords() {
+    RunDataRecordInt64* record_int64;
+    RunDataRecordInt* record_int;
+    RunDataRecordDouble* record_double;
+    const bool advanced = false;  // Not used
+
+    record_int = new RunDataRecordInt("presolved_model_num_col",
+                                   "",
+                                   advanced, &presolved_model_num_col, 0);
+    records.push_back(record_int);
+
+    record_int = new RunDataRecordInt("presolved_model_num_row",
+                                   "",
+                                   advanced, &presolved_model_num_row, 0);
+    records.push_back(record_int);
+
+    record_int = new RunDataRecordInt("presolved_model_num_nz",
+                                   "",
+                                   advanced, &presolved_model_num_nz, 0);
+    records.push_back(record_int);
+
+    record_int = new RunDataRecordInt("num_simplex_iterations_after_postsolve",
+                                   "",
+                                   advanced, &num_simplex_iterations_after_postsolve, 0);
+    records.push_back(record_int);
+
+    record_double = new RunDataRecordDouble("presolve_time",
+                                         "", advanced,
+                                         &presolve_time, 0);
+    records.push_back(record_double);
+
+    record_double = new RunDataRecordDouble("solve_time",
+                                         "", advanced,
+                                         &solve_time, 0);
+    records.push_back(record_double);
+
+    record_double = new RunDataRecordDouble("postsolve_time",
+                                         "", advanced,
+                                         &postsolve_time, 0);
+    records.push_back(record_double);
+
+  }
+
+ public:
+  std::vector<RunDataRecord*> records;
+};
+
+HighsStatus writeRunDataToFile(
+    FILE* file, const bool valid, const HighsRunData& run_data,
+    const HighsFileType file_type = HighsFileType::kFull);
+
+RunDataStatus getRunDataIndex(const HighsLogOptions& report_log_options,
+                        const std::string& name,
+                        const std::vector<RunDataRecord*>& run_data_records,
+                        HighsInt& index);
+
+RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
+                             const std::string& name, const bool valid,
+                             const std::vector<RunDataRecord*>& run_data_records,
+                             int64_t& value);
+RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
+                             const std::string& name, const bool valid,
+                             const std::vector<RunDataRecord*>& run_data_records,
+                             HighsInt& value);
+RunDataStatus getLocalRunDataValue(const HighsLogOptions& report_log_options,
+                             const std::string& name, const bool valid,
+                             const std::vector<RunDataRecord*>& run_data_records,
+                             double& value);
+
+RunDataStatus getLocalRunDataType(const HighsLogOptions& report_log_options,
+                            const std::string& name,
+                            const std::vector<RunDataRecord*>& run_data_records,
+                            HighsRunDataType& type);
+
+HighsStatus writeRunDataToFile(
+    FILE* file, const bool valid, const std::vector<RunDataRecord*>& run_data_records,
+    const HighsFileType file_type = HighsFileType::kFull);
+void reportRunData(FILE* file, const std::vector<RunDataRecord*>& run_data_records,
+                const HighsFileType file_type = HighsFileType::kFull);
+void reportRunData(FILE* file, const RunDataRecordInt64& run_data,
+                const HighsFileType file_type = HighsFileType::kFull);
+void reportRunData(FILE* file, const RunDataRecordInt& run_data,
+                const HighsFileType file_type = HighsFileType::kFull);
+void reportRunData(FILE* file, const RunDataRecordDouble& run_data,
+                const HighsFileType file_type = HighsFileType::kFull);
+
+#endif

--- a/highs/meson.build
+++ b/highs/meson.build
@@ -252,6 +252,7 @@ _srcs = [
     'lp_data/HighsModelUtils.cpp',
     'lp_data/HighsOptions.cpp',
     'lp_data/HighsRanging.cpp',
+    'lp_data/HighsRunData.cpp',
     'lp_data/HighsSolution.cpp',
     'lp_data/HighsSolutionDebug.cpp',
     'lp_data/HighsSolve.cpp',

--- a/highs/meson.build
+++ b/highs/meson.build
@@ -296,6 +296,7 @@ _srcs = [
     'pdlp/hipdlp/scaling.cc',
     'presolve/HPresolve.cpp',
     'presolve/HPresolveAnalysis.cpp',
+    'presolve/HPresolveTest.cpp',
     'presolve/HighsPostsolveStack.cpp',
     'presolve/HighsSymmetry.cpp',
     'presolve/ICrash.cpp',

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4990,10 +4990,6 @@ HPresolve::Result HPresolve::singletonColStuffing(
   HighsInt numFixedCols = 0;
   // Temporary for fix-col-stuffing
   bool report_stuffing = true;
-  if (report_stuffing && col == 0) {
-    printf("HPresolve::singletonColStuffing for col = 0\n");
-  }
-
   struct candidate {
     HighsInt col;
     double val;
@@ -5113,15 +5109,16 @@ HPresolve::Result HPresolve::singletonColStuffing(
       // abandoned.
       //
       // Question: The greedy algorithm is only guaranteed to assign
-      // values optimally if the variables are continuous. What
-      // presolve consequences are there if integer variables are
-      // assigned according to a sub-optimal assignment of values?
-      //
-      // Perhaps the criterion minWeight != maxWeight (ie not all |aj|
-      // values being equal) leading to abandonment of stuffing if
-      // there are only integer columns overcomes this. However, is it
+      // values optimally if the variables are continuous. The
+      // criterion minWeight != maxWeight (ie not all |aj| values
+      // being equal) leading to abandonment of stuffing if there are
+      // only integer columns overcomes this. However, is it
       // guaranteed that with those continuous decisions the knapsack
       // is solved optimally?
+      //
+      // Question: Is there value in solving the knapsack problem by
+      // DP if all variables are integer, and not all |aj| values are
+      // equal?
       if (isSingleton(j)) {
         // check singleton
         if (aj > 0) {
@@ -5245,19 +5242,24 @@ HPresolve::Result HPresolve::singletonColStuffing(
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
                  direction * rhs <= sumLower + primal_feastol) {
+        // Only allow fixing if there is no degeneracy
+        const bool allow_fixing =
+            direction * rhs + delta <= sumLower + primal_feastol;
         if (report_stuffing) {
           printf(
               "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = "
               "%11.4g | "
               "Logic: direction * rhs = %11.4g <= %11.4g = sumLower + "
-              "primal_feastol\n",
+              "primal_feastol: %s fixing\n",
               int(-t.multiplier), int(t.col),
               -t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
               double(delta), double(direction * rhs),
-              double(sumLower + primal_feastol));
+              double(sumLower + primal_feastol), allow_fixing ? "allow" : "no");
         }
-        numFixedCols++;
-        HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
+        if (allow_fixing) {
+          numFixedCols++;
+          HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
+        }
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5221,61 +5221,39 @@ HPresolve::Result HPresolve::singletonColStuffing(
     for (const auto& t : candidates) {
       // both bounds have to be finite
       if (model->col_lower_[t.col] == -kHighsInf ||
-          model->col_upper_[t.col] == kHighsInf)
-        break;
-      // Temporary for fix-col-stuffing
-      //      report_stuffing = false;
-      /*
-        t.col == 532 ||
-        t.col == 399 ||
-        t.col == 58653 ||
-        t.col == 58520 ||
-        t.col == 234479;
-      */
-      //      if (report_stuffing) { printf("ColStuffing: Checking candidate
-      //      t.col - %d\n", int(t.col));      }
+          model->col_upper_[t.col] == kHighsInf) break;
       // compute delta (bound difference)
       HighsCDouble delta =
           t.multiplier * t.val *
           (static_cast<HighsCDouble>(model->col_upper_[t.col]) -
            static_cast<HighsCDouble>(model->col_lower_[t.col]));
       // check if variable can be fixed
-      const bool logic0 = direction * rhs <= sumLower + primal_feastol;
-      const bool logic1 = delta <= direction * rhs - sumLower + primal_feastol;
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
         if (report_stuffing)
           printf(
-              "ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; "
-              "RHS0 = %11.4g\n",
+              "ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = %11.4g | "
+              "Logic: delta = %11.4g <= %11.4g = direction * rhs - sumUpper + primal_feastol\n",
               int(t.multiplier), int(t.col),
               t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
               double(delta),
+	      double(delta),
               double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
-      } else if (sumLowerFinite && logic0) {
-	//         direction * rhs <= sumLower + primal_feastol) {
+      } else if (sumLowerFinite &&
+		 direction * rhs <= sumLower + primal_feastol) {
         if (report_stuffing) {
           printf(
-              "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; "
-              "RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + "
-              "primal_feastol = %11.4g\n",
+              "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %11.4g | "
+              "Logic: direction * rhs = %11.4g <= %11.4g = sumLower + primal_feastol\n",
               int(-t.multiplier), int(t.col),
               -t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
               double(delta),
-              double(direction * rhs - sumUpper + primal_feastol),
               double(direction * rhs), double(sumLower + primal_feastol));
-          printf(
-              "ColStuffing:1 direction * rhs - sumLower - primal_feastol = "
-              "%11.4g; logic = %s\n\n",
-              double(direction * rhs - sumLower + primal_feastol),
-              logic1 ? "T" : "F");
         }
-        if (logic0) {
-          numFixedCols++;
-          HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
-        }
+	numFixedCols++;
+	HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5221,7 +5221,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
     for (const auto& t : candidates) {
       // both bounds have to be finite
       if (model->col_lower_[t.col] == -kHighsInf ||
-          model->col_upper_[t.col] == kHighsInf) break;
+          model->col_upper_[t.col] == kHighsInf)
+        break;
       // compute delta (bound difference)
       HighsCDouble delta =
           t.multiplier * t.val *
@@ -5232,28 +5233,31 @@ HPresolve::Result HPresolve::singletonColStuffing(
           delta <= direction * rhs - sumUpper + primal_feastol) {
         if (report_stuffing)
           printf(
-              "ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = %11.4g | "
-              "Logic: delta = %11.4g <= %11.4g = direction * rhs - sumUpper + primal_feastol\n",
+              "ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = "
+              "%11.4g | "
+              "Logic: delta = %11.4g <= %11.4g = direction * rhs - sumUpper + "
+              "primal_feastol\n",
               int(t.multiplier), int(t.col),
               t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
-              double(delta),
-	      double(delta),
+              double(delta), double(delta),
               double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
-		 direction * rhs <= sumLower + primal_feastol) {
+                 direction * rhs <= sumLower + primal_feastol) {
         if (report_stuffing) {
           printf(
-              "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %11.4g | "
-              "Logic: direction * rhs = %11.4g <= %11.4g = sumLower + primal_feastol\n",
+              "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = "
+              "%11.4g | "
+              "Logic: direction * rhs = %11.4g <= %11.4g = sumLower + "
+              "primal_feastol\n",
               int(-t.multiplier), int(t.col),
               -t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
-              double(delta),
-              double(direction * rhs), double(sumLower + primal_feastol));
+              double(delta), double(direction * rhs),
+              double(sumLower + primal_feastol));
         }
-	numFixedCols++;
-	HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
+        numFixedCols++;
+        HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;
@@ -5870,7 +5874,7 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
   //    - stop
   //
 
-  auto presolveReturn = [&] () {
+  auto presolveReturn = [&]() {
     if (mipsolver != nullptr) HPRESOLVE_CHECKED_CALL(scaleMIP(postsolve_stack));
 
     // analysePresolveRuleLog() should return true - no errors

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5247,9 +5247,9 @@ HPresolve::Result HPresolve::singletonColStuffing(
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
-                 direction * rhs <= sumLower + primal_feastol) {
-	const bool alt_logic =
-	  delta <= direction * rhs - sumLower + primal_feastol;
+                 delta <= direction * rhs - sumLower + primal_feastol) {
+	const bool alt_logic =direction * rhs <= sumLower + primal_feastol
+	  ;
 	
 	if (report_stuffing) {
 	    printf("ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + primal_feastol = %11.4g\n",
@@ -5265,10 +5265,10 @@ HPresolve::Result HPresolve::singletonColStuffing(
 		   double(direction * rhs - sumLower + primal_feastol),
 		   alt_logic ? "T" : "F");
 	}
-	if (alt_logic) {
+	//	if (alt_logic) {
 	  numFixedCols++;
 	  HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
-	}
+	  //	}
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4988,8 +4988,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
   // count number of fixed columns
   HighsInt numFixedCols = 0;
-  // Temporary for fix-col-stuffing
-  bool report_stuffing = true;
+
   struct candidate {
     HighsInt col;
     double val;
@@ -5028,8 +5027,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
                           double& maxWeight, size_t& numIntegerCandidates) {
     if (model->integrality_[col] == HighsVarType::kInteger)
       numIntegerCandidates++;
-    // Temporary for fix-col-stuffing
-    assert(direction * val > 0);
+
     minWeight = std::min(minWeight, direction * val);
     maxWeight = std::max(maxWeight, direction * val);
     candidates.push_back(candidate{col, val, direction});
@@ -5071,54 +5069,6 @@ HPresolve::Result HPresolve::singletonColStuffing(
       double sumUpperBound = model->col_upper_[j];
       bool isCandidate = allowIntegerCandidates ||
                          model->integrality_[j] != HighsVarType::kInteger;
-      // Considering row as a knapsack
-      //
-      // minimize c^Tx st a^Tx <= W; l <= x <= u
-      //
-      // NB minimize
-      //
-      // If cj/aj >= 0, then dual fixing means that xj can _probably_
-      // be fixed
-      //
-      // If aj > 0, then xj is contributing positively to the
-      // knapsack, but if cj >=0 its optimal value would appear to be
-      // lj, and it must be if cj > 0, in which case lj = -inf implies
-      // dual infeasibility.
-      //
-      // However, if cj = 0 and lj = -inf, then it is not logically
-      // correct to fix it to its lower bound and claim dual
-      // infeasibility. The row is redundant since, whatever values
-      // are assigned to the other variables, xj can be made
-      // sufficiently negative so that a^Tx <= W.
-      //
-      // If lj is finite, then it is fair to fix xj = lj
-      //
-      // If aj < 0 then then xj is contributing negatively to the
-      // knapsack, and if cj < 0 its optimal value is uj, in which
-      // case uj = inf implies dual infeasibility. If cj = 0 then, as
-      // above, if uj is finite fix xj = uj, otherwise the row is
-      // redundant.
-      //
-      // If cj/aj < 0, then xj is a candidate to have its value
-      // assigned optimally. This is done greedily according to the
-      // sorted values of cj/aj, over all such candidates
-      //
-      // Perhaps the cj = 0 issue is moot, since fixing to an infinte
-      // bound leads to at least one of sumLowerFinite and
-      // sumUpperFinite being false, so set of candidates is
-      // abandoned.
-      //
-      // Question: The greedy algorithm is only guaranteed to assign
-      // values optimally if the variables are continuous. The
-      // criterion minWeight != maxWeight (ie not all |aj| values
-      // being equal) leading to abandonment of stuffing if there are
-      // only integer columns overcomes this. However, is it
-      // guaranteed that with those continuous decisions the knapsack
-      // is solved optimally?
-      //
-      // Question: Is there value in solving the knapsack problem by
-      // DP if all variables are integer, and not all |aj| values are
-      // equal?
       if (isSingleton(j)) {
         // check singleton
         if (aj > 0) {
@@ -5209,12 +5159,6 @@ HPresolve::Result HPresolve::singletonColStuffing(
     sortCols(candidates);
 
     // check candidates
-    // Temporary for fix-col-stuffing
-    if (report_stuffing)
-      printf(
-          "ColStuffing: num candidates = %d; sumLower = %g; sumUpper = %g; rhs "
-          "= %g\n",
-          int(candidates.size()), double(sumLower), double(sumUpper), rhs);
     for (const auto& t : candidates) {
       // both bounds have to be finite
       if (model->col_lower_[t.col] == -kHighsInf ||
@@ -5228,38 +5172,20 @@ HPresolve::Result HPresolve::singletonColStuffing(
       // check if variable can be fixed
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
-        if (report_stuffing)
-          printf(
-              "ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = "
-              "%11.4g | "
-              "Logic: delta = %11.4g <= %11.4g = direction * rhs - sumUpper + "
-              "primal_feastol\n",
-              int(t.multiplier), int(t.col),
-              t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
-              double(delta), double(delta),
-              double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
-                 direction * rhs <= sumLower + primal_feastol) {
-        // Only allow fixing if there is no degeneracy
-        const bool allow_fixing =
-            direction * rhs + delta <= sumLower + primal_feastol;
-        if (report_stuffing) {
-          printf(
-              "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = "
-              "%11.4g | "
-              "Logic: direction * rhs = %11.4g <= %11.4g = sumLower + "
-              "primal_feastol: %s fixing\n",
-              int(-t.multiplier), int(t.col),
-              -t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
-              double(delta), double(direction * rhs),
-              double(sumLower + primal_feastol), allow_fixing ? "allow" : "no");
-        }
-        if (allow_fixing) {
-          numFixedCols++;
-          HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
-        }
+                 delta <= sumLower - direction * rhs + primal_feastol) {
+        // Previously
+        //
+        // direction * rhs <= sumLower + primal_feastol
+        //
+        // But this led to fixing at -t.multiplier until row activity
+        // was at its bound, which is primal optmal but degenerate,
+        // and does not yield an optimal basis if column costs are
+        // positive
+        numFixedCols++;
+        HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;
@@ -5842,9 +5768,6 @@ HPresolve::Result HPresolve::fastPresolveLoop(
 
     HPRESOLVE_CHECKED_CALL(presolveChangedCols(postsolve_stack));
 
-    // Temporary for fix-col-stuffing
-    HPRESOLVE_CHECKED_CALL(checkLimits(postsolve_stack));
-
   } while (problemSizeReduction() > 0.01);
 
   return Result::kOk;
@@ -6220,12 +6143,7 @@ HPresolve::Result HPresolve::checkLimits(HighsPostsolveStack& postsolve_stack) {
 
   if ((numreductions & 1023u) == 0) HPRESOLVE_CHECKED_CALL(checkTimeLimit());
 
-  // Temporary for fix-col-stuffing
-  const bool limit_reached = numreductions >= reductionLimit;
-  if (limit_reached) {
-    printf("HPresolve::checkLimits Reduction limit reached\n");
-  }
-  return limit_reached ? Result::kStopped : Result::kOk;
+  return numreductions >= reductionLimit ? Result::kStopped : Result::kOk;
 }
 
 void HPresolve::storeCurrentProblemSize() {
@@ -7040,8 +6958,6 @@ HPresolve::Result HPresolve::presolveColSingletons(
     HighsInt col = singletonColumns[i];
     if (colDeleted[col]) continue;
     HPRESOLVE_CHECKED_CALL(colPresolve(postsolve_stack, col));
-    // Temporary for fix-col-stuffing
-    HPRESOLVE_CHECKED_CALL(checkLimits(postsolve_stack));
   }
   singletonColumns.erase(
       std::remove_if(

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4989,7 +4989,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
   // count number of fixed columns
   HighsInt numFixedCols = 0;
   // Temporary for fix-col-stuffing
-  bool report_stuffing = false;
+  bool report_stuffing = true;
   if (report_stuffing && col == 0) {
     printf("HPresolve::singletonColStuffing for col = 0\n");
   }
@@ -5213,7 +5213,6 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
     // check candidates
     // Temporary for fix-col-stuffing
-    bool report_stuffing = false;
     if (report_stuffing)
       printf(
           "ColStuffing: num candidates = %d; sumLower = %g; sumUpper = %g; rhs "
@@ -5225,7 +5224,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
           model->col_upper_[t.col] == kHighsInf)
         break;
       // Temporary for fix-col-stuffing
-      report_stuffing = false;
+      //      report_stuffing = false;
       /*
         t.col == 532 ||
         t.col == 399 ||

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4988,8 +4988,9 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
   // count number of fixed columns
   HighsInt numFixedCols = 0;
-    // Temporary for fix-col-stuffing
-  if (col == 0) {
+  // Temporary for fix-col-stuffing
+  bool report_stuffing = false;
+  if (report_stuffing && col == 0) {
     printf("HPresolve::singletonColStuffing for col = 0\n");
   }
 
@@ -5134,8 +5135,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
                          numIntegerCandidates);
           }
         } else {
-	  // aj < 0
-	  assert(aj < 0);
+          // aj < 0
+          assert(aj < 0);
           if (cj <= 0)
             // dual fixing: fix to upper bound
             sumLowerBound = sumUpperBound;
@@ -5211,23 +5212,29 @@ HPresolve::Result HPresolve::singletonColStuffing(
     sortCols(candidates);
 
     // check candidates
-    printf("ColStuffing: num candidates = %d; sumLower = %g; sumUpper = %g; rhs = %g\n",
-	   int(candidates.size()), double(sumLower), double(sumUpper), rhs);
+    // Temporary for fix-col-stuffing
+    bool report_stuffing = false;
+    if (report_stuffing)
+      printf(
+          "ColStuffing: num candidates = %d; sumLower = %g; sumUpper = %g; rhs "
+          "= %g\n",
+          int(candidates.size()), double(sumLower), double(sumUpper), rhs);
     for (const auto& t : candidates) {
       // both bounds have to be finite
       if (model->col_lower_[t.col] == -kHighsInf ||
           model->col_upper_[t.col] == kHighsInf)
         break;
-    // Temporary for fix-col-stuffing
-      const bool report_stuffing = true;
+      // Temporary for fix-col-stuffing
+      report_stuffing = false;
       /*
-	t.col == 532 ||
-	t.col == 399 ||
-	t.col == 58653 ||
-	t.col == 58520 ||
-	t.col == 234479;
+        t.col == 532 ||
+        t.col == 399 ||
+        t.col == 58653 ||
+        t.col == 58520 ||
+        t.col == 234479;
       */
-      //      if (report_stuffing) { printf("ColStuffing: Checking candidate t.col - %d\n", int(t.col));      }
+      //      if (report_stuffing) { printf("ColStuffing: Checking candidate
+      //      t.col - %d\n", int(t.col));      }
       // compute delta (bound difference)
       HighsCDouble delta =
           t.multiplier * t.val *
@@ -5236,39 +5243,41 @@ HPresolve::Result HPresolve::singletonColStuffing(
       // check if variable can be fixed
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
-	  if (report_stuffing)
-	    printf("ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; RHS0 = %11.4g\n",
-		 int(t.multiplier),
-		 int(t.col),
-		 t.multiplier < 0 ? "lower" : "upper",
-		   model->col_cost_[t.col],
-		 double(delta),
-		 double(direction * rhs - sumUpper + primal_feastol));
+        if (report_stuffing)
+          printf(
+              "ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; "
+              "RHS0 = %11.4g\n",
+              int(t.multiplier), int(t.col),
+              t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
+              double(delta),
+              double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
-                 delta <= direction * rhs - sumLower + primal_feastol) {
-	const bool alt_logic =direction * rhs <= sumLower + primal_feastol
-	  ;
-	
-	if (report_stuffing) {
-	    printf("ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + primal_feastol = %11.4g\n",
-		 int(-t.multiplier),
-		 int(t.col),
-		 -t.multiplier < 0 ? "lower" : "upper",
-		   model->col_cost_[t.col],
-		 double(delta),
-		 double(direction * rhs - sumUpper + primal_feastol),
-		 double(direction * rhs),
-		 double(sumLower + primal_feastol));
-	    printf("ColStuffing:1 direction * rhs - sumLower - primal_feastol = %11.4g; logic = %s\n\n",
-		   double(direction * rhs - sumLower + primal_feastol),
-		   alt_logic ? "T" : "F");
-	}
-	//	if (alt_logic) {
-	  numFixedCols++;
-	  HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
-	  //	}
+                 direction * rhs <= sumLower + primal_feastol) {
+        const bool alt_logic =
+            delta <= direction * rhs - sumLower + primal_feastol;
+
+        if (report_stuffing) {
+          printf(
+              "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; "
+              "RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + "
+              "primal_feastol = %11.4g\n",
+              int(-t.multiplier), int(t.col),
+              -t.multiplier < 0 ? "lower" : "upper", model->col_cost_[t.col],
+              double(delta),
+              double(direction * rhs - sumUpper + primal_feastol),
+              double(direction * rhs), double(sumLower + primal_feastol));
+          printf(
+              "ColStuffing:1 direction * rhs - sumLower - primal_feastol = "
+              "%11.4g; logic = %s\n\n",
+              double(direction * rhs - sumLower + primal_feastol),
+              alt_logic ? "T" : "F");
+        }
+        if (alt_logic) {
+          numFixedCols++;
+          HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
+        }
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;
@@ -6221,7 +6230,7 @@ HPresolve::Result HPresolve::checkLimits(HighsPostsolveStack& postsolve_stack) {
 
   if ((numreductions & 1023u) == 0) HPRESOLVE_CHECKED_CALL(checkTimeLimit());
 
-    // Temporary for fix-col-stuffing
+  // Temporary for fix-col-stuffing
   const bool limit_reached = numreductions >= reductionLimit;
   if (limit_reached) {
     printf("HPresolve::checkLimits Reduction limit reached\n");

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5031,6 +5031,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
                           double& maxWeight, size_t& numIntegerCandidates) {
     if (model->integrality_[col] == HighsVarType::kInteger)
       numIntegerCandidates++;
+    // Temporary for fix-col-stuffing
+    assert(direction * val > 0);
     minWeight = std::min(minWeight, direction * val);
     maxWeight = std::max(maxWeight, direction * val);
     candidates.push_back(candidate{col, val, direction});
@@ -5072,7 +5074,53 @@ HPresolve::Result HPresolve::singletonColStuffing(
       double sumUpperBound = model->col_upper_[j];
       bool isCandidate = allowIntegerCandidates ||
                          model->integrality_[j] != HighsVarType::kInteger;
-
+      // Considering row as a knapsack
+      //
+      // minimize c^Tx st a^Tx <= W; l <= x <= u
+      //
+      // NB minimize
+      //
+      // If cj/aj >= 0, then dual fixing means that xj can _probably_
+      // be fixed
+      //
+      // If aj > 0, then xj is contributing positively to the
+      // knapsack, but if cj >=0 its optimal value would appear to be
+      // lj, and it must be if cj > 0, in which case lj = -inf implies
+      // dual infeasibility.
+      //
+      // However, if cj = 0 and lj = -inf, then it is not logically
+      // correct to fix it to its lower bound and claim dual
+      // infeasibility. The row is redundant since, whatever values
+      // are assigned to the other variables, xj can be made
+      // sufficiently negative so that a^Tx <= W.
+      //
+      // If lj is finite, then it is fair to fix xj = lj
+      //
+      // If aj < 0 then then xj is contributing negatively to the
+      // knapsack, and if cj < 0 its optimal value is uj, in which
+      // case uj = inf implies dual infeasibility. If cj = 0 then, as
+      // above, if uj is finite fix xj = uj, otherwise the row is
+      // redundant.
+      //
+      // If cj/aj < 0, then xj is a candidate to have its value
+      // assigned optimally. This is done greedily according to the
+      // sorted values of cj/aj, over all such candidates
+      //
+      // Perhaps the cj = 0 issue is moot, since fixing to an infinte
+      // bound leads to at least one of sumLowerFinite and
+      // sumUpperFinite being false, so set of candidates is
+      // abandoned.
+      //
+      // Question: The greedy algorithm is only guaranteed to assign
+      // values optimally if the variables are continuous. What
+      // presolve consequences are there if integer variables are
+      // assigned according to a sub-optimal assignment of values?
+      //
+      // Perhaps the criterion minWeight != maxWeight (ie not all |aj|
+      // values being equal) leading to abandonment of stuffing if
+      // there are only integer columns overcomes this. However, is it
+      // guaranteed that with those continuous decisions the knapsack
+      // is solved optimally?
       if (isSingleton(j)) {
         // check singleton
         if (aj > 0) {
@@ -5086,6 +5134,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
                          numIntegerCandidates);
           }
         } else {
+	  // aj < 0
+	  assert(aj < 0);
           if (cj <= 0)
             // dual fixing: fix to upper bound
             sumLowerBound = sumUpperBound;
@@ -5161,22 +5211,23 @@ HPresolve::Result HPresolve::singletonColStuffing(
     sortCols(candidates);
 
     // check candidates
+    printf("ColStuffing: num candidates = %d; sumLower = %g; sumUpper = %g; rhs = %g\n",
+	   int(candidates.size()), double(sumLower), double(sumUpper), rhs);
     for (const auto& t : candidates) {
       // both bounds have to be finite
       if (model->col_lower_[t.col] == -kHighsInf ||
           model->col_upper_[t.col] == kHighsInf)
         break;
     // Temporary for fix-col-stuffing
-      const bool report_stuffing =
+      const bool report_stuffing = true;
+      /*
 	t.col == 532 ||
 	t.col == 399 ||
 	t.col == 58653 ||
 	t.col == 58520 ||
 	t.col == 234479;
-      if (report_stuffing) {
-	printf("ColStuffing: Checking candidate t.col - %d\n",
-	       int(t.col));
-      }
+      */
+      //      if (report_stuffing) { printf("ColStuffing: Checking candidate t.col - %d\n", int(t.col));      }
       // compute delta (bound difference)
       HighsCDouble delta =
           t.multiplier * t.val *
@@ -5186,10 +5237,11 @@ HPresolve::Result HPresolve::singletonColStuffing(
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
 	  if (report_stuffing)
-	    printf("ColStuffing:0 (%2d) fix %6d to %s: delta = %g; RHS0 = %11.4g\n",
+	    printf("ColStuffing:0 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; RHS0 = %11.4g\n",
 		 int(t.multiplier),
 		 int(t.col),
 		 t.multiplier < 0 ? "lower" : "upper",
+		   model->col_cost_[t.col],
 		 double(delta),
 		 double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
@@ -5197,23 +5249,26 @@ HPresolve::Result HPresolve::singletonColStuffing(
       } else if (sumLowerFinite &&
                  direction * rhs <= sumLower + primal_feastol) {
 	const bool alt_logic =
-	  delta <= direction * rhs - sumLower - primal_feastol;
+	  delta <= direction * rhs - sumLower + primal_feastol;
 	
 	if (report_stuffing) {
-	    printf("ColStuffing:1 (%2d) fix %6d to %s: delta = %g; RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + primal_feastol = %11.4g\n",
+	    printf("ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + primal_feastol = %11.4g\n",
 		 int(-t.multiplier),
 		 int(t.col),
 		 -t.multiplier < 0 ? "lower" : "upper",
+		   model->col_cost_[t.col],
 		 double(delta),
 		 double(direction * rhs - sumUpper + primal_feastol),
 		 double(direction * rhs),
 		 double(sumLower + primal_feastol));
 	    printf("ColStuffing:1 direction * rhs - sumLower - primal_feastol = %11.4g; logic = %s\n\n",
-		   double(direction * rhs - sumLower - primal_feastol),
+		   double(direction * rhs - sumLower + primal_feastol),
 		   alt_logic ? "T" : "F");
 	}
-        numFixedCols++;
-        HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
+	if (alt_logic) {
+	  numFixedCols++;
+	  HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
+	}
       }
       // update row activities
       if (sumLowerFinite) sumLower += delta;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -5240,6 +5240,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
           (static_cast<HighsCDouble>(model->col_upper_[t.col]) -
            static_cast<HighsCDouble>(model->col_lower_[t.col]));
       // check if variable can be fixed
+      const bool logic0 = direction * rhs <= sumLower + primal_feastol;
+      const bool logic1 = delta <= direction * rhs - sumLower + primal_feastol;
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
         if (report_stuffing)
@@ -5252,11 +5254,8 @@ HPresolve::Result HPresolve::singletonColStuffing(
               double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
-      } else if (sumLowerFinite &&
-                 direction * rhs <= sumLower + primal_feastol) {
-        const bool alt_logic =
-            delta <= direction * rhs - sumLower + primal_feastol;
-
+      } else if (sumLowerFinite && logic0) {
+	//         direction * rhs <= sumLower + primal_feastol) {
         if (report_stuffing) {
           printf(
               "ColStuffing:1 (%2d) fix %6d to %s: cost =  %11.4g; delta = %g; "
@@ -5271,9 +5270,9 @@ HPresolve::Result HPresolve::singletonColStuffing(
               "ColStuffing:1 direction * rhs - sumLower - primal_feastol = "
               "%11.4g; logic = %s\n\n",
               double(direction * rhs - sumLower + primal_feastol),
-              alt_logic ? "T" : "F");
+              logic1 ? "T" : "F");
         }
-        if (alt_logic) {
+        if (logic0) {
           numFixedCols++;
           HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
         }
@@ -5893,6 +5892,16 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
   //    - stop
   //
 
+  auto presolveReturn = [&] () {
+    if (mipsolver != nullptr) HPRESOLVE_CHECKED_CALL(scaleMIP(postsolve_stack));
+
+    // analysePresolveRuleLog() should return true - no errors
+    assert(analysis_.analysePresolveRuleLog());
+    // Possibly report presolve log
+    analysis_.analysePresolveRuleLog(true);
+    return Result::kOk;
+  };
+
   // convert model to minimization problem
   if (model->sense_ == ObjSense::kMaximize) {
     for (HighsInt i = 0; i != model->num_col_; ++i)
@@ -5940,6 +5949,10 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
     assert(this->timer);
     assert(this->timer->running());
 
+    if (options->presolve_rule_test) {
+      HPRESOLVE_CHECKED_CALL(presolveRuleTest(postsolve_stack));
+      return presolveReturn();
+    }
     HPRESOLVE_CHECKED_CALL(initialRowAndColPresolve(postsolve_stack));
 
     HighsInt numParallelRowColCalls = 0;
@@ -6117,13 +6130,7 @@ HPresolve::Result HPresolve::presolve(HighsPostsolveStack& postsolve_stack) {
                  "\nPresolve is switched off\n");
   }
 
-  if (mipsolver != nullptr) HPRESOLVE_CHECKED_CALL(scaleMIP(postsolve_stack));
-
-  // analysePresolveRuleLog() should return true - no errors
-  assert(analysis_.analysePresolveRuleLog());
-  // Possibly report presolve log
-  analysis_.analysePresolveRuleLog(true);
-  return Result::kOk;
+  return presolveReturn();
 }
 
 HPresolve::Result HPresolve::removeSlacks(

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4988,6 +4988,10 @@ HPresolve::Result HPresolve::singletonColStuffing(
 
   // count number of fixed columns
   HighsInt numFixedCols = 0;
+    // Temporary for fix-col-stuffing
+  if (col == 0) {
+    printf("HPresolve::singletonColStuffing for col = 0\n");
+  }
 
   struct candidate {
     HighsInt col;
@@ -5162,6 +5166,17 @@ HPresolve::Result HPresolve::singletonColStuffing(
       if (model->col_lower_[t.col] == -kHighsInf ||
           model->col_upper_[t.col] == kHighsInf)
         break;
+    // Temporary for fix-col-stuffing
+      const bool report_stuffing =
+	t.col == 532 ||
+	t.col == 399 ||
+	t.col == 58653 ||
+	t.col == 58520 ||
+	t.col == 234479;
+      if (report_stuffing) {
+	printf("ColStuffing: Checking candidate t.col - %d\n",
+	       int(t.col));
+      }
       // compute delta (bound difference)
       HighsCDouble delta =
           t.multiplier * t.val *
@@ -5170,10 +5185,33 @@ HPresolve::Result HPresolve::singletonColStuffing(
       // check if variable can be fixed
       if (sumUpperFinite &&
           delta <= direction * rhs - sumUpper + primal_feastol) {
+	  if (report_stuffing)
+	    printf("ColStuffing:0 (%2d) fix %6d to %s: delta = %g; RHS0 = %11.4g\n",
+		 int(t.multiplier),
+		 int(t.col),
+		 t.multiplier < 0 ? "lower" : "upper",
+		 double(delta),
+		 double(direction * rhs - sumUpper + primal_feastol));
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, t.multiplier));
       } else if (sumLowerFinite &&
                  direction * rhs <= sumLower + primal_feastol) {
+	const bool alt_logic =
+	  delta <= direction * rhs - sumLower - primal_feastol;
+	
+	if (report_stuffing) {
+	    printf("ColStuffing:1 (%2d) fix %6d to %s: delta = %g; RHS0 = %11.4g | direction * rhs = %11.4g; sumLower + primal_feastol = %11.4g\n",
+		 int(-t.multiplier),
+		 int(t.col),
+		 -t.multiplier < 0 ? "lower" : "upper",
+		 double(delta),
+		 double(direction * rhs - sumUpper + primal_feastol),
+		 double(direction * rhs),
+		 double(sumLower + primal_feastol));
+	    printf("ColStuffing:1 direction * rhs - sumLower - primal_feastol = %11.4g; logic = %s\n\n",
+		   double(direction * rhs - sumLower - primal_feastol),
+		   alt_logic ? "T" : "F");
+	}
         numFixedCols++;
         HPRESOLVE_CHECKED_CALL(fixCol(t.col, -t.multiplier));
       }
@@ -5758,6 +5796,9 @@ HPresolve::Result HPresolve::fastPresolveLoop(
 
     HPRESOLVE_CHECKED_CALL(presolveChangedCols(postsolve_stack));
 
+    // Temporary for fix-col-stuffing
+    HPRESOLVE_CHECKED_CALL(checkLimits(postsolve_stack));
+
   } while (problemSizeReduction() > 0.01);
 
   return Result::kOk;
@@ -6125,7 +6166,12 @@ HPresolve::Result HPresolve::checkLimits(HighsPostsolveStack& postsolve_stack) {
 
   if ((numreductions & 1023u) == 0) HPRESOLVE_CHECKED_CALL(checkTimeLimit());
 
-  return numreductions >= reductionLimit ? Result::kStopped : Result::kOk;
+    // Temporary for fix-col-stuffing
+  const bool limit_reached = numreductions >= reductionLimit;
+  if (limit_reached) {
+    printf("HPresolve::checkLimits Reduction limit reached\n");
+  }
+  return limit_reached ? Result::kStopped : Result::kOk;
 }
 
 void HPresolve::storeCurrentProblemSize() {
@@ -6940,6 +6986,8 @@ HPresolve::Result HPresolve::presolveColSingletons(
     HighsInt col = singletonColumns[i];
     if (colDeleted[col]) continue;
     HPRESOLVE_CHECKED_CALL(colPresolve(postsolve_stack, col));
+    // Temporary for fix-col-stuffing
+    HPRESOLVE_CHECKED_CALL(checkLimits(postsolve_stack));
   }
   singletonColumns.erase(
       std::remove_if(

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -501,6 +501,9 @@ class HPresolve {
   HighsInt debugGetCheckCol() const;
   HighsInt debugGetCheckRow() const;
 
+  Result presolveRuleTest(HighsPostsolveStack& postsolve_stack);
+  Result presolveRuleTestColStuffing(HighsPostsolveStack& postsolve_stack);
+
   // Not currently called
   static void debug(const HighsLp& lp, const HighsOptions& options);
 };

--- a/highs/presolve/HPresolveTest.cpp
+++ b/highs/presolve/HPresolveTest.cpp
@@ -9,30 +9,31 @@
 
 namespace presolve {
 
-HPresolve::Result HPresolve::presolveRuleTest(HighsPostsolveStack& postsolve_stack) {
+HPresolve::Result HPresolve::presolveRuleTest(
+    HighsPostsolveStack& postsolve_stack) {
   assert(options->presolve_rule_test);
   if (options->presolve_rule_test == kPresolveRuleColStuffing) {
     return presolveRuleTestColStuffing(postsolve_stack);
   }
   return Result::kOk;
 }
-HPresolve::Result HPresolve::presolveRuleTestColStuffing(HighsPostsolveStack& postsolve_stack) {
+HPresolve::Result HPresolve::presolveRuleTestColStuffing(
+    HighsPostsolveStack& postsolve_stack) {
   assert(options->presolve_rule_test == kPresolveRuleColStuffing);
   assert(model->num_row_ == 1);
   highsLogUser(options->log_options, HighsLogType::kInfo,
-                   "HPresolve::presolveRuleTestColStuffing\n");
+               "HPresolve::presolveRuleTestColStuffing\n");
   HPresolve::Result result = Result::kOk;
   for (HighsInt col = 0; col < model->num_col_; col++) {
     if (colDeleted[col]) continue;
     result = singletonColStuffing(postsolve_stack, col);
     if (result != Result::kOk) return result;
-    
   }
   highsLogUser(options->log_options, HighsLogType::kInfo,
-	       "HPresolve::presolveRuleTestColStuffing: Stuffing removed %d rows and %d columns\n",
-	       int(numDeletedRows), int(numDeletedCols));
+               "HPresolve::presolveRuleTestColStuffing: Stuffing removed %d "
+               "rows and %d columns\n",
+               int(numDeletedRows), int(numDeletedCols));
   // Possibly remove the row
   return rowPresolve(postsolve_stack, 0);
 }
 }  // namespace presolve
-

--- a/highs/presolve/HPresolveTest.cpp
+++ b/highs/presolve/HPresolveTest.cpp
@@ -18,6 +18,7 @@ HPresolve::Result HPresolve::presolveRuleTest(HighsPostsolveStack& postsolve_sta
 }
 HPresolve::Result HPresolve::presolveRuleTestColStuffing(HighsPostsolveStack& postsolve_stack) {
   assert(options->presolve_rule_test == kPresolveRuleColStuffing);
+  assert(model->num_row_ == 1);
   highsLogUser(options->log_options, HighsLogType::kInfo,
                    "HPresolve::presolveRuleTestColStuffing\n");
   HPresolve::Result result = Result::kOk;
@@ -25,8 +26,13 @@ HPresolve::Result HPresolve::presolveRuleTestColStuffing(HighsPostsolveStack& po
     if (colDeleted[col]) continue;
     result = singletonColStuffing(postsolve_stack, col);
     if (result != Result::kOk) return result;
+    
   }
-  return result;
+  highsLogUser(options->log_options, HighsLogType::kInfo,
+	       "HPresolve::presolveRuleTestColStuffing: Stuffing removed %d rows and %d columns\n",
+	       int(numDeletedRows), int(numDeletedCols));
+  // Possibly remove the row
+  return rowPresolve(postsolve_stack, 0);
 }
 }  // namespace presolve
 

--- a/highs/presolve/HPresolveTest.cpp
+++ b/highs/presolve/HPresolveTest.cpp
@@ -1,0 +1,32 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/*    This file is part of the HiGHS linear optimization suite           */
+/*                                                                       */
+/*    Available as open-source under the MIT License                     */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+#include "presolve/HPresolve.h"
+
+namespace presolve {
+
+HPresolve::Result HPresolve::presolveRuleTest(HighsPostsolveStack& postsolve_stack) {
+  assert(options->presolve_rule_test);
+  if (options->presolve_rule_test == kPresolveRuleColStuffing) {
+    return presolveRuleTestColStuffing(postsolve_stack);
+  }
+  return Result::kOk;
+}
+HPresolve::Result HPresolve::presolveRuleTestColStuffing(HighsPostsolveStack& postsolve_stack) {
+  assert(options->presolve_rule_test == kPresolveRuleColStuffing);
+  highsLogUser(options->log_options, HighsLogType::kInfo,
+                   "HPresolve::presolveRuleTestColStuffing\n");
+  HPresolve::Result result = Result::kOk;
+  for (HighsInt col = 0; col < model->num_col_; col++) {
+    if (colDeleted[col]) continue;
+    result = singletonColStuffing(postsolve_stack, col);
+    if (result != Result::kOk) return result;
+  }
+  return result;
+}
+}  // namespace presolve
+


### PR DESCRIPTION
This identifies and fixes the source of the postsolve errors with column stuffing when applied to the relaxation of 'neos-787933'. It's a draft PR because I've left in the debug printing that was useful in pinpointing the error.

It also introduces two other development utilities

**Presolve rule testing** so that presolve can be run to test specific reductions on minimal instances. This greatly expands the scope for testing presolve rules

**The `HighsRunData` class** to collect run-time data that had not been available via the API. In the case of presolve rule testing, it provides sanity checks that
 
- minimal instances are reduced to empty;
- after dual postsolve the solution is still optimal;
- after basis postsolve no simplex iterations are required

This class is also a route towards closing #2910