### PR TITLE
Build free-threaded (cp314t) wheels

### DIFF
--- a/.github/workflows/build-wheels-push.yml
+++ b/.github/workflows/build-wheels-push.yml
@@ -48,7 +48,13 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]
-        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314", "cp314t"]
+        exclude:
+          # numpy (pulled in by the test suite) has no 32-bit linux free-threaded wheels
+          - buildplat: [ubuntu-24.04, manylinux_i686]
+            python: "cp314t"
+          - buildplat: [ubuntu-24.04, musllinux_i686]
+            python: "cp314t"
     steps:
       - uses: actions/checkout@v6
       - name: Build wheels
@@ -79,7 +85,13 @@ jobs:
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
           - [windows-2022, win32]
-        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314", "cp314t"]
+        exclude:
+          # numpy (pulled in by the test suite) has no 32-bit linux free-threaded wheels
+          - buildplat: [ubuntu-24.04, manylinux_i686]
+            python: "cp314t"
+          - buildplat: [ubuntu-24.04, musllinux_i686]
+            python: "cp314t"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
This adds cp314t to the build matrix so free-threaded CPython 3.14 wheels are published. The bindings were already declared GIL safe in #2063, and cibuildwheel 4 builds free-threaded wheels by default; the matrix just never selects them.

The two linux 32 bit combos are excluded because numpy (used by the tests) ships no i686 free-threaded wheels.

Context: conda-forge only enables free-threaded builds for packages with cp314t wheels on PyPI, and highspy is one of the last blockers for a free-threaded cvxpy (conda-forge/cvxpy-feedstock#124).
