### PR TITLE
Add workflow to build pyodide package

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -265,4 +265,4 @@ jobs:
       - name: Test highspy
         run: |
           python3 -m pip install pytest
-          python3 -m pytest ./highspy
+          python3 -m pytest -k "not test_user_interrupts and not test_with_context_manager" ./highspy

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -257,6 +257,8 @@ jobs:
         run: |
           python3 -m pip install cibuildwheel
           python3 -m cibuildwheel --only cp314-pyodide_wasm32
+        env:
+          CIBW_TEST_COMMAND: ""
 
       - name: Install wheel
         run: |

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -242,3 +242,27 @@ jobs:
         run: |
           python -m pip install pytest
           python -m pytest ./highspy
+
+  build_wheel_wasm:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install correct python version
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.14
+
+      - name: Build wheel
+        run: |
+          python3 -m pip install cibuildwheel
+          python3 -m cibuildwheel --only cp314-pyodide_wasm32
+
+      - name: Install wheel
+        run: |
+          python3 -m pip install wheelhouse/*.whl
+
+      - name: Test highspy
+        run: |
+          python3 -m pip install pytest
+          python3 -m pytest ./highspy

--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -257,14 +257,3 @@ jobs:
         run: |
           python3 -m pip install cibuildwheel
           python3 -m cibuildwheel --only cp314-pyodide_wasm32
-        env:
-          CIBW_TEST_COMMAND: ""
-
-      - name: Install wheel
-        run: |
-          python3 -m pip install wheelhouse/*.whl
-
-      - name: Test highspy
-        run: |
-          python3 -m pip install pytest
-          python3 -m pytest -k "not test_user_interrupts and not test_with_context_manager" ./highspy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ repair-wheel-command = """
 [tool.cibuildwheel.pyodide]
 repair-wheel-command = """
 rm -rf /tmp/wheel_repair && mkdir -p /tmp/wheel_repair && \
-python -m zipfile -e {wheel} /tmp/wheel_repair &&  \
+python -m zipfile -e {wheel} /tmp/wheel_repair && \
 LIBDIR=$(dirname $(find /tmp/wheel_repair -name 'libhighs.so' | head -n1)) && \
 pyodide auditwheel repair --libdir "$LIBDIR" --output-dir {dest_dir} {wheel}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ repair-wheel-command = """
 [tool.cibuildwheel.pyodide]
 repair-wheel-command = """
 rm -rf /tmp/wheel_repair && mkdir -p /tmp/wheel_repair && \
-python -m zipfile -e {wheel} /tmp/wheel_repair && \
+python -m zipfile -e {wheel} /tmp/wheel_repair &&  \
 LIBDIR=$(dirname $(find /tmp/wheel_repair -name 'libhighs.so' | head -n1)) && \
 pyodide auditwheel repair --libdir "$LIBDIR" --output-dir {dest_dir} {wheel}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,11 @@ repair-wheel-command = """
     -e libunwind \
     -w {dest_dir} -v {wheel}
 """
+
+[tool.cibuildwheel.pyodide]
+repair-wheel-command = """
+rm -rf /tmp/wheel_repair && mkdir -p /tmp/wheel_repair && \
+python -m zipfile -e {wheel} /tmp/wheel_repair && \
+LIBDIR=$(dirname $(find /tmp/wheel_repair -name 'libhighs.so' | head -n1)) && \
+pyodide auditwheel repair --libdir "$LIBDIR" --output-dir {dest_dir} {wheel}
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,8 @@ repair-wheel-command = """
 """
 
 [tool.cibuildwheel.pyodide]
+test-requires = ["pytest"]
+test-command = "python -m pytest -k \"not test_user_interrupts and not test_with_context_manager\" {project}/highspy/tests -x"
 repair-wheel-command = """
 rm -rf /tmp/wheel_repair && mkdir -p /tmp/wheel_repair && \
 python -m zipfile -e {wheel} /tmp/wheel_repair && \


### PR DESCRIPTION
With the acceptance of [PEP 783](https://peps.python.org/pep-0783/), package maintainers can now build and publish Pyodide-compatible wheels (pyemscripten platform) directly to PyPI. Submiting this PR to build python package in HiGHS repository, will update the code in build-wheels-push.yml, so pyodide packages can be uploaded to PyPI