### PR TITLE
fix: wrong comment in postsolve basis

### DIFF
--- a/highs/presolve/HighsPostsolveStack.cpp
+++ b/highs/presolve/HighsPostsolveStack.cpp
@@ -402,10 +402,10 @@ void HighsPostsolveStack::SingletonRow::undo(const HighsOptions& options,
         break;
       case HighsBasisStatus::kUpper:
         if (coef > 0)
-          // tightened upper bound comes from row lower bound
+          // tightened upper bound comes from row upper bound
           basis.row_status[row] = HighsBasisStatus::kUpper;
         else
-          // tightened lower bound comes from row upper bound
+          // tightened upper bound comes from row lower bound
           basis.row_status[row] = HighsBasisStatus::kLower;
         break;
       default:


### PR DESCRIPTION
The comments in the `case HighsBasisStatus::kUpper` branch of
`HighsPostsolveStack::SingletonRow::undo` incorrectly referred to a
"tightened lower bound" and swapped the row bound origin, even though
this branch only handles the case where the column's *upper* bound was
tightened.