### PR TITLE
Certify simplex optimality only from a refactorized basis

### DIFF
--- a/highs/simplex/HEkk.cpp
+++ b/highs/simplex/HEkk.cpp
@@ -1009,6 +1009,7 @@ HighsStatus HEkk::solve(const bool force_phase2) {
     analysis_.simplexTimerStart(SimplexTotalClock);
   dual_simplex_cleanup_level_ = 0;
   dual_simplex_phase1_cleanup_level_ = 0;
+  force_refactor_on_rebuild_ = false;
 
   previous_iteration_cycling_detected = -kHighsIInf;
 
@@ -1968,7 +1969,14 @@ void HEkk::computeDualObjectiveValue(const HighsInt phase) {
 
 bool HEkk::rebuildRefactor(HighsInt rebuild_reason) {
   // If no updates have been performed, then don't refactor!
-  if (info_.update_count == 0) return false;
+  if (info_.update_count == 0) {
+    force_refactor_on_rebuild_ = false;
+    return false;
+  }
+  if (force_refactor_on_rebuild_) {
+    force_refactor_on_rebuild_ = false;
+    return true;
+  }
   // Otherwise, refactor by default
   bool refactor = true;
   double solution_error = 0;

--- a/highs/simplex/HEkk.h
+++ b/highs/simplex/HEkk.h
@@ -35,6 +35,7 @@ class HEkk {
         iteration_count_(0),
         dual_simplex_cleanup_level_(0),
         dual_simplex_phase1_cleanup_level_(0),
+        force_refactor_on_rebuild_(false),
         previous_iteration_cycling_detected(-kHighsIInf),
         solve_bailout_(false),
         called_return_from_solve_(false),
@@ -205,6 +206,7 @@ class HEkk {
   HighsInt iteration_count_;
   HighsInt dual_simplex_cleanup_level_;
   HighsInt dual_simplex_phase1_cleanup_level_;
+  bool force_refactor_on_rebuild_;
 
   HighsInt previous_iteration_cycling_detected;
 

--- a/highs/simplex/HEkkDual.cpp
+++ b/highs/simplex/HEkkDual.cpp
@@ -960,6 +960,11 @@ void HEkkDual::solvePhase2() {
     solve_phase = kSolvePhase1;
   } else if (row_out == kNoRowChosen) {
     // There is no candidate in CHUZR, even after rebuild so probably optimal
+    if (ekk_instance_.info_.update_count > 0) {
+      // Do not certify optimality from an updated factor
+      ekk_instance_.force_refactor_on_rebuild_ = true;
+      return;
+    }
     highsLogDev(ekk_instance_.options_->log_options, HighsLogType::kDetailed,
                 "dual-phase-2-optimal\n");
     // Remove any cost perturbations and see if basis is still dual feasible

--- a/highs/simplex/HEkkPrimal.cpp
+++ b/highs/simplex/HEkkPrimal.cpp
@@ -584,6 +584,11 @@ void HEkkPrimal::solvePhase2() {
                 "primal-return-phase1\n");
   } else if (variable_in == -1) {
     // There is no candidate in CHUZC, even after rebuild so probably optimal
+    if (ekk_instance_.info_.update_count > 0) {
+      // Do not certify optimality from an updated factor
+      ekk_instance_.force_refactor_on_rebuild_ = true;
+      return;
+    }
     highsLogDev(options.log_options, HighsLogType::kDetailed,
                 "primal-phase-2-optimal\n");
     // Remove any bound perturbations and see if basis is still primal feasible


### PR DESCRIPTION
Fixes #3194.

When dual or primal simplex concludes optimality at a rebuild whose factor still carries updates, force a refactorization and reassess instead of certifying. On the LP of #3194 the values computed through the update chain are wrong by 91.81 in the objective while showing no infeasibility; the same basis refactorized yields the correct solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)