### PR TITLE
Fix spurious "semi-variable infeasibilities" kSolveError: assess semi-continuous feasibility at the reformulation's bound-scaled tolerance

### DIFF
--- a/highs/lp_data/HighsSolution.cpp
+++ b/highs/lp_data/HighsSolution.cpp
@@ -641,21 +641,27 @@ void getVariableKktFailures(const double primal_feasibility_tolerance,
   if (semi_variable) {
     primal_infeasibility = 0;
     semi_infeasibility = 0;
+    // The withoutSemiVariables reformulation (x - lower*y >= 0, x - upper*y <= 0)
+    // only pins the binary y to integer within mip_feasibility_tolerance, which
+    // lets x deviate from 0 / lower by bound*tol; assess each side at that scale
+    // so this check stays consistent with the integrality check on y.
+    const double tol = mip_feasibility_tolerance;
+    const double upper_scale = upper < kHighsInf ? std::max(1.0, upper) : 1.0;
     if (value < mid) {
-      // Value is less than half way between 0 and lower, so treat its
-      // feasibility relative to 0
+      // feasibility relative to 0 (via x <= upper*y)
       semi_infeasibility = std::fabs(value);
-      if (semi_infeasibility < mip_feasibility_tolerance)
-        semi_infeasibility = 0;
+      if (semi_infeasibility < upper_scale * tol) semi_infeasibility = 0;
     } else {
+      double scale = 1.0;
       if (value < lower) {
         semi_infeasibility = lower - value;
+        scale = std::max(1.0, lower);  // via x >= lower*y
       } else if (value > upper) {
         semi_infeasibility = value - upper;
+        scale = upper_scale;
       }
       assert(semi_infeasibility >= 0);
-      if (semi_infeasibility < primal_feasibility_tolerance)
-        semi_infeasibility = 0;
+      if (semi_infeasibility < scale * tol) semi_infeasibility = 0;
     }
   }
 }


### PR DESCRIPTION
## Summary

A MIP with semi-continuous variables can terminate with
`HighsStatus::kError` and

    MIP solver claims optimality, but with num/max/sum N/.../...
    semi-variable infeasibilities: consider solving with smaller
    mip_feasibility_tolerance

even though the solve is otherwise fine. It happens when the MIP LP
relaxation is solved by an interior-point method (`mip_lp_solver = ipm`,
including HiPO) and the gap is driven to 0. It does not happen with
`mip_lp_solver = simplex`.

This is an internal inconsistency, not a genuine infeasibility, and the
error message's advice (smaller `mip_feasibility_tolerance`) does not
help — the deviation scales with a variable bound, not with the
tolerance.

## Reproduction

`highs model.mps` with:

    mip_lp_solver = ipm      # or mip_ipm_solver = hipo
    mip_rel_gap = 0
    presolve = on

On the attached `semi94.txt` (in MPS format, but GitHub does not allow for MPS attachments) this fails deterministically (semi-variable bounds `[504, 12600]`, `mip_feasibility_tolerance = 1e-6`):

    num/max/sum 3/0.0125565/0.0126913 semi-variable infeasibilities

Note `0.0125565 ≈ 12600 * 1e-6 = upper * mip_feasibility_tolerance`. Switching to `mip_lp_solver = simplex` solves it cleanly.

## Root cause

`withoutSemiVariables` models a semi-continuous `x` as a binary trig
[semi94.txt](https://github.com/user-attachments/files/30509992/semi94.txt)
ger
`y` with

    x - lower*y >= 0
    x - upper*y <= 0

The MIP only pins `y` to integer within `mip_feasibility_tolerance`
(`tol`). A `y` that rounds to 0 therefore still permits `x` up to
`upper*tol`; a `y` that rounds to 1 still permits `x` down to
`lower - lower*tol`. An interior-point relaxation leaves `y` resting near
`tol` (rather than at a vertex 0/1), so `x` actually sits that far off
its bound.

But `getVariableKktFailures` assessed semi-continuous feasibility against
the *raw* tolerance (`mip_feasibility_tolerance` near 0,
`primal_feasibility_tolerance` below `lower`), i.e. a factor of `bound`
tighter than what the reformulation can deliver. So the MIP legitimately
accepts an incumbent that this check then rejects — `checkOptimality`
turns the mismatch into `kError`. Simplex hides it because its vertex
solutions put `y` at exactly 0/1.

## Fix

Assess each side of the semi-continuous condition at the tolerance the
reformulation actually delivers: `upper * tol` for "x == 0" (via
`x <= upper*y`) and `lower * tol` for "x >= lower" (via `x >= lower*y`).
Genuine infeasibilities exceed `bound * tol` by orders of magnitude and
are still reported.

One-file change in `getVariableKktFailures` (`highs/lp_data/HighsSolution.cpp`).

## Verification

- Reproducer: 20/20 `kError` → 0/20, still `Optimal`.
- Behaviour under `simplex` unchanged (vertex solutions were already
  within the scaled tolerance).