### PR TITLE
Adding --threads to command line 

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ options:
                                    "choose" * default
                                    "on"
                                    "off"
+      --threads int              Set maximum number of threads to use:
+                                 0: automatic * default
       --run_crossover text       Set run_crossover option to:
                                    "choose"
                                    "on" * default

--- a/app/HighsRuntimeOptions.h
+++ b/app/HighsRuntimeOptions.h
@@ -27,6 +27,7 @@ struct HighsCommandLineOptions {
   bool cmd_notice = false;
   double cmd_time_limit = 0;
   int cmd_random_seed = 0;
+  int cmd_threads = 0;
 
   std::string model_file = "";
   std::string cmd_read_basis_file = "";
@@ -36,7 +37,6 @@ struct HighsCommandLineOptions {
   std::string cmd_presolve = "";
   std::string cmd_solver = "";
   std::string cmd_parallel = "";
-  std::string cmd_threads = "";
   std::string cmd_crossover = "";
   std::string cmd_write_solution_file = "";
   std::string cmd_write_model_file = "";
@@ -67,8 +67,7 @@ void setupCommandLineOptions(CLI::App& app,
       ->check(CLI::ExistingFile);
 
   app.add_option("--" + kReadSolutionFileString,
-                 cmd_options.cmd_read_solution_file,
-                 "File of solution to read")
+                 cmd_options.cmd_read_solution_file, "File of solution to read")
       // ->check(checkSingle)
       ->check(CLI::ExistingFile);
 
@@ -117,8 +116,8 @@ void setupCommandLineOptions(CLI::App& app,
                  "\"off\"");
 
   app.add_option("--" + kThreadsString, cmd_options.cmd_threads,
-                 "Set maximum number of threads used:\n"
-                 "0: automatic\n");
+                 "Set maximum number of threads to use:\n"
+                 "0: automatic * default");
 
   app.add_option("--" + kRunCrossoverString, cmd_options.cmd_crossover,
                  "Set run_crossover option to:\n"
@@ -249,10 +248,10 @@ bool loadOptions(const CLI::App& app, const HighsLogOptions& report_log_options,
   }
 
   // Threads option.
-  if (c.cmd_threads != "") {
-    if (setLocalOptionValue(report_log_options, kThreadsString,
-                            options.log_options, options.records,
-                            c.cmd_threads) != OptionStatus::kOk)
+  if (app.count("--" + kThreadsString) > 0) {
+    HighsInt value = c.cmd_threads;
+    if (setLocalOptionValue(report_log_options, kThreadsString, options.records,
+                            value) != OptionStatus::kOk)
       return false;
   }
 

--- a/app/HighsRuntimeOptions.h
+++ b/app/HighsRuntimeOptions.h
@@ -36,6 +36,7 @@ struct HighsCommandLineOptions {
   std::string cmd_presolve = "";
   std::string cmd_solver = "";
   std::string cmd_parallel = "";
+  std::string cmd_threads = "";
   std::string cmd_crossover = "";
   std::string cmd_write_solution_file = "";
   std::string cmd_write_model_file = "";
@@ -54,43 +55,43 @@ void setupCommandLineOptions(CLI::App& app,
 
   // Command line file specifications.
   app.add_option("--" + kModelFileString + "," + kModelFileString,
-                 cmd_options.model_file, "File of model to solve.")
+                 cmd_options.model_file, "File of model to solve")
       // Can't use required here because it breaks version printing with -v.
       // ->required()
       // ->check(checkSingle)
       ->check(CLI::ExistingFile);
 
   app.add_option("--" + kOptionsFileString, cmd_options.options_file,
-                 "File containing HiGHS options.")
+                 "File containing HiGHS options")
       // ->check(checkSingle)
       ->check(CLI::ExistingFile);
 
   app.add_option("--" + kReadSolutionFileString,
                  cmd_options.cmd_read_solution_file,
-                 "File of solution to read.")
+                 "File of solution to read")
       // ->check(checkSingle)
       ->check(CLI::ExistingFile);
 
   app.add_option("--" + kReadBasisFileString, cmd_options.cmd_read_basis_file,
-                 "File of initial basis to read.")
+                 "File of initial basis to read")
       // ->check(checkSingle)
       ->check(CLI::ExistingFile);
 
   app.add_option("--" + kWriteModelFileString, cmd_options.cmd_write_model_file,
-                 "File for writing out model.");
+                 "File for writing out model");
   // File does not need to exist
   //      ->check(CLI::ExistingFile)
   // ->check(checkSingle);
 
   app.add_option("--" + kWriteSolutionFileString,
                  cmd_options.cmd_write_solution_file,
-                 "File for writing out solution.");
+                 "File for writing out solution");
   // File does not need to exist
   //      ->check(CLI::ExistingFile)
   // ->check(checkSingle);
 
   app.add_option("--" + kWriteBasisFileString, cmd_options.cmd_write_basis_file,
-                 "File for writing out final basis.");
+                 "File for writing out final basis");
   // File does not need to exist
   //      ->check(CLI::ExistingFile)
   // ->check(checkSingle);
@@ -115,6 +116,10 @@ void setupCommandLineOptions(CLI::App& app,
                  "\"on\"\n"
                  "\"off\"");
 
+  app.add_option("--" + kThreadsString, cmd_options.cmd_threads,
+                 "Set maximum number of threads used:\n"
+                 "0: automatic\n");
+
   app.add_option("--" + kRunCrossoverString, cmd_options.cmd_crossover,
                  "Set run_crossover option to:\n"
                  "\"choose\"\n"
@@ -122,21 +127,21 @@ void setupCommandLineOptions(CLI::App& app,
                  "\"off\"");
 
   app.add_option("--" + kTimeLimitString, cmd_options.cmd_time_limit,
-                 "Run time limit (seconds - double).");
+                 "Run time limit (seconds - double)");
 
   app.add_option("--" + kRandomSeedString, cmd_options.cmd_random_seed,
-                 "Seed to initialize random number \ngeneration.");
+                 "Seed to initialize random number\ngeneration");
 
   app.add_option("--" + kRangingString, cmd_options.cmd_ranging,
-                 "Compute cost, bound, RHS and basic \nsolution ranging:\n"
+                 "Compute cost, bound, RHS and basic\nsolution ranging:\n"
                  "\"on\"\n"
                  "\"off\" * default");
 
   // Version.
-  app.add_flag("--version,-v", cmd_options.cmd_version, "Print version.");
+  app.add_flag("--version,-v", cmd_options.cmd_version, "Print version");
   app.add_flag("--notice", cmd_options.cmd_notice,
-               "Print third-party information.");
-  app.set_help_flag("-h,--help", "Print help.");
+               "Print third-party information");
+  app.set_help_flag("-h,--help", "Print help");
 
   app.get_formatter()->column_width(33);
 
@@ -240,6 +245,14 @@ bool loadOptions(const CLI::App& app, const HighsLogOptions& report_log_options,
     if (setLocalOptionValue(report_log_options, kParallelString,
                             options.log_options, options.records,
                             c.cmd_parallel) != OptionStatus::kOk)
+      return false;
+  }
+
+  // Threads option.
+  if (c.cmd_threads != "") {
+    if (setLocalOptionValue(report_log_options, kThreadsString,
+                            options.log_options, options.records,
+                            c.cmd_threads) != OptionStatus::kOk)
       return false;
   }
 

--- a/docs/src/executable.md
+++ b/docs/src/executable.md
@@ -52,6 +52,8 @@ options:
                                    "choose" * default 
                                    "on" 
                                    "off" 
+      --threads int              Set maximum number of threads to use:
+                                 0: automatic * default
       --run_crossover text       Set run_crossover option to: 
                                    "choose" 
                                    "on" * default 

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -755,7 +755,8 @@ class HighsOptions : public HighsOptionsStruct {
     records.push_back(record_string);
 
     record_int = new OptionRecordInt(
-        kThreadsString, "Maximum number of threads used by HiGHS (0: automatic)", advanced,
+        kThreadsString,
+        "Maximum number of threads used by HiGHS (0: automatic)", advanced,
         &threads, 0, 0, kHighsIInf);
     records.push_back(record_int);
 

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -288,6 +288,7 @@ const string kWriteBasisFileString = "write_basis_file";
 const string kPresolveString = "presolve";
 const string kSolverString = "solver";
 const string kParallelString = "parallel";
+const string kThreadsString = "threads";
 const string kRunCrossoverString = "run_crossover";
 const string kTimeLimitString = "time_limit";
 const string kOptionsFileString = "options_file";
@@ -328,6 +329,7 @@ struct HighsOptionsStruct {
   std::string presolve;
   std::string solver;
   std::string parallel;
+  HighsInt threads;
   std::string run_crossover;
   double time_limit;
   std::string read_solution_file;
@@ -351,7 +353,6 @@ struct HighsOptionsStruct {
   double optimality_tolerance;
   double objective_bound;
   double objective_target;
-  HighsInt threads;
   HighsInt user_objective_scale;
   HighsInt user_bound_scale;
   HighsInt highs_debug_level;
@@ -517,6 +518,7 @@ struct HighsOptionsStruct {
       : presolve(""),
         solver(""),
         parallel(""),
+        threads(0),
         run_crossover(""),
         time_limit(0.0),
         read_solution_file(""),
@@ -538,7 +540,6 @@ struct HighsOptionsStruct {
         optimality_tolerance(0.0),
         objective_bound(0.0),
         objective_target(0.0),
-        threads(0),
         user_objective_scale(0),
         user_bound_scale(0),
         highs_debug_level(0),
@@ -753,6 +754,11 @@ class HighsOptions : public HighsOptionsStruct {
         &parallel, kHighsChooseString);
     records.push_back(record_string);
 
+    record_int = new OptionRecordInt(
+        kThreadsString, "Maximum number of threads used by HiGHS (0: automatic)", advanced,
+        &threads, 0, 0, kHighsIInf);
+    records.push_back(record_int);
+
     record_string = new OptionRecordString(
         kRunCrossoverString, "Run IPM crossover: \"off\", \"choose\" or \"on\"",
         advanced, &run_crossover, kHighsOnString);
@@ -854,11 +860,6 @@ class HighsOptions : public HighsOptionsStruct {
     record_int =
         new OptionRecordInt(kRandomSeedString, "Random seed used in HiGHS",
                             advanced, &random_seed, 0, 0, kHighsIInf);
-    records.push_back(record_int);
-
-    record_int = new OptionRecordInt(
-        "threads", "Number of threads used by HiGHS (0: automatic)", advanced,
-        &threads, 0, 0, kHighsIInf);
     records.push_back(record_int);
 
     record_int = new OptionRecordInt(


### PR DESCRIPTION
Closes #3098 

And, no, I can't see how to indent the "0: automatic * default" line. CLI does this, but only does when the first character in the line is `"`.