### PR TITLE
Fix 2866

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -6944,7 +6944,7 @@ void HPresolve::removeFixedCol(HighsInt col, double fixval) {
 
 HPresolve::Result HPresolve::removeRowSingletons(
     HighsPostsolveStack& postsolve_stack) {
-  for (size_t i = 0; i != singletonRows.size(); ++i) {
+  for (size_t i = 0; i < singletonRows.size(); ++i) {
     HighsInt row = singletonRows[i];
     if (rowDeleted[row] || rowsize[row] > 1) continue;
     // row presolve will delegate to rowSingleton() if the row size is 1

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -6959,7 +6959,7 @@ HPresolve::Result HPresolve::removeRowSingletons(
 
 HPresolve::Result HPresolve::presolveColSingletons(
     HighsPostsolveStack& postsolve_stack) {
-  for (size_t i = 0; i != singletonColumns.size(); ++i) {
+  for (size_t i = 0; i < singletonColumns.size(); ++i) {
     HighsInt col = singletonColumns[i];
     if (colDeleted[col]) continue;
     HPRESOLVE_CHECKED_CALL(colPresolve(postsolve_stack, col));


### PR DESCRIPTION
This fixes the crash from the instance in the comments of #2866 

Explanation: While iterating over `singletonRows`, presolving one of the singletons reduces multiple (probably identical ones) to empty rows. Despite them being reduced `singletonRows` is not updated (is waiting to be cleared). When the size 0 row is then processed, they are not yet deleted and `rowPresolve` will be called on them during `removeRowSingletons`. This will then result in a nested call of `removeRowSingletons`. This is all fine, until we're back at the original loop, where the counter is at something non-zero, e.g., 2, and the loop is continuing because `2 != 0` (the new size of `singletonRows` from the nested call.

Fix: I've just changed the `!=` to a `<`.

@zeddybot I'm assuming you're a bot, and a lot of the information wasn't necessary, but the instance was helpful and the issue was clearly explained.