### PR TITLE
Parallel early termination

### DIFF
--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -949,19 +949,27 @@ restart:
         }
       }
       assert(early_terminated_worker != -1);
-      // Clear all buffered solve information from workers that are not
-      // the earliest to terminate
-      for (const HighsInt i : search_indices) {
-        if (i == early_terminated_worker) continue;
-        HighsMipWorker& worker = mipdata_->workers[i];
-        worker.nodequeue.clear();
-        worker.search_ptr_->resetStatistics();
-        worker.resetHeurStats();
-        worker.resetSepaStats();
-        worker.solutions_.clear();
+      if (early_terminated_worker == -1) {
+        mipdata_->worker_lp_iterations_stop.store(
+            std::numeric_limits<int64_t>::max(), std::memory_order_relaxed);
+        for (const HighsInt i : search_indices) {
+          mipdata_->workers[i].early_termination = false;
+        }
+      } else {
+        // Clear all buffered solve information from workers that are not
+        // the earliest to terminate
+        for (const HighsInt i : search_indices) {
+          if (i == early_terminated_worker) continue;
+          HighsMipWorker& worker = mipdata_->workers[i];
+          worker.nodequeue.clear();
+          worker.search_ptr_->resetStatistics();
+          worker.resetHeurStats();
+          worker.resetSepaStats();
+          worker.solutions_.clear();
+        }
+        search_indices.clear();
+        search_indices.emplace_back(early_terminated_worker);
       }
-      search_indices.clear();
-      search_indices.emplace_back(early_terminated_worker);
     }
 
     // Sync statistics, check infeasibility, and flush nodes from worker queues

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -681,6 +681,13 @@ restart:
     return mipdata_->workers[i].getGlobalDomain().infeasible() || pruned;
   };
 
+  auto assignEarlyTermination = [&](HighsMipWorker& worker) {
+    if (worker.getGlobalDomain().infeasible() ||
+        mipdata_->lower_bound > worker.optimality_limit) {
+      mipdata_->updateWorkerEarlyTermination(worker);
+    }
+  };
+
   auto separateAndStoreBasis = [&](HighsInt i) -> bool {
     HighsMipWorker& worker = mipdata_->workers[i];
     if (options_mip_->mip_allow_cut_separation_at_nodes) {
@@ -699,6 +706,7 @@ restart:
                                         ? worker.nodequeue
                                         : mipdata_->nodequeue;
       worker.search_ptr_->openNodesToQueue(globalqueue);
+      assignEarlyTermination(worker);
       return true;
     }
 
@@ -822,18 +830,15 @@ restart:
                           std::vector<RestartVote>& restarts,
                           const bool skip_separation, const HighsInt nodeLim,
                           const HighsInt plungeLimit, double avgiter) {
-    auto processNode = [&](HighsInt i) {
+    auto processNode = [&](const HighsInt i) {
       HighsMipWorker& worker = mipdata_->workers[i];
       int64_t nodes_explored = 0;
       if (!skip_separation) {
         evaluateNode(i);
+        assignEarlyTermination(worker);
         if (pruneNode(i)) return;
-        if (!mipdata_->parallelLockActive()) {
-          if (mipdata_->checkLimits()) return;
-          mipdata_->printDisplayLine();
-        } else {
-          if (worker.search_ptr_->checkLocalLimits()) return;
-        }
+        if (worker.search_ptr_->checkLimits()) return;
+        if (!mipdata_->parallelLockActive()) mipdata_->printDisplayLine();
         if (separateAndStoreBasis(i)) return;
       }
       worker.getConflictPool().performAging();
@@ -866,6 +871,7 @@ restart:
           mipdata_->printDisplayLine();
         }
       }
+      assignEarlyTermination(worker);
       if (nodeLim == kHighsIInf) {
         restarts[i] = checkRestart(worker, 1);
       }
@@ -928,9 +934,39 @@ restart:
 
     root_node = false;
 
+    // Check if one worker sent an early global termination signal
+    const int64_t early_termination_lp_iterations =
+        mipdata_->worker_lp_iterations_stop.load(std::memory_order_relaxed);
+    HighsInt early_terminated_worker = -1;
+    if (early_termination_lp_iterations !=
+        std::numeric_limits<int64_t>::max()) {
+      for (const HighsInt i : search_indices) {
+        if (mipdata_->workers[i].early_termination &&
+            mipdata_->workers[i].search_ptr_->lpiterations ==
+                early_termination_lp_iterations) {
+          early_terminated_worker = i;
+          break;
+        }
+      }
+      assert(early_terminated_worker != -1);
+      // Clear all buffered solve information from workers that are not
+      // the earliest to terminate
+      for (const HighsInt i : search_indices) {
+        if (i == early_terminated_worker) continue;
+        HighsMipWorker& worker = mipdata_->workers[i];
+        worker.nodequeue.clear();
+        worker.search_ptr_->resetStatistics();
+        worker.resetHeurStats();
+        worker.resetSepaStats();
+        worker.solutions_.clear();
+      }
+      search_indices.clear();
+      search_indices.emplace_back(early_terminated_worker);
+    }
+
     // Sync statistics, check infeasibility, and flush nodes from worker queues
     bool infeasible = false;
-    for (HighsInt i : search_indices) {
+    for (const HighsInt i : search_indices) {
       HighsMipWorker& worker = mipdata_->workers[i];
       if (worker.getGlobalDomain().infeasible()) {
         infeasible = true;
@@ -957,13 +993,15 @@ restart:
       break;
     }
 
-    mipdata_->updateLowerBound(std::min(
-        mipdata_->upper_bound, mipdata_->nodequeue.getBestLowerBound()));
-
     syncSolutions();
 
+    if (early_terminated_worker == -1) {
+      mipdata_->updateLowerBound(std::min(
+          mipdata_->upper_bound, mipdata_->nodequeue.getBestLowerBound()));
+    }
+
     limit_reached = mipdata_->checkLimits();
-    if (limit_reached) {
+    if (limit_reached || early_terminated_worker != -1) {
       mipdata_->printDisplayLine();
       break;
     }

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -683,7 +683,7 @@ restart:
 
   auto assignEarlyTermination = [&](HighsMipWorker& worker) {
     if (worker.getGlobalDomain().infeasible() ||
-        mipdata_->lower_bound > worker.optimality_limit) {
+        mipdata_->lower_bound > worker.getOptimalityLimit()) {
       mipdata_->updateWorkerEarlyTermination(worker);
     }
   };

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -82,6 +82,8 @@ HighsMipSolverData::HighsMipSolverData(HighsMipSolver& mipsolver)
   getDomain().addCutpool(getCutPool());
   getDomain().addConflictPool(getConflictPool());
   cliquetable.setAllowParallel(!mipsolver.submip);
+  worker_lp_iterations_stop.store(std::numeric_limits<int64_t>::max(),
+                                  std::memory_order_relaxed);
 }
 
 std::string HighsMipSolverData::solutionSourceToString(
@@ -798,6 +800,8 @@ void HighsMipSolverData::init() {
   upper_bound = kHighsInf;
   upper_limit = mipsolver.options_mip_->objective_bound;
   optimality_limit = mipsolver.options_mip_->objective_bound;
+  worker_lp_iterations_stop.store(std::numeric_limits<int64_t>::max(),
+                                  std::memory_order_relaxed);
   primal_dual_integral.initialise();
 
   if (mipsolver.options_mip_->mip_report_level == 0)

--- a/highs/mip/HighsMipSolverData.h
+++ b/highs/mip/HighsMipSolverData.h
@@ -9,6 +9,7 @@
 #ifndef HIGHS_MIP_SOLVER_DATA_H_
 #define HIGHS_MIP_SOLVER_DATA_H_
 
+#include <atomic>
 #include <vector>
 
 #include "mip/HighsCliqueTable.h"
@@ -77,6 +78,7 @@ struct HighsMipSolverData {
   std::deque<HighsPseudocost> pseudocosts;
   std::deque<HighsMipWorker> workers;
   bool parallel_lock;
+  std::atomic<int64_t> worker_lp_iterations_stop;
 
   HighsPrimalHeuristics heuristics;
   HighsCliqueTable cliquetable;
@@ -260,6 +262,17 @@ struct HighsMipSolverData {
 
   bool parallelLockActive() const {
     return (parallel_lock && hasMultipleWorkers());
+  }
+
+  void updateWorkerEarlyTermination(HighsMipWorker& worker) {
+    int64_t current = worker_lp_iterations_stop.load(std::memory_order_relaxed);
+    const int64_t candidate = worker.search_ptr_->lpiterations;
+    while (candidate < current &&
+           !worker_lp_iterations_stop.compare_exchange_weak(
+               current, candidate, std::memory_order_relaxed,
+               std::memory_order_relaxed)) {
+    }
+    worker.early_termination = true;
   }
 
   bool hasMultipleWorkers() const { return workers.size() > 1; }

--- a/highs/mip/HighsMipWorker.cpp
+++ b/highs/mip/HighsMipWorker.cpp
@@ -27,6 +27,7 @@ HighsMipWorker::HighsMipWorker(const HighsMipSolver& mipsolver,
   upper_limit = mipdata_.upper_limit;
   optimality_limit = mipdata_.optimality_limit;
   heuristics_allowed = true;
+  early_termination = false;
   search_ptr_ =
       std::unique_ptr<HighsSearch>(new HighsSearch(*this, getPseudocost()));
   sepa_ptr_ = std::unique_ptr<HighsSeparation>(new HighsSeparation(*this));

--- a/highs/mip/HighsMipWorker.cpp
+++ b/highs/mip/HighsMipWorker.cpp
@@ -146,6 +146,14 @@ bool HighsMipWorker::trySolution(const std::vector<double>& solution,
   return addIncumbent(solution, static_cast<double>(obj), solution_source);
 }
 
+double HighsMipWorker::getOptimalityLimit() const {
+  if (!mipdata_.parallelLockActive()) {
+    return mipdata_.optimality_limit;
+  } else {
+    return optimality_limit;
+  }
+}
+
 void HighsMipWorker::resetSepaStats() {
   sepa_stats.numNeighbourhoodQueries = 0;
   sepa_stats.sepa_lp_iterations = 0;

--- a/highs/mip/HighsMipWorker.h
+++ b/highs/mip/HighsMipWorker.h
@@ -75,6 +75,7 @@ class HighsMipWorker {
   double upper_bound;
   double upper_limit;
   double optimality_limit;
+  bool early_termination;
 
   std::vector<std::tuple<std::vector<double>, double, int>> solutions_;
 

--- a/highs/mip/HighsMipWorker.h
+++ b/highs/mip/HighsMipWorker.h
@@ -130,6 +130,8 @@ class HighsMipWorker {
 
   bool getAllowHeuristics() const { return heuristics_allowed; }
 
+  double getOptimalityLimit() const;
+
   int64_t& getNumNeighbourhoodQueries() {
     return sepa_stats.numNeighbourhoodQueries;
   }

--- a/highs/mip/HighsSearch.cpp
+++ b/highs/mip/HighsSearch.cpp
@@ -1949,8 +1949,9 @@ bool HighsSearch::checkLocalLimits() const {
   if (mipsolver.mipdata_->terminatorActive())
     if (mipsolver.mipdata_->terminatorTerminated()) return true;
 
-  if (mipsolver.mipdata_->worker_lp_iterations_stop.load(
-          std::memory_order_relaxed) <= lpiterations) {
+  const int64_t stop = mipsolver.mipdata_->worker_lp_iterations_stop.load(
+      std::memory_order_relaxed);
+  if (stop <= lpiterations) {
     return true;
   }
 

--- a/highs/mip/HighsSearch.cpp
+++ b/highs/mip/HighsSearch.cpp
@@ -795,21 +795,20 @@ void HighsSearch::openNodesToQueue(HighsNodeQueue& nodequeue) {
 
 void HighsSearch::flushStatistics(HighsMipSolver& mipsolver) {
   mipsolver.mipdata_->num_nodes += nnodes;
-  nnodes = 0;
-
   mipsolver.mipdata_->num_leaves += nleaves;
-  nleaves = 0;
-
   mipsolver.mipdata_->pruned_treeweight += treeweight;
-  treeweight = 0;
-
   mipsolver.mipdata_->total_lp_iterations += lpiterations;
-  lpiterations = 0;
-
   mipsolver.mipdata_->heuristic_lp_iterations += heurlpiterations;
-  heurlpiterations = 0;
-
   mipsolver.mipdata_->sb_lp_iterations += sblpiterations;
+  resetStatistics();
+}
+
+void HighsSearch::resetStatistics() {
+  nnodes = 0;
+  nleaves = 0;
+  treeweight = 0;
+  lpiterations = 0;
+  heurlpiterations = 0;
   sblpiterations = 0;
 }
 
@@ -1949,6 +1948,11 @@ bool HighsSearch::checkLimits(int64_t nodeOffset) const {
 bool HighsSearch::checkLocalLimits() const {
   if (mipsolver.mipdata_->terminatorActive())
     if (mipsolver.mipdata_->terminatorTerminated()) return true;
+
+  if (mipsolver.mipdata_->worker_lp_iterations_stop.load(
+          std::memory_order_relaxed) <= lpiterations) {
+    return true;
+  }
 
   if (!mipsolver.submip && mipworker.upper_bound < kHighsInf &&
       mipsolver.options_mip_->objective_target > -kHighsInf) {

--- a/highs/mip/HighsSearch.cpp
+++ b/highs/mip/HighsSearch.cpp
@@ -616,7 +616,7 @@ HighsInt HighsSearch::selectBranchingCandidate(int64_t maxSbIters,
           } else {
             downbound[candidate] = solobj;
           }
-          if (solobj > getOptimalityLimit()) {
+          if (solobj > mipworker.getOptimalityLimit()) {
             addBoundExceedingConflict();
 
             bool pruned = solobj > getCutoffBound();
@@ -877,7 +877,7 @@ HighsSearch::NodeResult HighsSearch::evaluateNode() {
 
   const auto& domchgstack = localdom.getDomainChangeStack();
 
-  if (!inheuristic && currnode.lower_bound > getOptimalityLimit())
+  if (!inheuristic && currnode.lower_bound > mipworker.getOptimalityLimit())
     return NodeResult::kSubOptimal;
 
   localdom.propagate();
@@ -1086,7 +1086,7 @@ HighsSearch::NodeResult HighsSearch::evaluateNode() {
     treeweight += std::ldexp(1.0, 1 - getCurrentDepth());
     currnode.opensubtrees = 0;
   } else if (!inheuristic) {
-    if (currnode.lower_bound > getOptimalityLimit()) {
+    if (currnode.lower_bound > mipworker.getOptimalityLimit()) {
       result = NodeResult::kSubOptimal;
       addBoundExceedingConflict();
     }
@@ -1736,7 +1736,7 @@ bool HighsSearch::backtrackPlunge(HighsNodeQueue& nodequeue) {
     }
 
     nodelb = std::max(nodelb, localdom.getObjectiveLowerBound());
-    bool nodeToQueue = nodelb > getOptimalityLimit();
+    bool nodeToQueue = nodelb > mipworker.getOptimalityLimit();
     // we check if switching to the other branch of an ancestor yields a higher
     // additive branch score than staying in this node and if so we postpone the
     // node and put it to the queue to backtrack further.
@@ -1907,14 +1907,6 @@ double HighsSearch::getUpperLimit() const {
 }
 
 double HighsSearch::getEpsilon() const { return mipsolver.mipdata_->epsilon; }
-
-double HighsSearch::getOptimalityLimit() const {
-  if (!mipsolver.mipdata_->parallelLockActive()) {
-    return mipsolver.mipdata_->optimality_limit;
-  } else {
-    return mipworker.optimality_limit;
-  }
-}
 
 const std::vector<double>& HighsSearch::getRootLpSol() const {
   return mipsolver.mipdata_->rootlpsol;

--- a/highs/mip/HighsSearch.h
+++ b/highs/mip/HighsSearch.h
@@ -206,6 +206,8 @@ class HighsSearch {
 
   void flushStatistics(HighsMipSolver& mipsolver);
 
+  void resetStatistics();
+
   void installNode(HighsNodeQueue::OpenNode&& node);
 
   void addInfeasibleConflict();

--- a/highs/mip/HighsSearch.h
+++ b/highs/mip/HighsSearch.h
@@ -252,7 +252,6 @@ class HighsSearch {
   double getFeasTol() const;
   double getUpperLimit() const;
   double getEpsilon() const;
-  double getOptimalityLimit() const;
 
   const std::vector<double>& getRootLpSol() const;
   const std::vector<HighsInt>& getIntegralCols() const;


### PR DESCRIPTION
This PR adds a deterministic stopping criteria during parallel MIP, so that some workers may terminate early in the case where another worker has already proven global optimality / infeasibility.

This should only affect cases where (1) a worker finds a primal solution where the existing global dual bound is within tolerances (2) a worker concludes that the problem is infeasible. In my test set it saves 5% of time on 3% of instances, and has no overhead + no effect on the solution path of everything else. I don't see a reason not to add this.

The biggest "change" here would be adding a `std::atomic` to `HighsMipSolverData`, and when checking limits doing a `std::memory_order_relaxed` load. 

Edit: The "improvement" on LP iterations and nodes is much higher and might make this PR look good, but it's simply cheating by discarding the information from all other workers (necessary for determinism)