### PR TITLE
fix(presolve): prevent floating-point underflow in dynamism-scaled tolerances

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ You can raise an [issue](https://github.com/ERGO-Code/HiGHS/issues) with HiGHS i
 
 HiGHS is open source for distribution rather than contribution. This applies particularly to the core C++ code of the solvers. However, there is definitely scope for external contribution to interfaces and documentation. If you want to contribute in this way, please open an issue before making a pull request, since pull requests to the HiGHS solvers will not normally be accepted. 
 
-Please note that any pull requests to HiGHS must be made to the `latest` branch, so that full testing can take place befor updating `master`. This ensures that `master` is always good to be downloaded by users. As a consequence, any changes should be developed as a branch of `latest` to reduce the chance of merge conflicts.
+Please note that any pull requests to HiGHS must be made to the `latest` branch, so that full testing can take place before updating `master`. This ensures that `master` is always good to be downloaded by users. As a consequence, any changes should be developed as a branch of `latest` to reduce the chance of merge conflicts.
 
 Note that, under the terms of the MIT license, by contributing to HiGHS you assign away your rights to the content of your contribution.
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4297,7 +4297,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
         direction * impliedRowBound == kHighsInf ||
         abs(static_cast<HighsCDouble>(rowSide) -
             static_cast<HighsCDouble>(impliedRowBound)) >
-            primal_feastol / dynamism)
+            std::max(double(primal_feastol / dynamism), 1e-15))
       return Result::kOk;
 
     // get stored row
@@ -4584,7 +4584,7 @@ HPresolve::Result HPresolve::detectDominatedCol(
                                   : -impliedDualRowBounds.getSumLowerOrig(
                                         col, -model->col_cost_[col]);
       if (std::abs(boundOnColDual) <=
-          options->dual_feasibility_tolerance / dynamism) {
+          std::max(double(options->dual_feasibility_tolerance / dynamism), 1e-15)) {
         // 1. column dual's upper bound is zero (since the column's lower bound
         // is infinite) and column dual's lower bound is zero as well
         // (direction = 1) or


### PR DESCRIPTION
### Problem
When solving MILP models containing large matrix coefficients (such as micrometer dimensions `10^12` or large Big-M indicators), HiGHS Presolve can incorrectly declare feasible models as `Infeasible` or fail to reduce valid forcing rows and columns.

### Technical Root Cause
In `HPresolve.cpp` (lines 4300 and 4587), `primal_feasibility_tolerance` and `dual_feasibility_tolerance` are scaled by dividing by the matrix `dynamism` ratio.

When dynamism is high (`>= 10^8`), `tolerance / dynamism` underflows below the IEEE 754 double precision machine epsilon (`2.22e-16`). For example, `1e-7 / 10^12 = 1e-19`.

As a result, comparisons like `std::abs(bound) <= 1e-19` fail due to standard floating-point noise (`~10^-15`), causing valid presolve reductions to fail and leading to false `Infeasible` status returns.

### The Fix
Clamp the dynamism-scaled tolerances to a lower bound of `1e-15` (IEEE 754 machine epsilon safeguard):
```cpp
std::max(double(primal_feastol / dynamism), 1e-15)
std::max(double(options->dual_feasibility_tolerance / dynamism), 1e-15)
```

### Reproducible LP Benchmark
```lp
Minimize
  obj: 2976800000000 x1 + 1000 y1
Subject To
  c1: 480000000000 z1 + 600000000000 z2 <= 2976800000000 x1
  c2: pos_x1 + 600000 - pos_x2 - 3000000 delta1 <= 0
Bounds
  0 <= pos_x1 <= 2440000
Binary
  x1 z1 z2 delta1
End
```