### PR TITLE
fix compiler warnings from version 1.15.1

### DIFF
--- a/highs/lp_data/HighsRunData.h
+++ b/highs/lp_data/HighsRunData.h
@@ -147,7 +147,6 @@ class HighsRunData : public HighsRunDataStruct {
   }
 
   void initRecords() {
-    RunDataRecordInt64* record_int64;
     RunDataRecordInt* record_int;
     RunDataRecordDouble* record_double;
     const bool advanced = false;  // Not used

--- a/highs/presolve/HighsSymmetry.h
+++ b/highs/presolve/HighsSymmetry.h
@@ -84,7 +84,7 @@ struct HighsOrbitopeMatrix {
   };
   HighsInt rowLength;
   HighsInt numRows;
-  HighsInt numSetPackingRows;
+  HighsInt numSetPackingRows = 0;
   HighsHashTable<HighsInt, HighsInt> columnToRow;
   std::vector<RowPackingStatus> rowIsSetPacking;
   std::vector<HighsInt> matrix;


### PR DESCRIPTION
Remove unused local variable `record_int64`.

Fix warning that `numSetPackingRows` may not be initialized in a symmetry class.