### PR TITLE
Simplified factorisation for HiPO

### DIFF
--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -267,7 +267,8 @@ set(hipo_sources
     ipm/hipo/ipm/Model.cpp
     ipm/hipo/ipm/PreProcess.cpp
     ipm/hipo/ipm/Refine.cpp
-    ipm/hipo/ipm/Solver.cpp)
+    ipm/hipo/ipm/Solver.cpp
+    ipm/hipo/ipm/UpLookingSolver.cpp)
 
 set(hipo_headers
     ipm/hipo/ipm/IpmData.h
@@ -282,7 +283,8 @@ set(hipo_headers
     ipm/hipo/ipm/Options.h
     ipm/hipo/ipm/PreProcess.h
     ipm/hipo/ipm/Solver.h
-    ipm/hipo/ipm/Status.h)
+    ipm/hipo/ipm/Status.h
+    ipm/hipo/ipm/UpLookingSolver.h)
 
 set(factor_highs_sources
     ipm/hipo/factorhighs/Analyse.cpp

--- a/docs/src/options/definitions.md
+++ b/docs/src/options/definitions.md
@@ -449,6 +449,11 @@
 - Type: string
 - Default: "choose"
 
+## [hipo\_fatcor](@id option-hipo-factor)
+- HiPO matrix factorisation: "choose", "multifrontal", or "uplooking"
+- Type: string
+- Default: "choose"
+
 ## [hipo\_block\_size](@id option-hipo-block-size)
 - Block size for dense linear algebra within HiPO
 - Type: integer

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -63,6 +63,14 @@ HiGHS has two interior point (IPM) solvers:
   use the augmented system, "normaleq" for normal equations, or
   "choose" to leave the choice to the solver.
 
+  The [__hipo\_factor__](@ref option-hipo-factor) option can be used to
+  select the factorisation to use: select "multifrontal" to force the use
+  of the parallel multifrontal factorisation (ideal for large and structured 
+  problems); select "uplooking" to force the use of the serial up-looking
+  factorisation (ideal for small and very sparse problems); select "choose" 
+  to leave the choice to the solver (recommended, as the solver can switch 
+  between the two factorisations during the iterations if needed).
+
   The option [__hipo\_ordering__](@ref option-hipo-ordering) can be used
   to select the fill-reducing heuristic to use during the
   factorisation:

--- a/highs/ipm/IpxWrapper.cpp
+++ b/highs/ipm/IpxWrapper.cpp
@@ -491,15 +491,8 @@ HighsStatus solveHipo(const HighsOptions& options, HighsTimer& timer,
   // const bool report_solve_data =
   //    kHighsAnalysisLevelSolverSummaryData & options.highs_analysis_level;
 
-  // Differently from IPX, HiPO returns a single status. So, dealing with
-  // statuses is a bit different.
   // hipo.solved(), hipo.stopped(), hipo.failed() can be used to query if the
   // status belongs to the solved, stopped or failed group.
-  // If primal-dual feasible solution is found (non-vertex solution), then the
-  // status is kStatusPDfeas.
-  // If crossover is successful, then the status is kStatusBasic.
-  // Otherwise, the specific crossover status can be accessed through the
-  // ipx_info stored in hipo_info.
 
   // Get solver and solution information.
   const hipo::Info hipo_info = hipo.getInfo();
@@ -584,8 +577,7 @@ HighsStatus solveHipo(const HighsOptions& options, HighsTimer& timer,
   }
 
   // Status should be optimal or imprecise
-  if (ipxStatusError(solve_status != hipo::kStatusPDFeas &&
-                         solve_status != hipo::kStatusBasic &&
+  if (ipxStatusError(solve_status != hipo::kStatusOptimal &&
                          solve_status != hipo::kStatusImprecise,
                      options, "Hipo",
                      "status should be optimal or imprecise but value is",
@@ -593,7 +585,6 @@ HighsStatus solveHipo(const HighsOptions& options, HighsTimer& timer,
     return HighsStatus::kError;
 
   const bool have_basic_solution =
-      hipo_info.ipx_used &&
       hipo_info.ipx_info.status_crossover != IPX_STATUS_not_run;
 
   const bool imprecise_solution =
@@ -1397,51 +1388,15 @@ HighsStatus reportHipoStatus(const HighsOptions& options,
     return HighsStatus::kOk;
   }
 
-  // these are warnings
-  else if (status == hipo::kStatusTimeLimit) {
-    highsLogUser(options.log_options, HighsLogType::kWarning,
-                 "Hipo: Time limit\n");
-    return HighsStatus::kWarning;
-  } else if (status == hipo::kStatusUserInterrupt) {
-    highsLogUser(options.log_options, HighsLogType::kWarning,
-                 "Hipo: User interrupt\n");
-    return HighsStatus::kWarning;
-  } else if (status == hipo::kStatusMaxIter) {
-    highsLogUser(options.log_options, HighsLogType::kWarning,
-                 "Hipo: Reached maximum iterations\n");
-    return HighsStatus::kWarning;
-  } else if (status == hipo::kStatusNoProgress) {
-    highsLogUser(options.log_options, HighsLogType::kWarning,
-                 "Hipo: No progress\n");
-    return HighsStatus::kWarning;
-  } else if (status == hipo::kStatusImprecise) {
-    highsLogUser(options.log_options, HighsLogType::kWarning,
-                 "Hipo: Imprecise solution\n");
+  else if (hipo.stopped()) {
+    highsLogUser(options.log_options, HighsLogType::kWarning, "Hipo: %s\n",
+                 hipo::statusString((hipo::Status)status).c_str());
     return HighsStatus::kWarning;
   }
 
-  // these are errors
-  else if (status == hipo::kStatusError) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Internal error\n");
-  } else if (status == hipo::kStatusOverflow) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Integer overflow\n");
-  } else if (status == hipo::kStatusErrorAnalyse) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Error in analyse phase\n");
-  } else if (status == hipo::kStatusErrorFactorise) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Error in factorise phase\n");
-  } else if (status == hipo::kStatusErrorSolve) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Error in solve phase\n");
-  } else if (status == hipo::kStatusBadModel) {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Invalid model\n");
-  } else {
-    highsLogUser(options.log_options, HighsLogType::kError,
-                 "Hipo: Unrecognized status\n");
+  else if (hipo.failed()) {
+    highsLogUser(options.log_options, HighsLogType::kError, "Hipo: %s\n",
+                 hipo::statusString((hipo::Status)status).c_str());
   }
   return HighsStatus::kError;
 }

--- a/highs/ipm/hipo/auxiliary/KrylovMethods.cpp
+++ b/highs/ipm/hipo/auxiliary/KrylovMethods.cpp
@@ -26,8 +26,9 @@ static void getRotation(double x, double y, double& c, double& s) {
     s = t * c;
   }
 }
-static void update(std::vector<double>& x, Int k, std::vector<double>& H, Int ldh,
-                   std::vector<double>& s, std::vector<std::vector<double>>& V) {
+static void update(std::vector<double>& x, Int k, std::vector<double>& H,
+                   Int ldh, std::vector<double>& s,
+                   std::vector<std::vector<double>>& V) {
   // Solve H * y = s
   std::vector<double> y = s;
   for (Int i = k; i >= 0; --i) {
@@ -37,7 +38,7 @@ static void update(std::vector<double>& x, Int k, std::vector<double>& H, Int ld
     }
   }
   // x += V * y
-  for (Int j = 0; j <= k; ++j) vectorAdd(x, V[j], y[j]);
+  for (Int j = 0; j <= k; ++j) vectorAdd(x, 1.0, V[j], y[j]);
 }
 
 Int Gmres(const AbstractMatrix* M, const AbstractMatrix* P,
@@ -73,7 +74,7 @@ Int Gmres(const AbstractMatrix* M, const AbstractMatrix* P,
   // preconditioned residual P^-1 * (b - M * x)
   std::vector<double> r = x;
   M->apply(r);
-  vectorAdd(r, b, 1.0, -1.0);
+  vectorAdd(r, -1.0, b, 1.0);
   if (P) P->apply(r);
   double beta = norm2(r);
 
@@ -102,7 +103,7 @@ Int Gmres(const AbstractMatrix* M, const AbstractMatrix* P,
     V.push_back(w);
     for (Int k = 0; k <= i; ++k) {
       H[k + ldh * i] = dotProd(V.back(), V[k]);
-      vectorAdd(V.back(), V[k], -H[k + ldh * i]);
+      vectorAdd(V.back(), 1.0, V[k], -H[k + ldh * i]);
     }
     H[i + 1 + ldh * i] = norm2(V.back());
 
@@ -112,7 +113,7 @@ Int Gmres(const AbstractMatrix* M, const AbstractMatrix* P,
     for (Int k = 0; k <= i; ++k) {
       double temp = dotProd(V.back(), V[k]);
       H[k + ldh * i] += temp;
-      vectorAdd(V.back(), V[k], -temp);
+      vectorAdd(V.back(), 1.0, V[k], -temp);
     }
     H[i + 1 + ldh * i] = norm2(V.back());
     // }
@@ -151,7 +152,7 @@ Int Cg(const AbstractMatrix* M, const AbstractMatrix* P,
 
   std::vector<double> r = x;
   M->apply(r);
-  vectorAdd(r, b, 1.0, -1.0);
+  vectorAdd(r, -1.0, b, 1.0);
 
   std::vector<double> z = r;
   if (P) P->apply(z);
@@ -167,8 +168,8 @@ Int Cg(const AbstractMatrix* M, const AbstractMatrix* P,
     w = p;
     M->apply(w);
     double alpha = rho_old / dotProd(p, w);
-    vectorAdd(x, p, alpha);
-    vectorAdd(r, w, -alpha);
+    vectorAdd(x, 1.0, p, alpha);
+    vectorAdd(r, 1.0, w, -alpha);
 
     z = r;
     if (P) P->apply(z);
@@ -176,7 +177,7 @@ Int Cg(const AbstractMatrix* M, const AbstractMatrix* P,
 
     if (norm2(r) < tol * norm_b) break;
 
-    vectorAdd(p, z, 1.0, rho_new / rho_old);
+    vectorAdd(p, rho_new / rho_old, z, 1.0);
     rho_old = rho_new;
     ++iter;
 

--- a/highs/ipm/hipo/auxiliary/VectorOperations.cpp
+++ b/highs/ipm/hipo/auxiliary/VectorOperations.cpp
@@ -5,8 +5,8 @@
 
 namespace hipo {
 
-void vectorAdd(std::vector<double>& v1, const std::vector<double>& v2,
-               double beta, double alpha) {
+void vectorAdd(std::vector<double>& v1, double alpha,
+               const std::vector<double>& v2, double beta) {
   for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] = alpha * v1[i] + beta * v2[i];
   }

--- a/highs/ipm/hipo/auxiliary/VectorOperations.cpp
+++ b/highs/ipm/hipo/auxiliary/VectorOperations.cpp
@@ -18,20 +18,6 @@ void vectorAdd(std::vector<double>& v1, const double alpha) {
   }
 }
 
-void vectorMultiply(std::vector<double>& v1, const std::vector<double>& v2,
-                    double alpha, double beta) {
-  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
-    v1[i] = alpha * v1[i] * v2[i] + beta;
-  }
-}
-
-void vectorAddMult(std::vector<double>& v1, const std::vector<double>& v2,
-                   const std::vector<double>& v3, double beta, double alpha) {
-  for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
-    v1[i] = alpha * v1[i] + beta * v2[i] * v3[i];
-  }
-}
-
 void vectorDivide(std::vector<double>& v1, const std::vector<double>& v2) {
   for (Int i = 0; i < static_cast<Int>(v1.size()); ++i) {
     v1[i] /= v2[i];
@@ -60,44 +46,12 @@ double norm2(const std::vector<double>& x) {
   return std::sqrt(norm);
 }
 
-double norm2(const std::vector<double>& x0, const std::vector<double>& x1) {
-  double norm{};
-  for (Int i = 0; i < static_cast<Int>(x0.size()); ++i) {
-    norm += (x0[i] * x0[i]);
-  }
-  for (Int i = 0; i < static_cast<Int>(x1.size()); ++i) {
-    norm += (x1[i] * x1[i]);
-  }
-  return std::sqrt(norm);
-}
-
 double infNorm(const std::vector<double>& x) {
   double norm{};
   for (Int i = 0; i < static_cast<Int>(x.size()); ++i) {
     norm = std::max(norm, std::fabs(x[i]));
   }
   return norm;
-}
-
-double infNorm(const std::vector<double>& x0, const std::vector<double>& x1) {
-  double norm{};
-  for (Int i = 0; i < static_cast<Int>(x0.size()); ++i) {
-    norm = std::max(norm, std::fabs(x0[i]));
-  }
-  for (Int i = 0; i < static_cast<Int>(x1.size()); ++i) {
-    norm = std::max(norm, std::fabs(x1[i]));
-  }
-  return norm;
-}
-
-double infNormDiff(const std::vector<double>& x, const std::vector<double>& y) {
-  assert(x.size() == y.size());
-  double inf_norm_diff = 0;
-  for (Int i = 0; i < static_cast<Int>(x.size()); i++) {
-    double diff = std::fabs(x[i] - y[i]);
-    inf_norm_diff = std::max(diff, inf_norm_diff);
-  }
-  return inf_norm_diff;
 }
 
 bool isNanVector(const std::vector<double>& x) {

--- a/highs/ipm/hipo/auxiliary/VectorOperations.h
+++ b/highs/ipm/hipo/auxiliary/VectorOperations.h
@@ -18,15 +18,6 @@ void vectorAdd(std::vector<double>& v1, const std::vector<double>& v2,
 // v1[i] + alpha
 void vectorAdd(std::vector<double>& v1, const double alpha);
 
-// alpha * v1[i] * v2[i] + beta
-void vectorMultiply(std::vector<double>& v1, const std::vector<double>& v2,
-                    double beta = 1.0, double alpha = 0.0);
-
-// alpha * v1[i] + beta * v2[i] * v3[i]
-void vectorAddMult(std::vector<double>& v1, const std::vector<double>& v2,
-                   const std::vector<double>& v3, double beta = 1.0,
-                   double alpha = 1.0);
-
 // v1[i] / v2[i]
 void vectorDivide(std::vector<double>& v1, const std::vector<double>& v2);
 
@@ -35,23 +26,14 @@ void vectorScale(std::vector<double>& v1, double alpha);
 
 // =======================================================================
 
-// scalar product
 double dotProd(const std::vector<double>& v1, const std::vector<double>& v2);
 
-// Euclidean norm
 double norm2(const std::vector<double>& x);
-double norm2(const std::vector<double>& x0, const std::vector<double>& x1);
 
 double infNorm(const std::vector<double>& x);
-double infNorm(const std::vector<double>& x0, const std::vector<double>& x1);
 
-// Infinity norm of the difference of two vectors
-double infNormDiff(const std::vector<double>& x, const std::vector<double>& y);
-
-// check for NaN
 bool isNanVector(const std::vector<double>& x);
 
-// check for Inf
 bool isInfVector(const std::vector<double>& x);
 
 }  // namespace hipo

--- a/highs/ipm/hipo/auxiliary/VectorOperations.h
+++ b/highs/ipm/hipo/auxiliary/VectorOperations.h
@@ -11,9 +11,9 @@ namespace hipo {
 // COMPONENT-WISE VECTOR OPERATIONS
 // =======================================================================
 
-// alpha * v1[i] + beta * v2[i]
-void vectorAdd(std::vector<double>& v1, const std::vector<double>& v2,
-               double beta = 1.0, double alpha = 1.0);
+// v1[i] = alpha * v1[i] + beta * v2[i]
+void vectorAdd(std::vector<double>& v1, double alpha,
+               const std::vector<double>& v2, double beta);
 
 // v1[i] + alpha
 void vectorAdd(std::vector<double>& v1, const double alpha);

--- a/highs/ipm/hipo/factorhighs/Analyse.cpp
+++ b/highs/ipm/hipo/factorhighs/Analyse.cpp
@@ -1309,6 +1309,8 @@ Int Analyse::run(Symbolic& S) {
   S.consecutive_sums_ = std::move(consecutive_sums_);
   S.clique_block_start_ = std::move(clique_block_start_);
 
+  S.empty_ = false;
+
   HIPO_CLOCK_STOP(1, data_, kTimeAnalyse);
 
   return kRetOk;

--- a/highs/ipm/hipo/factorhighs/Factorise.cpp
+++ b/highs/ipm/hipo/factorhighs/Factorise.cpp
@@ -345,6 +345,8 @@ bool Factorise::run(Numeric& num) {
   num.data_ = &data_;
   num.options_ = &FH_opt_;
 
+  if (num.prepare()) return true;
+
   HIPO_CLOCK_STOP(1, data_, kTimeFactorise);
 
   return false;

--- a/highs/ipm/hipo/factorhighs/HybridSolveHandler.cpp
+++ b/highs/ipm/hipo/factorhighs/HybridSolveHandler.cpp
@@ -12,11 +12,13 @@ namespace hipo {
 HybridSolveHandler::HybridSolveHandler(
     const Symbolic& S, const std::vector<std::vector<double>>& sn_columns,
     const std::vector<std::vector<Int>>& swaps,
+    const std::vector<std::vector<char>>& any_swap,
     const std::vector<std::vector<double>>& pivot_2x2,
     std::vector<double>& gemv_work, DataCollector& data,
     const FHoptions& options)
     : SolveHandler(S, sn_columns, data, options),
       swaps_{swaps},
+      any_swaps_{any_swap},
       pivot_2x2_{pivot_2x2},
       gemv_workspace_{gemv_work} {}
 
@@ -55,11 +57,17 @@ void HybridSolveHandler::forwardSolve(double* x) const {
       const Int jb = sn_size;
       const Int x_start = sn_start;
 
-      const Int* current_swaps = swaps_[sn].data();
+      const Int* current_swaps = nullptr;
+      bool any_swaps_in_block = false;
+
       if (options_.pivoting) {
         HIPO_CLOCK_START(2);
-        // apply swaps to portion of rhs that is affected
-        permuteWithSwaps(&x[x_start], current_swaps, jb);
+        any_swaps_in_block = any_swaps_[sn][0];
+        if (any_swaps_in_block) {
+          current_swaps = swaps_[sn].data();
+          // apply swaps to portion of rhs that is affected
+          permuteWithSwaps(&x[x_start], current_swaps, jb);
+        }
         HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_swap);
       }
 
@@ -79,7 +87,7 @@ void HybridSolveHandler::forwardSolve(double* x) const {
       }
       HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_dense);
 
-      if (options_.pivoting) {
+      if (any_swaps_in_block && options_.pivoting) {
         HIPO_CLOCK_START(2);
         // apply inverse swaps
         permuteWithSwaps(&x[x_start], current_swaps, jb, true);
@@ -98,11 +106,17 @@ void HybridSolveHandler::forwardSolve(double* x) const {
         // index to access vector x
         const Int x_start = sn_start + nb * j;
 
-        const Int* current_swaps = &swaps_[sn][nb * j];
+        const Int* current_swaps = nullptr;
+        bool any_swaps_in_block = false;
+
         if (options_.pivoting) {
           HIPO_CLOCK_START(2);
-          // apply swaps to portion of rhs that is affected
-          permuteWithSwaps(&x[x_start], current_swaps, jb);
+          any_swaps_in_block = any_swaps_[sn][j];
+          if (any_swaps_in_block) {
+            current_swaps = &swaps_[sn][nb * j];
+            // apply swaps to portion of rhs that is affected
+            permuteWithSwaps(&x[x_start], current_swaps, jb);
+          }
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_swap);
         }
 
@@ -131,7 +145,7 @@ void HybridSolveHandler::forwardSolve(double* x) const {
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_sparse);
         }
 
-        if (options_.pivoting) {
+        if (any_swaps_in_block && options_.pivoting) {
           HIPO_CLOCK_START(2);
           // apply inverse swaps
           permuteWithSwaps(&x[x_start], current_swaps, jb, true);
@@ -179,11 +193,17 @@ void HybridSolveHandler::backwardSolve(double* x) const {
       const Int jb = sn_size;
       const Int x_start = sn_start;
 
-      const Int* current_swaps = swaps_[sn].data();
+      const Int* current_swaps = nullptr;
+      bool any_swaps_in_block = false;
+
       if (options_.pivoting) {
         HIPO_CLOCK_START(2);
-        // apply swaps to portion of rhs that is affected
-        permuteWithSwaps(&x[x_start], current_swaps, jb);
+        any_swaps_in_block = any_swaps_[sn][0];
+        if (any_swaps_in_block) {
+          current_swaps = swaps_[sn].data();
+          // apply swaps to portion of rhs that is affected
+          permuteWithSwaps(&x[x_start], current_swaps, jb);
+        }
         HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_swap);
       }
 
@@ -203,7 +223,7 @@ void HybridSolveHandler::backwardSolve(double* x) const {
       }
       HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_dense);
 
-      if (options_.pivoting) {
+      if (any_swaps_in_block && options_.pivoting) {
         HIPO_CLOCK_START(2);
         // apply inverse swaps
         permuteWithSwaps(&x[x_start], current_swaps, jb, true);
@@ -222,11 +242,17 @@ void HybridSolveHandler::backwardSolve(double* x) const {
         // index to access vector x
         const Int x_start = sn_start + nb * j;
 
-        const Int* current_swaps = &swaps_[sn][nb * j];
+        const Int* current_swaps = nullptr;
+        bool any_swaps_in_block = false;
+
         if (options_.pivoting) {
           HIPO_CLOCK_START(2);
-          // apply swaps to portion of rhs that is affected
-          permuteWithSwaps(&x[x_start], current_swaps, jb);
+          any_swaps_in_block = any_swaps_[sn][j];
+          if (any_swaps_in_block) {
+            current_swaps = &swaps_[sn][nb * j];
+            // apply swaps to portion of rhs that is affected
+            permuteWithSwaps(&x[x_start], current_swaps, jb);
+          }
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_swap);
         }
 
@@ -255,7 +281,7 @@ void HybridSolveHandler::backwardSolve(double* x) const {
                           &x[x_start], 1, data_);
         HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_dense);
 
-        if (options_.pivoting) {
+        if (any_swaps_in_block && options_.pivoting) {
           HIPO_CLOCK_START(2);
           // apply inverse swaps
           permuteWithSwaps(&x[x_start], current_swaps, jb, true);

--- a/highs/ipm/hipo/factorhighs/HybridSolveHandler.cpp
+++ b/highs/ipm/hipo/factorhighs/HybridSolveHandler.cpp
@@ -12,11 +12,13 @@ namespace hipo {
 HybridSolveHandler::HybridSolveHandler(
     const Symbolic& S, const std::vector<std::vector<double>>& sn_columns,
     const std::vector<std::vector<Int>>& swaps,
-    const std::vector<std::vector<double>>& pivot_2x2, DataCollector& data,
+    const std::vector<std::vector<double>>& pivot_2x2,
+    std::vector<double>& gemv_work, DataCollector& data,
     const FHoptions& options)
     : SolveHandler(S, sn_columns, data, options),
       swaps_{swaps},
-      pivot_2x2_{pivot_2x2} {}
+      pivot_2x2_{pivot_2x2},
+      gemv_workspace_{gemv_work} {}
 
 void HybridSolveHandler::forwardSolve(double* x) const {
   // Forward solve.
@@ -111,21 +113,20 @@ void HybridSolveHandler::forwardSolve(double* x) const {
         SnCol_ind += diag_entries;
 
         // temporary space for gemv
-        const Int gemv_space = ldSn - nb * j - jb;
-        std::vector<double> y(gemv_space);
-        if (gemv_space > 0) {
-          callAndTime_dgemv('T', jb, gemv_space, 1.0,
+        const Int gemv_size = ldSn - nb * j - jb;
+        if (gemv_size > 0) {
+          callAndTime_dgemv('T', jb, gemv_size, 1.0,
                             &sn_columns_[sn][SnCol_ind], jb, &x[x_start], 1,
-                            0.0, y.data(), 1, data_);
+                            0.0, gemv_workspace_.data(), 1, data_);
 
-          SnCol_ind += jb * gemv_space;
+          SnCol_ind += jb * gemv_size;
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_dense);
 
           HIPO_CLOCK_START(2);
           // scatter solution of gemv
-          for (Int i = 0; i < gemv_space; ++i) {
+          for (Int i = 0; i < gemv_size; ++i) {
             const Int row = S_.rows(start_row + nb * j + jb + i);
-            x[row] -= y[i];
+            x[row] -= gemv_workspace_[i];
           }
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_sparse);
         }
@@ -230,22 +231,21 @@ void HybridSolveHandler::backwardSolve(double* x) const {
         }
 
         // temporary space for gemv
-        const Int gemv_space = ldSn - nb * j - jb;
-        std::vector<double> y(gemv_space);
-        if (gemv_space > 0) {
+        const Int gemv_size = ldSn - nb * j - jb;
+        if (gemv_size > 0) {
           HIPO_CLOCK_START(2);
           // scatter entries into y
-          for (Int i = 0; i < gemv_space; ++i) {
+          for (Int i = 0; i < gemv_size; ++i) {
             const Int row = S_.rows(start_row + nb * j + jb + i);
-            y[i] = x[row];
+            gemv_workspace_[i] = x[row];
           }
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_sparse);
 
           HIPO_CLOCK_START(2);
-          SnCol_ind -= jb * gemv_space;
-          callAndTime_dgemv('N', jb, gemv_space, -1.0,
-                            &sn_columns_[sn][SnCol_ind], jb, y.data(), 1, 1.0,
-                            &x[x_start], 1, data_);
+          SnCol_ind -= jb * gemv_size;
+          callAndTime_dgemv(
+              'N', jb, gemv_size, -1.0, &sn_columns_[sn][SnCol_ind], jb,
+              gemv_workspace_.data(), 1, 1.0, &x[x_start], 1, data_);
           HIPO_CLOCK_STOP(2, data_, kTimeSolveSolve_dense);
         }
 

--- a/highs/ipm/hipo/factorhighs/HybridSolveHandler.h
+++ b/highs/ipm/hipo/factorhighs/HybridSolveHandler.h
@@ -7,6 +7,7 @@ namespace hipo {
 
 class HybridSolveHandler : public SolveHandler {
   const std::vector<std::vector<Int>>& swaps_;
+  const std::vector<std::vector<char>>& any_swaps_;
   const std::vector<std::vector<double>>& pivot_2x2_;
   std::vector<double>& gemv_workspace_;
 
@@ -19,6 +20,7 @@ class HybridSolveHandler : public SolveHandler {
   HybridSolveHandler(const Symbolic& S,
                      const std::vector<std::vector<double>>& sn_columns,
                      const std::vector<std::vector<Int>>& swaps,
+                     const std::vector<std::vector<char>>& any_swap,
                      const std::vector<std::vector<double>>& pivot_2x2,
                      std::vector<double>& gemv_work, DataCollector& data,
                      const FHoptions& options);

--- a/highs/ipm/hipo/factorhighs/HybridSolveHandler.h
+++ b/highs/ipm/hipo/factorhighs/HybridSolveHandler.h
@@ -8,6 +8,7 @@ namespace hipo {
 class HybridSolveHandler : public SolveHandler {
   const std::vector<std::vector<Int>>& swaps_;
   const std::vector<std::vector<double>>& pivot_2x2_;
+  std::vector<double>& gemv_workspace_;
 
  public:
   void forwardSolve(double* x) const override;
@@ -19,7 +20,8 @@ class HybridSolveHandler : public SolveHandler {
                      const std::vector<std::vector<double>>& sn_columns,
                      const std::vector<std::vector<Int>>& swaps,
                      const std::vector<std::vector<double>>& pivot_2x2,
-                     DataCollector& data, const FHoptions& options);
+                     std::vector<double>& gemv_work, DataCollector& data,
+                     const FHoptions& options);
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/factorhighs/Numeric.cpp
+++ b/highs/ipm/hipo/factorhighs/Numeric.cpp
@@ -12,16 +12,21 @@
 
 namespace hipo {
 
+Int Numeric::prepare() {
+  if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
+  SH_.reset(new HybridSolveHandler(*S_, *sn_columns_, swaps_, pivot_2x2_,
+                                   *data_, *options_));
+  if (!SH_) return kRetGeneric;
+
+  return kRetOk;
+}
+
 Int Numeric::solve(double* x) const {
   // Return the number of solves performed
 
-  if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
+  if (!SH_) return kRetGeneric;
 
   HIPO_CLOCK_CREATE;
-
-  // initialise solve handler
-  HybridSolveHandler SH(*S_, *sn_columns_, swaps_, pivot_2x2_, *data_,
-                        *options_);
 
   // permute rhs
   HIPO_CLOCK_START(2);
@@ -30,9 +35,9 @@ Int Numeric::solve(double* x) const {
 
   // solve
   HIPO_CLOCK_START(2);
-  SH.forwardSolve(x);
-  SH.diagSolve(x);
-  SH.backwardSolve(x);
+  SH_->forwardSolve(x);
+  SH_->diagSolve(x);
+  SH_->backwardSolve(x);
   HIPO_CLOCK_STOP(2, *data_, kTimeSolveSolve);
 
   // unpermute solution
@@ -45,25 +50,19 @@ Int Numeric::solve(double* x) const {
 }
 
 Int Numeric::forwardSolve(double* x) const {
-  if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
-  HybridSolveHandler SH(*S_, *sn_columns_, swaps_, pivot_2x2_, *data_,
-                        *options_);
+  if (!SH_) return kRetGeneric;
   permuteVectorInverse(x, S_->iperm());
-  SH.forwardSolve(x);
+  SH_->forwardSolve(x);
   return kRetOk;
 }
 Int Numeric::diagSolve(double* x) const {
-  if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
-  HybridSolveHandler SH(*S_, *sn_columns_, swaps_, pivot_2x2_, *data_,
-                        *options_);
-  SH.diagSolve(x);
+  if (!SH_) return kRetGeneric;
+  SH_->diagSolve(x);
   return kRetOk;
 }
 Int Numeric::backwardSolve(double* x) const {
-  if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
-  HybridSolveHandler SH(*S_, *sn_columns_, swaps_, pivot_2x2_, *data_,
-                        *options_);
-  SH.backwardSolve(x);
+  if (!SH_) return kRetGeneric;
+  SH_->backwardSolve(x);
   permuteVector(x, S_->iperm());
   return kRetOk;
 }
@@ -99,10 +98,8 @@ void Numeric::getReg(double* reg) {
 }
 
 void Numeric::inertia(Int& pos, Int& neg, Int& zero, double tol) const {
-  if (!sn_columns_ || !S_ || !data_ || !options_) return;
-  HybridSolveHandler SH(*S_, *sn_columns_, swaps_, pivot_2x2_, *data_,
-                        *options_);
-  SH.inertia(pos, neg, zero, tol);
+  if (!SH_) return;
+  SH_->inertia(pos, neg, zero, tol);
 }
 
 }  // namespace hipo

--- a/highs/ipm/hipo/factorhighs/Numeric.cpp
+++ b/highs/ipm/hipo/factorhighs/Numeric.cpp
@@ -15,8 +15,12 @@ namespace hipo {
 Int Numeric::prepare() {
   if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
   SH_.reset(new HybridSolveHandler(*S_, *sn_columns_, swaps_, pivot_2x2_,
-                                   *data_, *options_));
+                                   gemv_workspace_, *data_, *options_));
   if (!SH_) return kRetGeneric;
+
+  // memory allocation should happen only the first time, then memory is reused.
+  // No need to zero memory each time, as it is overwritten by solveHandler.
+  gemv_workspace_.resize(S_->largestFront());
 
   return kRetOk;
 }

--- a/highs/ipm/hipo/factorhighs/Numeric.cpp
+++ b/highs/ipm/hipo/factorhighs/Numeric.cpp
@@ -14,13 +14,35 @@ namespace hipo {
 
 Int Numeric::prepare() {
   if (!sn_columns_ || !S_ || !data_ || !options_) return kRetInvalidPointer;
-  SH_.reset(new HybridSolveHandler(*S_, *sn_columns_, swaps_, pivot_2x2_,
-                                   gemv_workspace_, *data_, *options_));
+  SH_.reset(new HybridSolveHandler(*S_, *sn_columns_, swaps_, any_swaps_,
+                                   pivot_2x2_, gemv_workspace_, *data_,
+                                   *options_));
   if (!SH_) return kRetGeneric;
 
   // memory allocation should happen only the first time, then memory is reused.
   // No need to zero memory each time, as it is overwritten by solveHandler.
   gemv_workspace_.resize(S_->largestFront());
+
+  // compute which blocks of columns require swaps
+  if (options_->pivoting) {
+    any_swaps_.resize(S_->sn());
+    const Int nb = options_->nb;
+    for (Int sn = 0; sn < S_->sn(); ++sn) {
+      const Int sn_size = S_->snStart(sn + 1) - S_->snStart(sn);
+      const Int n_blocks = (sn_size - 1) / nb + 1;
+      any_swaps_[sn].assign(n_blocks, 0);
+
+      for (Int j = 0; j < n_blocks; ++j) {
+        const Int jb = std::min(nb, sn_size - nb * j);
+        for (Int i = 0; i < jb; ++i) {
+          if (swaps_[sn][nb * j + i] != i) {
+            any_swaps_[sn][j] = 1;
+            break;
+          }
+        }
+      }
+    }
+  }
 
   return kRetOk;
 }

--- a/highs/ipm/hipo/factorhighs/Numeric.h
+++ b/highs/ipm/hipo/factorhighs/Numeric.h
@@ -23,15 +23,11 @@ class Numeric {
   // swaps of columns for each supernode, ordered locally within a block
   std::vector<std::vector<Int>> swaps_{};
 
-  // information about 2x2 pivots
   std::vector<std::vector<double>> pivot_2x2_{};
-
-  // symbolic object
   const Symbolic* S_;
-
   DataCollector* data_ = nullptr;
-
   const FHoptions* options_;
+  std::unique_ptr<SolveHandler> SH_;
 
   friend class Factorise;
 
@@ -39,6 +35,8 @@ class Numeric {
   std::vector<double> total_reg_{};
 
  public:
+  Int prepare();
+
   Int solve(double* x) const;
   Int solve(double* x, Int k) const;
 

--- a/highs/ipm/hipo/factorhighs/Numeric.h
+++ b/highs/ipm/hipo/factorhighs/Numeric.h
@@ -28,6 +28,7 @@ class Numeric {
   DataCollector* data_ = nullptr;
   const FHoptions* options_;
   std::unique_ptr<SolveHandler> SH_;
+  std::vector<double> gemv_workspace_;
 
   friend class Factorise;
 

--- a/highs/ipm/hipo/factorhighs/Numeric.h
+++ b/highs/ipm/hipo/factorhighs/Numeric.h
@@ -23,6 +23,10 @@ class Numeric {
   // swaps of columns for each supernode, ordered locally within a block
   std::vector<std::vector<Int>> swaps_{};
 
+  // indicates whether a block of columns in a supernode has any non-identical
+  // swap
+  std::vector<std::vector<char>> any_swaps_{};
+
   std::vector<std::vector<double>> pivot_2x2_{};
   const Symbolic* S_;
   DataCollector* data_ = nullptr;

--- a/highs/ipm/hipo/factorhighs/Symbolic.cpp
+++ b/highs/ipm/hipo/factorhighs/Symbolic.cpp
@@ -36,6 +36,7 @@ Int64 Symbolic::cliqueSize(Int sn) const {
   return clique_block_start_[sn].back();
 }
 Int64 Symbolic::maxStackSize() const { return max_stack_size_; }
+Int Symbolic::largestFront() const { return largest_front_; }
 bool Symbolic::parTree() const { return parallel_tree_; }
 bool Symbolic::parNode() const { return parallel_node_; }
 double Symbolic::storage() const { return serial_storage_; }

--- a/highs/ipm/hipo/factorhighs/Symbolic.h
+++ b/highs/ipm/hipo/factorhighs/Symbolic.h
@@ -122,6 +122,7 @@ class Symbolic {
   Int64 cliqueBlockStart(Int sn, Int bl) const;
   Int64 cliqueSize(Int sn) const;
   Int64 maxStackSize() const;
+  Int largestFront() const;
   Int depth() const;
   bool parTree() const;
   bool parNode() const;

--- a/highs/ipm/hipo/factorhighs/Symbolic.h
+++ b/highs/ipm/hipo/factorhighs/Symbolic.h
@@ -10,6 +10,8 @@ namespace hipo {
 
 // Symbolic factorisation object
 class Symbolic {
+  bool empty_ = true;
+
   // Options for parallelism
   bool parallel_tree_ = false;
   bool parallel_node_ = false;
@@ -102,6 +104,7 @@ class Symbolic {
   void setParallel(bool par_tree, bool par_node);
 
   // provide const access to symbolic factorisation
+  bool empty() const { return empty_; }
   Int64 nz() const;
   double flops() const;
   double spops() const;

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -134,20 +134,20 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
 
   Int n = rhs_x.size();
 
-  std::vector<double> rhs;
-  rhs.insert(rhs.end(), rhs_x.begin(), rhs_x.end());
-  rhs.insert(rhs.end(), rhs_y.begin(), rhs_y.end());
+  as_buffer_.resize(rhs_x.size() + rhs_y.size());
+  std::copy(rhs_x.begin(), rhs_x.end(), as_buffer_.begin());
+  std::copy(rhs_y.begin(), rhs_y.end(), as_buffer_.begin() + n);
 
   Clock clock;
-  if (FH_.solve(rhs.data())) return kErrorSolve;
+  if (FH_.solve(as_buffer_.data())) return kErrorSolve;
 
   info_.solve_time += clock.stop();
   info_.solve_number++;
 
   data_.back().num_solves++;
 
-  lhs_x = std::vector<double>(rhs.begin(), rhs.begin() + n);
-  lhs_y = std::vector<double>(rhs.begin() + n, rhs.end());
+  lhs_x.assign(as_buffer_.begin(), as_buffer_.begin() + n);
+  lhs_y.assign(as_buffer_.begin() + n, as_buffer_.end());
 
   return kOk;
 }

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -183,23 +183,49 @@ Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
 Int FactorHighsSolver::setup() {
   Clock clock;
 
-  if (Int status = setNla()) return status;
-  setParallel();
+  if (kkt_.iperm.empty()) {
+    if (Int status = setNla()) return status;
+    setParallel();
 
-  if (!options_.timeless_log) {
-    std::stringstream log_stream;
-    log_stream << textline("Analyse time:") << fix(clock.stop(), 0, 2) << '\n';
-    logger_.print(log_stream.str().c_str());
+    if (!options_.timeless_log) {
+      std::stringstream log_stream;
+      log_stream << textline("Analyse time:") << fix(clock.stop(), 0, 2)
+                 << '\n';
+      logger_.print(log_stream.str().c_str());
+    }
+
+    S_.print(logger_, logger_.debug(1));
+
+    // Warn about large memory consumption
+    if (S_.storage() > kLargeStorageGB * 1024 * 1024 * 1024) {
+      logger_.printw("Large amount of memory required\n");
+    }
+
+    logger_.print("\n");
+  } else {
+    // permutation already available
+
+    const Int n = model_.A().num_col_;
+    const Int m = model_.A().num_row_;
+
+    std::vector<Int> perm(kkt_.n());
+    inversePerm(kkt_.iperm, perm);
+
+    if (kkt_.nla() == kHipoAugmentedString) {
+      assert(kkt_.n() == n + m);
+      std::vector<Int> signs(m + n, -1);
+      for (Int i = 0; i < m; ++i) signs[n + i] = 1;
+      return FH_.analyse(S_, kkt_.n(), kkt_.nz(), kkt_.rowsAS.data(),
+                         kkt_.ptrAS.data(), signs.data(), perm.data());
+    } else if (kkt_.nla() == kHipoNormalEqString) {
+      assert(kkt_.n() == m);
+      std::vector<Int> signs(m, 1);
+      return FH_.analyse(S_, kkt_.n(), kkt_.nz(), kkt_.rowsNE.data(),
+                         kkt_.ptrNE.data(), signs.data(), perm.data());
+    } else {
+      return kStatusErrorFactorise;
+    }
   }
-
-  S_.print(logger_, logger_.debug(1));
-
-  // Warn about large memory consumption
-  if (S_.storage() > kLargeStorageGB * 1024 * 1024 * 1024) {
-    logger_.printw("Large amount of memory required\n");
-  }
-
-  logger_.print("\n");
 
   return kStatusOk;
 }

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -40,7 +40,7 @@ Int FactorHighsSolver::analyseAS(Symbolic& S) {
   // Perform analyse phase of augmented system and return symbolic factorisation
   // in object S and the status.
 
-  if (kkt_.rowsAS.empty() || kkt_.ptrAS.empty()) return kStatusErrorAnalyse;
+  if (kkt_.rowsAS.empty() || kkt_.ptrAS.empty()) return kErrorAnalyse;
 
   const Int m = model_.A().num_row_;
   const Int n = model_.A().num_col_;
@@ -64,7 +64,7 @@ Int FactorHighsSolver::analyseNE(Symbolic& S) {
   // in object S and the status. Structure of the matrix must be already
   // computed.
 
-  if (kkt_.rowsNE.empty() || kkt_.ptrNE.empty()) return kStatusErrorAnalyse;
+  if (kkt_.rowsNE.empty() || kkt_.ptrNE.empty()) return kErrorAnalyse;
 
   // create vector of signs of pivots
   std::vector<Int> pivot_signs(model_.A().num_row_, 1);
@@ -95,12 +95,12 @@ Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
   Clock clock;
   if (FH_.factorise(kkt_.S, kkt_.n(), kkt_.nz(), kkt_.rowsAS.data(),
                     kkt_.ptrAS.data(), kkt_.valAS.data()))
-    return kStatusErrorFactorise;
+    return kErrorFactorise;
   info_.factor_time += clock.stop();
   info_.factor_number++;
 
   this->valid_ = true;
-  return kStatusOk;
+  return kOk;
 }
 
 Int FactorHighsSolver::factorNE(const std::vector<double>& scaling) {
@@ -115,12 +115,12 @@ Int FactorHighsSolver::factorNE(const std::vector<double>& scaling) {
   Clock clock;
   if (FH_.factorise(kkt_.S, kkt_.n(), kkt_.nz(), kkt_.rowsNE.data(),
                     kkt_.ptrNE.data(), kkt_.valNE.data()))
-    return kStatusErrorFactorise;
+    return kErrorFactorise;
   info_.factor_time += clock.stop();
   info_.factor_number++;
 
   this->valid_ = true;
-  return kStatusOk;
+  return kOk;
 }
 
 // =========================================================================
@@ -142,7 +142,7 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
   rhs.insert(rhs.end(), rhs_y.begin(), rhs_y.end());
 
   Clock clock;
-  if (FH_.solve(rhs.data())) return kStatusErrorSolve;
+  if (FH_.solve(rhs.data())) return kErrorSolve;
 
   info_.solve_time += clock.stop();
   info_.solve_number++;
@@ -153,7 +153,7 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
   lhs_x = std::vector<double>(rhs.begin(), rhs.begin() + n);
   lhs_y = std::vector<double>(rhs.begin() + n, rhs.end());
 
-  return kStatusOk;
+  return kOk;
 }
 
 Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
@@ -165,14 +165,14 @@ Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
   lhs = rhs;
 
   Clock clock;
-  if (FH_.solve(lhs.data())) return kStatusErrorSolve;
+  if (FH_.solve(lhs.data())) return kErrorSolve;
 
   info_.solve_time += clock.stop();
   info_.solve_number++;
 
   data_.back().num_solves++;
 
-  return kStatusOk;
+  return kOk;
 }
 
 // =========================================================================
@@ -203,7 +203,7 @@ Int FactorHighsSolver::setup() {
     logger_.print("\n");
   }
 
-  return kStatusOk;
+  return kOk;
 }
 
 Int FactorHighsSolver::chooseNla() {
@@ -238,7 +238,7 @@ Int FactorHighsSolver::chooseNla() {
       Int status = kkt_.buildNEstructure();
       if (status) {
         failure_NE = true;
-        if (status == kStatusOverflow) {
+        if (status == kErrorOverflow) {
           logger_.printInfo("Integer overflow forming NE matrix\n");
           overflow_NE = true;
         }
@@ -261,7 +261,7 @@ Int FactorHighsSolver::chooseNla() {
       Int AS_status = kkt_.buildASstructure();
       if (!AS_status) AS_status = analyseAS(symb_AS);
       if (AS_status) failure_AS = true;
-      if (AS_status == kStatusOverflow) {
+      if (AS_status == kErrorOverflow) {
         logger_.printInfo("Integer overflow forming AS matrix\n");
         overflow_AS = true;
       }
@@ -301,7 +301,7 @@ Int FactorHighsSolver::chooseNla() {
     run_analyse_AS();
   }
 
-  Int status = kStatusOk;
+  Int status = kOk;
 
   std::stringstream log_stream;
 
@@ -314,9 +314,9 @@ Int FactorHighsSolver::chooseNla() {
     log_stream << textline("Newton system:") << "NE preferred (AS failed)\n";
   } else if (failure_AS && failure_NE) {
     if (overflow_AS && overflow_NE)
-      status = kStatusOverflow;
+      status = kErrorOverflow;
     else
-      status = kStatusErrorAnalyse;
+      status = kErrorAnalyse;
 
     logger_.printe("Both NE and AS failed analyse phase\n");
   } else {
@@ -348,7 +348,7 @@ Int FactorHighsSolver::chooseNla() {
 
   logger_.print(log_stream.str().c_str());
 
-  if (status == kStatusOk) {
+  if (status == kOk) {
     if (options_.nla == kHipoAugmentedString) {
       kkt_.S = std::move(symb_AS);
       kkt_.freeNEmemory();
@@ -387,7 +387,7 @@ Int FactorHighsSolver::chooseOrdering(const std::vector<Int>& rows,
   if (nla == "NE") {
     if (ptr.back() >= kkt_.NE_nz_limit.load(std::memory_order_relaxed)) {
       logger_.printInfo("NE interrupted\n");
-      return kStatusErrorAnalyse;
+      return kErrorAnalyse;
     }
   }
 
@@ -516,7 +516,7 @@ Int FactorHighsSolver::chooseOrdering(const std::vector<Int>& rows,
     ordering = orderings_to_try[chosen];
   }
 
-  return num_success > 0 ? kStatusOk : kStatusErrorAnalyse;
+  return num_success > 0 ? kOk : kErrorAnalyse;
 }
 
 Int FactorHighsSolver::setNla() {
@@ -530,24 +530,24 @@ Int FactorHighsSolver::setNla() {
   if (options_.nla == kHipoAugmentedString) {
     Int status = kkt_.buildASstructure();
     if (!status) status = analyseAS(kkt_.S);
-    if (status == kStatusOverflow) {
+    if (status == kErrorOverflow) {
       logger_.printe("AS requested, integer overflow\n");
-      return kStatusOverflow;
+      return kErrorOverflow;
     } else if (status) {
       logger_.printe("AS requested, failed analyse phase\n");
-      return kStatusErrorAnalyse;
+      return kErrorAnalyse;
     }
     log_stream << textline("Newton system:") << "AS requested\n";
 
   } else if (options_.nla == kHipoNormalEqString) {
     Int status = kkt_.buildNEstructure();
     if (!status) status = analyseNE(kkt_.S);
-    if (status == kStatusOverflow) {
+    if (status == kErrorOverflow) {
       logger_.printe("NE requested, integer overflow\n");
-      return kStatusOverflow;
+      return kErrorOverflow;
     } else if (status) {
       logger_.printe("NE requested, failed analyse phase\n");
-      return kStatusErrorAnalyse;
+      return kErrorAnalyse;
     }
     log_stream << textline("Newton system:") << "NE requested\n";
 
@@ -564,7 +564,7 @@ Int FactorHighsSolver::setNla() {
                << '\n';
   logger_.print(log_stream.str().c_str());
 
-  return kStatusOk;
+  return kOk;
 }
 
 static bool usingAppleBlas() {

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -16,7 +16,6 @@ FactorHighsSolver::FactorHighsSolver(KktMatrix& kkt, Options& options,
                                      const Regularisation& regul, Info& info,
                                      IpmData& record, const Logger& logger)
     : FH_{},
-      S_{},
       kkt_{kkt},
       regul_{regul},
       info_{info},
@@ -94,7 +93,7 @@ Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
   FH_.setRegularisation(regul_.primal, regul_.dual);
 
   Clock clock;
-  if (FH_.factorise(S_, kkt_.n(), kkt_.nz(), kkt_.rowsAS.data(),
+  if (FH_.factorise(kkt_.S, kkt_.n(), kkt_.nz(), kkt_.rowsAS.data(),
                     kkt_.ptrAS.data(), kkt_.valAS.data()))
     return kStatusErrorFactorise;
   info_.factor_time += clock.stop();
@@ -114,7 +113,7 @@ Int FactorHighsSolver::factorNE(const std::vector<double>& scaling) {
   FH_.setRegularisation(regul_.primal, regul_.dual);
 
   Clock clock;
-  if (FH_.factorise(S_, kkt_.n(), kkt_.nz(), kkt_.rowsNE.data(),
+  if (FH_.factorise(kkt_.S, kkt_.n(), kkt_.nz(), kkt_.rowsNE.data(),
                     kkt_.ptrNE.data(), kkt_.valNE.data()))
     return kStatusErrorFactorise;
   info_.factor_time += clock.stop();
@@ -183,7 +182,7 @@ Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
 Int FactorHighsSolver::setup() {
   Clock clock;
 
-  if (kkt_.iperm.empty()) {
+  if (kkt_.S.empty()) {
     if (Int status = setNla()) return status;
     setParallel();
 
@@ -194,37 +193,14 @@ Int FactorHighsSolver::setup() {
       logger_.print(log_stream.str().c_str());
     }
 
-    S_.print(logger_, logger_.debug(1));
+    kkt_.S.print(logger_, logger_.debug(1));
 
     // Warn about large memory consumption
-    if (S_.storage() > kLargeStorageGB * 1024 * 1024 * 1024) {
+    if (kkt_.S.storage() > kLargeStorageGB * 1024 * 1024 * 1024) {
       logger_.printw("Large amount of memory required\n");
     }
 
     logger_.print("\n");
-  } else {
-    // permutation already available
-
-    const Int n = model_.A().num_col_;
-    const Int m = model_.A().num_row_;
-
-    std::vector<Int> perm(kkt_.n());
-    inversePerm(kkt_.iperm, perm);
-
-    if (kkt_.nla() == kHipoAugmentedString) {
-      assert(kkt_.n() == n + m);
-      std::vector<Int> signs(m + n, -1);
-      for (Int i = 0; i < m; ++i) signs[n + i] = 1;
-      return FH_.analyse(S_, kkt_.n(), kkt_.nz(), kkt_.rowsAS.data(),
-                         kkt_.ptrAS.data(), signs.data(), perm.data());
-    } else if (kkt_.nla() == kHipoNormalEqString) {
-      assert(kkt_.n() == m);
-      std::vector<Int> signs(m, 1);
-      return FH_.analyse(S_, kkt_.n(), kkt_.nz(), kkt_.rowsNE.data(),
-                         kkt_.ptrNE.data(), signs.data(), perm.data());
-    } else {
-      return kStatusErrorFactorise;
-    }
   }
 
   return kStatusOk;
@@ -374,10 +350,10 @@ Int FactorHighsSolver::chooseNla() {
 
   if (status == kStatusOk) {
     if (options_.nla == kHipoAugmentedString) {
-      S_ = std::move(symb_AS);
+      kkt_.S = std::move(symb_AS);
       kkt_.freeNEmemory();
     } else {
-      S_ = std::move(symb_NE);
+      kkt_.S = std::move(symb_NE);
       kkt_.freeASmemory();
     }
   }
@@ -553,7 +529,7 @@ Int FactorHighsSolver::setNla() {
 
   if (options_.nla == kHipoAugmentedString) {
     Int status = kkt_.buildASstructure();
-    if (!status) status = analyseAS(S_);
+    if (!status) status = analyseAS(kkt_.S);
     if (status == kStatusOverflow) {
       logger_.printe("AS requested, integer overflow\n");
       return kStatusOverflow;
@@ -565,7 +541,7 @@ Int FactorHighsSolver::setNla() {
 
   } else if (options_.nla == kHipoNormalEqString) {
     Int status = kkt_.buildNEstructure();
-    if (!status) status = analyseNE(S_);
+    if (!status) status = analyseNE(kkt_.S);
     if (status == kStatusOverflow) {
       logger_.printe("NE requested, integer overflow\n");
       return kStatusOverflow;
@@ -587,8 +563,6 @@ Int FactorHighsSolver::setNla() {
                                                         : ordering_NE_)
                << '\n';
   logger_.print(log_stream.str().c_str());
-
-  kkt_.iperm = S_.iperm();
 
   return kStatusOk;
 }
@@ -634,11 +608,11 @@ void FactorHighsSolver::setParallel() {
 
       // parallel_tree instead is chosen with a heuristic
 
-      double tree_speedup = S_.flops() / S_.critops();
-      double sn_size = (double)S_.size() / S_.sn();
+      double tree_speedup = kkt_.S.flops() / kkt_.S.critops();
+      double sn_size = (double)kkt_.S.size() / kkt_.S.sn();
 
-      bool enough_sn = S_.sn() > kMinNumberSn;
-      bool enough_flops = S_.flops() > kLargeFlopsThresh;
+      bool enough_sn = kkt_.S.sn() > kMinNumberSn;
+      bool enough_flops = kkt_.S.flops() > kLargeFlopsThresh;
       bool speedup_is_large = tree_speedup > kLargeSpeedupThresh;
       bool sn_are_large = sn_size > kLargeSnThresh;
       bool sn_are_not_small = sn_size > kSmallSnThresh;
@@ -654,13 +628,13 @@ void FactorHighsSolver::setParallel() {
 
     // If serial memory is too large, switch off tree parallelism to avoid
     // running out of memory
-    double num_GB = S_.storage() / 1024 / 1024 / 1024;
+    double num_GB = kkt_.S.storage() / 1024 / 1024 / 1024;
     if (num_GB > kLargeStorageGB) {
       parallel_tree = false;
     }
 
     // switch off tree parallelism if depth of recursion is too large
-    if (S_.depth() > kMaxTreeDepth) parallel_tree = false;
+    if (kkt_.S.depth() > kMaxTreeDepth) parallel_tree = false;
 
     if (parallel_tree && parallel_node)
       log_stream << "Full preferred\n";
@@ -675,16 +649,16 @@ void FactorHighsSolver::setParallel() {
     assert(1 == 0);
 
   logger_.print(log_stream.str().c_str());
-  S_.setParallel(parallel_tree, parallel_node);
+  kkt_.S.setParallel(parallel_tree, parallel_node);
 }
 
 // =========================================================================
 // Other stuff
 // =========================================================================
 
-double FactorHighsSolver::flops() const { return S_.flops(); }
-double FactorHighsSolver::spops() const { return S_.spops(); }
-double FactorHighsSolver::nz() const { return (double)S_.nz(); }
+double FactorHighsSolver::flops() const { return kkt_.S.flops(); }
+double FactorHighsSolver::spops() const { return kkt_.S.spops(); }
+double FactorHighsSolver::nz() const { return (double)kkt_.S.nz(); }
 void FactorHighsSolver::getReg(std::vector<double>& reg) {
   FH_.getRegularisation(reg.data());
 }

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -83,6 +83,7 @@ Int FactorHighsSolver::analyseNE(Symbolic& S) {
 
 Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
   assert(!this->valid_);
+  assert(kkt_.isAS());
 
   kkt_.buildASvalues(scaling);
 
@@ -102,6 +103,7 @@ Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
 
 Int FactorHighsSolver::factorNE(const std::vector<double>& scaling) {
   assert(!this->valid_);
+  assert(kkt_.isNE());
 
   kkt_.buildNEvalues(scaling);
 
@@ -128,6 +130,7 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
                                std::vector<double>& lhs_x,
                                std::vector<double>& lhs_y) {
   assert(this->valid_);
+  assert(kkt_.isAS());
 
   Int n = rhs_x.size();
 
@@ -152,6 +155,7 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
 Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
                                std::vector<double>& lhs) {
   assert(this->valid_);
+  assert(kkt_.isNE());
 
   lhs = rhs;
 

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -45,7 +45,6 @@ Int FactorHighsSolver::analyseAS(Symbolic& S) {
   const Int m = model_.A().num_row_;
   const Int n = model_.A().num_col_;
 
-  // create vector of signs of pivots
   std::vector<Int> pivot_signs(n + m, -1);
   for (Int i = 0; i < m; ++i) pivot_signs[n + i] = 1;
 
@@ -66,7 +65,6 @@ Int FactorHighsSolver::analyseNE(Symbolic& S) {
 
   if (kkt_.rowsNE.empty() || kkt_.ptrNE.empty()) return kErrorAnalyse;
 
-  // create vector of signs of pivots
   std::vector<Int> pivot_signs(model_.A().num_row_, 1);
 
   logger_.printInfo("Performing NE analyse phase\n");
@@ -84,7 +82,6 @@ Int FactorHighsSolver::analyseNE(Symbolic& S) {
 // =========================================================================
 
 Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
-  // only execute factorisation if it has not been done yet
   assert(!this->valid_);
 
   kkt_.buildASvalues(scaling);
@@ -104,7 +101,6 @@ Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
 }
 
 Int FactorHighsSolver::factorNE(const std::vector<double>& scaling) {
-  // only execute factorisation if it has not been done yet
   assert(!this->valid_);
 
   kkt_.buildNEvalues(scaling);
@@ -131,12 +127,10 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
                                const std::vector<double>& rhs_y,
                                std::vector<double>& lhs_x,
                                std::vector<double>& lhs_y) {
-  // only execute the solve if factorisation is valid
   assert(this->valid_);
 
   Int n = rhs_x.size();
 
-  // create single rhs
   std::vector<double> rhs;
   rhs.insert(rhs.end(), rhs_x.begin(), rhs_x.end());
   rhs.insert(rhs.end(), rhs_y.begin(), rhs_y.end());
@@ -149,7 +143,6 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
 
   data_.back().num_solves++;
 
-  // split lhs
   lhs_x = std::vector<double>(rhs.begin(), rhs.begin() + n);
   lhs_y = std::vector<double>(rhs.begin() + n, rhs.end());
 
@@ -158,10 +151,8 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
 
 Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
                                std::vector<double>& lhs) {
-  // only execute the solve if factorisation is valid
   assert(this->valid_);
 
-  // initialise lhs with rhs
   lhs = rhs;
 
   Clock clock;
@@ -195,7 +186,6 @@ Int FactorHighsSolver::setup() {
 
     kkt_.S.print(logger_, logger_.debug(1));
 
-    // Warn about large memory consumption
     if (kkt_.S.storage() > kLargeStorageGB * 1024 * 1024 * 1024) {
       logger_.printw("Large amount of memory required\n");
     }
@@ -207,8 +197,6 @@ Int FactorHighsSolver::setup() {
 }
 
 Int FactorHighsSolver::chooseNla() {
-  // Choose whether to use augmented system or normal equations.
-
   Symbolic symb_NE{};
   Symbolic symb_AS{};
   bool failure_NE = false;
@@ -305,7 +293,6 @@ Int FactorHighsSolver::chooseNla() {
 
   std::stringstream log_stream;
 
-  // Decision may be forced by failures
   if (failure_NE && !failure_AS) {
     options_.nla = kHipoAugmentedString;
     log_stream << textline("Newton system:") << "AS preferred (NE failed)\n";
@@ -325,7 +312,6 @@ Int FactorHighsSolver::chooseNla() {
     double ops_NE = symb_NE.flops() + symb_NE.spops() * kSpopsWeight;
     double ops_AS = symb_AS.flops() + symb_AS.spops() * kSpopsWeight;
 
-    // Average size of supernodes
     double sn_size_NE = (double)symb_NE.size() / symb_NE.sn();
     double sn_size_AS = (double)symb_AS.size() / symb_AS.sn();
 
@@ -370,7 +356,6 @@ Int FactorHighsSolver::chooseOrdering(const std::vector<Int>& rows,
   // - If ordering is "amd", "metis", "rcm" run only the ordering requested.
   // - If ordering is "choose", run "amd", "metis", and choose the best.
 
-  // select which fill-reducing orderings should be tried
   std::vector<std::string> orderings_to_try;
   if (options_.ordering != kHighsChooseString)
     orderings_to_try.push_back(options_.ordering);
@@ -572,7 +557,6 @@ static bool usingAppleBlas() {
 }
 
 void FactorHighsSolver::setParallel() {
-  // Set parallel options
   bool parallel_tree = false;
   bool parallel_node = false;
 

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.cpp
@@ -53,7 +53,7 @@ Int FactorHighsSolver::analyseAS(Symbolic& S) {
   Clock clock;
   Int status = chooseOrdering(kkt_.rowsAS, kkt_.ptrAS, pivot_signs, S,
                               ordering_AS_, "AS");
-  info_.analyse_AS_time += clock.stop();
+  info_.times[kAnalyseTime_AS] += clock.stop();
 
   return status;
 }
@@ -72,7 +72,7 @@ Int FactorHighsSolver::analyseNE(Symbolic& S) {
   Clock clock;
   Int status = chooseOrdering(kkt_.rowsNE, kkt_.ptrNE, pivot_signs, S,
                               ordering_NE_, "NE");
-  info_.analyse_NE_time += clock.stop();
+  info_.times[kAnalyseTime_NE] += clock.stop();
 
   return status;
 }
@@ -94,7 +94,7 @@ Int FactorHighsSolver::factorAS(const std::vector<double>& scaling) {
   if (FH_.factorise(kkt_.S, kkt_.n(), kkt_.nz(), kkt_.rowsAS.data(),
                     kkt_.ptrAS.data(), kkt_.valAS.data()))
     return kErrorFactorise;
-  info_.factor_time += clock.stop();
+  info_.times[kFactoriseTime] += clock.stop();
   info_.factor_number++;
 
   this->valid_ = true;
@@ -114,7 +114,7 @@ Int FactorHighsSolver::factorNE(const std::vector<double>& scaling) {
   if (FH_.factorise(kkt_.S, kkt_.n(), kkt_.nz(), kkt_.rowsNE.data(),
                     kkt_.ptrNE.data(), kkt_.valNE.data()))
     return kErrorFactorise;
-  info_.factor_time += clock.stop();
+  info_.times[kFactoriseTime] += clock.stop();
   info_.factor_number++;
 
   this->valid_ = true;
@@ -134,20 +134,23 @@ Int FactorHighsSolver::solveAS(const std::vector<double>& rhs_x,
 
   Int n = rhs_x.size();
 
+  Clock clock;
   as_buffer_.resize(rhs_x.size() + rhs_y.size());
   std::copy(rhs_x.begin(), rhs_x.end(), as_buffer_.begin());
   std::copy(rhs_y.begin(), rhs_y.end(), as_buffer_.begin() + n);
+  info_.times[kInsertSplitTime] += clock.stop();
 
-  Clock clock;
+  clock.start();
   if (FH_.solve(as_buffer_.data())) return kErrorSolve;
-
-  info_.solve_time += clock.stop();
+  info_.times[kSolveTime] += clock.stop();
   info_.solve_number++;
 
   data_.back().num_solves++;
 
+  clock.start();
   lhs_x.assign(as_buffer_.begin(), as_buffer_.begin() + n);
   lhs_y.assign(as_buffer_.begin() + n, as_buffer_.end());
+  info_.times[kInsertSplitTime] += clock.stop();
 
   return kOk;
 }
@@ -161,8 +164,7 @@ Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
 
   Clock clock;
   if (FH_.solve(lhs.data())) return kErrorSolve;
-
-  info_.solve_time += clock.stop();
+  info_.times[kSolveTime] += clock.stop();
   info_.solve_number++;
 
   data_.back().num_solves++;
@@ -175,16 +177,16 @@ Int FactorHighsSolver::solveNE(const std::vector<double>& rhs,
 // =========================================================================
 
 Int FactorHighsSolver::setup() {
-  Clock clock;
-
   if (kkt_.S.empty()) {
+    Clock clock;
     if (Int status = setNla()) return status;
     setParallel();
+    info_.times[kAnalyseTime] += clock.stop();
 
     if (!options_.timeless_log) {
       std::stringstream log_stream;
-      log_stream << textline("Analyse time:") << fix(clock.stop(), 0, 2)
-                 << '\n';
+      log_stream << textline("Analyse time:")
+                 << fix(info_.times[kAnalyseTime], 0, 2) << '\n';
       logger_.print(log_stream.str().c_str());
     }
 

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.h
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.h
@@ -15,7 +15,6 @@
 namespace hipo {
 
 class FactorHighsSolver : public LinearSolver {
-  // object to perform factorisation
   FHsolver FH_;
 
   KktMatrix& kkt_;
@@ -44,7 +43,6 @@ class FactorHighsSolver : public LinearSolver {
                     const Regularisation& regul, Info& info, IpmData& record,
                     const Logger& logger);
 
-  // Override functions
   Int factorAS(const std::vector<double>& scaling) override;
   Int factorNE(const std::vector<double>& scaling) override;
   Int solveNE(const std::vector<double>& rhs,

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.h
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.h
@@ -58,6 +58,7 @@ class FactorHighsSolver : public LinearSolver {
   double spops() const override;
   double nz() const override;
   void getReg(std::vector<double>& reg) override;
+  LinearSolverType type() const override { return kFactorHighsType; }
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.h
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.h
@@ -60,6 +60,7 @@ class FactorHighsSolver : public LinearSolver {
   double flops() const override;
   double spops() const override;
   double nz() const override;
+  Int n() const override;
   void getReg(std::vector<double>& reg) override;
 };
 

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.h
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.h
@@ -60,7 +60,6 @@ class FactorHighsSolver : public LinearSolver {
   double flops() const override;
   double spops() const override;
   double nz() const override;
-  Int n() const override;
   void getReg(std::vector<double>& reg) override;
 };
 

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.h
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.h
@@ -16,15 +16,15 @@ namespace hipo {
 
 class FactorHighsSolver : public LinearSolver {
   FHsolver FH_;
-
   KktMatrix& kkt_;
-
   const Regularisation& regul_;
   Info& info_;
   IpmData& data_;
   const Logger& logger_;
   const Model& model_;
   Options& options_;
+
+  std::vector<double> as_buffer_;
 
   std::string ordering_AS_ = "none";
   std::string ordering_NE_ = "none";

--- a/highs/ipm/hipo/ipm/FactorHighsSolver.h
+++ b/highs/ipm/hipo/ipm/FactorHighsSolver.h
@@ -18,9 +18,6 @@ class FactorHighsSolver : public LinearSolver {
   // object to perform factorisation
   FHsolver FH_;
 
-  // symbolic factorisation
-  Symbolic S_;
-
   KktMatrix& kkt_;
 
   const Regularisation& regul_;

--- a/highs/ipm/hipo/ipm/Info.h
+++ b/highs/ipm/hipo/ipm/Info.h
@@ -8,6 +8,37 @@
 
 namespace hipo {
 
+enum TimeProfileItem {
+  // matrix
+  kMatrixStructureTime_NE,
+  kMatrixStructureTime_AS,
+  kMatrixValuesTime,
+  // analyse
+  kAnalyseTime,
+  kAnalyseTime_NE,
+  kAnalyseTime_AS,
+  // factorise
+  kFactoriseTime,
+  // solve
+  kSolveTime,
+  kInsertSplitTime,
+  kRefinementResTime,
+  kRefinementOmegaTime,
+  // ipm phases
+  kInitialiseTime,
+  kPrepareTime,
+  kPredictorTime,
+  kCorrectorsTime,
+  kStepTime,
+  //
+  kSolve2x2Time,
+  kRecoverTime,
+  kRefineTime,
+  kResidualsTime,
+  //
+  KTimeProfileItemCount
+};
+
 struct Info {
   // Size of problem, as seen by the solver
   Int m_solver, n_solver;
@@ -34,20 +65,11 @@ struct Info {
   // Number of correctors used
   Int correctors;
 
-  // Total times to form matrix, factorise and solve linear systems
-  double analyse_NE_time{};
-  double analyse_AS_time{};
-  double matrix_time{};
-  double AS_structure_time{};
-  double NE_structure_time{};
-  double factor_time{};
-  double solve_time{};
-  double residual_time{};
-  double omega_time{};
-
   // Counters
   Int factor_number{};
   Int solve_number{};
+
+  double times[KTimeProfileItemCount];
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Info.h
+++ b/highs/ipm/hipo/ipm/Info.h
@@ -16,7 +16,8 @@ struct Info {
   Int m_original, n_original;
 
   // Status of solver, see IpmStatus.h
-  Status status = kStatusNotRun;
+  Status status = kStatusNotSet;
+  Int error = kOk;
 
   // residuals and objectives of final solution
   double p_res_rel, p_res_abs, d_res_rel, d_res_abs, p_obj, d_obj, pd_gap;

--- a/highs/ipm/hipo/ipm/IpmData.h
+++ b/highs/ipm/hipo/ipm/IpmData.h
@@ -24,6 +24,7 @@ struct IpmIterData {
   double nw_back_err = 0.0;
   double cw_back_err = 0.0;
   Int large_components_cw = 0;
+  Int factorisation_used = 0;
 };
 
 struct IpmData {

--- a/highs/ipm/hipo/ipm/IpmData.h
+++ b/highs/ipm/hipo/ipm/IpmData.h
@@ -21,9 +21,6 @@ struct IpmIterData {
   Int num_small_prod = 0;
   Int num_large_prod = 0;
   double omega = 0.0;
-  double nw_back_err = 0.0;
-  double cw_back_err = 0.0;
-  Int large_components_cw = 0;
   Int factorisation_used = 0;
 };
 

--- a/highs/ipm/hipo/ipm/Iterate.cpp
+++ b/highs/ipm/hipo/ipm/Iterate.cpp
@@ -586,6 +586,43 @@ void Iterate::makeStep(double alpha_primal, double alpha_dual) {
   vectorAdd(zu, delta.zu, alpha_dual);
 }
 
+void Iterate::saveBest(double feas_tol, double opt_tol, Int iter) {
+  const double primal_violation = pinf / feas_tol;
+  const double dual_violation = dinf / feas_tol;
+  const double gap_violation = pdgap / opt_tol;
+
+  double violation = std::max(primal_violation, dual_violation);
+  violation = std::max(violation, gap_violation);
+
+  if (violation < best_violation) {
+    best_x = x;
+    best_xl = xl;
+    best_xu = xu;
+    best_y = y;
+    best_zl = zl;
+    best_zu = zu;
+    best_violation = violation;
+    best_iter = iter;
+  }
+}
+
+bool Iterate::resetBest(Int iter) {
+  if (iter == best_iter) return false;
+
+  x = best_x;
+  xl = best_xl;
+  xu = best_xu;
+  y = best_y;
+  zl = best_zl;
+  zu = best_zu;
+
+  computeMu();
+  residual1234();
+  indicators();
+
+  return true;
+}
+
 bool Iterate::stagnation(std::stringstream& log_stream) {
   // too many iterations in a row with small stepsize
   bool stagnation = (bad_iter_ >= kMaxBadIter);

--- a/highs/ipm/hipo/ipm/Iterate.cpp
+++ b/highs/ipm/hipo/ipm/Iterate.cpp
@@ -438,7 +438,7 @@ double Iterate::infeasAfterDropping() const {
   return std::max(pinf_max, dinf_max);
 }
 
-Int Iterate::finalResiduals(Info& info) const {
+void Iterate::finalResiduals(Info& info) const {
   // If ipx has been used, the information is already available, otherwise,
   // compute it.
 
@@ -481,8 +481,6 @@ Int Iterate::finalResiduals(Info& info) const {
     info.d_obj = info.ipx_info.dobjval;
     info.pd_gap = std::abs(info.ipx_info.rel_objgap);
   }
-
-  return kStatusOk;
 }
 
 void Iterate::getReg(LinearSolver& LS, const std::string& nla) {

--- a/highs/ipm/hipo/ipm/Iterate.cpp
+++ b/highs/ipm/hipo/ipm/Iterate.cpp
@@ -20,12 +20,12 @@ void NewtonDir::clear() {
 }
 
 void NewtonDir::add(const NewtonDir& d) {
-  vectorAdd(x, d.x);
-  vectorAdd(y, d.y);
-  vectorAdd(xl, d.xl);
-  vectorAdd(xu, d.xu);
-  vectorAdd(zl, d.zl);
-  vectorAdd(zu, d.zu);
+  vectorAdd(x, 1.0, d.x, 1.0);
+  vectorAdd(y, 1.0, d.y, 1.0);
+  vectorAdd(xl, 1.0, d.xl, 1.0);
+  vectorAdd(xu, 1.0, d.xu, 1.0);
+  vectorAdd(zl, 1.0, d.zl, 1.0);
+  vectorAdd(zu, 1.0, d.zu, 1.0);
 }
 
 Iterate::Iterate(Model& model_input, Info& info_input, Regularisation& r)
@@ -592,12 +592,12 @@ void Iterate::makeStep(double alpha_primal, double alpha_dual) {
   else
     bad_iter_ = 0;
 
-  vectorAdd(x, delta.x, alpha_primal);
-  vectorAdd(xl, delta.xl, alpha_primal);
-  vectorAdd(xu, delta.xu, alpha_primal);
-  vectorAdd(y, delta.y, alpha_dual);
-  vectorAdd(zl, delta.zl, alpha_dual);
-  vectorAdd(zu, delta.zu, alpha_dual);
+  vectorAdd(x, 1.0, delta.x, alpha_primal);
+  vectorAdd(xl, 1.0, delta.xl, alpha_primal);
+  vectorAdd(xu, 1.0, delta.xu, alpha_primal);
+  vectorAdd(y, 1.0, delta.y, alpha_dual);
+  vectorAdd(zl, 1.0, delta.zl, alpha_dual);
+  vectorAdd(zu, 1.0, delta.zu, alpha_dual);
 }
 
 void Iterate::saveBest(double feas_tol, double opt_tol, Int iter) {

--- a/highs/ipm/hipo/ipm/Iterate.cpp
+++ b/highs/ipm/hipo/ipm/Iterate.cpp
@@ -28,8 +28,11 @@ void NewtonDir::add(const NewtonDir& d) {
   vectorAdd(zu, d.zu);
 }
 
-Iterate::Iterate(Model& model_input, Regularisation& r)
-    : model{model_input}, delta(model.m(), model.n()), regul{r} {
+Iterate::Iterate(Model& model_input, Info& info_input, Regularisation& r)
+    : model{model_input},
+      info{info_input},
+      delta(model.m(), model.n()),
+      regul{r} {
   clearIter();
   clearRes();
   clearIres();
@@ -199,6 +202,8 @@ void Iterate::dualInfeasUnscaled() {
 }
 
 void Iterate::residual1234() {
+  Clock clock;
+
   // res1
   res.r1 = model.b();
   model.A().alphaProductPlusY(-1.0, x, res.r1);
@@ -227,8 +232,12 @@ void Iterate::residual1234() {
     if (model.hasUb(i)) res.r4[i] += zu[i];
   }
   if (model.qp()) model.Q().alphaProductPlusY(model.sense(), x, res.r4);
+
+  info.times[kResidualsTime] += clock.stop();
 }
 void Iterate::residual56(double sigma) {
+  Clock clock;
+
   for (Int i = 0; i < model.n(); ++i) {
     // res5
     if (model.hasLb(i))
@@ -242,6 +251,8 @@ void Iterate::residual56(double sigma) {
     else
       res.r6[i] = 0.0;
   }
+
+  info.times[kResidualsTime] += clock.stop();
 }
 
 std::vector<double> Iterate::residual7(const Residuals& r) const {
@@ -438,7 +449,7 @@ double Iterate::infeasAfterDropping() const {
   return std::max(pinf_max, dinf_max);
 }
 
-void Iterate::finalResiduals(Info& info) const {
+void Iterate::finalResiduals() const {
   // If ipx has been used, the information is already available, otherwise,
   // compute it.
 

--- a/highs/ipm/hipo/ipm/Iterate.cpp
+++ b/highs/ipm/hipo/ipm/Iterate.cpp
@@ -28,7 +28,7 @@ void NewtonDir::add(const NewtonDir& d) {
   vectorAdd(zu, d.zu);
 }
 
-Iterate::Iterate(const Model& model_input, Regularisation& r)
+Iterate::Iterate(Model& model_input, Regularisation& r)
     : model{model_input}, delta(model.m(), model.n()), regul{r} {
   clearIter();
   clearRes();
@@ -608,6 +608,7 @@ void Iterate::saveBest(double feas_tol, double opt_tol, Int iter) {
     best_zu = zu;
     best_violation = violation;
     best_iter = iter;
+    model.saveBounds();
   }
 }
 
@@ -620,6 +621,7 @@ bool Iterate::resetBest(Int iter) {
   y = best_y;
   zl = best_zl;
   zu = best_zu;
+  model.resetBounds();
 
   computeMu();
   residual1234();

--- a/highs/ipm/hipo/ipm/Iterate.h
+++ b/highs/ipm/hipo/ipm/Iterate.h
@@ -155,7 +155,7 @@ struct Iterate {
                              std::vector<double>& y_cmp,
                              std::vector<double>& z_cmp) const;
 
-  Int finalResiduals(Info& info) const;
+  void finalResiduals(Info& info) const;
 
   // ===================================================================================
   // Compute residual of 6x6 linear system for iterative refinement.

--- a/highs/ipm/hipo/ipm/Iterate.h
+++ b/highs/ipm/hipo/ipm/Iterate.h
@@ -50,6 +50,10 @@ struct Iterate {
   double largest_dx_x_{}, largest_dy_y_{};
   double best_pinf_ = kHighsInf, best_dinf_ = kHighsInf;
 
+  double best_violation = kHighsInf;
+  Int best_iter = -1;
+  std::vector<double> best_x, best_xl, best_xu, best_y, best_zl, best_zu;
+
   // ===================================================================================
   // Functions to construct, clear and check for nan or inf
   // ===================================================================================
@@ -159,6 +163,9 @@ struct Iterate {
   void residuals6x6(const NewtonDir& d);
 
   void makeStep(double alpha_primal, double alpha_dual);
+
+  void saveBest(double feas_tol, double opt_tol, Int iter);
+  bool resetBest(Int iter);
 
   bool stagnation(std::stringstream& log_stream);
 

--- a/highs/ipm/hipo/ipm/Iterate.h
+++ b/highs/ipm/hipo/ipm/Iterate.h
@@ -31,6 +31,7 @@ struct Residuals {
 
 struct Iterate {
   Model& model;
+  Info& info;
   IpmData data;
   std::vector<double> x, xl, xu, y, zl, zu;
   Residuals res;
@@ -57,7 +58,7 @@ struct Iterate {
   // ===================================================================================
   // Functions to construct, clear and check for nan or inf
   // ===================================================================================
-  Iterate(Model& model_input, Regularisation& r);
+  Iterate(Model& model_input, Info& info_input, Regularisation& r);
 
   // clear existing data
   void clearIter();
@@ -155,7 +156,7 @@ struct Iterate {
                              std::vector<double>& y_cmp,
                              std::vector<double>& z_cmp) const;
 
-  void finalResiduals(Info& info) const;
+  void finalResiduals() const;
 
   // ===================================================================================
   // Compute residual of 6x6 linear system for iterative refinement.

--- a/highs/ipm/hipo/ipm/Iterate.h
+++ b/highs/ipm/hipo/ipm/Iterate.h
@@ -30,7 +30,7 @@ struct Residuals {
 };
 
 struct Iterate {
-  const Model& model;
+  Model& model;
   IpmData data;
   std::vector<double> x, xl, xu, y, zl, zu;
   Residuals res;
@@ -57,7 +57,7 @@ struct Iterate {
   // ===================================================================================
   // Functions to construct, clear and check for nan or inf
   // ===================================================================================
-  Iterate(const Model& model_input, Regularisation& r);
+  Iterate(Model& model_input, Regularisation& r);
 
   // clear existing data
   void clearIter();

--- a/highs/ipm/hipo/ipm/KktMatrix.cpp
+++ b/highs/ipm/hipo/ipm/KktMatrix.cpp
@@ -25,7 +25,7 @@ Int KktMatrix::buildASstructure() {
   const Int nzBlock11 = model.qp() ? nzQ : n;
 
   // AS matrix must fit into HighsInt
-  if ((Int64)nzBlock11 + m + nzA >= kHighsIInf) return kStatusOverflow;
+  if ((Int64)nzBlock11 + m + nzA >= kHighsIInf) return kErrorOverflow;
 
   ptrAS.resize(n + m + 1);
   rowsAS.resize(nzBlock11 + nzA + m);
@@ -67,7 +67,7 @@ Int KktMatrix::buildASstructure() {
 
   info.AS_structure_time = clock.stop();
 
-  return kStatusOk;
+  return kOk;
 }
 
 Int KktMatrix::buildASvalues(const std::vector<double>& scaling) {
@@ -86,7 +86,7 @@ Int KktMatrix::buildASvalues(const std::vector<double>& scaling) {
 
   info.matrix_time += clock.stop();
 
-  return kStatusOk;
+  return kOk;
 }
 
 Int KktMatrix::buildNEstructure() {
@@ -170,7 +170,7 @@ Int KktMatrix::buildNEstructure() {
     // if the total number of nonzeros exceeds the maximum, return error.
     if ((Int64)ptrNE[row] + nz_in_col >=
         NE_nz_limit.load(std::memory_order_relaxed))
-      return kStatusOverflow;
+      return kErrorOverflow;
 
     // update pointers
     ptrNE[row + 1] = ptrNE[row] + nz_in_col;
@@ -185,7 +185,7 @@ Int KktMatrix::buildNEstructure() {
   }
 
   info.NE_structure_time = clock.stop();
-  return kStatusOk;
+  return kOk;
 }
 
 Int KktMatrix::buildNEvalues(const std::vector<double>& scaling) {
@@ -242,7 +242,7 @@ Int KktMatrix::buildNEvalues(const std::vector<double>& scaling) {
 
   info.matrix_time += clock.stop();
 
-  return kStatusOk;
+  return kOk;
 }
 
 void KktMatrix::freeASmemory() {

--- a/highs/ipm/hipo/ipm/KktMatrix.cpp
+++ b/highs/ipm/hipo/ipm/KktMatrix.cpp
@@ -65,7 +65,7 @@ Int KktMatrix::buildASstructure() {
     ptrAS[n + i + 1] = ptrAS[n + i] + 1;
   }
 
-  info.AS_structure_time = clock.stop();
+  info.times[kMatrixStructureTime_AS] = clock.stop();
 
   return kOk;
 }
@@ -84,7 +84,7 @@ Int KktMatrix::buildASvalues(const std::vector<double>& scaling) {
     if (model.qp()) valAS[ptrAS[i]] -= model.sense() * model.Q().diag(i);
   }
 
-  info.matrix_time += clock.stop();
+  info.times[kMatrixValuesTime] += clock.stop();
 
   return kOk;
 }
@@ -184,7 +184,7 @@ Int KktMatrix::buildNEstructure() {
     }
   }
 
-  info.NE_structure_time = clock.stop();
+  info.times[kMatrixStructureTime_NE] = clock.stop();
   return kOk;
 }
 
@@ -240,7 +240,7 @@ Int KktMatrix::buildNEvalues(const std::vector<double>& scaling) {
     }
   }
 
-  info.matrix_time += clock.stop();
+ info.times[kMatrixValuesTime] += clock.stop();
 
   return kOk;
 }

--- a/highs/ipm/hipo/ipm/KktMatrix.cpp
+++ b/highs/ipm/hipo/ipm/KktMatrix.cpp
@@ -263,20 +263,23 @@ void KktMatrix::freeNEmemory() {
 }
 
 Int KktMatrix::n() const {
-  if (nla() == kHipoNormalEqString) return ptrNE.size() - 1;
-  if (nla() == kHipoAugmentedString) return ptrAS.size() - 1;
+  if (isNE()) return ptrNE.size() - 1;
+  if (isAS()) return ptrAS.size() - 1;
   return -1;
 }
 Int KktMatrix::nz() const {
-  if (nla() == kHipoNormalEqString) return rowsNE.size();
-  if (nla() == kHipoAugmentedString) return rowsAS.size();
+  if (isNE()) return rowsNE.size();
+  if (isAS()) return rowsAS.size();
   return -1;
 }
 std::string KktMatrix::nla() const {
-  if (!ptrNE.empty()) return kHipoNormalEqString;
-  if (!ptrAS.empty()) return kHipoAugmentedString;
+  if (isNE()) return kHipoNormalEqString;
+  if (isAS()) return kHipoAugmentedString;
   return "empty";
 }
+
+bool KktMatrix::isAS() const { return !ptrAS.empty(); }
+bool KktMatrix::isNE() const { return !ptrNE.empty(); }
 
 const std::vector<Int>& KktMatrix::iperm() const { return S.iperm(); }
 

--- a/highs/ipm/hipo/ipm/KktMatrix.cpp
+++ b/highs/ipm/hipo/ipm/KktMatrix.cpp
@@ -278,4 +278,6 @@ std::string KktMatrix::nla() const {
   return "empty";
 }
 
+const std::vector<Int>& KktMatrix::iperm() const { return S.iperm(); }
+
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/KktMatrix.h
+++ b/highs/ipm/hipo/ipm/KktMatrix.h
@@ -44,6 +44,8 @@ struct KktMatrix {
   Int n() const;
   Int nz() const;
   std::string nla() const;
+  bool isNE() const;
+  bool isAS() const;
   const std::vector<Int>& iperm() const;
 };
 

--- a/highs/ipm/hipo/ipm/KktMatrix.h
+++ b/highs/ipm/hipo/ipm/KktMatrix.h
@@ -7,6 +7,7 @@
 #include "Info.h"
 #include "Model.h"
 #include "ipm/hipo/auxiliary/IntConfig.h"
+#include "ipm/hipo/factorhighs/Symbolic.h"
 
 namespace hipo {
 
@@ -22,7 +23,7 @@ struct KktMatrix {
   std::vector<Int> rowsAS;
   std::vector<double> valAS;
 
-  std::vector<Int> iperm;
+  Symbolic S;
 
   const Model& model;
   const Regularisation& regul;
@@ -43,6 +44,7 @@ struct KktMatrix {
   Int n() const;
   Int nz() const;
   std::string nla() const;
+  const std::vector<Int>& iperm() const;
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/LinearSolver.h
+++ b/highs/ipm/hipo/ipm/LinearSolver.h
@@ -73,6 +73,7 @@ class LinearSolver {
   virtual double flops() const { return 0; }
   virtual double spops() const { return 0; }
   virtual double nz() const { return 0; }
+  virtual Int n() const { return 0; }
   virtual void getReg(std::vector<double>& reg){};
 };
 

--- a/highs/ipm/hipo/ipm/LinearSolver.h
+++ b/highs/ipm/hipo/ipm/LinearSolver.h
@@ -33,6 +33,8 @@ namespace hipo {
 // linear solver chosen, so that only the appropriate data (upper triangle,
 // lower triangle, or else) is constructed.
 
+enum LinearSolverType { kFactorHighsType = 1, kUpLookingType };
+
 class LinearSolver {
  public:
   bool valid_ = false;
@@ -65,6 +67,8 @@ class LinearSolver {
 
   virtual void clear() = 0;
 
+  virtual LinearSolverType type() const = 0;
+
   // =================================================================
   // Virtual functions.
   // These may be overridden by derived classes, if needed.
@@ -75,6 +79,17 @@ class LinearSolver {
   virtual double nz() const { return 0; }
   virtual void getReg(std::vector<double>& reg){};
 };
+
+inline std::string LinearSolverTypeToString(LinearSolverType t) {
+  static const std::map<LinearSolverType, std::string> type_map{
+      {kFactorHighsType, "FactorHighs"},
+      {kUpLookingType, "UpLooking"},
+  };
+  
+  auto found = type_map.find(t);
+  if (found != type_map.end()) return found->second;
+  return "XUnknown";
+}
 
 }  // namespace hipo
 

--- a/highs/ipm/hipo/ipm/LinearSolver.h
+++ b/highs/ipm/hipo/ipm/LinearSolver.h
@@ -73,7 +73,6 @@ class LinearSolver {
   virtual double flops() const { return 0; }
   virtual double spops() const { return 0; }
   virtual double nz() const { return 0; }
-  virtual Int n() const { return 0; }
   virtual void getReg(std::vector<double>& reg){};
 };
 

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -17,7 +17,7 @@ Int Model::init(const HighsLp& lp, const HighsHessian& Q) {
   if (qp()) completeHessian(n_, Q_);
   sense_ = lp.sense_;
 
-  if (checkData()) return kStatusBadModel;
+  if (checkData()) return kErrorModel;
 
   lp_orig_ = &lp;
   n_orig_ = n_;
@@ -34,7 +34,7 @@ Int Model::init(const HighsLp& lp, const HighsHessian& Q) {
   A_.ensureRowwise();
   A_.ensureColwise();
 
-  if (checkData()) return kStatusBadModel;
+  if (checkData()) return kErrorModel;
 
   ready_ = true;
 
@@ -70,10 +70,10 @@ void Model::nzBounds() {
 
 Int Model::checkData() const {
   // Check if model provided by the user is ok.
-  // Return kStatusBadModel if something is wrong.
+  // Return kErrorModel if something is wrong.
 
   // Dimensions are valid
-  if (n_ <= 0 || m_ < 0) return kStatusBadModel;
+  if (n_ <= 0 || m_ < 0) return kErrorModel;
 
   // Vectors are of correct size
   if (static_cast<Int>(c_.size()) != n_ || static_cast<Int>(b_.size()) != m_ ||
@@ -83,32 +83,30 @@ Int Model::checkData() const {
       static_cast<Int>(A_.start_.size()) != n_ + 1 ||
       static_cast<Int>(A_.index_.size()) != A_.start_.back() ||
       static_cast<Int>(A_.value_.size()) != A_.start_.back())
-    return kStatusBadModel;
+    return kErrorModel;
 
   // Hessian is ok, for QPs only
   if (qp() && (Q_.dim_ != n_ || Q_.format_ != HessianFormat::kTriangular))
-    return kStatusBadModel;
+    return kErrorModel;
 
   // Vectors are valid
   for (Int i = 0; i < n_; ++i)
-    if (!std::isfinite(c_[i])) return kStatusBadModel;
+    if (!std::isfinite(c_[i])) return kErrorModel;
   for (Int i = 0; i < m_; ++i)
-    if (!std::isfinite(b_[i])) return kStatusBadModel;
+    if (!std::isfinite(b_[i])) return kErrorModel;
   for (Int i = 0; i < n_; ++i) {
-    if (!std::isfinite(lower_[i]) && lower_[i] != -INFINITY)
-      return kStatusBadModel;
-    if (!std::isfinite(upper_[i]) && upper_[i] != INFINITY)
-      return kStatusBadModel;
-    if (lower_[i] > upper_[i]) return kStatusBadModel;
+    if (!std::isfinite(lower_[i]) && lower_[i] != -INFINITY) return kErrorModel;
+    if (!std::isfinite(upper_[i]) && upper_[i] != INFINITY) return kErrorModel;
+    if (lower_[i] > upper_[i]) return kErrorModel;
   }
   for (Int i = 0; i < m_; ++i)
     if (constraints_[i] != '<' && constraints_[i] != '=' &&
         constraints_[i] != '>')
-      return kStatusBadModel;
+      return kErrorModel;
 
   // Matrix is valid
   for (Int i = 0; i < A_.start_[n_]; ++i)
-    if (!std::isfinite(A_.value_[i])) return kStatusBadModel;
+    if (!std::isfinite(A_.value_[i])) return kErrorModel;
 
   return 0;
 }
@@ -359,7 +357,7 @@ Int Model::loadIntoIpx(ipx::LpSolver& lps) const {
   std::vector<char> ipx_constraints;
   double ipx_offset;
 
-  if (!lp_orig_) return kStatusError;
+  if (!lp_orig_) return kErrorInvalidPointer;
 
   fillInIpxData(*lp_orig_, ipx_n, ipx_m, ipx_offset, ipx_c, ipx_lower,
                 ipx_upper, ipx_A_ptr, ipx_A_rows, ipx_A_vals, ipx_b,

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -424,8 +424,8 @@ void Model::adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
       // getting close to lower bound
       const double new_lower = x[i] / kFreeVarsCloseRatio;
       logger.printDetailed(
-          "Free var %5d is at %8.1e with lb %8.1e, lb changed to %8.1e\n", i, x[i],
-          lower_[i], new_lower);
+          "Free var %5d is at %8.1e with lb %8.1e, lb changed to %8.1e\n", i,
+          x[i], lower_[i], new_lower);
       lower_[i] = new_lower;
       xl[i] = x[i] - lower_[i];
     }
@@ -433,11 +433,30 @@ void Model::adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
       // getting close to upper bound
       const double new_upper = x[i] / kFreeVarsCloseRatio;
       logger.printDetailed(
-          "Free var %5d is at %8.1e with ub %8.1e, ub changed to %8.1e\n", i, x[i],
-          upper_[i], new_upper);
+          "Free var %5d is at %8.1e with ub %8.1e, ub changed to %8.1e\n", i,
+          x[i], upper_[i], new_upper);
       upper_[i] = new_upper;
       xu[i] = upper_[i] - x[i];
     }
+  }
+}
+
+void Model::saveBounds() {
+  best_lower_.resize(free_variables_.size());
+  best_upper_.resize(free_variables_.size());
+  Int next = 0;
+  for (Int i : free_variables_) {
+    best_lower_[next] = lower_[i];
+    best_upper_[next] = upper_[i];
+    ++next;
+  }
+}
+void Model::resetBounds() {
+  Int next = 0;
+  for (Int i : free_variables_) {
+    lower_[i] = best_lower_[next];
+    upper_[i] = best_upper_[next];
+    ++next;
   }
 }
 

--- a/highs/ipm/hipo/ipm/Model.cpp
+++ b/highs/ipm/hipo/ipm/Model.cpp
@@ -299,7 +299,6 @@ void Model::print(const Logger& logger) const {
   }
   if (std::isinf(scalemin)) scalemin = 0.0;
 
-  // print ranges
   log_stream << textline("Range of A:") << "[" << sci(Amin, 5, 1) << ", "
              << sci(Amax, 5, 1) << "]\n";
 

--- a/highs/ipm/hipo/ipm/Model.h
+++ b/highs/ipm/hipo/ipm/Model.h
@@ -67,6 +67,8 @@ class Model {
 
   std::vector<Int> free_variables_;
 
+  std::vector<double> best_lower_, best_upper_;
+
   void preprocess();
   Int checkData() const;
   void computeNorms();
@@ -94,6 +96,9 @@ class Model {
 
   void adjustFreeVars(std::vector<double>& x, std::vector<double>& xl,
                       std::vector<double>& xu, const Logger& logger);
+
+  void saveBounds();
+  void resetBounds();
 
   // Check if variable has finite lower/upper bound
   bool hasLb(Int j) const { return std::isfinite(lower_[j]); }

--- a/highs/ipm/hipo/ipm/Model.h
+++ b/highs/ipm/hipo/ipm/Model.h
@@ -74,10 +74,8 @@ class Model {
   void computeNorms();
 
  public:
-  // Initialise the model
   Int init(const HighsLp& lp, const HighsHessian& Q);
 
-  // Print information of model
   void print(const Logger& logger) const;
 
   void printDense() const;
@@ -100,7 +98,6 @@ class Model {
   void saveBounds();
   void resetBounds();
 
-  // Check if variable has finite lower/upper bound
   bool hasLb(Int j) const { return std::isfinite(lower_[j]); }
   bool hasUb(Int j) const { return std::isfinite(upper_[j]); }
 

--- a/highs/ipm/hipo/ipm/Options.h
+++ b/highs/ipm/hipo/ipm/Options.h
@@ -14,6 +14,7 @@ struct Options {
   std::string parallel = kHighsChooseString;
   std::string parallel_type = kHipoBothString;
   std::string ordering = kHighsChooseString;
+  std::string factor = kHighsChooseString;
 
   // Ipm parameters
   Int max_iter = kMaxIterDefault;

--- a/highs/ipm/hipo/ipm/Parameters.h
+++ b/highs/ipm/hipo/ipm/Parameters.h
@@ -39,6 +39,13 @@ const double kMaxTreeDepth = 1000;
 // parameters for choice of ordering
 const double kFlopsOrderingThresh = 1.2;
 
+// parameters for choice of factorisation
+const double kUplookFlopsThresh = 1e6;
+const double kUplookNzPerColLower = 10;
+const double kUplookNzPerColUpper = 25;
+const double kUplookSpopsRatioLower = 20;
+const double kUplookSpopsRatioUpper = 100;
+
 // parameters for skipping AS or NE
 const double kNzBoundsRatio = 50.0;
 

--- a/highs/ipm/hipo/ipm/Refine.cpp
+++ b/highs/ipm/hipo/ipm/Refine.cpp
@@ -13,11 +13,11 @@ void Solver::refine(NewtonDir& delta) {
   // compute the residuals of the linear system in it_->ires
   clock.start();
   it_->residuals6x6(delta);
-  info_.residual_time += clock.stop();
+  info_.times[kRefinementResTime] += clock.stop();
 
   clock.start();
   double omega = computeOmega(delta);
-  info_.omega_time += clock.stop();
+  info_.times[kRefinementOmegaTime] += clock.stop();
 
   double old_omega{};
 
@@ -32,13 +32,13 @@ void Solver::refine(NewtonDir& delta) {
 
     clock.start();
     it_->residuals6x6(temp);
-    info_.residual_time += clock.stop();
+    info_.times[kRefinementResTime] += clock.stop();
 
     old_omega = omega;
 
     clock.start();
     omega = computeOmega(temp);
-    info_.omega_time += clock.stop();
+    info_.times[kRefinementOmegaTime] += clock.stop();
 
     if (omega < old_omega) {
       delta = temp;

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1180,13 +1180,13 @@ void Solver::printOutput(bool reset) const {
   if (!reset) {
     logger_.print("%5d ", iter_);
   } else {
-    logger_.print("   >  ");
+    logger_.print(">%4d ",it_->best_iter);
   }
 
   logger_.print("%16.8e %16.8e %10.2e %10.2e %9.2e", it_->pobj, it_->dobj,
                 it_->pinf, it_->dinf, it_->pdgap);
   if (!options_.timeless_log) logger_.print(" %7.1f", control_.elapsed());
-  if (logger_.debug(1)) {
+  if (logger_.debug(1) && !reset) {
     const IpmIterData& data = it_->data.back();
     logger_.print(
         " %6.2f %6.2f %6.2f %6.2f %5d %5d %8.1e %8.1e %8.1e %8.1e %8.1e %8.1e "

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1068,13 +1068,12 @@ bool Solver::checkBadIter() {
             "HiPO stagnated but HiGHS considers the solution acceptable\n");
         logger_.print("=== Primal-dual feasible point found\n");
         info_.status = kStatusPDFeas;
-      } else
+      } else {
         info_.status = kStatusNoProgress;
-      terminate = true;
-
-      if (it_->resetBest(iter_)) {
-        printOutput(true);
+        if (it_->resetBest(iter_)) printOutput(true);
       }
+
+      terminate = true;
     }
   }
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -184,6 +184,7 @@ bool Solver::prepareIter() {
   // Prepare next iteration.
   // Return true if Ipm main loop should be stopped
 
+  it_->saveBest(options_.feasibility_tol, options_.optimality_tol, iter_);
   if (checkIterate()) return true;
   if (checkBadIter()) return true;
   if (checkTermination()) return true;
@@ -1070,6 +1071,10 @@ bool Solver::checkBadIter() {
       } else
         info_.status = kStatusNoProgress;
       terminate = true;
+
+      if (it_->resetBest(iter_)) {
+        printOutput(true);
+      }
     }
   }
 
@@ -1170,11 +1175,17 @@ void Solver::printHeader() const {
   }
 }
 
-void Solver::printOutput() const {
+void Solver::printOutput(bool reset) const {
   printHeader();
 
-  logger_.print("%5d %16.8e %16.8e %10.2e %10.2e %9.2e", iter_, it_->pobj,
-                it_->dobj, it_->pinf, it_->dinf, it_->pdgap);
+  if (!reset) {
+    logger_.print("%5d ", iter_);
+  } else {
+    logger_.print("   >  ");
+  }
+
+  logger_.print("%16.8e %16.8e %10.2e %10.2e %9.2e", it_->pobj, it_->dobj,
+                it_->pinf, it_->dinf, it_->pdgap);
   if (!options_.timeless_log) logger_.print(" %7.1f", control_.elapsed());
   if (logger_.debug(1)) {
     const IpmIterData& data = it_->data.back();

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -110,7 +110,7 @@ void Solver::doSolve() {
   reset();
 
   // iterate object needs to be initialised before potentially interrupting
-  it_.reset(new Iterate(model_, regul_));
+  it_.reset(new Iterate(model_, info_, regul_));
   if (!it_) {
     info_.error = kErrorFailedAllocation;
     return;
@@ -126,7 +126,7 @@ void Solver::doSolve() {
   runIpx();
   if (errorOrInterrupt()) return;
 
-  it_->finalResiduals(info_);
+  it_->finalResiduals();
 }
 
 void Solver::runIpm() {
@@ -137,12 +137,14 @@ void Solver::runIpm() {
     if (predictor()) break;
     if (correctors()) break;
     makeStep();
+    printOutput();
   }
 }
 
 bool Solver::initialise() {
   // Prepare ipm for execution.
   // Return true if an error occurred.
+  Clock clock;
 
   start_time_ = control_.elapsed();
 
@@ -171,12 +173,14 @@ bool Solver::initialise() {
 
   if (checkInterrupt()) return true;
 
+  info_.times[kInitialiseTime] += clock.stop();
   return false;
 }
 
 bool Solver::prepareIter() {
   // Prepare next iteration.
   // Return true if Ipm main loop should be stopped
+  Clock clock;
 
   it_->saveBest(options_.feasibility_tol, options_.optimality_tol, iter_);
   if (checkIterate()) return true;
@@ -197,12 +201,14 @@ bool Solver::prepareIter() {
 
   it_->computeScaling();
 
+  info_.times[kPrepareTime] += clock.stop();
   return false;
 }
 
 bool Solver::predictor() {
   // Compute affine scaling direction.
   // Return true if an error occurred.
+  Clock clock;
 
   if (checkInterrupt()) return true;
 
@@ -211,18 +217,21 @@ bool Solver::predictor() {
 
   if (solveNewtonSystem(it_->delta)) return true;
 
+  info_.times[kPredictorTime] += clock.stop();
   return false;
 }
 
 bool Solver::correctors() {
   // Compute multiple centrality correctors.
   // Return true if an error occurred.
+  Clock clock;
 
   if (checkInterrupt()) return true;
 
   sigmaCorrectors();
   if (centralityCorrectors()) return true;
 
+  info_.times[kCorrectorsTime] += clock.stop();
   return false;
 }
 
@@ -357,6 +366,8 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
 }
 
 void Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
+  Clock clock;
+
   std::vector<double>& theta_inv = it_->scaling;
 
   std::vector<double> res7 = it_->residual7(rhs);
@@ -412,6 +423,8 @@ void Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
       return;
     }
   }
+
+  info_.times[kSolve2x2Time] += clock.stop();
 }
 
 void Solver::solve6x6(NewtonDir& delta, const Residuals& rhs) {
@@ -420,7 +433,9 @@ void Solver::solve6x6(NewtonDir& delta, const Residuals& rhs) {
   recoverDirection(delta, rhs);
 }
 
-void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) const {
+void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) {
+  Clock clock;
+
   const std::vector<double>& xl = it_->xl;
   const std::vector<double>& xu = it_->xu;
   const std::vector<double>& zl = it_->zl;
@@ -432,7 +447,7 @@ void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) const {
   const std::vector<double>& res6 = rhs.r6;
 
   for (Int i = 0; i < n_; ++i) {
-    if (model_.hasLb(i) || model_.hasUb(i)) {
+    if (model_.hasLb(i)) {
       delta.xl[i] = delta.x[i] - res2[i];
       delta.zl[i] = (res5[i] - zl[i] * delta.xl[i]) / xl[i];
     } else {
@@ -441,7 +456,7 @@ void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) const {
     }
   }
   for (Int i = 0; i < n_; ++i) {
-    if (model_.hasLb(i) || model_.hasUb(i)) {
+    if (model_.hasUb(i)) {
       delta.xu[i] = res3[i] - delta.x[i];
       delta.zu[i] = (res6[i] - zu[i] * delta.xu[i]) / xu[i];
     } else {
@@ -449,6 +464,8 @@ void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) const {
       delta.zu[i] = 0.0;
     }
   }
+
+  info_.times[kRecoverTime] += clock.stop();
 }
 
 double Solver::stepToBoundary(const std::vector<double>& x,
@@ -586,12 +603,13 @@ void Solver::stepSizes() {
 }
 
 void Solver::makeStep() {
+  Clock clock;
   stepSizes();
   it_->makeStep(alpha_primal_, alpha_dual_);
   it_->residual1234();
   it_->computeMu();
   it_->indicators();
-  printOutput();
+  info_.times[kStepTime] += clock.stop();
 }
 
 bool Solver::startingPoint() {
@@ -841,6 +859,8 @@ void Solver::sigmaCorrectors() {
 }
 
 void Solver::residualsMcc() {
+  Clock clock;
+
   // compute right-hand side for multiple centrality correctors
   std::vector<double>& xl = it_->xl;
   std::vector<double>& xu = it_->xu;
@@ -914,6 +934,8 @@ void Solver::residualsMcc() {
       res6[i] = 0.0;
     }
   }
+
+  info_.times[kResidualsTime] += clock.stop();
 }
 
 bool Solver::centralityCorrectors() {
@@ -1333,32 +1355,48 @@ void Solver::printSummary() const {
     log_stream << textline("Solves:") << integer(info_.solve_number) << '\n';
 
     if (!options_.timeless_log) {
-      log_stream << textline("Analyse AS time:")
-                 << fix(info_.analyse_AS_time, 0, 2) << '\n';
-      log_stream << textline("Analyse NE time:")
-                 << fix(info_.analyse_NE_time, 0, 2) << '\n';
-      log_stream << textline("Matrix time:") << fix(info_.matrix_time, 0, 2)
-                 << '\n';
-      log_stream << textline("AS structure time:")
-                 << fix(info_.AS_structure_time, 0, 2) << '\n';
-      log_stream << textline("NE structure time:")
-                 << fix(info_.NE_structure_time, 0, 2) << '\n';
-      log_stream << textline("Factorisation time:")
-                 << fix(info_.factor_time, 0, 2) << '\n';
-      log_stream << textline("Solve time:") << fix(info_.solve_time, 0, 2)
-                 << '\n';
-      log_stream << textline("Residual time:") << fix(info_.residual_time, 0, 2)
-                 << '\n';
-      log_stream << textline("Omega time:") << fix(info_.omega_time, 0, 2)
-                 << '\n';
       log_stream << textline("Avg time per factorisation:")
-                 << sci(info_.factor_time / info_.factor_number, 0, 2) << '\n';
+                 << sci(info_.times[kFactoriseTime] / info_.factor_number, 0, 2)
+                 << '\n';
       log_stream << textline("Avg time per solve:")
-                 << sci(info_.solve_time / info_.solve_number, 0, 2) << '\n';
+                 << sci(info_.times[kSolveTime] / info_.solve_number, 0, 2)
+                 << '\n';
     }
   }
-
   logger_.print(log_stream.str().c_str());
+
+  logger_.print("\nTime profile\n");
+
+  logger_.print(" Initialise           %.2f\n", info_.times[kInitialiseTime]);
+  logger_.print(" Prepare iter         %.2f\n", info_.times[kPrepareTime]);
+  logger_.print(" Predictor            %.2f\n", info_.times[kPredictorTime]);
+  logger_.print(" Correctors           %.2f\n", info_.times[kCorrectorsTime]);
+  logger_.print(" Step                 %.2f\n", info_.times[kStepTime]);
+  logger_.print("\n");
+
+  logger_.print(" 2x2 system           %.2f\n", info_.times[kSolve2x2Time]);
+  logger_.print(" Recover direction    %.2f\n", info_.times[kRecoverTime]);
+  logger_.print(" Residuals            %.2f\n", info_.times[kResidualsTime]);
+  logger_.print("\n");
+
+  logger_.print(" Structure NE         %.2f\n",
+                info_.times[kMatrixStructureTime_NE]);
+  logger_.print(" Structure AS         %.2f\n",
+                info_.times[kMatrixStructureTime_AS]);
+  logger_.print(" Matrix values        %.2f\n", info_.times[kMatrixValuesTime]);
+
+  logger_.print(" Analyse NE           %.2f\n", info_.times[kAnalyseTime_NE]);
+  logger_.print(" Analyse AS           %.2f\n", info_.times[kAnalyseTime_AS]);
+
+  logger_.print(" Factorise            %.2f\n", info_.times[kFactoriseTime]);
+
+  logger_.print(" Solve                %.2f\n", info_.times[kSolveTime]);
+  logger_.print(" Residual             %.2f\n",
+                info_.times[kRefinementResTime]);
+  logger_.print(" Omega                %.2f\n",
+                info_.times[kRefinementOmegaTime]);
+  logger_.print(" Insert/split         %.2f\n", info_.times[kInsertSplitTime]);
+  logger_.print("\n");
 }
 
 void Solver::getOriginalDims(Int& num_row, Int& num_col) const {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -685,7 +685,7 @@ bool Solver::startingPoint() {
   model_.A().alphaProductPlusY(1.0, temp_m, xl, true);
 
   // x += dx;
-  vectorAdd(x, xl, 1.0);
+  vectorAdd(x, 1.0, xl, 1.0);
   // *********************************************************************
 
   // *********************************************************************
@@ -885,10 +885,10 @@ void Solver::residualsMcc() {
   std::vector<double> xut = xu;
   std::vector<double> zlt = zl;
   std::vector<double> zut = zu;
-  vectorAdd(xlt, it_->delta.xl, alpha_p);
-  vectorAdd(xut, it_->delta.xu, alpha_p);
-  vectorAdd(zlt, it_->delta.zl, alpha_d);
-  vectorAdd(zut, it_->delta.zu, alpha_d);
+  vectorAdd(xlt, 1.0, it_->delta.xl, alpha_p);
+  vectorAdd(xut, 1.0, it_->delta.xu, alpha_p);
+  vectorAdd(zlt, 1.0, it_->delta.zl, alpha_d);
+  vectorAdd(zut, 1.0, it_->delta.zu, alpha_d);
 
   // compute right-hand side for mcc
   for (Int i = 0; i < n_; ++i) {
@@ -963,16 +963,16 @@ bool Solver::centralityCorrectors() {
 
     if (alpha_p >= alpha_p_old + kMccIncreaseAlpha * kMccIncreaseMin) {
       // accept primal corrector
-      vectorAdd(it_->delta.x, corrector.x, wp);
-      vectorAdd(it_->delta.xl, corrector.xl, wp);
-      vectorAdd(it_->delta.xu, corrector.xu, wp);
+      vectorAdd(it_->delta.x, 1.0, corrector.x, wp);
+      vectorAdd(it_->delta.xl, 1.0, corrector.xl, wp);
+      vectorAdd(it_->delta.xu, 1.0, corrector.xu, wp);
       alpha_p_old = alpha_p;
     }
     if (alpha_d >= alpha_d_old + kMccIncreaseAlpha * kMccIncreaseMin) {
       // accept dual corrector
-      vectorAdd(it_->delta.y, corrector.y, wd);
-      vectorAdd(it_->delta.zl, corrector.zl, wd);
-      vectorAdd(it_->delta.zu, corrector.zu, wd);
+      vectorAdd(it_->delta.y, 1.0, corrector.y, wd);
+      vectorAdd(it_->delta.zl, 1.0, corrector.zl, wd);
+      vectorAdd(it_->delta.zu, 1.0, corrector.zu, wd);
       alpha_d_old = alpha_d;
     }
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -162,9 +162,9 @@ bool Solver::initialise() {
   // - multifrontal is dominated by assembly operations
   bool switch_to_uplooking =
       LS_->flops() < kUplookFlopsThresh ||
-      LS_->nz() < kUplookNzPerColLower * LS_->n() ||
+      LS_->nz() < kUplookNzPerColLower * kkt_->n() ||
       LS_->flops() < kUplookSpopsRatioLower * LS_->spops() ||
-      (LS_->nz() < kUplookNzPerColUpper * LS_->n() &&
+      (LS_->nz() < kUplookNzPerColUpper * kkt_->n() &&
        LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
 
   // always use for now

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1268,7 +1268,8 @@ void Solver::printOutput(bool reset) const {
   if (!reset) {
     logger_.print("%5d ", iter_);
   } else {
-    logger_.print(">%4d ", it_->best_iter);
+    logger_.print(" Resetting to iteration %d\n", it_->best_iter);
+    logger_.print("%5d ", it_->best_iter);
   }
 
   logger_.print("%16.8e %16.8e %10.2e %10.2e %9.2e", it_->pobj, it_->dobj,

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -342,18 +342,18 @@ void Solver::refineWithIpx() {
 }
 
 bool Solver::solveNewtonSystem(NewtonDir& delta) {
-  solve6x6(delta, it_->res);
-  refine(delta);
+  bool terminate = solve6x6(delta, it_->res);
 
-  bool terminate = false;
-
-  // Check for NaN of Inf
-  if (it_->isDirNan(delta)) {
-    logger_.printInfo("Direction is nan\n");
-    terminate = true;
-  } else if (it_->isDirInf(delta)) {
-    logger_.printInfo("Direction is inf\n");
-    terminate = true;
+  if (!terminate) {
+    refine(delta);
+    // Check for NaN of Inf
+    if (it_->isDirNan(delta)) {
+      logger_.printInfo("Direction is nan\n");
+      terminate = true;
+    } else if (it_->isDirInf(delta)) {
+      logger_.printInfo("Direction is inf\n");
+      terminate = true;
+    }
   }
 
   if (terminate) {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -123,7 +123,7 @@ void Solver::doSolve() {
   runIpm();
   if (errorOrInterrupt()) return;
 
-  refineWithIpx();
+  runIpx();
   if (errorOrInterrupt()) return;
 
   it_->finalResiduals(info_);
@@ -261,7 +261,10 @@ bool Solver::prepareIpx() {
     info_.error = kErrorIpx;
     return true;
   }
+  return false;
+}
 
+bool Solver::prepareIpxStartingPoint() {
   std::vector<double> x, xl, xu, slack, y, zl, zu;
   getInteriorSolution(x, xl, xu, slack, y, zl, zu);
 
@@ -278,34 +281,43 @@ bool Solver::prepareIpx() {
   return false;
 }
 
-void Solver::refineWithIpx() {
+void Solver::runIpx() {
   if (checkInterrupt()) return;
 
-  bool refine = false;
   if (statusNeedsRefinement() && refinementIsOn()) {
     logger_.print("\nRestarting with IPX\n");
-    refine = true;
+    refineWithIpx();
   } else if (statusAllowsCrossover() && crossoverIsOn()) {
     logger_.print("\nRunning crossover with IPX\n");
+    crossoverWithIpx();
   } else {
     return;
   }
+}
 
+void Solver::refineWithIpx() {
   if (prepareIpx()) return;
-
+  if (prepareIpxStartingPoint()) return;
   ipx_lps_.Solve();
   info_.ipx_used = true;
-
   info_.ipx_info = ipx_lps_.GetInfo();
-
-  if (refine)
-    setStatus1(IpxToHipoStatus(info_.ipx_info.status_ipm));
-  else
-    setStatus2(IpxToHipoStatus(info_.ipx_info.status_ipm));
-
+  setStatus1(IpxToHipoStatus(info_.ipx_info.status_ipm));
   if (info_.ipx_info.status_crossover != IPX_STATUS_not_run)
     setStatus2(IpxToHipoStatus(info_.ipx_info.status_crossover));
+  if (info_.ipx_info.errflag) info_.error = kErrorIpx;
+}
 
+void Solver::crossoverWithIpx() {
+  // at the moment this is almost identical to refineWithIpx, but in the future
+  // it will use ipx_lps_.CrossoverFromStartingPoint
+  if (prepareIpx()) return;
+  if (prepareIpxStartingPoint()) return;
+  ipx_lps_.Solve();
+  info_.ipx_used = true;
+  info_.ipx_info = ipx_lps_.GetInfo();
+  setStatus2(IpxToHipoStatus(info_.ipx_info.status_ipm));
+  if (info_.ipx_info.status_crossover != IPX_STATUS_not_run)
+    setStatus2(IpxToHipoStatus(info_.ipx_info.status_crossover));
   if (info_.ipx_info.errflag) info_.error = kErrorIpx;
 }
 
@@ -1026,6 +1038,8 @@ bool Solver::checkStagnation() {
 bool Solver::checkBadIter() {
   bool terminate = false;
   bool stagnation = iter_ > 0 ? checkStagnation() : false;
+
+  if (iter_ == 18) stagnation = true;
 
   // check for infeasibility
   bool mu_is_large =

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -168,7 +168,7 @@ bool Solver::initialise() {
        LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
 
   // always use for now
-  switch_to_uplooking = true;
+  switch_to_uplooking = false;
 
   if (switch_to_uplooking) {
     LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -369,10 +369,12 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
       LS_->clear();
       it_->data.back().factorisation_used = LS_->type();
       logger_.printInfo("Switching to FactorHighs because of bad direction\n");
+      resetToBestIter(iter_ - 1);
 
       // Solve again. This does not create an infinite loop, as the if statement
       // cannot trigger in the second solve.
       delta.clear();
+      it_->data.back().omega = 0.0;
       terminate = solveNewtonSystem(delta);
     } else
       info_.status = kStatusError;
@@ -1116,7 +1118,7 @@ bool Solver::checkBadIter() {
         LS_->clear();
         it_->bad_iter_ = 0;
         logger_.printInfo("Switching to FactorHighs because of no progress\n");
-        if (it_->resetBest(iter_)) printOutput(true);
+        resetToBestIter(iter_);
       } else {
         // stagnation detected, solution may still be good for highs kktCheck
         if (info_.status != kStatusPDFeas && checkTerminationKkt()) {
@@ -1126,7 +1128,7 @@ bool Solver::checkBadIter() {
           info_.status = kStatusPDFeas;
         } else {
           info_.status = kStatusNoProgress;
-          if (it_->resetBest(iter_)) printOutput(true);
+          resetToBestIter(iter_);
         }
 
         terminate = true;
@@ -1214,6 +1216,11 @@ bool Solver::checkInterrupt() {
     terminate = true;
   }
   return terminate;
+}
+
+void Solver::resetToBestIter(Int iter, bool print) {
+  bool did_reset = it_->resetBest(iter);
+  if (did_reset && print) printOutput(true);
 }
 
 void Solver::printHeader() const {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1216,6 +1216,10 @@ bool Solver::switchToMultifrontal() {
     } else {
       LS_->clear();
       it_->bad_iter_ = 0;
+      it_->best_pinf_ = kHighsInf;
+      it_->best_dinf_ = kHighsInf;
+      it_->largest_dx_x_ = 0;
+      it_->largest_dy_y_ = 0;
       switch_successfull = true;
     }
   }

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -156,10 +156,25 @@ bool Solver::initialise() {
   }
   LS_->clear();
 
-  // switch to up-looking factorisation
-  LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
-  LS_->setup();
-  LS_->clear();
+  // Use uplooking factorisation instead of multifrontal if
+  // - very few operations needed or
+  // - very few nz per column in L or
+  // - multifrontal is dominated by assembly operations
+  bool switch_to_uplooking =
+      LS_->flops() < kUplookFlopsThresh ||
+      LS_->nz() < kUplookNzPerColLower * LS_->n() ||
+      LS_->flops() < kUplookSpopsRatioLower * LS_->spops() ||
+      (LS_->nz() < kUplookNzPerColUpper * LS_->n() &&
+       LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
+
+  // always use for now
+  switch_to_uplooking = true;
+
+  if (switch_to_uplooking) {
+    LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
+    LS_->setup();
+    LS_->clear();
+  }
 
   it_->data.append();
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -15,9 +15,9 @@ namespace hipo {
 Int Solver::load(const HighsLp& lp, const HighsHessian& Q) {
   if (model_.init(lp, Q)) {
     logger_.printInfo("Error with model\n");
-    return kStatusBadModel;
+    return kErrorModel;
   }
-  return kStatusOk;
+  return kOk;
 }
 
 void Solver::setOptions(const HighsOptions& highs_options) {
@@ -95,8 +95,15 @@ void Solver::reset() {
 }
 
 void Solver::solve() {
+  doSolve();
+  info_.ipm_iter = iter_;
+  finaliseStatus();
+  printSummary();
+}
+
+void Solver::doSolve() {
   if (!model_.ready()) {
-    info_.status = kStatusBadModel;
+    info_.error = kErrorModel;
     return;
   }
 
@@ -105,7 +112,7 @@ void Solver::solve() {
   // iterate object needs to be initialised before potentially interrupting
   it_.reset(new Iterate(model_, regul_));
   if (!it_) {
-    info_.status = kStatusError;
+    info_.error = kErrorFailedAllocation;
     return;
   }
 
@@ -114,9 +121,12 @@ void Solver::solve() {
   printInfo();
 
   runIpm();
+  if (errorOrInterrupt()) return;
+
   refineWithIpx();
+  if (errorOrInterrupt()) return;
+
   it_->finalResiduals(info_);
-  printSummary();
 }
 
 void Solver::runIpm() {
@@ -128,8 +138,6 @@ void Solver::runIpm() {
     if (correctors()) break;
     makeStep();
   }
-
-  terminate();
 }
 
 bool Solver::initialise() {
@@ -140,7 +148,7 @@ bool Solver::initialise() {
 
   kkt_.reset(new KktMatrix(model_, regul_, info_, logger_));
   if (!kkt_) {
-    info_.status = kStatusError;
+    info_.error = kErrorFailedAllocation;
     return true;
   }
 
@@ -164,11 +172,6 @@ bool Solver::initialise() {
   if (checkInterrupt()) return true;
 
   return false;
-}
-
-void Solver::terminate() {
-  info_.ipm_iter = iter_;
-  if (info_.status == kStatusNotRun) info_.status = kStatusMaxIter;
 }
 
 bool Solver::prepareIter() {
@@ -255,6 +258,7 @@ bool Solver::prepareIpx() {
 
   if (load_status) {
     logger_.printInfo("Error loading model into IPX\n");
+    info_.error = kErrorIpx;
     return true;
   }
 
@@ -267,6 +271,7 @@ bool Solver::prepareIpx() {
 
   if (start_point_status) {
     logger_.printInfo("Error loading starting point into IPX\n");
+    info_.error = kErrorIpx;
     return true;
   }
 
@@ -276,8 +281,10 @@ bool Solver::prepareIpx() {
 void Solver::refineWithIpx() {
   if (checkInterrupt()) return;
 
+  bool refine = false;
   if (statusNeedsRefinement() && refinementIsOn()) {
     logger_.print("\nRestarting with IPX\n");
+    refine = true;
   } else if (statusAllowsCrossover() && crossoverIsOn()) {
     logger_.print("\nRunning crossover with IPX\n");
   } else {
@@ -291,33 +298,31 @@ void Solver::refineWithIpx() {
 
   info_.ipx_info = ipx_lps_.GetInfo();
 
-  info_.status = IpxToHipoStatus(info_.ipx_info.status_ipm);
+  if (refine)
+    setStatus1(IpxToHipoStatus(info_.ipx_info.status_ipm));
+  else
+    setStatus2(IpxToHipoStatus(info_.ipx_info.status_ipm));
 
-  std::stringstream log_stream;
-  log_stream << "IPX reports: ipm "
-             << ipx::StatusString(info_.ipx_info.status_ipm);
   if (info_.ipx_info.status_crossover != IPX_STATUS_not_run)
-    log_stream << ", crossover "
-               << ipx::StatusString(info_.ipx_info.status_crossover);
-  log_stream << '\n';
-  logger_.print(log_stream.str().c_str());
+    setStatus2(IpxToHipoStatus(info_.ipx_info.status_crossover));
 
-  if (info_.ipx_info.status_crossover == IPX_STATUS_optimal) {
-    info_.status = kStatusBasic;
-  }
+  if (info_.ipx_info.errflag) info_.error = kErrorIpx;
 }
 
 bool Solver::solveNewtonSystem(NewtonDir& delta) {
-  bool terminate = solve6x6(delta, it_->res);
+  solve6x6(delta, it_->res);
+  bool terminate = info_.error;
 
   if (!terminate) {
     refine(delta);
     if (it_->isDirNan(delta)) {
       logger_.printInfo("Direction is nan\n");
       terminate = true;
+      info_.error = kErrorNan;
     } else if (it_->isDirInf(delta)) {
       logger_.printInfo("Direction is inf\n");
       terminate = true;
+      info_.error = kErrorNan;
     }
   }
 
@@ -333,14 +338,13 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
       delta.clear();
       it_->data.back().omega = 0.0;
       terminate = solveNewtonSystem(delta);
-    } else
-      info_.status = kStatusError;
+    }
   }
 
   return terminate;
 }
 
-bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
+void Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
   std::vector<double>& theta_inv = it_->scaling;
 
   std::vector<double> res7 = it_->residual7(rhs);
@@ -350,18 +354,18 @@ bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
     std::vector<double> res8 = it_->residual8(rhs, res7);
 
     if (!LS_->valid_) {
-      if (Int status = LS_->factorNE(theta_inv)) {
-        logger_.printe("Error while factorising normal equations\n");
-        info_.status = (Status)status;
-        return true;
+      info_.error = LS_->factorNE(theta_inv);
+      if (info_.error) {
+        logger_.printInfo("Error while factorising normal equations\n");
+        return;
       }
       it_->getReg(*LS_, options_.nla);
     }
 
-    if (Int status = LS_->solveNE(res8, delta.y)) {
-      logger_.printe("Error while solving normal equations\n");
-      info_.status = (Status)status;
-      return true;
+    info_.error = LS_->solveNE(res8, delta.y);
+    if (info_.error) {
+      logger_.printInfo("Error while solving normal equations\n");
+      return;
     }
 
     // Compute delta.x
@@ -382,28 +386,26 @@ bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
   // AUGMENTED SYSTEM
   else {
     if (!LS_->valid_) {
-      if (Int status = LS_->factorAS(theta_inv)) {
-        logger_.printe("Error while factorising augmented system\n");
-        info_.status = (Status)status;
-        return true;
+      info_.error = LS_->factorAS(theta_inv);
+      if (info_.error) {
+        logger_.printInfo("Error while factorising augmented system\n");
+        return;
       }
       it_->getReg(*LS_, options_.nla);
     }
 
-    if (Int status = LS_->solveAS(res7, rhs.r1, delta.x, delta.y)) {
-      logger_.printe("Error while solving augmented system\n");
-      info_.status = (Status)status;
-      return true;
+    info_.error = LS_->solveAS(res7, rhs.r1, delta.x, delta.y);
+    if (info_.error) {
+      logger_.printInfo("Error while solving augmented system\n");
+      return;
     }
   }
-
-  return false;
 }
 
-bool Solver::solve6x6(NewtonDir& delta, const Residuals& rhs) {
-  if (solve2x2(delta, rhs)) return true;
+void Solver::solve6x6(NewtonDir& delta, const Residuals& rhs) {
+  solve2x2(delta, rhs);
+  if (info_.error) return;
   recoverDirection(delta, rhs);
-  return false;
 }
 
 void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) const {
@@ -615,15 +617,15 @@ bool Solver::startingPoint() {
     // temp_m
 
     // factorise A*A^T
-    if (Int status = LS_->factorNE(empty_scaling)) {
-      logger_.printe("Error while factorising normal equations\n");
-      info_.status = (Status)status;
+    info_.error = LS_->factorNE(empty_scaling);
+    if (info_.error) {
+      logger_.printInfo("Error while factorising normal equations\n");
       return true;
     }
 
-    if (Int status = LS_->solveNE(y, temp_m)) {
-      logger_.printe("Error while solving normal equations\n");
-      info_.status = (Status)status;
+    info_.error = LS_->solveNE(y, temp_m);
+    if (info_.error) {
+      logger_.printInfo("Error while solving normal equations\n");
       return true;
     }
 
@@ -632,18 +634,18 @@ bool Solver::startingPoint() {
     // [ -I  A^T] [...] = [ -x]
     // [  A   0 ] [ dx] = [ b ]
 
-    if (Int status = LS_->factorAS(empty_scaling)) {
-      logger_.printe("Error while factorising augmented system\n");
-      info_.status = (Status)status;
+    info_.error = LS_->factorAS(empty_scaling);
+    if (info_.error) {
+      logger_.printInfo("Error while factorising augmented system\n");
       return true;
     }
 
     std::vector<double> rhs_x(n_);
     for (Int i = 0; i < n_; ++i) rhs_x[i] = -x[i];
     std::vector<double> lhs_x(n_);
-    if (Int status = LS_->solveAS(rhs_x, y, lhs_x, temp_m)) {
-      logger_.printe("Error while solving augmented system\n");
-      info_.status = (Status)status;
+    info_.error = LS_->solveAS(rhs_x, y, lhs_x, temp_m);
+    if (info_.error) {
+      logger_.printInfo("Error while solving augmented system\n");
       return true;
     }
   }
@@ -700,9 +702,9 @@ bool Solver::startingPoint() {
     std::fill(temp_m.begin(), temp_m.end(), 0.0);
     model_.A().alphaProductPlusY(1.0, cPlusQx, temp_m);
 
-    if (Int status = LS_->solveNE(temp_m, y)) {
-      logger_.printe("Error while solvingF normal equations\n");
-      info_.status = (Status)status;
+    info_.error = LS_->solveNE(temp_m, y);
+    if (info_.error) {
+      logger_.printInfo("Error while solvingF normal equations\n");
       return true;
     }
 
@@ -714,9 +716,9 @@ bool Solver::startingPoint() {
     std::vector<double> rhs_y(m_, 0.0);
     std::vector<double> lhs_x(n_);
 
-    if (Int status = LS_->solveAS(cPlusQx, rhs_y, lhs_x, y)) {
-      logger_.printe("Error while solving augmented system\n");
-      info_.status = (Status)status;
+    info_.error = LS_->solveAS(cPlusQx, rhs_y, lhs_x, y);
+    if (info_.error) {
+      logger_.printInfo("Error while solving augmented system\n");
       return true;
     }
   }
@@ -992,11 +994,11 @@ void Solver::bestWeight(const NewtonDir& delta, const NewtonDir& corrector,
 bool Solver::checkIterate() {
   if (it_->isNan()) {
     logger_.printInfo("\nIterate is nan\n");
-    info_.status = kStatusError;
+    info_.error = kErrorNan;
     return true;
   } else if (it_->isInf()) {
     logger_.printInfo("\nIterate is inf\n");
-    info_.status = kStatusError;
+    info_.error = kErrorNan;
     return true;
   }
 
@@ -1006,6 +1008,7 @@ bool Solver::checkIterate() {
         (model_.hasUb(i) && it_->xu[i] < 0) ||
         (model_.hasUb(i) && it_->zu[i] < 0)) {
       logger_.printInfo("\nIterate has negative component\n");
+      info_.error = kErrorNegativeComponent;
       return true;
     }
   }
@@ -1045,27 +1048,32 @@ bool Solver::checkBadIter() {
     if (pobj_is_larger) {
       // problem is likely to be primal unbounded, i.e. dual infeasible
       logger_.print("=== Dual infeasible\n");
-      info_.status = kStatusDualInfeasible;
+      setStatus(kStatusDualInfeasible);
       terminate = true;
     } else if (dobj_is_larger) {
       // problem is likely to be dual unbounded, i.e. primal infeasible
       logger_.print("=== Primal infeasible\n");
-      info_.status = kStatusPrimalInfeasible;
+      setStatus(kStatusPrimalInfeasible);
       terminate = true;
     } else if (stagnation) {
       if (switchToMultifrontal()) {
         logger_.printInfo("Switching to FactorHighs because of no progress\n");
         resetToBestIter(iter_);
       } else {
-        // stagnation detected, solution may still be good for highs kktCheck
-        if (info_.status != kStatusPDFeas && checkTerminationKkt()) {
-          logger_.printw(
-              "HiPO stagnated but HiGHS considers the solution acceptable\n");
-          logger_.print("=== Primal-dual feasible point found\n");
-          info_.status = kStatusPDFeas;
-        } else {
-          info_.status = kStatusNoProgress;
+        if (getStatus1() == kStatusOptimal) {
+          assert(crossoverIsOn());
+          setStatus2(kStatusNoProgress);
           resetToBestIter(iter_);
+        } else {
+          if (checkTerminationKkt()) {
+            logger_.printw(
+                "HiPO stagnated but HiGHS considers the solution acceptable\n");
+            logger_.print("=== Primal-dual feasible point found\n");
+            setStatus1(kStatusOptimal);
+          } else {
+            setStatus1(kStatusNoProgress);
+            resetToBestIter(iter_);
+          }
         }
 
         terminate = true;
@@ -1085,9 +1093,10 @@ bool Solver::checkTermination() {
 
   if (feasible && optimal) {
     if (crossoverIsOn()) {
-      if (info_.status != kStatusPDFeas)
+      if (getStatus1() != kStatusOptimal) {
         logger_.print("=== Primal-dual feasible point found\n");
-      info_.status = kStatusPDFeas;
+        setStatus1(kStatusOptimal);
+      }
       bool ready_for_crossover =
           it_->infeasAfterDropping() < options_.crossover_tol;
       if (ready_for_crossover) {
@@ -1098,9 +1107,8 @@ bool Solver::checkTermination() {
     } else {
       terminate = model_.qp() ? true : checkTerminationKkt();
       if (terminate) {
-        assert(info_.status != kStatusPDFeas);
         logger_.print("=== Primal-dual feasible point found\n");
-        info_.status = kStatusPDFeas;
+        setStatus1(kStatusOptimal);
       }
     }
   }
@@ -1149,7 +1157,7 @@ bool Solver::checkInterrupt() {
   bool terminate = false;
   Int status = control_.interruptCheck(iter_);
   if (status) {
-    info_.status = (Status)status;
+    setStatus((Status)status);
     terminate = true;
   }
   return terminate;
@@ -1164,13 +1172,12 @@ bool Solver::initialiseLinearSolver() {
   LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
                                   it_->data, logger_));
   if (!LS_) {
-    info_.status = kStatusError;
+    info_.error = kErrorFailedAllocation;
     return true;
   }
-  if (Int status = LS_->setup()) {
-    info_.status = (Status)status;
-    return true;
-  }
+  info_.error = LS_->setup();
+  if (info_.error) return true;
+
   LS_->clear();
 
   // Use uplooking factorisation instead of multifrontal if
@@ -1195,7 +1202,7 @@ bool Solver::initialiseLinearSolver() {
   if (do_switch) {
     LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
     if (!LS_) {
-      info_.status = kStatusError;
+      info_.error = kErrorFailedAllocation;
       return true;
     }
     LS_->setup();
@@ -1212,10 +1219,11 @@ bool Solver::switchToMultifrontal() {
     LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
                                     it_->data, logger_));
     if (!LS_) {
-      info_.status = kStatusError;
+      info_.error = kErrorFailedAllocation;
     } else {
       LS_->clear();
       it_->bad_iter_ = 0;
+      info_.error = kOk;
       switch_successfull = true;
     }
   }
@@ -1290,6 +1298,13 @@ void Solver::printSummary() const {
                << fix(control_.elapsed() - start_time_, 0, 2) << "\n";
 
   log_stream << textline("Status:") << statusString(info_.status) << "\n";
+  if (info_.ipx_info.status_crossover != IPX_STATUS_not_run)
+    log_stream << textline("Status Crossover:")
+               << statusString(IpxToHipoStatus(info_.ipx_info.status_crossover))
+               << "\n";
+  if (info_.error)
+    log_stream << textline("Error:") << errorString((Error)info_.error) << "\n";
+
   log_stream << textline("HiPO iterations:") << integer(iter_) << "\n";
   if (info_.ipx_used)
     log_stream << textline("IPX iterations:") << integer(info_.ipx_info.iter)
@@ -1393,16 +1408,20 @@ void Solver::chooseNumberOfCorrectors() {
   }
 }
 
-bool Solver::statusIsSolved() const { return info_.status >= kStatusSolved; }
-bool Solver::statusIsStopped() const { return info_.status < kStatusFailed; }
+bool Solver::statusIsSolved() const {
+  return info_.status >= kStatusTypeSolved;
+}
+bool Solver::statusIsStopped() const {
+  return info_.status > kStatusTypeStopped && info_.status < kStatusTypeFailed;
+}
 bool Solver::statusIsFailed() const {
-  return info_.status >= kStatusFailed && info_.status < kStatusSolved;
+  return info_.status > kStatusTypeFailed && info_.status < kStatusTypeSolved;
 }
 bool Solver::statusAllowsCrossover() const {
-  return info_.status >= kStatusPDFeas;
+  return getStatus1() == kStatusOptimal;
 }
 bool Solver::statusNeedsRefinement() const {
-  return info_.status == kStatusNoProgress || info_.status == kStatusImprecise;
+  return getStatus1() == kStatusNoProgress || getStatus1() == kStatusImprecise;
 }
 bool Solver::refinementIsOn() const {
   return options_.refine_with_ipx && !model_.qp();
@@ -1413,5 +1432,44 @@ bool Solver::crossoverIsOn() const {
 bool Solver::solved() const { return statusIsSolved(); }
 bool Solver::stopped() const { return statusIsStopped(); }
 bool Solver::failed() const { return statusIsFailed(); }
+
+bool Solver::errorOrInterrupt() const {
+  return getStatus() == kStatusTimeLimit ||
+         getStatus() == kStatusUserInterrupt || info_.error;
+}
+
+// status1 should only be set if status2 is empty.
+// status2 should only be set if status1 is optimal or imprecise.
+// final status should consider status2 if non empty, or status 1 otherwise.
+
+void Solver::setStatus1(Status status) {
+  assert(getStatus2() == kStatusNotSet);
+  status_phase1 = status;
+}
+void Solver::setStatus2(Status status) {
+  assert(getStatus1() == kStatusOptimal || getStatus1() == kStatusImprecise);
+  status_phase2 = status;
+}
+void Solver::setStatus(Status status) {
+  if (status_phase1 == kStatusNotSet)
+    setStatus1(status);
+  else
+    setStatus2(status);
+}
+
+Status Solver::getStatus1() const { return status_phase1; }
+Status Solver::getStatus2() const { return status_phase2; }
+Status Solver::getStatus() const {
+  if (getStatus2() != kStatusNotSet)
+    return getStatus2();
+  else
+    return getStatus1();
+}
+
+void Solver::finaliseStatus() {
+  info_.status = getStatus();
+  if (info_.error) info_.status = kStatusError;
+  if (info_.status == kStatusNotSet) info_.status = kStatusMaxIter;
+}
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1265,7 +1265,7 @@ void Solver::printHeader() const {
     if (!options_.timeless_log) logger_.print("    time");
     if (logger_.debug(1)) {
       logger_.print(
-          "     alpha p/d   sigma af/co   cor  solv  Fact    static reg p/d    "
+          "     alpha p/d   sigma af/co   cor  solv  fact    static reg p/d    "
           " minT     maxT  (xj * zj / mu)_range_&_num   max_res");
     }
     logger_.print("\n");
@@ -1353,37 +1353,43 @@ void Solver::printSummary() const {
   }
   logger_.print(log_stream.str().c_str());
 
-  logger_.print("\nTime profile\n");
+  if (logger_.debug(1)) {
+    logger_.print("\nTime profile\n");
 
-  logger_.print(" Initialise           %.2f\n", info_.times[kInitialiseTime]);
-  logger_.print(" Prepare iter         %.2f\n", info_.times[kPrepareTime]);
-  logger_.print(" Predictor            %.2f\n", info_.times[kPredictorTime]);
-  logger_.print(" Correctors           %.2f\n", info_.times[kCorrectorsTime]);
-  logger_.print(" Step                 %.2f\n", info_.times[kStepTime]);
-  logger_.print("\n");
+    logger_.print(" Initialise           %.2f\n", info_.times[kInitialiseTime]);
+    logger_.print(" Prepare iter         %.2f\n", info_.times[kPrepareTime]);
+    logger_.print(" Predictor            %.2f\n", info_.times[kPredictorTime]);
+    logger_.print(" Correctors           %.2f\n", info_.times[kCorrectorsTime]);
+    logger_.print(" Step                 %.2f\n", info_.times[kStepTime]);
+    logger_.print("\n");
 
-  logger_.print(" 2x2 system           %.2f\n", info_.times[kSolve2x2Time]);
-  logger_.print(" Recover direction    %.2f\n", info_.times[kRecoverTime]);
-  logger_.print(" Residuals            %.2f\n", info_.times[kResidualsTime]);
-  logger_.print("\n");
+    logger_.print(" 2x2 system           %.2f\n", info_.times[kSolve2x2Time]);
+    logger_.print(" Recover direction    %.2f\n", info_.times[kRecoverTime]);
+    logger_.print(" Residuals            %.2f\n", info_.times[kResidualsTime]);
+    logger_.print("\n");
 
-  logger_.print(" Structure NE         %.2f\n",
-                info_.times[kMatrixStructureTime_NE]);
-  logger_.print(" Structure AS         %.2f\n",
-                info_.times[kMatrixStructureTime_AS]);
-  logger_.print(" Matrix values        %.2f\n", info_.times[kMatrixValuesTime]);
+    logger_.print(" Structure NE         %.2f\n",
+                  info_.times[kMatrixStructureTime_NE]);
+    logger_.print(" Structure AS         %.2f\n",
+                  info_.times[kMatrixStructureTime_AS]);
+    logger_.print(" Matrix values        %.2f\n",
+                  info_.times[kMatrixValuesTime]);
 
-  logger_.print(" Analyse NE           %.2f\n", info_.times[kAnalyseTime_NE]);
-  logger_.print(" Analyse AS           %.2f\n", info_.times[kAnalyseTime_AS]);
+    logger_.print(" Analyse NE           %.2f\n", info_.times[kAnalyseTime_NE]);
+    logger_.print(" Analyse AS           %.2f\n", info_.times[kAnalyseTime_AS]);
 
-  logger_.print(" Factorise            %.2f\n", info_.times[kFactoriseTime]);
+    logger_.print(" Factorise            %.2f\n", info_.times[kFactoriseTime]);
 
-  logger_.print(" Solve                %.2f\n", info_.times[kSolveTime]);
-  logger_.print(" Residual             %.2f\n",
-                info_.times[kRefinementResTime]);
-  logger_.print(" Omega                %.2f\n",
-                info_.times[kRefinementOmegaTime]);
-  logger_.print(" Insert/split         %.2f\n", info_.times[kInsertSplitTime]);
+    logger_.print(" Solve                %.2f\n", info_.times[kSolveTime]);
+    logger_.print(" Residual             %.2f\n",
+                  info_.times[kRefinementResTime]);
+    logger_.print(" Omega                %.2f\n",
+                  info_.times[kRefinementOmegaTime]);
+    logger_.print(" Insert/split         %.2f\n",
+                  info_.times[kInsertSplitTime]);
+    logger_.print("\n");
+  }
+
   logger_.print("\n");
 }
 
@@ -1488,7 +1494,7 @@ void Solver::setStatus2(Status status) {
   status_phase2 = status;
 }
 void Solver::setStatus(Status status) {
-  if (status_phase1 == kStatusNotSet)
+  if (getStatus1() == kStatusNotSet)
     setStatus1(status);
   else
     setStatus2(status);

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -52,6 +52,7 @@ void Solver::setOptions(const HighsOptions& highs_options) {
   options_.parallel_type = highs_options.hipo_parallel_type;
   options_.nla = highs_options.hipo_system;
   options_.ordering = highs_options.hipo_ordering;
+  options_.factor = highs_options.hipo_factor;
   options_.block_size = highs_options.hipo_block_size;
 
   options_orig_ = options_;
@@ -156,22 +157,7 @@ bool Solver::initialise() {
   }
   LS_->clear();
 
-  // Use uplooking factorisation instead of multifrontal if
-  // - very few operations needed or
-  // - very few nz per column in L or
-  // - multifrontal is dominated by assembly operations
-  bool switch_to_uplooking =
-      LS_->flops() < kUplookFlopsThresh ||
-      LS_->nz() < kUplookNzPerColLower * kkt_->n() ||
-      LS_->flops() < kUplookSpopsRatioLower * LS_->spops() ||
-      (LS_->nz() < kUplookNzPerColUpper * kkt_->n() &&
-       LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
-
-  if (switch_to_uplooking) {
-    LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
-    LS_->setup();
-    LS_->clear();
-  }
+  chooseFactorisation();
 
   it_->data.append();
   it_->data.back().factorisation_used = LS_->type();
@@ -356,22 +342,14 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
   }
 
   if (terminate) {
-    if (LS_->type() == kUpLookingType) {
+    if (switchToMultifrontal()) {
       // try FactorHighs factorisation before giving up
-      LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
-                                      it_->data, logger_));
-      if (!LS_) {
-        info_.status = kStatusError;
-        return true;
-      }
-      LS_->clear();
       it_->data.back().factorisation_used = LS_->type();
-      it_->bad_iter_ = 0;
       logger_.printInfo("Switching to FactorHighs because of bad direction\n");
       resetToBestIter(iter_ - 1);
 
-      // Solve again. This does not create an infinite loop, as the if statement
-      // cannot trigger in the second solve.
+      // Solve again. This does not create an infinite loop, as
+      // switchToMultifrontal() is false in the second solve.
       delta.clear();
       it_->data.back().omega = 0.0;
       terminate = solveNewtonSystem(delta);
@@ -1106,16 +1084,7 @@ bool Solver::checkBadIter() {
       info_.status = kStatusPrimalInfeasible;
       terminate = true;
     } else if (stagnation) {
-      if (LS_->type() == kUpLookingType) {
-        // try FactorHighs factorisation before giving up
-        LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
-                                        it_->data, logger_));
-        if (!LS_) {
-          info_.status = kStatusError;
-          return true;
-        }
-        LS_->clear();
-        it_->bad_iter_ = 0;
+      if (switchToMultifrontal()) {
         logger_.printInfo("Switching to FactorHighs because of no progress\n");
         resetToBestIter(iter_);
       } else {
@@ -1220,6 +1189,49 @@ bool Solver::checkInterrupt() {
 void Solver::resetToBestIter(Int iter, bool print) {
   bool did_reset = it_->resetBest(iter);
   if (did_reset && print) printOutput(true);
+}
+
+void Solver::chooseFactorisation() {
+  // Use uplooking factorisation instead of multifrontal if
+  // - very few operations needed or
+  // - very few nz per column in L or
+  // - multifrontal is dominated by assembly operations
+  const bool should_switch_to_uplooking =
+      LS_->flops() < kUplookFlopsThresh ||
+      LS_->nz() < kUplookNzPerColLower * kkt_->n() ||
+      LS_->flops() < kUplookSpopsRatioLower * LS_->spops() ||
+      (LS_->nz() < kUplookNzPerColUpper * kkt_->n() &&
+       LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
+
+  bool do_switch;
+  if (options_.factor == kHipoFactorMultifrontal)
+    do_switch = false;
+  else if (options_.factor == kHipoFactorUplooking)
+    do_switch = true;
+  else
+    do_switch = should_switch_to_uplooking;
+
+  if (do_switch) {
+    LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
+    LS_->setup();
+    LS_->clear();
+  }
+}
+
+bool Solver::switchToMultifrontal() {
+  // return true if switch successfull
+  if (LS_->type() == kUpLookingType && options_.factor == kHighsChooseString) {
+    LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
+                                    it_->data, logger_));
+    if (!LS_) {
+      info_.status = kStatusError;
+      return false;
+    }
+    LS_->clear();
+    it_->bad_iter_ = 0;
+    return true;
+  }
+  return false;
 }
 
 void Solver::printHeader() const {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <iostream>
 
+#include "UpLookingSolver.h"
 #include "ipm/IpxWrapper.h"
 #include "ipm/hipo/auxiliary/Logger.h"
 #include "lp_data/HighsSolution.h"
@@ -153,6 +154,11 @@ bool Solver::initialise() {
     info_.status = (Status)status;
     return true;
   }
+  LS_->clear();
+
+  // switch to up-looking factorisation
+  LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
+  LS_->setup();
   LS_->clear();
 
   it_->data.append();

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -212,14 +212,6 @@ bool Solver::prepareIter() {
 
   ++iter_;
 
-  if (iter_ > 10 && LS_->type() == kUpLookingType) {
-    LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
-                                    it_->data, logger_));
-
-    LS_->setup();
-    LS_->clear();
-  }
-
   model_.adjustFreeVars(it_->x, it_->xl, it_->xu, logger_);
 
   // Clear Newton direction
@@ -353,18 +345,39 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
   solve6x6(delta, it_->res);
   refine(delta);
 
+  bool terminate = false;
+
   // Check for NaN of Inf
   if (it_->isDirNan(delta)) {
     logger_.printInfo("Direction is nan\n");
-    info_.status = kStatusError;
-    return true;
+    terminate = true;
   } else if (it_->isDirInf(delta)) {
     logger_.printInfo("Direction is inf\n");
-    info_.status = kStatusError;
-    return true;
+    terminate = true;
   }
 
-  return false;
+  if (terminate) {
+    if (LS_->type() == kUpLookingType) {
+      // try FactorHighs factorisation before giving up
+      LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
+                                      it_->data, logger_));
+      if (!LS_) {
+        info_.status = kStatusError;
+        return true;
+      }
+      LS_->clear();
+      it_->data.back().factorisation_used = LS_->type();
+      logger_.printInfo("Switching to FactorHighs because of bad direction\n");
+
+      // Solve again. This does not create an infinite loop, as the if statement
+      // cannot trigger in the second solve.
+      delta.clear();
+      terminate = solveNewtonSystem(delta);
+    } else
+      info_.status = kStatusError;
+  }
+
+  return terminate;
 }
 
 bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
@@ -1091,15 +1104,29 @@ bool Solver::checkBadIter() {
       info_.status = kStatusPrimalInfeasible;
       terminate = true;
     } else if (stagnation) {
-      // stagnation detected, solution may still be good for highs kktCheck
-      if (info_.status != kStatusPDFeas && checkTerminationKkt()) {
-        logger_.printw(
-            "HiPO stagnated but HiGHS considers the solution acceptable\n");
-        logger_.print("=== Primal-dual feasible point found\n");
-        info_.status = kStatusPDFeas;
-      } else
-        info_.status = kStatusNoProgress;
-      terminate = true;
+      if (LS_->type() == kUpLookingType) {
+        // try FactorHighs factorisation before giving up
+        LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
+                                        it_->data, logger_));
+        if (!LS_) {
+          info_.status = kStatusError;
+          return true;
+        }
+        LS_->clear();
+        it_->bad_iter_ = 0;
+        logger_.printInfo("Switching to FactorHighs because of no progress\n");
+      } else {
+        // stagnation detected, solution may still be good for highs kktCheck
+        if (info_.status != kStatusPDFeas && checkTerminationKkt()) {
+          logger_.printw(
+              "HiPO stagnated but HiGHS considers the solution acceptable\n");
+          logger_.print("=== Primal-dual feasible point found\n");
+          info_.status = kStatusPDFeas;
+        } else
+          info_.status = kStatusNoProgress;
+
+        terminate = true;
+      }
     }
   }
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -167,8 +167,6 @@ bool Solver::initialise() {
       (LS_->nz() < kUplookNzPerColUpper * kkt_->n() &&
        LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
 
-  switch_to_uplooking = true;
-
   if (switch_to_uplooking) {
     LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
     LS_->setup();
@@ -368,6 +366,7 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
       }
       LS_->clear();
       it_->data.back().factorisation_used = LS_->type();
+      it_->bad_iter_ = 0;
       logger_.printInfo("Switching to FactorHighs because of bad direction\n");
       resetToBestIter(iter_ - 1);
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -151,8 +151,7 @@ bool Solver::initialise() {
 
   if (checkInterrupt()) return true;
 
-  // decide number of correctors to use
-  maxCorrectors();
+  chooseNumberOfCorrectors();
 
   if (startingPoint()) return true;
 
@@ -186,16 +185,13 @@ bool Solver::prepareIter() {
 
   model_.adjustFreeVars(it_->x, it_->xl, it_->xu, logger_);
 
-  // Clear Newton direction
   it_->clearDir();
 
-  // Clear any existing data in the linear solver
   LS_->clear();
 
   it_->data.append();
   it_->data.back().factorisation_used = LS_->type();
 
-  // compute theta inverse
   it_->computeScaling();
 
   return false;
@@ -207,7 +203,6 @@ bool Solver::predictor() {
 
   if (checkInterrupt()) return true;
 
-  // compute sigma and residuals for affine scaling direction
   sigmaAffine();
   it_->residual56(sigma_);
 
@@ -296,7 +291,6 @@ void Solver::refineWithIpx() {
 
   info_.ipx_info = ipx_lps_.GetInfo();
 
-  // Convert between ipx and hipo status
   info_.status = IpxToHipoStatus(info_.ipx_info.status_ipm);
 
   std::stringstream log_stream;
@@ -318,7 +312,6 @@ bool Solver::solveNewtonSystem(NewtonDir& delta) {
 
   if (!terminate) {
     refine(delta);
-    // Check for NaN of Inf
     if (it_->isDirNan(delta)) {
       logger_.printInfo("Direction is nan\n");
       terminate = true;
@@ -356,7 +349,6 @@ bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
   if (options_.nla == kHipoNormalEqString) {
     std::vector<double> res8 = it_->residual8(rhs, res7);
 
-    // factorise normal equations, if not yet done
     if (!LS_->valid_) {
       if (Int status = LS_->factorNE(theta_inv)) {
         logger_.printe("Error while factorising normal equations\n");
@@ -366,7 +358,6 @@ bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
       it_->getReg(*LS_, options_.nla);
     }
 
-    // solve with normal equations
     if (Int status = LS_->solveNE(res8, delta.y)) {
       logger_.printe("Error while solving normal equations\n");
       info_.status = (Status)status;
@@ -390,7 +381,6 @@ bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
 
   // AUGMENTED SYSTEM
   else {
-    // factorise augmented system, if not yet done
     if (!LS_->valid_) {
       if (Int status = LS_->factorAS(theta_inv)) {
         logger_.printe("Error while factorising augmented system\n");
@@ -400,7 +390,6 @@ bool Solver::solve2x2(NewtonDir& delta, const Residuals& rhs) {
       it_->getReg(*LS_, options_.nla);
     }
 
-    // solve with augmented system
     if (Int status = LS_->solveAS(res7, rhs.r1, delta.x, delta.y)) {
       logger_.printe("Error while solving augmented system\n");
       info_.status = (Status)status;
@@ -418,7 +407,6 @@ bool Solver::solve6x6(NewtonDir& delta, const Residuals& rhs) {
 }
 
 void Solver::recoverDirection(NewtonDir& delta, const Residuals& rhs) const {
-  // Recover components xl, xu, zl, zu of partial direction delta.
   const std::vector<double>& xl = it_->xl;
   const std::vector<double>& xu = it_->xu;
   const std::vector<double>& zl = it_->zl;
@@ -499,7 +487,6 @@ void Solver::stepsToBoundary(double& alpha_primal, double& alpha_dual,
 }
 
 void Solver::stepSizes() {
-  // Compute primal and dual stepsizes.
   std::vector<double>& xl = it_->xl;
   std::vector<double>& xu = it_->xu;
   std::vector<double>& zl = it_->zl;
@@ -849,7 +836,6 @@ void Solver::residualsMcc() {
   std::vector<double>& res6 = it_->res.r6;
   double& mu = it_->mu;
 
-  // clear existing residuals
   it_->clearRes();
 
   // stepsizes of current direction
@@ -923,17 +909,15 @@ bool Solver::centralityCorrectors() {
 
   Int cor;
   for (cor = 0; cor < info_.correctors; ++cor) {
-    // compute rhs for corrector
     residualsMcc();
 
-    // compute corrector
-    NewtonDir corr(m_, n_);
-    if (solveNewtonSystem(corr)) return true;
+    NewtonDir corrector(m_, n_);
+    if (solveNewtonSystem(corrector)) return true;
 
     double alpha_p, alpha_d;
     double wp = alpha_p_old * alpha_d_old;
     double wd = wp;
-    bestWeight(it_->delta, corr, wp, wd, alpha_p, alpha_d);
+    bestWeight(it_->delta, corrector, wp, wd, alpha_p, alpha_d);
 
     if (alpha_p < alpha_p_old + kMccIncreaseAlpha * kMccIncreaseMin &&
         alpha_d < alpha_d_old + kMccIncreaseAlpha * kMccIncreaseMin) {
@@ -943,16 +927,16 @@ bool Solver::centralityCorrectors() {
 
     if (alpha_p >= alpha_p_old + kMccIncreaseAlpha * kMccIncreaseMin) {
       // accept primal corrector
-      vectorAdd(it_->delta.x, corr.x, wp);
-      vectorAdd(it_->delta.xl, corr.xl, wp);
-      vectorAdd(it_->delta.xu, corr.xu, wp);
+      vectorAdd(it_->delta.x, corrector.x, wp);
+      vectorAdd(it_->delta.xl, corrector.xl, wp);
+      vectorAdd(it_->delta.xu, corrector.xu, wp);
       alpha_p_old = alpha_p;
     }
     if (alpha_d >= alpha_d_old + kMccIncreaseAlpha * kMccIncreaseMin) {
       // accept dual corrector
-      vectorAdd(it_->delta.y, corr.y, wd);
-      vectorAdd(it_->delta.zl, corr.zl, wd);
-      vectorAdd(it_->delta.zu, corr.zu, wd);
+      vectorAdd(it_->delta.y, corrector.y, wd);
+      vectorAdd(it_->delta.zl, corrector.zl, wd);
+      vectorAdd(it_->delta.zu, corrector.zu, wd);
       alpha_d_old = alpha_d;
     }
 
@@ -1006,7 +990,6 @@ void Solver::bestWeight(const NewtonDir& delta, const NewtonDir& corrector,
 }
 
 bool Solver::checkIterate() {
-  // Check that iterate is not NaN or Inf
   if (it_->isNan()) {
     logger_.printInfo("\nIterate is nan\n");
     info_.status = kStatusError;
@@ -1017,7 +1000,6 @@ bool Solver::checkIterate() {
     return true;
   }
 
-  // check that no component is negative
   for (Int i = 0; i < n_; ++i) {
     if ((model_.hasLb(i) && it_->xl[i] < 0) ||
         (model_.hasLb(i) && it_->zl[i] < 0) ||
@@ -1288,7 +1270,6 @@ void Solver::printInfo() const {
   std::stringstream log_stream;
   log_stream << "\nRunning HiPO\n";
 
-  // Print number of threads
   if (options_.parallel == kHighsOffString)
     log_stream << textline("Threads:") << 1 << '\n';
   else
@@ -1297,7 +1278,6 @@ void Solver::printInfo() const {
 
   logger_.print(log_stream.str().c_str());
 
-  // print information about model
   model_.print(logger_);
 }
 
@@ -1372,12 +1352,11 @@ void Solver::getInteriorSolution(
 Int Solver::getBasicSolution(std::vector<double>& x, std::vector<double>& slack,
                              std::vector<double>& y, std::vector<double>& z,
                              Int* cbasis, Int* vbasis) const {
-  // interface to ipx getBasicSolution
   return ipx_lps_.GetBasicSolution(x.data(), slack.data(), y.data(), z.data(),
                                    cbasis, vbasis);
 }
 
-void Solver::maxCorrectors() {
+void Solver::chooseNumberOfCorrectors() {
   if (kMaxCorrectors > 0) {
     // Compute estimate of effort to factorise and solve
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -167,7 +167,6 @@ bool Solver::initialise() {
       (LS_->nz() < kUplookNzPerColUpper * kkt_->n() &&
        LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
 
-  // always use for now
   switch_to_uplooking = false;
 
   if (switch_to_uplooking) {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -141,9 +141,7 @@ void Solver::runIpm() {
   }
 }
 
-bool Solver::initialise() {
-  // Prepare ipm for execution.
-  // Return true if an error occurred.
+isFailure Solver::initialise() {
   Clock clock;
 
   start_time_ = control_.elapsed();
@@ -177,9 +175,7 @@ bool Solver::initialise() {
   return false;
 }
 
-bool Solver::prepareIter() {
-  // Prepare next iteration.
-  // Return true if Ipm main loop should be stopped
+shouldTerminate Solver::prepareIter() {
   Clock clock;
 
   it_->saveBest(options_.feasibility_tol, options_.optimality_tol, iter_);
@@ -205,9 +201,7 @@ bool Solver::prepareIter() {
   return false;
 }
 
-bool Solver::predictor() {
-  // Compute affine scaling direction.
-  // Return true if an error occurred.
+isFailure Solver::predictor() {
   Clock clock;
 
   if (checkInterrupt()) return true;
@@ -221,9 +215,7 @@ bool Solver::predictor() {
   return false;
 }
 
-bool Solver::correctors() {
-  // Compute multiple centrality correctors.
-  // Return true if an error occurred.
+isFailure Solver::correctors() {
   Clock clock;
 
   if (checkInterrupt()) return true;
@@ -235,9 +227,7 @@ bool Solver::correctors() {
   return false;
 }
 
-bool Solver::prepareIpx() {
-  // Return true if an error occurred;
-
+isFailure Solver::prepareIpx() {
   assert(!model_.qp());
 
   ipx::Parameters ipx_param;
@@ -273,7 +263,7 @@ bool Solver::prepareIpx() {
   return false;
 }
 
-bool Solver::prepareIpxStartingPoint() {
+isFailure Solver::prepareIpxStartingPoint() {
   std::vector<double> x, xl, xu, slack, y, zl, zu;
   getInteriorSolution(x, xl, xu, slack, y, zl, zu);
 
@@ -299,8 +289,6 @@ void Solver::runIpx() {
   } else if (statusAllowsCrossover() && crossoverIsOn()) {
     logger_.print("\nRunning crossover with IPX\n");
     crossoverWithIpx();
-  } else {
-    return;
   }
 }
 
@@ -330,7 +318,7 @@ void Solver::crossoverWithIpx() {
   if (info_.ipx_info.errflag) info_.error = kErrorIpx;
 }
 
-bool Solver::solveNewtonSystem(NewtonDir& delta) {
+isFailure Solver::solveNewtonSystem(NewtonDir& delta) {
   solve6x6(delta, it_->res);
   bool terminate = info_.error;
 
@@ -612,9 +600,7 @@ void Solver::makeStep() {
   info_.times[kStepTime] += clock.stop();
 }
 
-bool Solver::startingPoint() {
-  // Return true if an error occurred
-
+isFailure Solver::startingPoint() {
   std::vector<double>& x = it_->x;
   std::vector<double>& xl = it_->xl;
   std::vector<double>& xu = it_->xu;
@@ -938,7 +924,7 @@ void Solver::residualsMcc() {
   info_.times[kResidualsTime] += clock.stop();
 }
 
-bool Solver::centralityCorrectors() {
+isFailure Solver::centralityCorrectors() {
   // compute stepsizes of current direction
   double alpha_p_old, alpha_d_old;
   stepsToBoundary(alpha_p_old, alpha_d_old, it_->delta);
@@ -1025,39 +1011,41 @@ void Solver::bestWeight(const NewtonDir& delta, const NewtonDir& corrector,
   }
 }
 
-bool Solver::checkIterate() {
+shouldTerminate Solver::checkIterate() {
+  bool terminate = false;
+
   if (it_->isNan()) {
     logger_.printInfo("\nIterate is nan\n");
     info_.error = kErrorNan;
-    return true;
+    terminate = true;
   } else if (it_->isInf()) {
     logger_.printInfo("\nIterate is inf\n");
     info_.error = kErrorNan;
-    return true;
-  }
-
-  for (Int i = 0; i < n_; ++i) {
-    if ((model_.hasLb(i) && it_->xl[i] < 0) ||
-        (model_.hasLb(i) && it_->zl[i] < 0) ||
-        (model_.hasUb(i) && it_->xu[i] < 0) ||
-        (model_.hasUb(i) && it_->zu[i] < 0)) {
-      logger_.printInfo("\nIterate has negative component\n");
-      info_.error = kErrorNegativeComponent;
-      return true;
+    bool terminate = true;
+  } else {
+    for (Int i = 0; i < n_; ++i) {
+      if ((model_.hasLb(i) && it_->xl[i] < 0) ||
+          (model_.hasLb(i) && it_->zl[i] < 0) ||
+          (model_.hasUb(i) && it_->xu[i] < 0) ||
+          (model_.hasUb(i) && it_->zu[i] < 0)) {
+        logger_.printInfo("\nIterate has negative component\n");
+        info_.error = kErrorNegativeComponent;
+        terminate = true;
+      }
     }
   }
 
-  return false;
+  return terminate;
 }
 
-bool Solver::checkStagnation() {
+shouldTerminate Solver::checkStagnation() {
   std::stringstream log_stream;
   bool stagnation = it_->stagnation(log_stream);
   logger_.printInfo(log_stream.str().c_str());
   return stagnation;
 }
 
-bool Solver::checkBadIter() {
+shouldTerminate Solver::checkBadIter() {
   bool terminate = false;
   bool stagnation = iter_ > 0 ? checkStagnation() : false;
 
@@ -1118,7 +1106,7 @@ bool Solver::checkBadIter() {
   return terminate;
 }
 
-bool Solver::checkTermination() {
+shouldTerminate Solver::checkTermination() {
   bool feasible = it_->pinf < options_.feasibility_tol &&
                   it_->dinf < options_.feasibility_tol;
   bool optimal = it_->pdgap < options_.optimality_tol;
@@ -1150,7 +1138,7 @@ bool Solver::checkTermination() {
   return terminate;
 }
 
-bool Solver::checkTerminationKkt() {
+isSuccess Solver::checkTerminationKkt() {
   if (model_.qp()) {
     // Not yet implemented for QP
     logger_.printInfo("kktCheck skipped for QP\n");
@@ -1187,7 +1175,7 @@ bool Solver::checkTerminationKkt() {
   return false;
 }
 
-bool Solver::checkInterrupt() {
+shouldTerminate Solver::checkInterrupt() {
   bool terminate = false;
   Int status = control_.interruptCheck(iter_);
   if (status) {
@@ -1202,7 +1190,7 @@ void Solver::resetToBestIter(Int iter, bool print) {
   if (did_reset && print) printOutput(true);
 }
 
-bool Solver::initialiseLinearSolver() {
+isFailure Solver::initialiseLinearSolver() {
   LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
                                   it_->data, logger_));
   if (!LS_) {
@@ -1246,7 +1234,7 @@ bool Solver::initialiseLinearSolver() {
   return false;
 }
 
-bool Solver::switchToMultifrontal() {
+isSuccess Solver::switchToMultifrontal() {
   bool switch_successfull = false;
 
   if (LS_->type() == kUpLookingType && options_.factor == kHighsChooseString) {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1298,10 +1298,9 @@ void Solver::printSummary() const {
                << fix(control_.elapsed() - start_time_, 0, 2) << "\n";
 
   log_stream << textline("Status:") << statusString(info_.status) << "\n";
-  if (info_.ipx_info.status_crossover != IPX_STATUS_not_run)
-    log_stream << textline("Status Crossover:")
-               << statusString(IpxToHipoStatus(info_.ipx_info.status_crossover))
-               << "\n";
+  log_stream << textline("Status Crossover:")
+             << statusString(IpxToHipoStatus(info_.ipx_info.status_crossover))
+             << "\n";
   if (info_.error)
     log_stream << textline("Error:") << errorString((Error)info_.error) << "\n";
 

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -144,20 +144,7 @@ bool Solver::initialise() {
     return true;
   }
 
-  // initialise linear solver
-  LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
-                                  it_->data, logger_));
-  if (!LS_) {
-    info_.status = kStatusError;
-    return true;
-  }
-  if (Int status = LS_->setup()) {
-    info_.status = (Status)status;
-    return true;
-  }
-  LS_->clear();
-
-  chooseFactorisation();
+  if (initialiseLinearSolver()) return true;
 
   it_->data.append();
   it_->data.back().factorisation_used = LS_->type();
@@ -1191,7 +1178,19 @@ void Solver::resetToBestIter(Int iter, bool print) {
   if (did_reset && print) printOutput(true);
 }
 
-void Solver::chooseFactorisation() {
+bool Solver::initialiseLinearSolver() {
+  LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
+                                  it_->data, logger_));
+  if (!LS_) {
+    info_.status = kStatusError;
+    return true;
+  }
+  if (Int status = LS_->setup()) {
+    info_.status = (Status)status;
+    return true;
+  }
+  LS_->clear();
+
   // Use uplooking factorisation instead of multifrontal if
   // - very few operations needed or
   // - very few nz per column in L or
@@ -1213,25 +1212,33 @@ void Solver::chooseFactorisation() {
 
   if (do_switch) {
     LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
+    if (!LS_) {
+      info_.status = kStatusError;
+      return true;
+    }
     LS_->setup();
     LS_->clear();
   }
+
+  return false;
 }
 
 bool Solver::switchToMultifrontal() {
-  // return true if switch successfull
+  bool switch_successfull = false;
+
   if (LS_->type() == kUpLookingType && options_.factor == kHighsChooseString) {
     LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
                                     it_->data, logger_));
     if (!LS_) {
       info_.status = kStatusError;
-      return false;
+    } else {
+      LS_->clear();
+      it_->bad_iter_ = 0;
+      switch_successfull = true;
     }
-    LS_->clear();
-    it_->bad_iter_ = 0;
-    return true;
   }
-  return false;
+
+  return switch_successfull;
 }
 
 void Solver::printHeader() const {

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -167,7 +167,7 @@ bool Solver::initialise() {
       (LS_->nz() < kUplookNzPerColUpper * kkt_->n() &&
        LS_->flops() < kUplookSpopsRatioUpper * LS_->spops());
 
-  switch_to_uplooking = false;
+  switch_to_uplooking = true;
 
   if (switch_to_uplooking) {
     LS_.reset(new UpLookingSolver(*kkt_, info_, it_->data, regul_, model_));
@@ -176,6 +176,7 @@ bool Solver::initialise() {
   }
 
   it_->data.append();
+  it_->data.back().factorisation_used = LS_->type();
 
   if (checkInterrupt()) return true;
 
@@ -211,6 +212,14 @@ bool Solver::prepareIter() {
 
   ++iter_;
 
+  if (iter_ > 10 && LS_->type() == kUpLookingType) {
+    LS_.reset(new FactorHighsSolver(*kkt_, options_, model_, regul_, info_,
+                                    it_->data, logger_));
+
+    LS_->setup();
+    LS_->clear();
+  }
+
   model_.adjustFreeVars(it_->x, it_->xl, it_->xu, logger_);
 
   // Clear Newton direction
@@ -220,6 +229,7 @@ bool Solver::prepareIter() {
   LS_->clear();
 
   it_->data.append();
+  it_->data.back().factorisation_used = LS_->type();
 
   // compute theta inverse
   it_->computeScaling();
@@ -1183,8 +1193,8 @@ void Solver::printHeader() const {
     if (!options_.timeless_log) logger_.print("    time");
     if (logger_.debug(1)) {
       logger_.print(
-          "     alpha p/d   sigma af/co   cor  solv    static reg p/d     minT "
-          "    maxT  (xj * zj / mu)_range_&_num   max_res");
+          "     alpha p/d   sigma af/co   cor  solv  Fact    static reg p/d    "
+          " minT     maxT  (xj * zj / mu)_range_&_num   max_res");
     }
     logger_.print("\n");
   }
@@ -1199,13 +1209,15 @@ void Solver::printOutput() const {
   if (logger_.debug(1)) {
     const IpmIterData& data = it_->data.back();
     logger_.print(
-        " %6.2f %6.2f %6.2f %6.2f %5d %5d %8.1e %8.1e %8.1e %8.1e %8.1e %8.1e "
-        "%4d "
-        "%4d %9.1e",
+        " %6.2f %6.2f %6.2f %6.2f %5d %5d %5c %8.1e %8.1e %8.1e %8.1e %8.1e "
+        "%8.1e %4d %4d %9.1e",
         alpha_primal_, alpha_dual_, data.sigma_aff, data.sigma, data.correctors,
-        data.num_solves, regul_.primal, regul_.dual, data.min_theta,
-        data.max_theta, data.min_prod, data.max_prod, data.num_small_prod,
-        data.num_large_prod, data.omega);
+        data.num_solves,
+        LinearSolverTypeToString((LinearSolverType)data.factorisation_used)
+            .front(),
+        regul_.primal, regul_.dual, data.min_theta, data.max_theta,
+        data.min_prod, data.max_prod, data.num_small_prod, data.num_large_prod,
+        data.omega);
   }
   logger_.print("\n");
 }

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1039,8 +1039,6 @@ bool Solver::checkBadIter() {
   bool terminate = false;
   bool stagnation = iter_ > 0 ? checkStagnation() : false;
 
-  if (iter_ == 18) stagnation = true;
-
   // check for infeasibility
   bool mu_is_large =
       it_->best_mu > 0.0 ? it_->mu > it_->best_mu * kDivergeTol : false;

--- a/highs/ipm/hipo/ipm/Solver.cpp
+++ b/highs/ipm/hipo/ipm/Solver.cpp
@@ -1407,20 +1407,18 @@ void Solver::chooseNumberOfCorrectors() {
   }
 }
 
-bool Solver::statusIsSolved() const {
-  return info_.status >= kStatusTypeSolved;
-}
-bool Solver::statusIsStopped() const {
+bool Solver::solved() const { return info_.status >= kStatusTypeSolved; }
+bool Solver::stopped() const {
   return info_.status > kStatusTypeStopped && info_.status < kStatusTypeFailed;
 }
-bool Solver::statusIsFailed() const {
+bool Solver::failed() const {
   return info_.status > kStatusTypeFailed && info_.status < kStatusTypeSolved;
 }
 bool Solver::statusAllowsCrossover() const {
   return getStatus1() == kStatusOptimal;
 }
 bool Solver::statusNeedsRefinement() const {
-  return getStatus1() == kStatusNoProgress || getStatus1() == kStatusImprecise;
+  return getStatus1() == kStatusNoProgress;
 }
 bool Solver::refinementIsOn() const {
   return options_.refine_with_ipx && !model_.qp();
@@ -1428,9 +1426,6 @@ bool Solver::refinementIsOn() const {
 bool Solver::crossoverIsOn() const {
   return options_.crossover == kHighsOnString && !model_.qp();
 }
-bool Solver::solved() const { return statusIsSolved(); }
-bool Solver::stopped() const { return statusIsStopped(); }
-bool Solver::failed() const { return statusIsFailed(); }
 
 bool Solver::errorOrInterrupt() const {
   return getStatus() == kStatusTimeLimit ||

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -8,13 +8,13 @@
 #include "Info.h"
 #include "Iterate.h"
 #include "LinearSolver.h"
-#include "ipm/hipo/auxiliary/Logger.h"
 #include "Model.h"
 #include "Options.h"
 #include "Parameters.h"
 #include "Status.h"
 #include "ipm/hipo/auxiliary/Auxiliary.h"
 #include "ipm/hipo/auxiliary/IntConfig.h"
+#include "ipm/hipo/auxiliary/Logger.h"
 #include "ipm/hipo/auxiliary/VectorOperations.h"
 #include "ipm/hipo/factorhighs/FactorHiGHS.h"
 #include "ipm/ipx/lp_solver.h"
@@ -328,7 +328,7 @@ class Solver {
   // ===================================================================================
   void printInfo() const;
   void printHeader() const;
-  void printOutput() const;
+  void printOutput(bool reset = false) const;
   void printSummary() const;
 
   void resetOptions();

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -166,7 +166,7 @@ class Solver {
   //  Deltazl = Xl^{-1} * (res5 - zl * Deltaxl)
   //  Deltazu = Xu^{-1} * (res6 - zu * Deltaxu)
   // ===================================================================================
-  void recoverDirection(NewtonDir& delta, const Residuals& rhs) const;
+  void recoverDirection(NewtonDir& delta, const Residuals& rhs);
 
   // ===================================================================================
   // Functions for iterative refinement on the large 6x6 system

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -45,6 +45,16 @@ class Solver {
   Logger logger_;
   double start_time_;
 
+  // Status of ipm iterations up to pd feas solution found (potentially using
+  // ipx to refine, in which case the ipx status_ipm is converted to hipo
+  // status).
+  Status status_phase1 = kStatusNotSet;
+
+  // Status of ipm iterations after pd feas solution found, or status of
+  // crossover if it is run, in which case ipx status_crossover is converted to
+  // hipo status.
+  Status status_phase2 = kStatusNotSet;
+
  public:
   // ===================================================================================
   // Load an LP or QP:
@@ -94,9 +104,9 @@ class Solver {
 
  private:
   // Functions to run the various stages of the ipm
+  void doSolve();
   void runIpm();
   bool initialise();
-  void terminate();
   bool prepareIter();
   bool predictor();
   bool correctors();
@@ -148,8 +158,8 @@ class Solver {
   // NB: normal equations available only if Q is zero or diagonal.
   // ===================================================================================
   bool solveNewtonSystem(NewtonDir& delta);
-  bool solve2x2(NewtonDir& delta, const Residuals& rhs);
-  bool solve6x6(NewtonDir& delta, const Residuals& rhs);
+  void solve2x2(NewtonDir& delta, const Residuals& rhs);
+  void solve6x6(NewtonDir& delta, const Residuals& rhs);
 
   // ===================================================================================
   // Reconstruct the solution of the full Newton system:
@@ -286,7 +296,7 @@ class Solver {
   bool checkInterrupt();
 
   // ===================================================================================
-  // Check if the current status has various properties.
+  // Check and set status
   // ===================================================================================
   bool statusIsSolved() const;
   bool statusIsStopped() const;
@@ -295,6 +305,15 @@ class Solver {
   bool statusAllowsCrossover() const;
   bool refinementIsOn() const;
   bool crossoverIsOn() const;
+  bool errorOrInterrupt() const;
+
+  void setStatus1(Status status);
+  void setStatus2(Status status);
+  void setStatus(Status status);
+  Status getStatus1() const;
+  Status getStatus2() const;
+  Status getStatus() const;
+  void finaliseStatus();
 
   // ===================================================================================
   // Print to screen

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -334,6 +334,9 @@ class Solver {
   void resetOptions();
   void reset();
   void resetToBestIter(Int iter, bool print = true);
+
+  void chooseFactorisation();
+  bool switchToMultifrontal();
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -26,6 +26,10 @@
 
 namespace hipo {
 
+using isFailure = bool;
+using shouldTerminate = bool;
+using isSuccess = bool;
+
 class Solver {
   Model model_;
   std::unique_ptr<LinearSolver> LS_;
@@ -106,16 +110,16 @@ class Solver {
   // Functions to run the various stages of the ipm
   void doSolve();
   void runIpm();
-  bool initialise();
-  bool prepareIter();
-  bool predictor();
-  bool correctors();
+  isFailure initialise();
+  shouldTerminate prepareIter();
+  isFailure predictor();
+  isFailure correctors();
 
   // ===================================================================================
   // Interface with IPX
   // ===================================================================================
-  bool prepareIpx();
-  bool prepareIpxStartingPoint();
+  isFailure prepareIpx();
+  isFailure prepareIpxStartingPoint();
   void runIpx();
   void refineWithIpx();
   void crossoverWithIpx();
@@ -154,7 +158,7 @@ class Solver {
   //
   // NB: normal equations available only if Q is zero or diagonal.
   // ===================================================================================
-  bool solveNewtonSystem(NewtonDir& delta);
+  isFailure solveNewtonSystem(NewtonDir& delta);
   void solve2x2(NewtonDir& delta, const Residuals& rhs);
   void solve6x6(NewtonDir& delta, const Residuals& rhs);
 
@@ -218,7 +222,7 @@ class Solver {
   // Compute the Mehrotra starting point.
   // This requires to solve two linear systems with matrix A*A^T.
   // ===================================================================================
-  bool startingPoint();
+  isFailure startingPoint();
 
   // ===================================================================================
   // Compute the sigma to use for affine scaling direction or correctors, based
@@ -256,7 +260,7 @@ class Solver {
   // for linear programming" and Colombo, Gondzio, "Further Development of
   // Multiple Centrality Correctors for Interior Point Methods".
   // ===================================================================================
-  bool centralityCorrectors();
+  isFailure centralityCorrectors();
 
   // ===================================================================================
   // Given the current direction delta and the latest corrector, compute the
@@ -269,14 +273,14 @@ class Solver {
   // ===================================================================================
   // If the current iterate is nan or inf, abort the iterations.
   // ===================================================================================
-  bool checkIterate();
+  shouldTerminate checkIterate();
 
   // ===================================================================================
   // Stop if detection is detected, or if the problem is primal or dual
   // infeasible.
   // ===================================================================================
-  bool checkStagnation();
-  bool checkBadIter();
+  shouldTerminate checkStagnation();
+  shouldTerminate checkBadIter();
 
   // ===================================================================================
   // Check the termination criterion:
@@ -284,13 +288,13 @@ class Solver {
   //  - dual infeasiblity    < tolerance
   //  - relative dual gap    < tolerance
   // ===================================================================================
-  bool checkTermination();
-  bool checkTerminationKkt();
+  shouldTerminate checkTermination();
+  isSuccess checkTerminationKkt();
 
   // ===================================================================================
   // Check for user interrupt or time limit
   // ===================================================================================
-  bool checkInterrupt();
+  shouldTerminate checkInterrupt();
 
   // ===================================================================================
   // Check and set status
@@ -321,8 +325,8 @@ class Solver {
   void reset();
   void resetToBestIter(Int iter, bool print = true);
 
-  bool initialiseLinearSolver();
-  bool switchToMultifrontal();
+  isFailure initialiseLinearSolver();
+  isSuccess switchToMultifrontal();
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -335,7 +335,7 @@ class Solver {
   void reset();
   void resetToBestIter(Int iter, bool print = true);
 
-  void chooseFactorisation();
+  bool initialiseLinearSolver();
   bool switchToMultifrontal();
 };
 

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -333,6 +333,7 @@ class Solver {
 
   void resetOptions();
   void reset();
+  void resetToBestIter(Int iter, bool print = true);
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -28,46 +28,21 @@ namespace hipo {
 
 class Solver {
   Model model_;
-
-  // Linear solver interface
   std::unique_ptr<LinearSolver> LS_;
-
   std::unique_ptr<KktMatrix> kkt_;
-
-  // Iterate object interface
   std::unique_ptr<Iterate> it_;
-
-  // Size of the problem
   Int m_{}, n_{};
-
-  // Iterations counters
   Int iter_{};
-
-  // Stepsizes
   double alpha_primal_{}, alpha_dual_{};
-
-  // Coefficient for reduction of mu
   double sigma_{};
-
-  // Values for static regularisation
   Regularisation regul_{};
-
-  // General information
   Info info_;
-
   Control control_;
-
-  // Run-time options
   Options options_{};
   Options options_orig_{};
   HighsOptions Hoptions_{};
-
-  // Interface to ipx
   ipx::LpSolver ipx_lps_;
-
-  // Interface to Highs logging
   Logger logger_;
-
   double start_time_;
 
  public:
@@ -109,12 +84,10 @@ class Solver {
   const Info& getInfo() const;
   void getOriginalDims(Int& num_row, Int& num_col) const;
 
-  // check the status of the solver
   bool solved() const;
   bool stopped() const;
   bool failed() const;
 
-  // Set the IPX timer offset
   void setIpxTimerOffset(const double offset) {
     this->ipx_lps_.setTimerOffset(offset);
   }
@@ -145,7 +118,7 @@ class Solver {
   // cost of factorisation and solve. Based on the heuristic in "Multiple
   // Centrality Corrections in a Primal-Dual Method for Linear Programming".
   // ===================================================================================
-  void maxCorrectors();
+  void chooseNumberOfCorrectors();
 
   // ===================================================================================
   // Solve:

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -112,16 +112,13 @@ class Solver {
   bool correctors();
 
   // ===================================================================================
-  // Load model and parameters into ipx and set the last iterate as starting
-  // point.
+  // Interface with IPX
   // ===================================================================================
   bool prepareIpx();
-
-  // ===================================================================================
-  // If solution is not precise, try running ipx starting from last iterate.
-  // If solution is precise and crossover is requested, run ipx.
-  // ===================================================================================
+  bool prepareIpxStartingPoint();
+  void runIpx();
   void refineWithIpx();
+  void crossoverWithIpx();
 
   // ===================================================================================
   // Determine the maximum number of correctors to use, based on the relative

--- a/highs/ipm/hipo/ipm/Solver.h
+++ b/highs/ipm/hipo/ipm/Solver.h
@@ -298,9 +298,6 @@ class Solver {
   // ===================================================================================
   // Check and set status
   // ===================================================================================
-  bool statusIsSolved() const;
-  bool statusIsStopped() const;
-  bool statusIsFailed() const;
   bool statusNeedsRefinement() const;
   bool statusAllowsCrossover() const;
   bool refinementIsOn() const;

--- a/highs/ipm/hipo/ipm/Status.h
+++ b/highs/ipm/hipo/ipm/Status.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 
+#include "ipm/hipo/auxiliary/IntConfig.h"
 #include "ipm/ipx/ipx_status.h"
 
 namespace hipo {

--- a/highs/ipm/hipo/ipm/Status.h
+++ b/highs/ipm/hipo/ipm/Status.h
@@ -4,84 +4,97 @@
 #include <map>
 #include <string>
 
-#include "ipm/hipo/auxiliary/IntConfig.h"
 #include "ipm/ipx/ipx_status.h"
 
 namespace hipo {
 
-// Status is used both as return value for intermediate functions and as final
-// status of the solver.
+enum Error {
+  kOk = 0,
+  kErrorModel,
+  kErrorOverflow,
+  kErrorAnalyse,
+  kErrorFactorise,
+  kErrorSolve,
+  kErrorIpx,
+  kErrorNan,
+  kErrorNegativeComponent,
+  kErrorInvalidPointer,
+  kErrorFailedAllocation,
+};
 
 enum Status {
-  // used only to return positive status
-  kStatusOk,
-
-  // Stopped status: solver did not converge and does not have errors
-  kStatusNotRun,
+  kStatusTypeStopped = 100,
+  kStatusNotSet,
   kStatusNoProgress,
   kStatusMaxIter,
   kStatusTimeLimit,
   kStatusUserInterrupt,
 
-  // Failed status: solver has some error or interrupt
-  kStatusFailed,
+  kStatusTypeFailed,
   kStatusError,
-  kStatusOverflow,
-  kStatusErrorAnalyse,
-  kStatusErrorFactorise,
-  kStatusErrorSolve,
-  kStatusBadModel,
   kStatusUnknown,
 
-  // Solved status: solver found a solution
-  kStatusSolved,
+  kStatusTypeSolved,
+  kStatusImprecise,
   kStatusPrimalInfeasible,
   kStatusDualInfeasible,
-  kStatusImprecise,
-  kStatusPDFeas,
-  kStatusBasic
+  kStatusOptimal,
 };
 
 inline Status IpxToHipoStatus(Int ipx_status) {
   static const std::map<Int, Status> status_map{
-      {IPX_STATUS_not_run, kStatusNotRun},
-      {IPX_STATUS_iter_limit, kStatusMaxIter},
+      {IPX_STATUS_not_run, kStatusNotSet},
       {IPX_STATUS_no_progress, kStatusNoProgress},
-      {IPX_STATUS_failed, kStatusError},
+      {IPX_STATUS_iter_limit, kStatusMaxIter},
       {IPX_STATUS_time_limit, kStatusTimeLimit},
       {IPX_STATUS_user_interrupt, kStatusUserInterrupt},
+      {IPX_STATUS_failed, kStatusError},
+      {IPX_STATUS_imprecise, kStatusImprecise},
       {IPX_STATUS_primal_infeas, kStatusPrimalInfeasible},
       {IPX_STATUS_dual_infeas, kStatusDualInfeasible},
-      {IPX_STATUS_optimal, kStatusPDFeas},
-      {IPX_STATUS_imprecise, kStatusImprecise}};
+      {IPX_STATUS_optimal, kStatusOptimal},
+  };
 
   auto found = status_map.find(ipx_status);
   if (found != status_map.end()) return found->second;
   return kStatusUnknown;
 }
 
+inline std::string errorString(Error error) {
+  static const std::map<Error, std::string> status_map{
+      {kErrorModel, "Error with model"},
+      {kErrorOverflow, "Integer overflow"},
+      {kErrorAnalyse, "Error in analyse phase"},
+      {kErrorFactorise, "Error in factorise phase"},
+      {kErrorSolve, "Error in solve phase"},
+      {kErrorIpx, "Error in IPX"},
+      {kErrorNan, "NaN detected"},
+      {kErrorNegativeComponent, "Negative component detected"},
+      {kErrorInvalidPointer, "Invalid pointer"},
+      {kErrorFailedAllocation, "Failed allocation"},
+  };
+
+  auto found = status_map.find(error);
+  if (found != status_map.end()) return found->second;
+  return "Unknown error";
+}
+
 inline std::string statusString(Status status) {
   static const std::map<Status, std::string> status_map{
-      {kStatusNotRun, "not run"},
-      {kStatusMaxIter, "max iterations"},
-      {kStatusNoProgress, "no progress"},
-      {kStatusImprecise, "imprecise"},
-      {kStatusError, "internal error"},
-      {kStatusOverflow, "integer overflow"},
-      {kStatusErrorAnalyse, "error in analyse phase"},
-      {kStatusErrorFactorise, "error in factorise phase"},
-      {kStatusErrorSolve, "error in solve phase"},
-      {kStatusBadModel, "invalid model"},
-      {kStatusTimeLimit, "time limit"},
-      {kStatusUserInterrupt, "user interrupt"},
-      {kStatusPrimalInfeasible, "primal infeasible"},
-      {kStatusDualInfeasible, "dual infeasible"},
-      {kStatusPDFeas, "primal-dual feasible"},
-      {kStatusBasic, "crossover optimal"}};
+      {kStatusNotSet, "Not run"},
+      {kStatusNoProgress, "No progress"},
+      {kStatusMaxIter, "Reached maximum iterations"},
+      {kStatusTimeLimit, "Time limit"},
+      {kStatusUserInterrupt, "User interrupt"},
+      {kStatusError, "Internal error"},
+      {kStatusImprecise, "Imprecise solution"},
+      {kStatusPrimalInfeasible, "Primal infeasible"},
+      {kStatusDualInfeasible, "Dual infeasible"},
+      {kStatusOptimal, "Optimal"}};
 
   auto found = status_map.find(status);
   if (found != status_map.end()) return found->second;
-  return "unknown";
+  return "Unknown status";
 }
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -1,0 +1,292 @@
+#include "UpLookingSolver.h"
+
+#include "ipm/hipo/auxiliary/Auxiliary.h"
+
+namespace hipo {
+
+UpLookingSolver::UpLookingSolver(KktMatrix& kkt, Info& info, IpmData& data,
+                                 const Regularisation& regul,
+                                 const Model& model)
+    : kkt_{kkt},
+      ptr_{kkt_.ptrAS.empty() ? kkt_.ptrNE : kkt_.ptrAS},
+      rows_{kkt_.rowsAS.empty() ? kkt_.rowsNE : kkt_.rowsAS},
+      val_{kkt_.valAS.empty() ? kkt_.valNE : kkt_.valAS},
+      n_{static_cast<Int>(ptr_.size() - 1)},
+      info_{info},
+      data_{data},
+      regul_{regul},
+      model_{model} {}
+
+void UpLookingSolver::etreeAndCounts(const std::vector<Int>& ptr,
+                                     const std::vector<Int>& rows,
+                                     std::vector<Int64>& colcount) {
+  // compute elimination tree and column counts
+  parent_.assign(n_, -1);
+  colcount.assign(n_, 1);
+  std::vector<Int> ancestor(n_, 0);
+
+  for (Int col = 0; col < n_; ++col) {
+    ancestor[col] = col;
+    for (Int el = ptr[col]; el < ptr[col + 1]; ++el) {
+      Int row = rows[el];
+      while (ancestor[row] != col) {
+        if (parent_[row] < 0) parent_[row] = col;
+        ++colcount[row];
+        ancestor[row] = col;
+        row = parent_[row];
+      }
+    }
+  }
+}
+
+Int UpLookingSolver::setup() {
+  // KktMatrix stores lower triangle, unpermuted.
+  // Transform it into upper triangle and permute it.
+  std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
+  transpose(ptr_, rows_, ptrT, rowsT);
+  std::vector<double> empty_val;
+  permuteSym(kkt_.iperm, ptrT, rowsT, empty_val, false);
+
+  std::vector<Int64> colcount;
+  etreeAndCounts(ptrT, rowsT, colcount);
+
+  Int64 nzL{};
+  flops_ = 0.0;
+  for (Int64 i : colcount) {
+    nzL += i;
+    flops_ += (i - 1) * (i - 1);
+  }
+
+  ptrL_.resize(n_ + 1);
+  rowsL_.resize(nzL);
+  valL_.resize(nzL);
+
+  counts2Ptr(ptrL_, colcount);
+
+  regularisation_.assign(n_, 0.0);
+
+  signs_.assign(n_, 1.0);
+  if (!kkt_.ptrAS.empty())
+    for (Int i = 0; i < model_.A().num_col_; ++i) signs_[i] = -1.0;
+  permuteVectorInverse(signs_, kkt_.iperm);
+
+  return kStatusOk;
+}
+
+void UpLookingSolver::factor(const std::vector<Int>& ptr,
+                             const std::vector<Int>& rows,
+                             const std::vector<double>& val) {
+  // Up-looking factorisation.
+  // It computes L one row at a time.
+  // If the first k rows have been computed, then we already have a
+  // factorisation of M(1:k,1:k) = LDL^T (in Matlab notation). The next row of L
+  // is [l^T 1], the next element of D is d, and the next row of M is [b^T a]:
+  //
+  // [ L   ] [D  ] [L^T l] = [ M  b]
+  // [l^T 1] [  d] [    1]   [b^T a]
+  //
+  // Then
+  // - l is found solving LDl = b
+  // - d is found solving l^TDl + d = a
+  //
+  // A must be upper triangular.
+  // L is computed as lower triangular. The diagonal of L is used to store D^-1.
+
+  std::vector<bool> mark(n_, false);
+  std::vector<Int> stack(n_);
+  Int top = 0;
+  std::vector<Int> revpattern(n_);
+  std::vector<double> x(n_, 0.0);
+  std::vector<Int64> next = ptrL_;
+
+  for (Int row = 0; row < n_; ++row) {
+    // ===================================================================
+    //  Sparsity pattern of row of L
+    // ===================================================================
+    // Compute the sparsity pattern of current row of L by traversing the row
+    // subtree (see ereach in Davis' book)
+
+    Int rowcount = 0;
+
+    for (Int el = ptr[row]; el < ptr[row + 1]; ++el) {
+      Int i = rows[el];
+      top = 0;
+
+      assert(i <= row);
+
+      while (i >= 0 && i < row && !mark[i]) {
+        mark[i] = true;
+        stack[top++] = i;
+        i = parent_[i];
+      }
+
+      while (top > 0) {
+        --top;
+        revpattern[rowcount] = stack[top];
+        ++rowcount;
+      }
+    }
+
+    // ===================================================================
+    //  Values of row of L
+    // ===================================================================
+    // Compute l, by computing L^-1 * b in x, and then multiplying by Dinv
+
+    x[row] = 0.0;
+    for (Int el = ptr[row]; el < ptr[row + 1]; ++el) x[rows[el]] = val[el];
+    double d = x[row];
+    x[row] = 0.0;
+
+    for (Int i = 0; i < rowcount; ++i) {
+      const Int col = revpattern[rowcount - 1 - i];
+
+      double value = x[col];
+      x[col] = 0.0;
+      assert(rowsL_[ptrL_[col]] == col);
+      for (Int el = ptrL_[col] + 1; el < next[col]; ++el)
+        x[rowsL_[el]] -= valL_[el] * value;
+
+      const double Dinv = valL_[ptrL_[col]];
+      rowsL_[next[col]] = row;
+      valL_[next[col]] = value * Dinv;
+
+      d -= value * valL_[next[col]];
+      next[col]++;
+
+      mark[col] = false;
+    }
+
+    // diagonal entry
+    double old_pivot = d;
+    if (signs_[row] > 0)
+      d += regul_.dual;
+    else
+      d -= regul_.primal;
+
+    if (d * signs_[row] < reg_threshold_) {
+      d = reg_value_ * signs_[row];
+    }
+
+    regularisation_[row] = d - old_pivot;
+
+    valL_[ptrL_[row]] = 1.0 / d;
+    rowsL_[next[row]] = row;
+    next[row]++;
+  }
+}
+
+void UpLookingSolver::solve(std::vector<double>& x) {
+  // forward solve
+  for (Int i = 0; i < n_; ++i) {
+    for (Int el = ptrL_[i] + 1; el < ptrL_[i + 1]; ++el) {
+      x[rowsL_[el]] -= valL_[el] * x[i];
+    }
+  }
+
+  // diag solve
+  for (Int i = 0; i < n_; ++i) {
+    x[i] *= valL_[ptrL_[i]];
+  }
+
+  // backward solve
+  for (Int i = n_ - 1; i >= 0; --i) {
+    for (Int el = ptrL_[i] + 1; el < ptrL_[i + 1]; ++el) {
+      x[i] -= valL_[el] * x[rowsL_[el]];
+    }
+  }
+}
+
+Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
+  assert(!valid_);
+  assert(kkt_.ptrNE.empty());
+
+  Clock clock;
+  kkt_.buildASvalues(scaling);
+  info_.matrix_time += clock.stop();
+
+  // construct permuted upper triangle
+  std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
+  std::vector<double> valT(val_.size());
+  transpose(ptr_, rows_, val_, ptrT, rowsT, valT);
+  permuteSym(kkt_.iperm, ptrT, rowsT, valT, false);
+
+  clock.start();
+  factor(ptrT, rowsT, valT);
+  info_.factor_time += clock.stop();
+  info_.factor_number++;
+
+  valid_ = true;
+  return kStatusOk;
+}
+Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
+  assert(!valid_);
+  assert(kkt_.ptrAS.empty());
+
+  Clock clock;
+  kkt_.buildNEvalues(scaling);
+  info_.matrix_time += clock.stop();
+
+  // construct permuted upper triangle
+  std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
+  std::vector<double> valT(val_.size());
+  transpose(ptr_, rows_, val_, ptrT, rowsT, valT);
+  permuteSym(kkt_.iperm, ptrT, rowsT, valT, false);
+
+  clock.start();
+  factor(ptrT, rowsT, valT);
+  info_.factor_time += clock.stop();
+  info_.factor_number++;
+
+  valid_ = true;
+  return kStatusOk;
+}
+
+Int UpLookingSolver::solveAS(const std::vector<double>& rhs_x,
+                             const std::vector<double>& rhs_y,
+                             std::vector<double>& lhs_x,
+                             std::vector<double>& lhs_y) {
+  assert(valid_);
+
+  Int n = rhs_x.size();
+
+  // create single rhs
+  std::vector<double> rhs;
+  rhs.insert(rhs.end(), rhs_x.begin(), rhs_x.end());
+  rhs.insert(rhs.end(), rhs_y.begin(), rhs_y.end());
+
+  Clock clock;
+  permuteVectorInverse(rhs, kkt_.iperm);
+  solve(rhs);
+  permuteVector(rhs, kkt_.iperm);
+  info_.solve_time += clock.stop();
+  info_.solve_number++;
+  data_.back().num_solves++;
+
+  // split lhs
+  lhs_x = std::vector<double>(rhs.begin(), rhs.begin() + n);
+  lhs_y = std::vector<double>(rhs.begin() + n, rhs.end());
+
+  return kStatusOk;
+}
+Int UpLookingSolver::solveNE(const std::vector<double>& rhs,
+                             std::vector<double>& lhs) {
+  assert(valid_);
+
+  lhs = rhs;
+  Clock clock;
+  permuteVectorInverse(lhs, kkt_.iperm);
+  solve(lhs);
+  permuteVector(lhs, kkt_.iperm);
+  info_.solve_time += clock.stop();
+  info_.solve_number++;
+  data_.back().num_solves++;
+
+  return kStatusOk;
+}
+
+void UpLookingSolver::getReg(std::vector<double>& reg) {
+  reg = regularisation_;
+  permuteVector(reg, kkt_.iperm);
+}
+
+}  // namespace hipo

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -70,7 +70,7 @@ Int UpLookingSolver::setup() {
     for (Int i = 0; i < model_.A().num_col_; ++i) signs_[i] = -1.0;
   permuteVectorInverse(signs_, kkt_.iperm());
 
-  return kStatusOk;
+  return kOk;
 }
 
 void UpLookingSolver::factor(const std::vector<Int>& ptr,
@@ -216,7 +216,7 @@ Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
   info_.factor_number++;
 
   valid_ = true;
-  return kStatusOk;
+  return kOk;
 }
 Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
   assert(!valid_);
@@ -238,7 +238,7 @@ Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
   info_.factor_number++;
 
   valid_ = true;
-  return kStatusOk;
+  return kOk;
 }
 
 Int UpLookingSolver::solveAS(const std::vector<double>& rhs_x,
@@ -266,7 +266,7 @@ Int UpLookingSolver::solveAS(const std::vector<double>& rhs_x,
   lhs_x = std::vector<double>(rhs.begin(), rhs.begin() + n);
   lhs_y = std::vector<double>(rhs.begin() + n, rhs.end());
 
-  return kStatusOk;
+  return kOk;
 }
 Int UpLookingSolver::solveNE(const std::vector<double>& rhs,
                              std::vector<double>& lhs) {
@@ -281,7 +281,7 @@ Int UpLookingSolver::solveNE(const std::vector<double>& rhs,
   info_.solve_number++;
   data_.back().num_solves++;
 
-  return kStatusOk;
+  return kOk;
 }
 
 void UpLookingSolver::getReg(std::vector<double>& reg) {

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -249,22 +249,20 @@ Int UpLookingSolver::solveAS(const std::vector<double>& rhs_x,
 
   Int n = rhs_x.size();
 
-  // create single rhs
-  std::vector<double> rhs;
-  rhs.insert(rhs.end(), rhs_x.begin(), rhs_x.end());
-  rhs.insert(rhs.end(), rhs_y.begin(), rhs_y.end());
+  as_buffer_.resize(rhs_x.size() + rhs_y.size());
+  std::copy(rhs_x.begin(), rhs_x.end(), as_buffer_.begin());
+  std::copy(rhs_y.begin(), rhs_y.end(), as_buffer_.begin() + n);
 
   Clock clock;
-  permuteVectorInverse(rhs, kkt_.iperm());
-  solve(rhs);
-  permuteVector(rhs, kkt_.iperm());
+  permuteVectorInverse(as_buffer_, kkt_.iperm());
+  solve(as_buffer_);
+  permuteVector(as_buffer_, kkt_.iperm());
   info_.solve_time += clock.stop();
   info_.solve_number++;
   data_.back().num_solves++;
 
-  // split lhs
-  lhs_x = std::vector<double>(rhs.begin(), rhs.begin() + n);
-  lhs_y = std::vector<double>(rhs.begin() + n, rhs.end());
+  lhs_x.assign(as_buffer_.begin(), as_buffer_.begin() + n);
+  lhs_y.assign(as_buffer_.begin() + n, as_buffer_.end());
 
   return kOk;
 }

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -8,9 +8,9 @@ UpLookingSolver::UpLookingSolver(KktMatrix& kkt, Info& info, IpmData& data,
                                  const Regularisation& regul,
                                  const Model& model)
     : kkt_{kkt},
-      ptr_{kkt_.ptrAS.empty() ? kkt_.ptrNE : kkt_.ptrAS},
-      rows_{kkt_.rowsAS.empty() ? kkt_.rowsNE : kkt_.rowsAS},
-      val_{kkt_.valAS.empty() ? kkt_.valNE : kkt_.valAS},
+      ptr_{kkt_.isNE() ? kkt_.ptrNE : kkt_.ptrAS},
+      rows_{kkt_.isNE() ? kkt_.rowsNE : kkt_.rowsAS},
+      val_{kkt_.isNE() ? kkt_.valNE : kkt_.valAS},
       n_{static_cast<Int>(ptr_.size() - 1)},
       info_{info},
       data_{data},
@@ -66,7 +66,7 @@ Int UpLookingSolver::setup() {
   regularisation_.assign(n_, 0.0);
 
   signs_.assign(n_, 1.0);
-  if (!kkt_.ptrAS.empty())
+  if (kkt_.isAS())
     for (Int i = 0; i < model_.A().num_col_; ++i) signs_[i] = -1.0;
   permuteVectorInverse(signs_, kkt_.iperm());
 
@@ -198,7 +198,7 @@ void UpLookingSolver::solve(std::vector<double>& x) {
 
 Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
   assert(!valid_);
-  assert(kkt_.ptrNE.empty());
+  assert(kkt_.isAS());
 
   Clock clock;
   kkt_.buildASvalues(scaling);
@@ -220,7 +220,7 @@ Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
 }
 Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
   assert(!valid_);
-  assert(kkt_.ptrAS.empty());
+  assert(kkt_.isNE());
 
   Clock clock;
   kkt_.buildNEvalues(scaling);

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -45,7 +45,7 @@ Int UpLookingSolver::setup() {
   std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
   transpose(ptr_, rows_, ptrT, rowsT);
   std::vector<double> empty_val;
-  permuteSym(kkt_.iperm, ptrT, rowsT, empty_val, false);
+  permuteSym(kkt_.iperm(), ptrT, rowsT, empty_val, false);
 
   std::vector<Int64> colcount;
   etreeAndCounts(ptrT, rowsT, colcount);
@@ -68,7 +68,7 @@ Int UpLookingSolver::setup() {
   signs_.assign(n_, 1.0);
   if (!kkt_.ptrAS.empty())
     for (Int i = 0; i < model_.A().num_col_; ++i) signs_[i] = -1.0;
-  permuteVectorInverse(signs_, kkt_.iperm);
+  permuteVectorInverse(signs_, kkt_.iperm());
 
   return kStatusOk;
 }
@@ -208,7 +208,7 @@ Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
   std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
   std::vector<double> valT(val_.size());
   transpose(ptr_, rows_, val_, ptrT, rowsT, valT);
-  permuteSym(kkt_.iperm, ptrT, rowsT, valT, false);
+  permuteSym(kkt_.iperm(), ptrT, rowsT, valT, false);
 
   clock.start();
   factor(ptrT, rowsT, valT);
@@ -230,7 +230,7 @@ Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
   std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
   std::vector<double> valT(val_.size());
   transpose(ptr_, rows_, val_, ptrT, rowsT, valT);
-  permuteSym(kkt_.iperm, ptrT, rowsT, valT, false);
+  permuteSym(kkt_.iperm(), ptrT, rowsT, valT, false);
 
   clock.start();
   factor(ptrT, rowsT, valT);
@@ -255,9 +255,9 @@ Int UpLookingSolver::solveAS(const std::vector<double>& rhs_x,
   rhs.insert(rhs.end(), rhs_y.begin(), rhs_y.end());
 
   Clock clock;
-  permuteVectorInverse(rhs, kkt_.iperm);
+  permuteVectorInverse(rhs, kkt_.iperm());
   solve(rhs);
-  permuteVector(rhs, kkt_.iperm);
+  permuteVector(rhs, kkt_.iperm());
   info_.solve_time += clock.stop();
   info_.solve_number++;
   data_.back().num_solves++;
@@ -274,9 +274,9 @@ Int UpLookingSolver::solveNE(const std::vector<double>& rhs,
 
   lhs = rhs;
   Clock clock;
-  permuteVectorInverse(lhs, kkt_.iperm);
+  permuteVectorInverse(lhs, kkt_.iperm());
   solve(lhs);
-  permuteVector(lhs, kkt_.iperm);
+  permuteVector(lhs, kkt_.iperm());
   info_.solve_time += clock.stop();
   info_.solve_number++;
   data_.back().num_solves++;
@@ -286,7 +286,7 @@ Int UpLookingSolver::solveNE(const std::vector<double>& rhs,
 
 void UpLookingSolver::getReg(std::vector<double>& reg) {
   reg = regularisation_;
-  permuteVector(reg, kkt_.iperm);
+  permuteVector(reg, kkt_.iperm());
 }
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -202,7 +202,7 @@ Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
 
   Clock clock;
   kkt_.buildASvalues(scaling);
-  info_.matrix_time += clock.stop();
+  info_.times[kMatrixValuesTime] += clock.stop();
 
   // construct permuted upper triangle
   std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
@@ -212,7 +212,7 @@ Int UpLookingSolver::factorAS(const std::vector<double>& scaling) {
 
   clock.start();
   factor(ptrT, rowsT, valT);
-  info_.factor_time += clock.stop();
+  info_.times[kFactoriseTime] += clock.stop();
   info_.factor_number++;
 
   valid_ = true;
@@ -224,7 +224,7 @@ Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
 
   Clock clock;
   kkt_.buildNEvalues(scaling);
-  info_.matrix_time += clock.stop();
+  info_.times[kMatrixValuesTime] += clock.stop();
 
   // construct permuted upper triangle
   std::vector<Int> ptrT(ptr_.size()), rowsT(rows_.size());
@@ -234,7 +234,7 @@ Int UpLookingSolver::factorNE(const std::vector<double>& scaling) {
 
   clock.start();
   factor(ptrT, rowsT, valT);
-  info_.factor_time += clock.stop();
+  info_.times[kFactoriseTime] += clock.stop();
   info_.factor_number++;
 
   valid_ = true;
@@ -249,20 +249,24 @@ Int UpLookingSolver::solveAS(const std::vector<double>& rhs_x,
 
   Int n = rhs_x.size();
 
+  Clock clock;
   as_buffer_.resize(rhs_x.size() + rhs_y.size());
   std::copy(rhs_x.begin(), rhs_x.end(), as_buffer_.begin());
   std::copy(rhs_y.begin(), rhs_y.end(), as_buffer_.begin() + n);
+  info_.times[kInsertSplitTime] += clock.stop();
 
-  Clock clock;
+  clock.start();
   permuteVectorInverse(as_buffer_, kkt_.iperm());
   solve(as_buffer_);
   permuteVector(as_buffer_, kkt_.iperm());
-  info_.solve_time += clock.stop();
+  info_.times[kSolveTime] += clock.stop();
   info_.solve_number++;
   data_.back().num_solves++;
 
+  clock.start();
   lhs_x.assign(as_buffer_.begin(), as_buffer_.begin() + n);
   lhs_y.assign(as_buffer_.begin() + n, as_buffer_.end());
+  info_.times[kInsertSplitTime] += clock.stop();
 
   return kOk;
 }
@@ -275,7 +279,7 @@ Int UpLookingSolver::solveNE(const std::vector<double>& rhs,
   permuteVectorInverse(lhs, kkt_.iperm());
   solve(lhs);
   permuteVector(lhs, kkt_.iperm());
-  info_.solve_time += clock.stop();
+  info_.times[kSolveTime] += clock.stop();
   info_.solve_number++;
   data_.back().num_solves++;
 

--- a/highs/ipm/hipo/ipm/UpLookingSolver.cpp
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.cpp
@@ -61,7 +61,7 @@ Int UpLookingSolver::setup() {
   rowsL_.resize(nzL);
   valL_.resize(nzL);
 
-  counts2Ptr(ptrL_, colcount);
+  counts2Ptr(n_, ptrL_.data(), colcount.data());
 
   regularisation_.assign(n_, 0.0);
 

--- a/highs/ipm/hipo/ipm/UpLookingSolver.h
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.h
@@ -48,7 +48,7 @@ class UpLookingSolver : public LinearSolver {
 
  public:
   UpLookingSolver(KktMatrix& kkt, Info& info, IpmData& data,
-                  const Regularisation& regul,const Model& model);
+                  const Regularisation& regul, const Model& model);
 
   Int factorAS(const std::vector<double>& scaling) override;
   Int factorNE(const std::vector<double>& scaling) override;
@@ -62,6 +62,7 @@ class UpLookingSolver : public LinearSolver {
   double flops() const override { return flops_; }
   double spops() const override { return 0; }
   double nz() const override { return valL_.size(); }
+  Int n() const override { return n_; }
   void getReg(std::vector<double>& reg) override;
 };
 

--- a/highs/ipm/hipo/ipm/UpLookingSolver.h
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.h
@@ -1,0 +1,70 @@
+#ifndef HIPO_UP_LOOKING_SOLVER_H
+#define HIPO_UP_LOOKING_SOLVER_H
+
+#include "Info.h"
+#include "IpmData.h"
+#include "KktMatrix.h"
+#include "LinearSolver.h"
+#include "Model.h"
+
+// Up-looking factorisation
+// Based on Tim Davis "Direct Methods for Sparse Linear Systems", cholmod, qdldl
+
+namespace hipo {
+
+class UpLookingSolver : public LinearSolver {
+  KktMatrix& kkt_;
+
+  // reference to matrix that is actually used (AS or NE)
+  std::vector<Int>& ptr_;
+  std::vector<Int>& rows_;
+  std::vector<double>& val_;
+
+  const Int n_;
+
+  std::vector<Int64> ptrL_;
+  std::vector<Int> rowsL_;
+  std::vector<double> valL_;
+
+  std::vector<double> regularisation_;
+  std::vector<Int> signs_;
+
+  const double reg_threshold_ = 1e-13;
+  const double reg_value_ = 2e-7;
+
+  std::vector<Int> parent_;
+  double flops_;
+
+  Info& info_;
+  IpmData& data_;
+  const Regularisation& regul_;
+  const Model& model_;
+
+  void etreeAndCounts(const std::vector<Int>& ptr, const std::vector<Int>& rows,
+                      std::vector<Int64>& colcount);
+  void factor(const std::vector<Int>& ptr, const std::vector<Int>& rows,
+              const std::vector<double>& val);
+  void solve(std::vector<double>& x);
+
+ public:
+  UpLookingSolver(KktMatrix& kkt, Info& info, IpmData& data,
+                  const Regularisation& regul,const Model& model);
+
+  Int factorAS(const std::vector<double>& scaling) override;
+  Int factorNE(const std::vector<double>& scaling) override;
+  Int solveNE(const std::vector<double>& rhs,
+              std::vector<double>& lhs) override;
+  Int solveAS(const std::vector<double>& rhs_x,
+              const std::vector<double>& rhs_y, std::vector<double>& lhs_x,
+              std::vector<double>& lhs_y) override;
+  Int setup() override;
+  void clear() override { valid_ = false; }
+  double flops() const override { return flops_; }
+  double spops() const override { return 0; }
+  double nz() const override { return valL_.size(); }
+  void getReg(std::vector<double>& reg) override;
+};
+
+}  // namespace hipo
+
+#endif

--- a/highs/ipm/hipo/ipm/UpLookingSolver.h
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.h
@@ -63,6 +63,8 @@ class UpLookingSolver : public LinearSolver {
   double spops() const override { return 0; }
   double nz() const override { return valL_.size(); }
   void getReg(std::vector<double>& reg) override;
+
+  LinearSolverType type() const override { return kUpLookingType; }
 };
 
 }  // namespace hipo

--- a/highs/ipm/hipo/ipm/UpLookingSolver.h
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.h
@@ -62,7 +62,6 @@ class UpLookingSolver : public LinearSolver {
   double flops() const override { return flops_; }
   double spops() const override { return 0; }
   double nz() const override { return valL_.size(); }
-  Int n() const override { return n_; }
   void getReg(std::vector<double>& reg) override;
 };
 

--- a/highs/ipm/hipo/ipm/UpLookingSolver.h
+++ b/highs/ipm/hipo/ipm/UpLookingSolver.h
@@ -35,6 +35,8 @@ class UpLookingSolver : public LinearSolver {
   std::vector<Int> parent_;
   double flops_;
 
+  std::vector<double> as_buffer_;
+
   Info& info_;
   IpmData& data_;
   const Regularisation& regul_;

--- a/highs/lp_data/HighsOptions.cpp
+++ b/highs/lp_data/HighsOptions.cpp
@@ -207,6 +207,19 @@ bool optionHipoOrderingOk(const HighsLogOptions& report_log_options,
   return false;
 }
 
+bool optionHipoFactorOk(const HighsLogOptions& report_log_options,
+                        const string& value) {
+  if (value == kHipoFactorMultifrontal || value == kHipoFactorUplooking ||
+      value == kHighsChooseString)
+    return true;
+  highsLogUser(
+      report_log_options, HighsLogType::kError,
+      "Value \"%s\" for %s option is not one of \"%s\", \"%s\" or \"%s\"\n",
+      value.c_str(), kHipoFactorString.c_str(), kHipoFactorMultifrontal.c_str(),
+      kHipoFactorUplooking.c_str(), kHighsChooseString.c_str());
+  return false;
+}
+
 bool boolFromString(std::string value, bool& bool_value) {
   std::transform(value.begin(), value.end(), value.begin(),
                  [](unsigned char c) { return std::tolower(c); });
@@ -493,6 +506,9 @@ OptionStatus checkOptionValue(const HighsLogOptions& report_log_options,
       return OptionStatus::kIllegalValue;
   } else if (option.name == kHipoOrderingString) {
     if (!optionHipoOrderingOk(report_log_options, value))
+      return OptionStatus::kIllegalValue;
+  } else if (option.name == kHipoFactorString) {
+    if (!optionHipoFactorOk(report_log_options, value))
       return OptionStatus::kIllegalValue;
   }
   return OptionStatus::kOk;

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -332,6 +332,10 @@ const string kHipoMetisString = "metis";
 const string kHipoAmdString = "amd";
 const string kHipoRcmString = "rcm";
 
+const string kHipoFactorString = "hipo_factor";
+const string kHipoFactorMultifrontal = "multifrontal";
+const string kHipoFactorUplooking = "uplooking";
+
 struct HighsOptionsStruct {
   // Run-time options read from the command line
   std::string presolve;
@@ -397,6 +401,7 @@ struct HighsOptionsStruct {
   std::string hipo_system;
   std::string hipo_parallel_type;
   std::string hipo_ordering;
+  std::string hipo_factor;
   HighsInt hipo_block_size;
 
   // Options for PDLP solver
@@ -577,6 +582,7 @@ struct HighsOptionsStruct {
         hipo_system(""),
         hipo_parallel_type(""),
         hipo_ordering(""),
+        hipo_factor(""),
         hipo_block_size(0),
         pdlp_features_off(0),
         pdlp_iteration_limit(0),
@@ -1329,6 +1335,13 @@ class HighsOptions : public HighsOptionsStruct {
                                "HiPO matrix reordering: \"choose\", \"metis\", "
                                "\"amd\" or \"rcm\"",
                                advanced, &hipo_ordering, kHighsChooseString);
+    records.push_back(record_string);
+
+    record_string = new OptionRecordString(
+        kHipoFactorString,
+        "HiPO matrix factorisation: \"choose\", \"multifrontal\" "
+        "or \"uplooking\"",
+        advanced, &hipo_factor, kHighsChooseString);
     records.push_back(record_string);
 
     record_int = new OptionRecordInt(

--- a/highs/lp_data/HighsOptions.h
+++ b/highs/lp_data/HighsOptions.h
@@ -144,6 +144,8 @@ bool optionHipoSystemOk(const HighsLogOptions& report_log_options,
                         const string& value);
 bool optionHipoOrderingOk(const HighsLogOptions& report_log_options,
                           const string& value);
+bool optionHipoFactorOk(const HighsLogOptions& report_log_options,
+                        const string& value);
 
 bool boolFromString(std::string value, bool& bool_value);
 

--- a/highs/meson.build
+++ b/highs/meson.build
@@ -202,6 +202,7 @@ _hipo_srcs = [
     'ipm/hipo/ipm/PreProcess.cpp',
     'ipm/hipo/ipm/Refine.cpp',
     'ipm/hipo/ipm/Solver.cpp',
+    'ipm/hipo/ipm/UpLookingSolver.cpp',
     'ipm/hipo/factorhighs/Analyse.cpp',
     'ipm/hipo/factorhighs/CallAndTimeBlas.cpp',
     'ipm/hipo/factorhighs/CliqueStack.cpp',


### PR DESCRIPTION
- Add up-looking factorisation. This is a simplified sparse factorisation that works well when the matrix is very sparse. 
- Add criterion to select whether to use the up-looking factorisation or the multi-frontal one.
- Add option `hipo_factor` to force the choice of a specific factorisation.
- Add possibility of switching between the two factorisations. This is used mainly if the up-looking factorisation (which is slightly less robust for now) fails, to continue iterating using the multi-frontal one
- If HiPO fails, it resets to the best iteration that it found before switching to IPX or switching factorisation.
- Changed the way HiPO manages the status of the solve process, keeping track of errors separately from the status.
- Removed unnecessary memory allocations and swaps from the triangular solves, as suggested by #3152.
- Changed the internal time profiling.
- Removed a lot of useless comments, unused functions, and improved general readability of the code.