### PR TITLE
Add reverse CI to test Uno with HiGHS and HiPO

### DIFF
--- a/.github/workflows/uno-reverse-ci.yml
+++ b/.github/workflows/uno-reverse-ci.yml
@@ -1,0 +1,174 @@
+# Check that the current HiGHS PR does not break Uno.
+#
+# uno-highs: current LP / QP solver interface of HiGHS vs the latest Uno release.
+# uno-hipo:  HiPO linear solver interface (still in flight) vs Uno's `hipo` branch.
+name: uno-reverse-ci
+
+on:
+  push:
+    branches: [hipo-c, latest, master]
+  pull_request:
+    branches: [hipo-c, latest, master]
+  workflow_dispatch:
+    inputs:
+      uno_repository:
+        description: "Uno repository (owner/name)"
+        default: "cvanaret/Uno"
+      uno_highs_ref:
+        description: "uno-highs job: Uno tag/branch/SHA to test (empty = latest Uno release)"
+        default: ""
+      uno_hipo_ref:
+        description: "uno-hipo job: Uno tag/branch/SHA to test (the in-flight HiPO branch)"
+        default: "hipo"
+  schedule:
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  uno-highs:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout HiGHS (current branch)
+        uses: actions/checkout@v4
+        with:
+          path: HiGHS
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ git libopenblas-dev liblapack-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake openblas lapack
+
+      - name: Build and install HiGHS
+        run: |
+          echo "HiGHS commit: $(git -C HiGHS rev-parse --short HEAD)"
+          cmake -S HiGHS -B HiGHS/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DFAST_BUILD=ON \
+            -DALL_TESTS=OFF \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/highs-install
+          cmake --build HiGHS/build --parallel
+          cmake --install HiGHS/build
+
+      - name: Resolve latest Uno release tag
+        id: uno_release
+        run: |
+          ref="${{ github.event.inputs.uno_highs_ref }}"
+          if [ -z "$ref" ]; then
+            repo="${{ github.event.inputs.uno_repository || 'cvanaret/Uno' }}"
+            ref=$(curl -fsSL \
+              -H "Authorization: Bearer ${{ github.token }}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${repo}/releases/latest" | jq -r .tag_name)
+          fi
+          [ -n "$ref" ] && [ "$ref" != "null" ] || { echo "no Uno release found"; exit 1; }
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "Uno release ref: $ref"
+
+      - name: Checkout Uno (latest release)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.uno_repository || 'cvanaret/Uno' }}
+          ref: ${{ steps.uno_release.outputs.ref }}
+          path: Uno
+
+      - name: Build Uno against HiGHS
+        run: |
+          echo "Uno commit: $(git -C Uno rev-parse --short HEAD)"
+          cmake -S Uno -B Uno/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_TESTS=ON \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/highs-install \
+            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/highs-install/include/highs
+          cmake --build Uno/build --target run_unotest --parallel
+
+      - name: Run Uno tests (HiGHS solver)
+        run: |
+          libdir="${{ github.workspace }}/highs-install/lib"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            export DYLD_LIBRARY_PATH="$libdir:$DYLD_LIBRARY_PATH"
+          else
+            export LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH"
+          fi
+          # --no-tests=error fails if HiGHS was not built into Uno (no test matched).
+          ctest --test-dir Uno/build -R HiGHSSolver --output-on-failure --no-tests=error
+
+  uno-hipo:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # ON = shared extras (libhighs_extras.so, dlopen'd), OFF = static extras (linked in).
+        os: [ubuntu-latest]
+        extras: ["ON", "OFF"]
+        include:
+          - os: macos-latest
+            extras: "ON"
+    steps:
+      - name: Checkout HiGHS (current branch)
+        uses: actions/checkout@v4
+        with:
+          path: HiGHS
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ git libopenblas-dev liblapack-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake openblas lapack
+
+      - name: Build and install HiGHS with HiPO (BUILD_SHARED_EXTRAS_LIB=${{ matrix.extras }})
+        run: |
+          echo "HiGHS commit: $(git -C HiGHS rev-parse --short HEAD)"
+          cmake -S HiGHS -B HiGHS/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DHIPO=ON \
+            -DFAST_BUILD=ON \
+            -DBUILD_SHARED_EXTRAS_LIB=${{ matrix.extras }} \
+            -DALL_TESTS=OFF \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/highs-install
+          cmake --build HiGHS/build --parallel
+          cmake --install HiGHS/build
+
+      - name: Checkout Uno (HiPO branch)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.uno_repository || 'cvanaret/Uno' }}
+          ref: ${{ github.event.inputs.uno_hipo_ref || 'hipo' }}
+          path: Uno
+
+      - name: Build Uno against HiGHS with HiPO
+        run: |
+          echo "Uno commit: $(git -C Uno rev-parse --short HEAD)"
+          cmake -S Uno -B Uno/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_TESTS=ON \
+            -DHIGHS_WITH_HIPO=ON \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/highs-install \
+            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/highs-install/include/highs
+          cmake --build Uno/build --target run_unotest --parallel
+
+      - name: Run Uno tests (HiPO solver)
+        run: |
+          libdir="${{ github.workspace }}/highs-install/lib:${{ github.workspace }}/HiGHS/build/lib"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            export DYLD_LIBRARY_PATH="$libdir:$DYLD_LIBRARY_PATH"
+          else
+            export LD_LIBRARY_PATH="$libdir:$LD_LIBRARY_PATH"
+          fi
+          # --no-tests=error fails if HiPO was not built into Uno (no test matched).
+          ctest --test-dir Uno/build -R HiPOSolver --output-on-failure --no-tests=error

--- a/.github/workflows/uno-reverse-ci.yml
+++ b/.github/workflows/uno-reverse-ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake openblas lapack
+        run: brew install cmake openblas lapack gcc
 
       - name: Build and install HiGHS
         run: |
@@ -86,11 +86,18 @@ jobs:
       - name: Build Uno against HiGHS
         run: |
           echo "Uno commit: $(git -C Uno rev-parse --short HEAD)"
+          # macOS: point the linker at libgfortran (Uno links -lgfortran without its -L path).
+          ldflags=""
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            gfdir=$(dirname "$(gfortran -print-file-name=libgfortran.dylib)")
+            ldflags="-DCMAKE_EXE_LINKER_FLAGS=-L${gfdir} -DCMAKE_SHARED_LINKER_FLAGS=-L${gfdir}"
+          fi
           cmake -S Uno -B Uno/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DENABLE_TESTS=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/highs-install \
-            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/highs-install/include/highs
+            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/highs-install/include/highs \
+            $ldflags
           cmake --build Uno/build --target run_unotest --parallel
 
       - name: Run Uno tests (HiGHS solver)
@@ -129,7 +136,7 @@ jobs:
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
-        run: brew install cmake openblas lapack
+        run: brew install cmake openblas lapack gcc
 
       - name: Build and install HiGHS with HiPO (BUILD_SHARED_EXTRAS_LIB=${{ matrix.extras }})
         run: |
@@ -154,12 +161,19 @@ jobs:
       - name: Build Uno against HiGHS with HiPO
         run: |
           echo "Uno commit: $(git -C Uno rev-parse --short HEAD)"
+          # macOS: point the linker at libgfortran (Uno links -lgfortran without its -L path).
+          ldflags=""
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            gfdir=$(dirname "$(gfortran -print-file-name=libgfortran.dylib)")
+            ldflags="-DCMAKE_EXE_LINKER_FLAGS=-L${gfdir} -DCMAKE_SHARED_LINKER_FLAGS=-L${gfdir}"
+          fi
           cmake -S Uno -B Uno/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DENABLE_TESTS=ON \
             -DHIGHS_WITH_HIPO=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/highs-install \
-            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/highs-install/include/highs
+            -DHIGHS_INCLUDE_DIR=${{ github.workspace }}/highs-install/include/highs \
+            $ldflags
           cmake --build Uno/build --target run_unotest --parallel
 
       - name: Run Uno tests (HiPO solver)


### PR DESCRIPTION
@galabovaa @filikat @cvanaret

I propose to merge this PR in the branch `hipo-c` and not `latest`.
I added a few comments to explain the current situation (branch `hipo-c` here and `hipo` in Uno) and what we want in the future.

Charlie, I only run the google tests for `HiPOSolver` but we can uncomment the Uno tests for `HiGHSSolver` once you fixed them.

I prefer that we add CI tests in an incremental way such that we can easily isolate the culprit if something is failing.