### PR TITLE
Restore per-coefficient bound substitutions before untransforming a path cut (#3171)

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1605,3 +1605,43 @@ TEST_CASE("issue-3118a", "[highs_test_mip_solver]") {
 
   highs.resetGlobalScheduler(true);
 }
+
+TEST_CASE("issue-3171", "[highs_test_mip_solver]") {
+  // A path mixing cut is assembled from several base rows, each transformed by
+  // its own HighsTransformedLp::transform() call, and mapped back by a single
+  // untransform() at the end. The substitution chosen for each column lives in
+  // the shared boundTypes array, and untransform() reads whatever is in there
+  // when it runs.
+  //
+  // A base row is transformed before its right hand side is checked for the
+  // required monotonicity, and dropped only afterwards, so a discarded row's
+  // mutation of boundTypes survives. Since the substitution chosen for a binary
+  // depends on the sign of its coefficient in the row being transformed, a
+  // discarded row can flip a binary's complementation, and untransform() then
+  // resubstitutes a different variable than the coefficients were computed
+  // against. The resulting cut is not globally valid and can remove the
+  // optimum, after which the search closes and reports the incumbent as optimal
+  // at a zero gap.
+  //
+  // Without the fix this model is solved incorrectly, silently: the returned
+  // point is feasible and integral and the gap is certified 0. The optimum was
+  // verified independently of the branch and bound search, by fixing every
+  // integer column to the reported values and solving the remaining LP.
+  const std::string filename =
+      std::string(HIGHS_DIR) + "/check/instances/3171-1.mps";
+  const double optimal_objective = 42215.525000540001;
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  REQUIRE(highs.readModel(filename) == HighsStatus::kOk);
+  // the defect is reached under default options; pin the search so that the
+  // test does not depend on the scheduler or the random seed
+  REQUIRE(highs.setOptionValue("random_seed", 0) == HighsStatus::kOk);
+  REQUIRE(highs.setOptionValue("threads", 1) == HighsStatus::kOk);
+  REQUIRE(highs.setOptionValue("parallel", kHighsOffString) ==
+          HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kOptimal);
+  REQUIRE(objectiveOk(highs.getInfo().objective_function_value,
+                      optimal_objective, dev_run));
+  highs.resetGlobalScheduler(true);
+}

--- a/check/instances/3171-1.mps
+++ b/check/instances/3171-1.mps
@@ -1,0 +1,636 @@
+NAME          3171-1
+ROWS
+ N  COST    
+ E  bal0    
+ L  cap0    
+ E  bal1    
+ L  cap1    
+ G  min1    
+ E  bal2    
+ L  cap2    
+ G  min2    
+ E  bal3    
+ L  cap3    
+ G  min3    
+ E  bal4    
+ L  cap4    
+ G  min4    
+ E  bal5    
+ L  cap5    
+ G  min5    
+ E  bal6    
+ L  cap6    
+ G  min6    
+ E  bal7    
+ L  cap7    
+ G  min7    
+ E  bal8    
+ L  cap8    
+ G  min8    
+ E  bal9    
+ L  cap9    
+ G  min9    
+ E  bal10   
+ L  cap10   
+ G  min10   
+ E  bal11   
+ L  cap11   
+ G  min11   
+ E  bal12   
+ L  cap12   
+ G  min12   
+ E  bal13   
+ L  cap13   
+ G  min13   
+ E  bal14   
+ L  cap14   
+ G  min14   
+ E  bal15   
+ L  cap15   
+ G  min15   
+ E  bal16   
+ L  cap16   
+ E  bal17   
+ L  cap17   
+ E  bal18   
+ L  cap18   
+ E  bal19   
+ L  cap19   
+ E  bal20   
+ L  cap20   
+ E  bal21   
+ L  cap21   
+ E  bal22   
+ L  cap22   
+ G  min22   
+ E  bal23   
+ L  cap23   
+ E  bal24   
+ L  cap24   
+ L  cyc0    
+ L  cyc1    
+ L  cyc2    
+ L  cyc3    
+ L  cyc5    
+ L  cyc6    
+ L  cyc7    
+ L  cyc8    
+ L  cyc9    
+ L  cyc10   
+ L  cyc11   
+ L  cyc12   
+ L  cyc13   
+ L  cyc14   
+ L  cyc15   
+ L  cyc18   
+ L  cyc22   
+ L  cyc23   
+ L  cyc26   
+COLUMNS
+    x0        COST      0.5848
+    x0        bal0      1
+    x0        cap0      1
+    x1        COST      4.0194
+    x1        bal1      1
+    x1        cap1      1
+    x1        min1      1
+    x2        COST      4.7162
+    x2        bal2      1
+    x2        cap2      1
+    x2        min2      1
+    x3        COST      2.0177
+    x3        bal3      1
+    x3        cap3      1
+    x3        min3      1
+    x4        COST      1.9631
+    x4        bal4      1
+    x4        cap4      1
+    x4        min4      1
+    x5        COST      0.6887
+    x5        bal5      1
+    x5        cap5      1
+    x5        min5      1
+    x6        COST      3.9546
+    x6        bal6      1
+    x6        cap6      1
+    x6        min6      1
+    x7        COST      3.4019
+    x7        bal7      1
+    x7        cap7      1
+    x7        min7      1
+    x8        COST      3.7888
+    x8        bal8      1
+    x8        cap8      1
+    x8        min8      1
+    x9        COST      1.6003
+    x9        bal9      1
+    x9        cap9      1
+    x9        min9      1
+    x10       COST      2.6173
+    x10       bal10     1
+    x10       cap10     1
+    x10       min10     1
+    x11       COST      3.0378
+    x11       bal11     1
+    x11       cap11     1
+    x11       min11     1
+    x12       COST      3.451
+    x12       bal12     1
+    x12       cap12     1
+    x12       min12     1
+    x13       COST      3.7954
+    x13       bal13     1
+    x13       cap13     1
+    x13       min13     1
+    x14       COST      2.8486
+    x14       bal14     1
+    x14       cap14     1
+    x14       min14     1
+    x15       COST      3.7517
+    x15       bal15     1
+    x15       cap15     1
+    x15       min15     1
+    x16       COST      3.2385
+    x16       bal16     1
+    x16       cap16     1
+    x17       COST      1.0732
+    x17       bal17     1
+    x17       cap17     1
+    x18       COST      1.5092
+    x18       bal18     1
+    x18       cap18     1
+    x19       COST      1.2789
+    x19       bal19     1
+    x19       cap19     1
+    x20       COST      2.3069
+    x20       bal20     1
+    x20       cap20     1
+    x21       COST      1.1266
+    x21       bal21     1
+    x21       cap21     1
+    x22       COST      4.7435
+    x22       bal22     1
+    x22       cap22     1
+    x22       min22     1
+    x23       COST      2.7308
+    x23       bal23     1
+    x23       cap23     1
+    x24       COST      3.3885
+    x24       bal24     1
+    x24       cap24     1
+    s0        COST      1.6853
+    s0        bal0      -1
+    s0        bal1      1
+    s1        COST      0.4044
+    s1        bal1      -1
+    s1        bal2      1
+    s2        COST      1.3623
+    s2        bal2      -1
+    s2        bal3      1
+    s3        COST      0.6979
+    s3        bal3      -1
+    s3        bal4      1
+    s4        COST      1.5432
+    s4        bal4      -1
+    s4        bal5      1
+    s5        COST      1.342
+    s5        bal5      -1
+    s5        bal6      1
+    s6        COST      1.0642
+    s6        bal6      -1
+    s6        bal7      1
+    s7        COST      0.7355
+    s7        bal7      -1
+    s7        bal8      1
+    s8        COST      0.9302
+    s8        bal8      -1
+    s8        bal9      1
+    s9        COST      0.8402
+    s9        bal9      -1
+    s9        bal10     1
+    s10       COST      1.4193
+    s10       bal10     -1
+    s10       bal11     1
+    s11       COST      0.5941
+    s11       bal11     -1
+    s11       bal12     1
+    s12       COST      0.4356
+    s12       bal12     -1
+    s12       bal13     1
+    s13       COST      1.9367
+    s13       bal13     -1
+    s13       bal14     1
+    s14       COST      0.3266
+    s14       bal14     -1
+    s14       bal15     1
+    s15       COST      1.5609
+    s15       bal15     -1
+    s15       bal16     1
+    s16       COST      1.9467
+    s16       bal16     -1
+    s16       bal17     1
+    s17       COST      1.6249
+    s17       bal17     -1
+    s17       bal18     1
+    s18       COST      0.8093
+    s18       bal18     -1
+    s18       bal19     1
+    s19       COST      1.0846
+    s19       bal19     -1
+    s19       bal20     1
+    s20       COST      0.8254
+    s20       bal20     -1
+    s20       bal21     1
+    s21       COST      1.0207
+    s21       bal21     -1
+    s21       bal22     1
+    s22       COST      1.9059
+    s22       bal22     -1
+    s22       bal23     1
+    s23       COST      0.3341
+    s23       bal23     -1
+    s23       bal24     1
+    s24       COST      1.3017
+    s24       bal24     -1
+    MARK0000  'MARKER'                 'INTORG'
+    y0        COST      3287.284
+    y0        cap0      -24.427
+    y1        COST      3682.67
+    y1        cap1      -25.144
+    y1        min1      -13.432
+    y2        COST      1524.613
+    y2        cap2      -32.774
+    y2        min2      -21.371
+    y3        COST      1961.865
+    y3        cap3      -26.387
+    y3        min3      -11.027
+    y4        COST      4107.433
+    y4        cap4      -31.815
+    y4        min4      -19.205
+    y5        COST      3449.128
+    y5        cap5      -24.663
+    y5        min5      -9.582
+    y6        COST      854.136
+    y6        cap6      -27.287
+    y6        min6      -5.814
+    y7        COST      1551.176
+    y7        cap7      -29.904
+    y7        min7      -6.074
+    y8        COST      831.014
+    y8        cap8      -32.373
+    y8        min8      -22.073
+    y9        COST      4824.364
+    y9        cap9      -31.451
+    y9        min9      -11.765
+    y10       COST      1247.71
+    y10       cap10     -36.908
+    y10       min10     -14.416
+    y11       COST      2716.845
+    y11       cap11     -36.049
+    y11       min11     -22.875
+    y12       COST      1012.623
+    y12       cap12     -33.756
+    y12       min12     -15.757
+    y13       COST      4110.066
+    y13       cap13     -28.947
+    y13       min13     -6.928
+    y14       COST      2884.502
+    y14       cap14     -25.081
+    y14       min14     -16.88
+    y15       COST      4057.008
+    y15       cap15     -24.578
+    y15       min15     -13.63
+    y16       COST      566.044
+    y16       cap16     -33.569
+    y17       COST      3096.366
+    y17       cap17     -37.122
+    y18       COST      1795.734
+    y18       cap18     -33.444
+    y19       COST      577.118
+    y19       cap19     -32.5
+    y20       COST      721.036
+    y20       cap20     -24.859
+    y21       COST      3197.163
+    y21       cap21     -36.419
+    y22       COST      3527.957
+    y22       cap22     -26.165
+    y22       min22     -14.438
+    y23       COST      3726.333
+    y23       cap23     -28.858
+    y24       COST      3527.908
+    y24       cap24     -31.107
+    z0        COST      -127.009
+    z0        cyc0      1
+    z0        cap11     -0.72098
+    z0        min11     -0.22875
+    z0        cap6      0.54574
+    z0        min6      0.05814
+    z1        COST      -127.009
+    z1        cyc1      1
+    z1        cyc0      1
+    z1        cap9      -0.62902
+    z1        min9      0.11765
+    z1        cap18     -0.66888
+    z2        COST      -127.009
+    z2        cyc2      1
+    z2        cyc1      1
+    z2        cap22     0.5233
+    z2        min22     0.14438
+    z2        cap23     -0.57716
+    z2        cap1      0.50288
+    z2        min1      0.13432
+    z3        COST      -127.009
+    z3        cyc3      1
+    z3        cyc2      1
+    z3        cap24     -0.62214
+    z3        cap13     -0.57894
+    z3        min13     0.06928
+    z4        COST      -127.009
+    z4        cyc3      1
+    z4        cap2      0.65548
+    z4        min2      -0.21371
+    z4        cap10     -0.73816
+    z4        min10     0.14416
+    z4        cap21     -0.72838
+    z5        COST      -127.009
+    z5        cyc5      1
+    z5        cyc9      1
+    z5        cap3      -0.52774
+    z5        min3      -0.11027
+    z5        cap13     -0.57894
+    z5        min13     0.06928
+    z5        cap1      0.50288
+    z5        min1      0.13432
+    z5        cap7      0.59808
+    z5        min7      0.06074
+    z6        COST      -127.009
+    z6        cyc6      1
+    z6        cyc5      1
+    z6        cap17     -0.74244
+    z6        cap24     0.62214
+    z6        cap15     0.49156
+    z6        min15     0.1363
+    z7        COST      -127.009
+    z7        cyc7      1
+    z7        cyc6      1
+    z7        cap12     0.67512
+    z7        min12     0.15757
+    z7        cap6      -0.54574
+    z7        min6      0.05814
+    z7        cap16     0.67138
+    z8        COST      -127.009
+    z8        cyc8      1
+    z8        cyc7      1
+    z8        cap16     -0.67138
+    z8        cap12     0.67512
+    z8        min12     -0.15757
+    z8        cap19     0.65
+    z9        COST      -127.009
+    z9        cyc9      1
+    z9        cyc8      1
+    z9        cap10     -0.73816
+    z9        min10     -0.14416
+    z9        cap1      -0.50288
+    z9        min1      0.13432
+    z10       COST      -127.009
+    z10       cyc10     1
+    z10       cyc18     1
+    z10       cap22     -0.5233
+    z10       min22     -0.14438
+    z10       cap18     -0.66888
+    z11       COST      -127.009
+    z11       cyc11     1
+    z11       cyc10     1
+    z11       cap14     0.50162
+    z11       min14     -0.1688
+    z11       cap1      -0.50288
+    z11       min1      -0.13432
+    z12       COST      -127.009
+    z12       cyc12     1
+    z12       cyc11     1
+    z12       cap0      0.48854
+    z12       cap20     0.49718
+    z12       cap21     0.72838
+    z13       COST      -127.009
+    z13       cyc13     1
+    z13       cyc12     1
+    z13       cap9      0.62902
+    z13       min9      0.11765
+    z13       cap1      0.50288
+    z13       min1      -0.13432
+    z14       COST      -127.009
+    z14       cyc14     1
+    z14       cyc13     1
+    z14       cap1      0.50288
+    z14       min1      -0.13432
+    z14       cap23     0.57716
+    z15       COST      -127.009
+    z15       cyc15     1
+    z15       cyc14     1
+    z15       cap18     -0.66888
+    z15       cap15     -0.49156
+    z15       min15     0.1363
+    z15       cap6      -0.54574
+    z15       min6      0.05814
+    z16       COST      -127.009
+    z16       cyc15     1
+    z16       cap12     0.67512
+    z16       min12     0.15757
+    z16       cap19     0.65
+    z18       COST      -127.009
+    z18       cyc18     1
+    z18       cap16     0.67138
+    z18       cap2      -0.65548
+    z18       min2      0.21371
+    z18       cap1      0.50288
+    z18       min1      -0.13432
+    z18       cap20     0.49718
+    z20       COST      -127.009
+    z20       cap19     0.65
+    z20       cap10     -0.73816
+    z20       min10     -0.14416
+    z20       cap23     -0.57716
+    z20       cap2      -0.65548
+    z20       min2      -0.21371
+    z22       COST      -127.009
+    z22       cyc22     1
+    z22       cap5      -0.49326
+    z22       min5      0.09582
+    z22       cap22     0.5233
+    z22       min22     0.14438
+    z23       COST      -127.009
+    z23       cyc23     1
+    z23       cyc22     1
+    z23       cap12     0.67512
+    z23       min12     0.15757
+    z23       cap6      0.54574
+    z23       min6      0.05814
+    z24       COST      -127.009
+    z24       cyc23     1
+    z24       cap10     0.73816
+    z24       min10     -0.14416
+    z24       cap24     -0.62214
+    z24       cap4      -0.6363
+    z24       min4      0.19205
+    z26       COST      -127.009
+    z26       cyc26     1
+    z26       cap18     0.66888
+    z26       cap19     -0.65
+    z26       cap13     -0.57894
+    z26       min13     -0.06928
+    z27       COST      -127.009
+    z27       cyc26     1
+    z27       cap1      -0.50288
+    z27       min1      -0.13432
+    z27       cap21     0.72838
+    z27       cap12     -0.67512
+    z27       min12     -0.15757
+    z27       cap13     0.57894
+    z27       min13     -0.06928
+    MARK0001  'MARKER'                 'INTEND'
+RHS
+    RHS_V     bal0      18.26
+    RHS_V     bal1      11.602
+    RHS_V     bal2      11.179
+    RHS_V     bal3      31.454
+    RHS_V     bal4      21.268
+    RHS_V     bal5      7.192
+    RHS_V     bal6      31.521
+    RHS_V     bal7      26.888
+    RHS_V     bal8      16.811
+    RHS_V     bal9      10.234
+    RHS_V     bal10     34.795
+    RHS_V     bal11     16.682
+    RHS_V     bal12     30.901
+    RHS_V     bal13     17.787
+    RHS_V     bal14     38.96
+    RHS_V     bal15     36.356
+    RHS_V     bal16     16.979
+    RHS_V     bal17     32.483
+    RHS_V     bal18     37.172
+    RHS_V     bal19     15.488
+    RHS_V     bal20     16.895
+    RHS_V     bal21     23.992
+    RHS_V     bal22     32.179
+    RHS_V     bal23     25.904
+    RHS_V     bal24     18.585
+    RHS_V     cyc0      1
+    RHS_V     cyc1      1
+    RHS_V     cyc2      1
+    RHS_V     cyc3      1
+    RHS_V     cyc5      1
+    RHS_V     cyc6      1
+    RHS_V     cyc7      1
+    RHS_V     cyc8      1
+    RHS_V     cyc9      1
+    RHS_V     cyc10     1
+    RHS_V     cyc11     1
+    RHS_V     cyc12     1
+    RHS_V     cyc13     1
+    RHS_V     cyc14     1
+    RHS_V     cyc15     1
+    RHS_V     cyc18     1
+    RHS_V     cyc22     1
+    RHS_V     cyc23     1
+    RHS_V     cyc26     1
+BOUNDS
+ UP BOUND     x0        24.427
+ UP BOUND     x1        25.144
+ UP BOUND     x2        32.774
+ UP BOUND     x3        26.387
+ UP BOUND     x4        31.815
+ UP BOUND     x5        24.663
+ UP BOUND     x6        27.287
+ UP BOUND     x7        29.904
+ UP BOUND     x8        32.373
+ UP BOUND     x9        31.451
+ UP BOUND     x10       36.908
+ UP BOUND     x11       36.049
+ UP BOUND     x12       33.756
+ UP BOUND     x13       28.947
+ UP BOUND     x14       25.081
+ UP BOUND     x15       24.578
+ UP BOUND     x16       33.569
+ UP BOUND     x17       37.122
+ UP BOUND     x18       33.444
+ UP BOUND     x19       32.5
+ UP BOUND     x20       24.859
+ UP BOUND     x21       36.419
+ UP BOUND     x22       26.165
+ UP BOUND     x23       28.858
+ UP BOUND     x24       31.107
+ UP BOUND     s0        46.762
+ UP BOUND     s1        46.762
+ UP BOUND     s2        46.762
+ UP BOUND     s3        46.762
+ UP BOUND     s4        46.762
+ UP BOUND     s5        46.762
+ UP BOUND     s6        46.762
+ UP BOUND     s7        46.762
+ UP BOUND     s8        46.762
+ UP BOUND     s9        46.762
+ UP BOUND     s10       46.762
+ UP BOUND     s11       46.762
+ UP BOUND     s12       46.762
+ UP BOUND     s13       46.762
+ UP BOUND     s14       46.762
+ UP BOUND     s15       46.762
+ UP BOUND     s16       46.762
+ UP BOUND     s17       46.762
+ UP BOUND     s18       46.762
+ UP BOUND     s19       46.762
+ UP BOUND     s20       46.762
+ UP BOUND     s21       46.762
+ UP BOUND     s22       46.762
+ UP BOUND     s23       46.762
+ UP BOUND     s24       46.762
+ BV BOUND     y0      
+ BV BOUND     y1      
+ BV BOUND     y2      
+ BV BOUND     y3      
+ BV BOUND     y4      
+ BV BOUND     y5      
+ BV BOUND     y6      
+ BV BOUND     y7      
+ BV BOUND     y8      
+ BV BOUND     y9      
+ BV BOUND     y10     
+ BV BOUND     y11     
+ BV BOUND     y12     
+ BV BOUND     y13     
+ BV BOUND     y14     
+ BV BOUND     y15     
+ BV BOUND     y16     
+ BV BOUND     y17     
+ BV BOUND     y18     
+ BV BOUND     y19     
+ BV BOUND     y20     
+ BV BOUND     y21     
+ BV BOUND     y22     
+ BV BOUND     y23     
+ BV BOUND     y24     
+ BV BOUND     z0      
+ BV BOUND     z1      
+ BV BOUND     z2      
+ BV BOUND     z3      
+ BV BOUND     z4      
+ BV BOUND     z5      
+ BV BOUND     z6      
+ BV BOUND     z7      
+ BV BOUND     z8      
+ BV BOUND     z9      
+ BV BOUND     z10     
+ BV BOUND     z11     
+ BV BOUND     z12     
+ BV BOUND     z13     
+ BV BOUND     z14     
+ BV BOUND     z15     
+ BV BOUND     z16     
+ BV BOUND     z18     
+ BV BOUND     z20     
+ BV BOUND     z22     
+ BV BOUND     z23     
+ BV BOUND     z24     
+ BV BOUND     z26     
+ BV BOUND     z27     
+ENDATA

--- a/highs/mip/HighsPathSeparator.cpp
+++ b/highs/mip/HighsPathSeparator.cpp
@@ -401,6 +401,17 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
         std::vector<double> solval;
         std::vector<double> upper;
         std::vector<uint8_t> isIntegral;
+        // Bound substitution that transform() used for each index when its cut
+        // coefficient was computed. transform() keeps this state per column in
+        // transLp, so a later call - in particular for a base row that is
+        // rejected below, or one belonging to a different path - can change it
+        // before the cut is untransformed. Untransforming with a different
+        // substitution silently inverts the complementation of a variable and
+        // produces an invalid cut, so record the substitutions here and restore
+        // them before calling untransform().
+        std::vector<HighsTransformedLp::BoundType> boundTypes;
+        boundTypes.reserve(lp.num_col_ + lp.num_row_);
+        bool inconsistentBoundTypes = false;
         inds.reserve(lp.num_col_ + lp.num_row_);
         solval.reserve(lp.num_col_ + lp.num_row_);
         upper.reserve(lp.num_col_ + lp.num_row_);
@@ -443,6 +454,7 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
               inds.push_back(index);
               solval.push_back(tmpSolval[j]);
               upper.push_back(tmpUpper[j]);
+              boundTypes.push_back(transLp.boundType(index));
               isIntegral.push_back(lpRelaxation.isColIntegral(index));
               if (isIntegral.back())
                 delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
@@ -451,13 +463,24 @@ void HighsPathSeparator::separateLpSolution(HighsLpRelaxation& lpRelaxation,
               assert(inds[*pos - 1] == index);
               assert(solval[*pos - 1] == tmpSolval[j]);
               assert(upper[*pos - 1] == tmpUpper[j]);
+              // Base rows that disagree on the substitution for a shared column
+              // cannot be combined into a single cut
+              if (boundTypes[*pos - 1] != transLp.boundType(index))
+                inconsistentBoundTypes = true;
               if (isIntegral[*pos - 1])
                 delta = std::max(std::abs(aggregatedPath[k].second[j]), delta);
             }
           }
         }
 
-        if (pathLen > 1) {
+        if (pathLen > 1 && !inconsistentBoundTypes) {
+          // Restore the bound substitutions that the cut coefficients below are
+          // computed with, undoing any change made by a transform() call for a
+          // base row that is not part of the path
+          HighsInt numRecorded = inds.size();
+          for (HighsInt j = 0; j < numRecorded; ++j)
+            transLp.setBoundType(inds[j], boundTypes[j]);
+
           delta = std::exp2(std::ceil(std::log2(delta + 1.0)));
 
           HighsInt numInds = inds.size();

--- a/highs/mip/HighsTransformedLp.h
+++ b/highs/mip/HighsTransformedLp.h
@@ -27,6 +27,14 @@ class HighsLpRelaxation;
 /// Helper class to compute single-row relaxations from the current LP
 /// relaxation by substituting bounds and aggregating rows
 class HighsTransformedLp {
+ public:
+  enum class BoundType : uint8_t {
+    kSimpleUb,
+    kSimpleLb,
+    kVariableUb,
+    kVariableLb,
+  };
+
  private:
   const HighsLpRelaxation& lprelaxation;
   const HighsDomain& globaldom_;
@@ -38,12 +46,6 @@ class HighsTransformedLp {
   std::vector<double> lbDist;
   std::vector<double> ubDist;
   std::vector<double> boundDist;
-  enum class BoundType : uint8_t {
-    kSimpleUb,
-    kSimpleLb,
-    kVariableUb,
-    kVariableLb,
-  };
   std::vector<BoundType> boundTypes;
   HighsSparseVectorSum vectorsum;
 
@@ -60,6 +62,18 @@ class HighsTransformedLp {
 
   bool untransform(std::vector<double>& vals, std::vector<HighsInt>& inds,
                    double& rhs, bool integral = false);
+
+  // The bound substitution that the most recent call to transform() used for
+  // the given column. A cut that is assembled from several transformed base
+  // rows must be untransformed with the same substitutions that were used when
+  // its coefficients were computed, so callers that keep a cut across further
+  // transform() calls need to record these and restore them before calling
+  // untransform().
+  BoundType boundType(HighsInt col) const { return boundTypes[col]; }
+
+  void setBoundType(HighsInt col, BoundType boundType) {
+    boundTypes[col] = boundType;
+  }
 
   const HighsDomain& getGlobaldom() const { return globaldom_; }
 };


### PR DESCRIPTION
Addresses #3171.

The first commit adds the reproducer as a failing regression test, on its own, so the defect is
visible without any fix applied. The second commit contains the fix.

### The model

`check/instances/3171-1.mps` — 85 rows, 99 columns, 49 binaries, 300 nonzeros. It is solved
incorrectly under **default options**, with no option pinning: HiGHS reports `Optimal` at `Gap 0%`
with objective `42332.2356068` against an optimum of `42215.5250005`, suboptimal by 116.71, a
relative error of 0.276% — about 28x the default relative gap tolerance, so not a tolerance
artefact. It is decided at the root, in zero nodes.

The optimum does not rest on trusting the branch and bound search, or on trusting a patched build:
fixing all 49 integer columns to the values of the better point and solving the remaining LP with
**unmodified** HiGHS returns `Optimal 42215.5250005`. So a feasible integral point 116.71 better
than the reported optimum demonstrably exists. `--presolve off` returns `42215.5250005` as well,
which means the contradiction is visible within a single unmodified binary.

The failure is seed-dependent — it occurs on seeds 0 and 5 of the first 8 — so the test pins
`random_seed` to 0 (the default) along with `threads` and `parallel`, to keep it off the scheduler.

### The defect

`HighsPathSeparator`'s path-mixing cut is assembled from several base rows, each transformed by its
own `HighsTransformedLp::transform()` call, and mapped back by a single `untransform()` at the end.
`HighsTransformedLp` keeps the chosen substitution per column in the shared `boundTypes` array, and
`untransform()` reads whatever is in there when it runs.

The transform loop transforms base row `k` **before** testing whether its right-hand side keeps the
required monotonicity, and drops the row only afterwards:

```cpp
if (!transLp.transform(aggregatedPath[k].second, tmpUpper, tmpSolval,
                       aggregatedPath[k].first, rhs[k], integralPositive)) {
  pathLen = k;                 // row dropped - but boundTypes already mutated
  break;
}
...
} else if (rhs[k] >= rhs[k - 1] - mip.mipdata_->feastol) {
  pathLen = k;                 // row dropped - but boundTypes already mutated
  break;
}
```

The discarded row's mutation survives. Since the substitution chosen for a binary depends on the
sign of its coefficient in the row being transformed, a discarded row can flip a binary's
complementation, and `untransform()` then resubstitutes a different variable than the coefficients
were computed against. Nothing in the current code ties the two together.

The existing assertions in that loop cannot catch it: `solval` is `lbDist[col]` for both
`kSimpleLb` and `kVariableLb` and `ubDist[col]` for both `kSimpleUb` and `kVariableUb`, and `upper`
is `ub - lb` in every case, so neither value changes when the substitution flips.

### The change

Record the substitution used for each index when its cut coefficient is computed, and restore those
substitutions immediately before calling `untransform()`. Also refuse to build the cut when two
base rows of the same path disagree about a shared column, since then no single resubstitution is
correct for all of the coefficients.

This needs `BoundType` made public on `HighsTransformedLp` plus a `boundType()` / `setBoundType()`
accessor pair; the separator then records `transLp.boundType(index)` alongside `solval` / `upper`
when an index is first seen, flags a disagreement on later occurrences, and restores the recorded
values before untransforming.

### Evidence on a production model

Besides the attached reproducer, this fires on a real 10404 x 18899 MIP, where it costs 2978.48 on
the objective. That model still returns the wrong answer with the fixes for #3170 and #3173 both
applied, so the three defects are independent:

| build | objective, `presolve=on` | |
|---|---|---|
| `latest` | `-12370583.0955` | wrong |
| `latest` + #3170 + #3173 | `-12370583.0955` | wrong |
| `latest` + #3170 + #3173 + this | `-12373561.5756` | correct |

`presolve=off` returns the correct `-12373561.5756` throughout. The node count rises from 103 to
376 with the fix, which is the search doing its job: without it an invalid cut was closing the tree
early.

Instrumenting that model gives the mismatch directly. Instrumenting the
separator to record the substitution used when each coefficient was computed, and compare it
against the one in force at `untransform()`, gives exactly one mismatched column:

```
col 14096   substitution at untransform() = kSimpleLb
            y used when the coefficient was computed = 1     (complemented, y = 1 - x)
            y implied by the substitution used        = 0     (y = x - 0)
            coefficient -1   ->   error exactly +1
```

Evaluating that cut in the transformed space at the known optimum gives violation `0`; after
`untransform()` it gives violation `1`. The arithmetic is otherwise sound — the entire error is the
one flipped complementation. With the change, that model returns the correct optimum.

I can supply the model, or the instrumentation patch that makes the mismatch observable in a single
solve, if either would help.

### What it took to find the model, and why that matters for review

Delta-debugging the large model does not work: deleting a single row with zero LP dual, which
provably cannot change the root LP optimum, is already enough to destroy the trigger, because the
path the separator walks depends on row and column indices and on hash-table iteration order.

Generating models is what worked, but only after the search was aimed at the actual mechanism.
Roughly 100,000 unshaped random MIPs produced no trigger at all. Three conditions turn out to gate
it, all readable from the code:

* the binary must sit at exactly 0.5 in the LP relaxation — the sign-dependent branch in
  `transform()` is reached only when `simpleLbDist` and `simpleUbDist` tie, so any other LP value
  picks the bound type by distance and no two rows can disagree;
* the separator aggregates cumulatively with positive multipliers, so the binary's running
  coefficient has to *change sign* between the row that records it and the row that is discarded;
* the discarded row must still leave a path of length two or more, or no cut is produced at all.

Generating for those — odd cycles with equal rewards to pin binaries at 0.5, and alternating
near-cancelling coefficients so the running sum crosses zero — produced 5 substitution flips in
about 250,000 models, of which this is the one that also loses the optimum. The other four generate
the invalid cut without it cutting anything off, which is worth knowing: the defect fires more
often than it changes an answer.

That rarity is a caveat on the test, not on the defect. The test is one seed on one model, and the
conjunction it depends on is narrow, so it is a witness rather than broad coverage. The
`inconsistentBoundTypes` guard added here is what makes the general situation detectable rather
than silent.

### Adverse effects

Measured on `latest`:

| | result |
|---|---|
| the 33 MIP models in `check/instances` | identical status, objective, node count and LP iteration count |
| full unit test suite | 1259307 assertions in 335 test cases, pass |
| the 10404 x 18899 model above | corrected |
| the attached reproducer | corrected |

The change can only suppress a cut, never produce a different one, so the risk is losing cuts that
were previously generated and valid. On the models above none is lost. I have not benchmarked
against MIPLIB or anything at production scale, so I cannot rule out a cut-quality cost where paths
of length two or more are common.

### What this does not close

`bestVub` / `bestVlb` are shared mutable state as well, and `transform()` may tighten them in place
via `cleanupVub()` / `cleanupVlb()`, so a coefficient computed from an earlier base row can be
untransformed against a tightened bound. This restores the bound *type* but not the bound *values*.
I have no reproducer for that case and did not want to widen the change on speculation.

Both are the same design issue: the cut is untransformed by reading state back out of a shared,
still-mutating `HighsTransformedLp`, rather than carrying the transformation it was built with. If
you would prefer a structural change along those lines, that would close this, the `bestVub` case,
and #3170's class as well, and this PR is probably not the right starting point for it.

### Testing

* the new `issue-3171` test fails on `latest` at the first commit and passes at the second;
* the attached model returns the brute-force-independent optimum under every seed and both
  `presolve` settings once fixed;
* the numbers in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
