### PR TITLE
Now scaling the LP offset so it is consistent with user cost and bound scaling; also scaling any dual bound in `HighsInfo`

### DIFF
--- a/highs/lp_data/HighsInterface.cpp
+++ b/highs/lp_data/HighsInterface.cpp
@@ -3200,11 +3200,9 @@ HighsStatus Highs::userScaleSolution(HighsUserScaleData& data,
   }
   if (!update_kkt) return return_status;
   // In scaling the objective function value, have to consider the offset
-  double objective_function_value =
-      info_.objective_function_value - model_.lp_.offset_;
-  objective_function_value *= (bound_scale_value * objective_scale_value);
-  objective_function_value += model_.lp_.offset_;
-  info_.objective_function_value = objective_function_value;
+  info_.objective_function_value *= (bound_scale_value * objective_scale_value);
+  if (has_integrality)
+    info_.mip_dual_bound *= (bound_scale_value * objective_scale_value);
   getKktFailures(options_, model_, solution_, basis_, info_);
   return reportKktFailures(model_.lp_, options_, info_,
                            "After removing user scaling")

--- a/highs/lp_data/HighsLpUtils.cpp
+++ b/highs/lp_data/HighsLpUtils.cpp
@@ -793,14 +793,14 @@ HighsStatus userScaleLp(HighsLp& lp, HighsUserScaleData& data,
 }
 
 void userScaleLp(HighsLp& lp, HighsUserScaleData& data, const bool apply) {
-  userScaleCosts(lp.integrality_, lp.col_cost_, data, apply);
+  userScaleCosts(lp.integrality_, lp.offset_, lp.col_cost_, data, apply);
   userScaleColBounds(lp.integrality_, lp.col_lower_, lp.col_upper_, data,
                      apply);
   userScaleMatrix(lp.integrality_, lp.a_matrix_, data, apply);
   userScaleRowBounds(lp.row_lower_, lp.row_upper_, data, apply);
 }
 
-void userScaleCosts(const vector<HighsVarType>& integrality,
+void userScaleCosts(const vector<HighsVarType>& integrality, double& offset,
                     vector<double>& cost, HighsUserScaleData& data,
                     const bool apply) {
   data.num_infinite_costs = 0;
@@ -822,6 +822,7 @@ void userScaleCosts(const vector<HighsVarType>& integrality,
     if (std::abs(value) > data.infinite_cost) data.num_infinite_costs++;
     if (apply) cost[iCol] = value;
   }
+  if (apply) offset *= (bound_scale_value * objective_scale_value);
 }
 
 void userScaleColBounds(const vector<HighsVarType>& integrality,

--- a/highs/lp_data/HighsLpUtils.h
+++ b/highs/lp_data/HighsLpUtils.h
@@ -68,7 +68,7 @@ HighsStatus userScaleLp(HighsLp& lp, HighsUserScaleData& data,
 void userScaleLp(HighsLp& lp, HighsUserScaleData& data,
                  const bool apply = true);
 
-void userScaleCosts(const vector<HighsVarType>& integrality,
+void userScaleCosts(const vector<HighsVarType>& integrality, double& offset,
                     vector<double>& cost, HighsUserScaleData& data,
                     const bool apply = true);
 


### PR DESCRIPTION
When user cost and bound scaling is applied, both scale the objective value. As observed in #3178, unless any offset is also scaled, this can lead to changes in the gap in the MIP solver, and a different optimal solution.

This closes #3178 