### PR TITLE
Bazel fixup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -118,6 +118,10 @@ cc_library(
     ],
     linkopts = select({
         "@rules_cc//cc/compiler:msvc-cl": ["-DEFAULTLIB:shell32.lib"],
+        "@platforms//os:linux": [
+          "-Wl,--no-as-needed -ldl",
+          "-pthread",
+        ],
         "//conditions:default": ["-lpthread"],
     }),
     visibility = ["//visibility:public"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,25 +5,11 @@ module(
     version = "1.15.1",
 )
 
-bazel_dep(
-    name = "bazel_skylib",
-    version = "1.9.0",
-)
-
-bazel_dep(
-    name = "rules_cc",
-    version = "0.2.17",
-)
-
-bazel_dep(
-    name = "zlib",
-    version = "1.3.2",
-)
-
-bazel_dep(
-    name = "rules_cuda",
-    version = "0.3.0",
-)
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.20")
+bazel_dep(name = "zlib", version = "1.3.2")
+bazel_dep(name = "rules_cuda", version = "0.3.0")
 
 # Load the extension
 cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")


### PR DESCRIPTION
in `BUILD.bazel` explicitly link to `ld` and `pthread` on linux to avoid error on debian11 runner from BCR (Bazel Central Registry).

related to:
* https://github.com/bazelbuild/bazel-central-registry/pull/9635