### PR TITLE
Fix assertion failure

### DIFF
--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -730,12 +730,14 @@ HighsDomain::ObjectivePropagation::ObjectivePropagation(HighsDomain* domain)
       if (domain->col_lower_[col] == -kHighsInf)
         ++numInfObjLower;
       else
-        objectiveLower += domain->col_lower_[col] * cost[col];
+        objectiveLower +=
+            static_cast<HighsCDouble>(domain->col_lower_[col]) * cost[col];
     } else {
       if (domain->col_upper_[col] == kHighsInf)
         ++numInfObjLower;
       else
-        objectiveLower += domain->col_upper_[col] * cost[col];
+        objectiveLower +=
+            static_cast<HighsCDouble>(domain->col_upper_[col]) * cost[col];
     }
   }
 
@@ -845,12 +847,12 @@ void HighsDomain::ObjectivePropagation::updateActivityLbChange(
     if (oldbound == -kHighsInf)
       --numInfObjLower;
     else
-      objectiveLower -= oldbound * cost[col];
+      objectiveLower -= static_cast<HighsCDouble>(oldbound) * cost[col];
 
     if (newbound == -kHighsInf)
       ++numInfObjLower;
     else
-      objectiveLower += newbound * cost[col];
+      objectiveLower += static_cast<HighsCDouble>(newbound) * cost[col];
 
     debugCheckObjectiveLower();
 
@@ -965,12 +967,12 @@ void HighsDomain::ObjectivePropagation::updateActivityUbChange(
     if (oldbound == kHighsInf)
       --numInfObjLower;
     else
-      objectiveLower -= oldbound * cost[col];
+      objectiveLower -= static_cast<HighsCDouble>(oldbound) * cost[col];
 
     if (newbound == kHighsInf)
       ++numInfObjLower;
     else
-      objectiveLower += newbound * cost[col];
+      objectiveLower += static_cast<HighsCDouble>(newbound) * cost[col];
 
     debugCheckObjectiveLower();
 
@@ -1105,18 +1107,19 @@ void HighsDomain::ObjectivePropagation::debugCheckObjectiveLower() const {
     HighsInt col = objNonzeros[i];
     if (cost[col] > 0) {
       if (domain->col_lower_[col] > -kHighsInf)
-        lowerFromScratch += domain->col_lower_[col] * cost[col];
+        lowerFromScratch +=
+            static_cast<HighsCDouble>(domain->col_lower_[col]) * cost[col];
       else
         ++numInf;
     } else {
       if (domain->col_upper_[col] < kHighsInf)
-        lowerFromScratch += domain->col_upper_[col] * cost[col];
+        lowerFromScratch +=
+            static_cast<HighsCDouble>(domain->col_upper_[col]) * cost[col];
       else
         ++numInf;
     }
   }
-  assert(std::fabs(double(lowerFromScratch - objectiveLower)) <=
-         domain->feastol());
+  assert(abs(lowerFromScratch - objectiveLower) <= domain->feastol());
   assert(numInf == numInfObjLower);
 #endif
 }

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -2952,7 +2952,8 @@ void HPresolve::substitute(HighsInt row, HighsInt col, double rhs) {
 
   // substitute column in the objective function
   if (model->col_cost_[col] != 0.0) {
-    HighsCDouble objscale = model->col_cost_[col] * substrowscale;
+    HighsCDouble objscale =
+        static_cast<HighsCDouble>(model->col_cost_[col]) * substrowscale;
     model->offset_ = static_cast<double>(model->offset_ - objscale * rhs);
     assert(std::isfinite(model->offset_));
     for (HighsInt rowiter : rowpositions) {
@@ -2967,7 +2968,7 @@ void HPresolve::substitute(HighsInt row, HighsInt col, double rhs) {
     }
     assert(std::abs(model->col_cost_[col]) <=
            std::max(options->dual_feasibility_tolerance,
-                    kHighsTiny * std::abs(static_cast<double>(objscale))));
+                    static_cast<double>(kHighsTiny * abs(objscale))));
     model->col_cost_[col] = 0.0;
   }
 
@@ -5170,7 +5171,7 @@ HPresolve::Result HPresolve::singletonColStuffing(
         break;
       // compute delta (bound difference)
       HighsCDouble delta =
-          t.multiplier * t.val *
+          t.multiplier * static_cast<HighsCDouble>(t.val) *
           (static_cast<HighsCDouble>(model->col_upper_[t.col]) -
            static_cast<HighsCDouble>(model->col_lower_[t.col]));
       // check if variable can be fixed
@@ -7104,10 +7105,12 @@ HPresolve::Result HPresolve::strengthenInequalities(
       double ub = model->col_upper_[col] - model->col_lower_[col];
       if (weight > 0) {
         comp = 1;
-        maxviolation += model->col_upper_[col] * weight;
+        maxviolation +=
+            static_cast<HighsCDouble>(model->col_upper_[col]) * weight;
       } else {
         comp = -1;
-        maxviolation += model->col_lower_[col] * weight;
+        maxviolation +=
+            static_cast<HighsCDouble>(model->col_lower_[col]) * weight;
         weight = -weight;
       }
 
@@ -7227,16 +7230,15 @@ HPresolve::Result HPresolve::strengthenInequalities(
                               HighsInt direction) {
       for (HighsInt i : indices) {
         assert(Arow[positions[i]] == row);
-        double coefdelta =
-            direction * static_cast<double>(reducedcost[i] - maxviolation);
+        HighsCDouble coefdelta = direction * (reducedcost[i] - maxviolation);
         HighsInt col = Acol[positions[i]];
 
         if (complementation[i] == -1) {
           rhs += coefdelta * model->col_lower_[col];
-          addToMatrix(row, col, coefdelta);
+          addToMatrix(row, col, static_cast<double>(coefdelta));
         } else {
           rhs -= coefdelta * model->col_upper_[col];
-          addToMatrix(row, col, -coefdelta);
+          addToMatrix(row, col, static_cast<double>(-coefdelta));
         }
       }
     };


### PR DESCRIPTION
Fix assertion failure encountered when running the reproduction example from #3074 (by using `HighsCDouble`):

> Assertion failed: (std::abs(model->col_cost_[col]) <= std::max(options->dual_feasibility_tolerance, kHighsTiny * std::abs(static_cast<double>(objscale)))), function substitute, file HPresolve.cpp, line 2970.

Note that this does not resolve the slow convergence with presolve.