### PR TITLE
Add context manager support to highspy

### DIFF
--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -1371,10 +1371,6 @@ PYBIND11_MODULE(_core, m, py::mod_gil_not_used()) {
                      &HighsOptions::mip_min_logging_interval);
   py::class_<Highs>(m, "_Highs", py::module_local())
       .def(py::init<>())
-      .def("__enter__", [](Highs& self) -> Highs& { return self; })
-      .def("__exit__",
-           [](Highs& self, py::object exc_type, py::object exc_value,
-              py::object traceback) { self.clear(); })
       .def("version", &Highs::version)
       .def("versionMajor", &Highs::versionMajor)
       .def("versionMinor", &Highs::versionMinor)

--- a/highspy/highs_bindings.cpp
+++ b/highspy/highs_bindings.cpp
@@ -1371,6 +1371,10 @@ PYBIND11_MODULE(_core, m, py::mod_gil_not_used()) {
                      &HighsOptions::mip_min_logging_interval);
   py::class_<Highs>(m, "_Highs", py::module_local())
       .def(py::init<>())
+      .def("__enter__", [](Highs& self) -> Highs& { return self; })
+      .def("__exit__",
+           [](Highs& self, py::object exc_type, py::object exc_value,
+              py::object traceback) { self.clear(); })
       .def("version", &Highs::version)
       .def("versionMajor", &Highs::versionMajor)
       .def("versionMinor", &Highs::versionMinor)

--- a/highspy/highspy/highs.py
+++ b/highspy/highspy/highs.py
@@ -97,6 +97,18 @@ class Highs(_Highs):
         self.callbacks = [HighsCallback(cb.HighsCallbackType(_), self) for _ in range(int(cb.HighsCallbackType.kCallbackMax) + 1)]
         self.enableCallbacks()
 
+    # support 'with' syntax (context manager)
+    def __enter__(self):
+        return self
+
+    # support 'with' syntax (context manager)
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.is_solver_running():
+            self.cancelSolve()
+            self.wait()
+
+        self.clear()
+
     # Silence logging
     def silent(self, turn_off_output: bool = True):
         """

--- a/highspy/tests/test_highspy.py
+++ b/highspy/tests/test_highspy.py
@@ -1314,6 +1314,7 @@ class TestHighsPy(unittest.TestCase):
         h.joinSolve(h.startSolve(), 0)
 
         # replace wait function with Ctrl+C signal
+        __tmp_wait = highspy.highs.Highs.wait
         highspy.highs.Highs.wait = lambda self, t: signal.raise_signal(signal.SIGINT)  # type: ignore[assignment]
         h.HandleKeyboardInterrupt = False
 
@@ -1328,6 +1329,9 @@ class TestHighsPy(unittest.TestCase):
             h.startSolve()
             h.joinSolve(None, 5)
             unittest.main(exit=False)
+
+        # restore wait function (avoid issues in other tests)
+        highspy.highs.Highs.wait = __tmp_wait
 
     def test_callbacks(self):
         N = 8

--- a/highspy/tests/test_highspy.py
+++ b/highspy/tests/test_highspy.py
@@ -1632,6 +1632,32 @@ class TestHighsPy(unittest.TestCase):
             h.minimize(x)
             self.assertEqual(h.val(x), 0.0)
 
+        # manually call enter/exit to test threading, e.g.,
+        # 
+        # with Highs() as h:
+        #    ...
+        #    h.startSolve()
+        #
+        h = highspy.Highs()
+        h.__enter__()
+
+        # nqueens
+        N = 10
+        x = h.addBinaries(N, N)
+        y = np.fliplr(x)
+
+        h.addConstrs(x.sum(axis = 0) == 1)
+        h.addConstrs(x.sum(axis = 1) == 1),
+        h.addConstrs(x.diagonal(k).sum() <= 1 for k in range(-N + 1, N)) 
+        h.addConstrs(y.diagonal(k).sum() <= 1 for k in range(-N + 1, N))
+
+        h.HandleUserInterrupt = True
+        h.startSolve()
+        self.assertEqual(h.is_solver_running(), True)
+
+        h.__exit__(None, None, None)
+        self.assertEqual(h.is_solver_running(), False)
+
 
 class TestHighsLinearExpressionPy(unittest.TestCase):
     def setUp(self):

--- a/highspy/tests/test_highspy.py
+++ b/highspy/tests/test_highspy.py
@@ -1626,6 +1626,11 @@ class TestHighsPy(unittest.TestCase):
         self.assertTrue(x.__ne__(None))
         self.assertRaises(Exception, lambda: x.__ne__(5))
 
+    def test_with_context_manager(self):
+        with highspy.Highs() as h:
+            x = h.addVariable()
+            h.minimize(x)
+            self.assertEqual(h.val(x), 0.0)
 
 
 class TestHighsLinearExpressionPy(unittest.TestCase):


### PR DESCRIPTION
For example: 

```python
with Highs() as h:
   ...
   h.solve()
```

Feature requested by Adrián during HiGHS 2026 workshop.

Note that this still might not actually release all memory immediately; it is still somewhat dependent on the python garbage collection implementation.