### PR TITLE
Do not discard a MIP solution when its repair LP fails to solve (#3180)

### DIFF
--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 
 #include "../extern/pdqsort/pdqsort.h"
+#include "lp_data/HighsLpUtils.h"
 #include "lp_data/HighsModelUtils.h"
 #include "mip/HighsPseudocost.h"
 #include "mip/HighsRedcostFixing.h"
@@ -1239,11 +1240,31 @@ try_again:
     // HiPO or IPX to solve an LP without a basis, use simplex
     tmpSolver.setOptionValue("solver", kSimplexString);
     tmpSolver.optimizeLp();
+    // The repair LP is solved in the original space, which for a badly scaled
+    // model can defeat the dual simplex ratio test ("excessive dual values")
+    // or its primal counterpart. That is a failure of the solver, not a
+    // statement about the solution, so retry once without presolve rather than
+    // discarding a solution that may be the incumbent - or the optimum. Only
+    // worth doing if presolve was used for the first attempt: otherwise the
+    // retry would solve an identical LP and fail in the same way.
+    if (use_presolve &&
+        tmpSolver.getModelStatus() == HighsModelStatus::kSolveError) {
+      tmpSolver.setOptionValue("presolve", kHighsOffString);
+      tmpSolver.optimizeLp();
+    }
     this->total_repair_lp_iterations +=
         tmpSolver.getInfo().simplex_iteration_count;
     if (tmpSolver.getInfo().primal_solution_status == kSolutionStatusFeasible) {
       this->total_repair_lp_feasible++;
       solution = tmpSolver.getSolution();
+      // Recompute the row activities from the repaired column values. The
+      // feasibility test below is given solution.row_value and trusts it, but
+      // the values returned by the LP solver need only satisfy the LP to its
+      // own tolerance, so they can differ from a quad-precision recomputation -
+      // which is what the check applied to the returned solution uses. Without
+      // this, a repaired solution can pass here and fail that later check.
+      calculateRowValuesQuad(*mipsolver.orig_model_, solution.col_value,
+                             solution.row_value);
       allow_try_again = false;
       goto try_again;
     }

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1240,13 +1240,6 @@ try_again:
     // HiPO or IPX to solve an LP without a basis, use simplex
     tmpSolver.setOptionValue("solver", kSimplexString);
     tmpSolver.optimizeLp();
-    // The repair LP is solved in the original space, which for a badly scaled
-    // model can defeat the dual simplex ratio test ("excessive dual values")
-    // or its primal counterpart. That is a failure of the solver, not a
-    // statement about the solution, so retry once without presolve rather than
-    // discarding a solution that may be the incumbent - or the optimum. Only
-    // worth doing if presolve was used for the first attempt: otherwise the
-    // retry would solve an identical LP and fail in the same way.
     if (use_presolve &&
         tmpSolver.getModelStatus() == HighsModelStatus::kSolveError) {
       tmpSolver.setOptionValue("presolve", kHighsOffString);
@@ -1257,12 +1250,6 @@ try_again:
     if (tmpSolver.getInfo().primal_solution_status == kSolutionStatusFeasible) {
       this->total_repair_lp_feasible++;
       solution = tmpSolver.getSolution();
-      // Recompute the row activities from the repaired column values. The
-      // feasibility test below is given solution.row_value and trusts it, but
-      // the values returned by the LP solver need only satisfy the LP to its
-      // own tolerance, so they can differ from a quad-precision recomputation -
-      // which is what the check applied to the returned solution uses. Without
-      // this, a repaired solution can pass here and fail that later check.
       calculateRowValuesQuad(*mipsolver.orig_model_, solution.col_value,
                              solution.row_value);
       allow_try_again = false;


### PR DESCRIPTION
Fixes #3180.

### The defect

When a MIP solution is feasible for the presolved model but violates the original model by more
than `mip_feasibility_tolerance`, `HighsMipSolverData` repairs it by fixing the integer columns and
re-solving the LP in the original space. The repaired solution is accepted only if that LP returns a
feasible primal solution, so a *failure of the solver* is treated exactly like a solution that is
genuinely bad: it is discarded, and `kHighsInf` is returned so it is not used for bounding.

The repair LP is solved in the original space with the dual simplex, which on a badly scaled model
can fail the ratio test — "excessive dual values", or its primal counterpart — and return
`kSolveError`. When the discarded solution is the optimum, the search reports a worse incumbent as
`Optimal` at a zero gap. The repair LP runs with `output_flag = false`, so the error it raised is
never shown either.

### The change

Two parts, both in `HighsMipSolverData::transformNewIntegerFeasibleSolution`.

**Retry a failed repair LP without presolve.**

```cpp
    tmpSolver.optimizeLp();
    if (tmpSolver.getModelStatus() == HighsModelStatus::kSolveError) {
      tmpSolver.setOptionValue("presolve", kHighsOffString);
      tmpSolver.optimizeLp();
    }
```

The failing LPs solve to optimality that way; primal simplex and IPM also solve them, so if you
would rather fall back differently, any of the three recovers the solution.

**Recompute the row activities from the repaired column values.**

```cpp
      solution = tmpSolver.getSolution();
      calculateRowValuesQuad(*mipsolver.orig_model_, solution.col_value,
                             solution.row_value);
```

This part is not optional, and it is the subtler of the two. `solutionFeasible()` is passed
`&solution.row_value` and, when a row-value vector is supplied, trusts it instead of recomputing:

```cpp
if (pass_row_value) {
  ...                                    // used as given
} else {
  calculateRowValuesQuad(*lp, col_value, row_value);
}
```

After a repair those activities come from the repair LP and need only satisfy that LP to its own
tolerance, whereas the check later applied to the returned solution recomputes them in quad
precision. Without recomputing, a repaired solution can pass here at `1e-7` and then fail that check
at `1.5e-7`, turning a reported `Optimal` into `Solve error`. With the retry alone I reproduced
exactly that on a generated model; with both parts the same model correctly rejects the marginal
point and keeps a genuinely feasible one.

### Effect

| | result |
|---|---|
| 12710 x 23091 production MIP | `-3755449.094926` -> `-3755469.767048` (correct); 17 previously discarded solutions recovered |
| 14412 x 26520 production MIP | unchanged and correct at `-19105203.4816` |
| generated MIP, repair LP fails | `-7.60954221608e+14` -> `-7.60954325469e+14` (correct) |
| generated MIP, marginal repair | now `Optimal` with no error, where the retry alone gave a false optimum |
| the 26 MIP models in `check/instances` | identical objectives to stock `latest` |
| full unit test suite | 1259300 assertions in 334 test cases, pass |

Measured on this branch alone — `latest` plus this commit, with no other changes applied — so the
result does not depend on anything else I have reported.

The retry is reached only when a repair LP has already failed, and the recomputation only when a
repair has already succeeded, so neither can perturb a model where no solution is ever repaired.

### What I would advise against

Addressing this in `HPresolve::scaleMIP`, which is where the violation that triggers the repair
comes from — it scales rows down, and the feasibility tolerance is not scale invariant, so a row
scaled by `s` and satisfied to `feastol` in the presolved space is satisfied only to `feastol / |s|`
in the original one.

Suppressing the down-scaling does fix the first model and leaves `check/instances` unchanged in
objective, node count and LP iteration count. But on the second production model above it *causes* a
wrong answer — `-19104998.2316` against a correct `-19105203.4816` — even though that model never
reaches the untransformed-violation path. Any change to `scaleMIP` perturbs models that have no
defect. The repair path is the right place: it already exists, it already recovers 17 of the 34
repairs on the first model, and it is inert otherwise.

### On a regression test

I have a generated MIP that reproduces the discard — 134 rows x 356 columns, 72 integers — but it
needs the pinned option set and its objective coefficients span `1e-6` to `1e12`, which is the kind
of instance that was objected to on #3172. I have not added it as a test for that reason, and am
happy to supply it if you would like it, or to look for a numerically tamer one.

### Testing

* both production models correct under `presolve` on and off;
* the reproducers for #3170, #3171 and #3173 unchanged and correct;
* the numbers in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
