### PR TITLE
ipo off for debug builds

### DIFF
--- a/.github/workflows/sanitizers-cmake.yml
+++ b/.github/workflows/sanitizers-cmake.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDEBUG_MEMORY=${{ matrix.sanitizer }} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
-          cmake --build . --parallel
+          cmake --build . -j2
 
       - name: Run
         working-directory: ${{github.workspace}}/build
@@ -51,7 +51,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DDEBUG_MEMORY=${{ matrix.sanitizer }} -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
-          cmake --build . --parallel
+          cmake --build . -j2
 
       - name: Run
         working-directory: ${{github.workspace}}/build
@@ -77,7 +77,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDEBUG_MEMORY=${{ matrix.sanitizer }} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-          cmake --build . --parallel
+          cmake --build . -j2
 
       - name: Run
         working-directory: ${{github.workspace}}/build
@@ -103,7 +103,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DDEBUG_MEMORY=${{ matrix.sanitizer }} -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-          cmake --build . --parallel
+          cmake --build . -j2
 
       - name: Run
         working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,11 @@ if (BUILD_CXX)
       message(STATUS "IPO / LTO is not supported for 32-bit linux.")
   endif()
 
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+      set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+      message(STATUS "IPO / LTO: disabled for Debug build")
+  endif()
+
 endif()
 
 


### PR DESCRIPTION
Switch off IPO for debug builds

Was causing trouble to the debugger, as spotted by @filikat 

Possibly occuring now because of highs_extras? 

Not super sure if we should merge this, one possible drawback is that I think it may be slowing down the valgrind tests 

https://github.com/ERGO-Code/HiGHS/actions/runs/28382771311
https://github.com/ERGO-Code/HiGHS/actions/runs/28380402678

1:13 vs 1:51 in this case, but I see one 2:07 valgrind without the changes, so I am really not sure if it would affect it or just a runner feature. 

What do you all think? 