### PR TITLE
Test an LP with HiPO in the Julia CI job

### DIFF
--- a/.github/workflows/julia-tests.yml
+++ b/.github/workflows/julia-tests.yml
@@ -109,7 +109,7 @@ jobs:
       - shell: julia --color=yes {0}
         run: |
           import HiGHS_jll
-          file = joinpath(ENV["GITHUB_WORKSPACE"], "check", "instances", "flugpl.mps")
+          file = joinpath(ENV["GITHUB_WORKSPACE"], "check", "instances", "25fv47.mps")
           run(`$(HiGHS_jll.highs()) --solver=hipo $file`)
           run(`$(HiGHS_jll.highs()) $file`)
       - shell: julia --color=yes {0}


### PR DESCRIPTION
v1.15 broke HiPO support in HiGHS, even though I thought we were testing it: https://github.com/jump-dev/HiGHS.jl/pull/347

It might be fixed in `latest`, so testing this. I need to figure out a more robust way to check if HiPO is actually compiled in the binary.