### PR TITLE
Guard conflict-analysis walks over prevboundval_ against running past the chain start

### DIFF
--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -3043,8 +3043,11 @@ bool HighsDomain::ConflictSet::resolveLinearGeq(HighsCDouble M, double Mupper,
             M -= reasonDomchg.delta;
             // ++numDropped;
           } else {
-            while (relaxLb <= localdom.prevboundval_[locdomchg.pos].first)
-              locdomchg.pos = localdom.prevboundval_[locdomchg.pos].second;
+            while (relaxLb <= localdom.prevboundval_[locdomchg.pos].first) {
+              HighsInt prevPos = localdom.prevboundval_[locdomchg.pos].second;
+              if (prevPos == -1) break;
+              locdomchg.pos = prevPos;
+            }
 
             // bound can be relaxed
             M += vals[i] * (static_cast<HighsCDouble>(relaxLb) - lb);
@@ -3078,8 +3081,11 @@ bool HighsDomain::ConflictSet::resolveLinearGeq(HighsCDouble M, double Mupper,
             // ++numDropped;
           } else {
             // bound can be relaxed
-            while (relaxUb >= localdom.prevboundval_[locdomchg.pos].first)
-              locdomchg.pos = localdom.prevboundval_[locdomchg.pos].second;
+            while (relaxUb >= localdom.prevboundval_[locdomchg.pos].first) {
+              HighsInt prevPos = localdom.prevboundval_[locdomchg.pos].second;
+              if (prevPos == -1) break;
+              locdomchg.pos = prevPos;
+            }
 
             M += vals[i] * (static_cast<HighsCDouble>(relaxUb) - ub);
             // ++numRelaxed;
@@ -3163,8 +3169,11 @@ bool HighsDomain::ConflictSet::resolveLinearLeq(HighsCDouble M, double Mlower,
             // ++numDropped;
           } else {
             // bound can be relaxed
-            while (relaxLb <= localdom.prevboundval_[locdomchg.pos].first)
-              locdomchg.pos = localdom.prevboundval_[locdomchg.pos].second;
+            while (relaxLb <= localdom.prevboundval_[locdomchg.pos].first) {
+              HighsInt prevPos = localdom.prevboundval_[locdomchg.pos].second;
+              if (prevPos == -1) break;
+              locdomchg.pos = prevPos;
+            }
 
             M += vals[i] * (static_cast<HighsCDouble>(relaxLb) - lb);
             // ++numRelaxed;
@@ -3197,8 +3206,11 @@ bool HighsDomain::ConflictSet::resolveLinearLeq(HighsCDouble M, double Mlower,
             // ++numDropped;
           } else {
             // bound can be relaxed
-            while (relaxUb >= localdom.prevboundval_[locdomchg.pos].first)
-              locdomchg.pos = localdom.prevboundval_[locdomchg.pos].second;
+            while (relaxUb >= localdom.prevboundval_[locdomchg.pos].first) {
+              HighsInt prevPos = localdom.prevboundval_[locdomchg.pos].second;
+              if (prevPos == -1) break;
+              locdomchg.pos = prevPos;
+            }
 
             M += vals[i] * (static_cast<HighsCDouble>(relaxUb) - ub);
             // ++numRelaxed;
@@ -3367,10 +3379,7 @@ bool HighsDomain::ConflictSet::explainInfeasibilityConflict(
 
       while (localdom.prevboundval_[pos].first >= conflict[i].boundval) {
         pos = localdom.prevboundval_[pos].second;
-        // since we checked that the bound value is not active globally and is
-        // active for the local domain at pos
-        // pos should never become -1
-        assert(pos != -1);
+        if (pos == -1) return false;
       }
     } else {
       double ub = localdom.getColUpperPos(conflict[i].column,
@@ -3379,10 +3388,7 @@ bool HighsDomain::ConflictSet::explainInfeasibilityConflict(
 
       while (localdom.prevboundval_[pos].first <= conflict[i].boundval) {
         pos = localdom.prevboundval_[pos].second;
-        // since we checked that the bound value is not active globally and is
-        // active for the local domain at pos
-        // pos should never become -1
-        assert(pos != -1);
+        if (pos == -1) return false;
       }
     }
 
@@ -3648,10 +3654,7 @@ bool HighsDomain::ConflictSet::explainBoundChangeConflict(
 
       while (localdom.prevboundval_[pos].first >= conflict[i].boundval) {
         pos = localdom.prevboundval_[pos].second;
-        // since we checked that the bound value is not active globally and is
-        // active for the local domain at pos
-        // pos should never become -1
-        assert(pos != -1);
+        if (pos == -1) return false;
       }
     } else {
       double ub =
@@ -3661,10 +3664,7 @@ bool HighsDomain::ConflictSet::explainBoundChangeConflict(
 
       while (localdom.prevboundval_[pos].first <= conflict[i].boundval) {
         pos = localdom.prevboundval_[pos].second;
-        // since we checked that the bound value is not active globally and is
-        // active for the local domain at pos
-        // pos should never become -1
-        assert(pos != -1);
+        if (pos == -1) return false;
       }
     }
 


### PR DESCRIPTION
Fixes #3190.

The eight backward walks over a column's bound-change chain assumed the chain terminal (predecessor position -1) is unreachable. The invariant is numeric and can break, after which the walk reads prevboundval_[-1] and chases garbage indices. The relaxation walks now stop at the chain's first entry, which stays in the explanation as a valid superset; the assert-guarded walks now report the bound change as unexplainable so the optional conflict cut is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)