### PR TITLE
Presolve/postsolve debug utilities

### DIFF
--- a/check/TestRunData.cpp
+++ b/check/TestRunData.cpp
@@ -75,8 +75,7 @@ TEST_CASE("highs-run-data-presolve", "[highs_run_data]") {
     const bool reduces_to_empty = false;
     for (auto& solver : solvers) {
       h.setOptionValue("solver", solver);
-      if (dev_run)
-	printf("\n!>>>>%s-%s<<<<\n", model.c_str(), solver.c_str());
+      if (dev_run) printf("\n!>>>>%s-%s<<<<\n", model.c_str(), solver.c_str());
 
       REQUIRE(h.presolve() == HighsStatus::kOk);
       HighsLp presolved_lp = h.getPresolvedLp();
@@ -93,7 +92,6 @@ TEST_CASE("highs-run-data-presolve", "[highs_run_data]") {
 
 void testRunData(Highs& h, const bool irreducible, const bool reduces_to_empty,
                  const std::string& run_data_file) {
-  
   assert(!(irreducible && reduces_to_empty));
   const HighsRunData& run_data = h.getRunData();
   const HighsLp& lp = h.getLp();

--- a/highs/lp_data/Highs.cpp
+++ b/highs/lp_data/Highs.cpp
@@ -3999,7 +3999,7 @@ HighsPostsolveStatus Highs::runPostsolve() {
     return HighsPostsolveStatus::kNoPrimalSolutionError;
   const bool have_dual_solution =
       presolve_.data_.recovered_solution_.dual_valid;
-  const HighsInt report_3040_col = -21792;
+  const HighsInt report_3040_col = -578;
   presolve_.data_.postSolveStack.undo(
       options_, presolve_.data_.recovered_solution_,
       presolve_.data_.recovered_basis_, report_3040_col);

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -1381,15 +1381,22 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
     assert(col_value.size() == static_cast<size_t>(lp->num_col_));
 
   // Lambda to update violation record
-  auto updateViolation = [&](double v, HighsInt index, HighsInt& num, double& max_v, HighsInt& max_index) {
-      if (v <= 0) return;
-      if (v > mip_feasibility_tolerance) num++;
-      if (v > max_v) { max_v = v; max_index = index; }
+  auto updateViolation = [&](double v, HighsInt index, HighsInt& num,
+                             double& max_v, HighsInt& max_index) {
+    if (v <= 0) return;
+    if (v > mip_feasibility_tolerance) num++;
+    if (v > max_v) {
+      max_v = v;
+      max_index = index;
+    }
   };
 
-  auto updatePrimalViolation = [&](double value, HighsInt index, bool is_column) {
-    const double lower = is_column ? lp->col_lower_[index] : lp->row_lower_[index];
-    const double upper = is_column ? lp->col_upper_[index] : lp->row_upper_[index];
+  auto updatePrimalViolation = [&](double value, HighsInt index,
+                                   bool is_column) {
+    const double lower =
+        is_column ? lp->col_lower_[index] : lp->row_lower_[index];
+    const double upper =
+        is_column ? lp->col_upper_[index] : lp->row_upper_[index];
     double primal_infeasibility;
     if (value < lower - mip_feasibility_tolerance) {
       primal_infeasibility = lower - value;
@@ -1399,43 +1406,26 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
       return;
     }
     if (is_column) {
-      updateViolation(primal_infeasibility, index,
-		      num_bound_violations,
-		      bound_violation,
-		      col_of_max_bound_violation);
+      updateViolation(primal_infeasibility, index, num_bound_violations,
+                      bound_violation, col_of_max_bound_violation);
     } else {
-      updateViolation(primal_infeasibility, index,
-		      num_row_violations,
-		      row_violation,
-		      row_of_max_row_violation);
-    }    
+      updateViolation(primal_infeasibility, index, num_row_violations,
+                      row_violation, row_of_max_row_violation);
+    }
   };
-  
+
+  // Check column integrality and feasibility
+  bool is_column = true;
   for (HighsInt i = 0; i != lp->num_col_; ++i) {
     const double value = col_value[i];
     obj += static_cast<HighsCDouble>(lp->col_cost_[i]) * value;
     if (lp->integrality_[i] == HighsVarType::kInteger)
-      updateViolation(fractionality(value), i,
-		      num_integrality_violations,
-		      integrality_violation,
-		      col_of_max_integrality_violation);
-    const double lower = lp->col_lower_[i];
-    const double upper = lp->col_upper_[i];
-    double primal_infeasibility;
-    if (value < lower - mip_feasibility_tolerance) {
-      primal_infeasibility = lower - value;
-    } else if (value > upper + mip_feasibility_tolerance) {
-      primal_infeasibility = value - upper;
-    } else {
-      continue;
-    }
-    updateViolation(primal_infeasibility, i,
-		    num_bound_violations,
-		    bound_violation,
-		    col_of_max_bound_violation);
+      updateViolation(fractionality(value), i, num_integrality_violations,
+                      integrality_violation, col_of_max_integrality_violation);
+    updatePrimalViolation(value, i, is_column);
   }
 
-  // Check row feasibility if there are a positive number of rows.
+  // Check row feasibility if there is a positive number of rows
   //
   // If there are no rows and pass_row_value is nullptr, then
   // row_value_p is also nullptr since row_value is not resized
@@ -1451,24 +1441,9 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
         pass_row_value ? (*pass_row_value).data() : row_value.data();
     assert(row_value_p);
 
-    for (HighsInt i = 0; i != lp->num_row_; ++i) {
-      const double value = row_value_p[i];
-      const double lower = lp->row_lower_[i];
-      const double upper = lp->row_upper_[i];
-
-      double primal_infeasibility;
-      if (value < lower - mip_feasibility_tolerance) {
-        primal_infeasibility = lower - value;
-      } else if (value > upper + mip_feasibility_tolerance) {
-        primal_infeasibility = value - upper;
-      } else {
-        continue;
-      }
-      updateViolation(primal_infeasibility, i,
-		      num_row_violations,
-		      row_violation,
-		      row_of_max_row_violation);
-    }
+    bool is_column = false;
+    for (HighsInt i = 0; i != lp->num_row_; ++i)
+      updatePrimalViolation(row_value_p[i], i, is_column);
   }
 
   const bool feasible = bound_violation <= mip_feasibility_tolerance &&

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -1379,21 +1379,46 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
 
   if (kAllowDeveloperAssert)
     assert(col_value.size() == static_cast<size_t>(lp->num_col_));
+
+  // Lambda to update violation record
+  auto updateViolation = [&](double v, HighsInt index, HighsInt& num, double& max_v, HighsInt& max_index) {
+      if (v <= 0) return;
+      if (v > mip_feasibility_tolerance) num++;
+      if (v > max_v) { max_v = v; max_index = index; }
+  };
+
+  auto updatePrimalViolation = [&](double value, HighsInt index, bool is_column) {
+    const double lower = is_column ? lp->col_lower_[index] : lp->row_lower_[index];
+    const double upper = is_column ? lp->col_upper_[index] : lp->row_upper_[index];
+    double primal_infeasibility;
+    if (value < lower - mip_feasibility_tolerance) {
+      primal_infeasibility = lower - value;
+    } else if (value > upper + mip_feasibility_tolerance) {
+      primal_infeasibility = value - upper;
+    } else {
+      return;
+    }
+    if (is_column) {
+      updateViolation(primal_infeasibility, index,
+		      num_bound_violations,
+		      bound_violation,
+		      col_of_max_bound_violation);
+    } else {
+      updateViolation(primal_infeasibility, index,
+		      num_row_violations,
+		      row_violation,
+		      row_of_max_row_violation);
+    }    
+  };
+  
   for (HighsInt i = 0; i != lp->num_col_; ++i) {
     const double value = col_value[i];
     obj += static_cast<HighsCDouble>(lp->col_cost_[i]) * value;
-
-    if (lp->integrality_[i] == HighsVarType::kInteger) {
-      double violation = fractionality(value);
-      if (violation) {
-        if (violation > mip_feasibility_tolerance) num_integrality_violations++;
-        if (violation > integrality_violation) {
-          integrality_violation = violation;
-          col_of_max_integrality_violation = i;
-        }
-      }
-    }
-
+    if (lp->integrality_[i] == HighsVarType::kInteger)
+      updateViolation(fractionality(value), i,
+		      num_integrality_violations,
+		      integrality_violation,
+		      col_of_max_integrality_violation);
     const double lower = lp->col_lower_[i];
     const double upper = lp->col_upper_[i];
     double primal_infeasibility;
@@ -1401,17 +1426,13 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
       primal_infeasibility = lower - value;
     } else if (value > upper + mip_feasibility_tolerance) {
       primal_infeasibility = value - upper;
-    } else
+    } else {
       continue;
-
-    if (primal_infeasibility) {
-      if (primal_infeasibility > mip_feasibility_tolerance)
-        num_bound_violations++;
-      if (primal_infeasibility > bound_violation) {
-        bound_violation = primal_infeasibility;
-        col_of_max_bound_violation = i;
-      }
     }
+    updateViolation(primal_infeasibility, i,
+		    num_bound_violations,
+		    bound_violation,
+		    col_of_max_bound_violation);
   }
 
   // Check row feasibility if there are a positive number of rows.
@@ -1440,17 +1461,13 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
         primal_infeasibility = lower - value;
       } else if (value > upper + mip_feasibility_tolerance) {
         primal_infeasibility = value - upper;
-      } else
+      } else {
         continue;
-
-      if (primal_infeasibility) {
-        if (primal_infeasibility > mip_feasibility_tolerance)
-          num_row_violations++;
-        if (primal_infeasibility > row_violation) {
-          row_violation = primal_infeasibility;
-          row_of_max_row_violation = i;
-        }
       }
+      updateViolation(primal_infeasibility, i,
+		      num_row_violations,
+		      row_violation,
+		      row_of_max_row_violation);
     }
   }
 

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -1350,15 +1350,28 @@ std::array<char, 128> getGapString(const double gap_,
 bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
                                       const std::vector<double>& col_value,
                                       const std::vector<double>* pass_row_value,
-				      MipViolation& violation,
+                                      MipViolation& violation,
                                       HighsCDouble& obj) const {
   violation.clear();
   double& bound_violation = violation.bound_violation;
-  double& row_violation = violation.row_violation;
   double& integrality_violation = violation.integrality_violation;
+  double& row_violation = violation.row_violation;
+  HighsInt& num_bound_violations = violation.num_bound_violations;
+  HighsInt& num_integrality_violations = violation.num_integrality_violations;
+  HighsInt& num_row_violations = violation.num_row_violations;
+  HighsInt& col_of_max_bound_violation = violation.col_of_max_bound_violation;
+  HighsInt& col_of_max_integrality_violation =
+      violation.col_of_max_integrality_violation;
+  HighsInt& row_of_max_row_violation = violation.row_of_max_row_violation;
   assert(bound_violation == 0);
-  assert(row_violation == 0);
   assert(integrality_violation == 0);
+  assert(row_violation == 0);
+  assert(num_bound_violations == 0);
+  assert(num_integrality_violations == 0);
+  assert(num_row_violations == 0);
+  assert(col_of_max_bound_violation == -1);
+  assert(col_of_max_integrality_violation == -1);
+  assert(row_of_max_row_violation == -1);
   const double mip_feasibility_tolerance =
       options_mip_->mip_feasibility_tolerance;
 
@@ -1371,8 +1384,14 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
     obj += static_cast<HighsCDouble>(lp->col_cost_[i]) * value;
 
     if (lp->integrality_[i] == HighsVarType::kInteger) {
-      integrality_violation =
-          std::max(fractionality(value), integrality_violation);
+      double violation = fractionality(value);
+      if (violation) {
+        if (violation > mip_feasibility_tolerance) num_integrality_violations++;
+        if (violation > integrality_violation) {
+          integrality_violation = violation;
+          col_of_max_integrality_violation = i;
+        }
+      }
     }
 
     const double lower = lp->col_lower_[i];
@@ -1385,7 +1404,14 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
     } else
       continue;
 
-    bound_violation = std::max(bound_violation, primal_infeasibility);
+    if (primal_infeasibility) {
+      if (primal_infeasibility > mip_feasibility_tolerance)
+        num_bound_violations++;
+      if (primal_infeasibility > bound_violation) {
+        bound_violation = primal_infeasibility;
+        col_of_max_bound_violation = i;
+      }
+    }
   }
 
   // Check row feasibility if there are a positive number of rows.
@@ -1417,7 +1443,14 @@ bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
       } else
         continue;
 
-      row_violation = std::max(row_violation, primal_infeasibility);
+      if (primal_infeasibility) {
+        if (primal_infeasibility > mip_feasibility_tolerance)
+          num_row_violations++;
+        if (primal_infeasibility > row_violation) {
+          row_violation = primal_infeasibility;
+          row_of_max_row_violation = i;
+        }
+      }
     }
   }
 
@@ -1466,53 +1499,51 @@ void HighsMipSolver::setProfiling(HighsProfiling* profiling) {
 
 void MipViolation::clear() {
   this->bound_violation = 0;
-  this->integrality_violation = 0; 
+  this->integrality_violation = 0;
   this->row_violation = 0;
   this->num_bound_violations = 0;
   this->num_integrality_violations = 0;
   this->num_row_violations = 0;
-  this->col_of_max_bound_violation = 0;
-  this->col_of_max_integrality_violation = 0;
-  this->row_of_max_row_violation = 0;
+  this->col_of_max_bound_violation = -1;
+  this->col_of_max_integrality_violation = -1;
+  this->row_of_max_row_violation = -1;
 }
 
-void MipViolation::copy(double& bound_violation_,
-			double& row_violation_,
-			double& integrality_violation_) const {
+void MipViolation::copy(double& bound_violation_, double& row_violation_,
+                        double& integrality_violation_) const {
   bound_violation_ = this->bound_violation;
   row_violation_ = this->row_violation;
   integrality_violation_ = this->integrality_violation;
 }
 
 void MipViolation::log(const HighsLogOptions& log_options,
-		       const double objective_value,
-		       const std::string& source) const {
+                       const double objective_value,
+                       const std::string& source) const {
   if (*(log_options.log_dev_level) > 0) {
     highsLogDev(log_options, HighsLogType::kWarning,
-		"%s with objective %g has untransformed violations:\n",
-		source.c_str(), objective_value);
-    highsLogDev(log_options, HighsLogType::kWarning,
-		"   bound       (%d) with max of %.4g in column %d\n",
-		int(this->num_bound_violations),
-		this->bound_violation,
-		int(this->col_of_max_bound_violation));
-    highsLogDev(log_options, HighsLogType::kWarning,
-		"   integrality (%d) with max of %.4g in column %d\n",
-		int(this->num_integrality_violations),
-		this->integrality_violation,
-		int(this->col_of_max_integrality_violation));
-    highsLogDev(log_options, HighsLogType::kWarning,
-		"   row         (%d) with max of %.4g in row %d\n",
-		int(this->num_row_violations),
-		this->row_violation,
-		int(this->row_of_max_row_violation));
-  } else {      
+                "%s with objective %g has untransformed violations:\n",
+                source.c_str(), objective_value);
+    if (this->num_bound_violations)
+      highsLogDev(log_options, HighsLogType::kWarning,
+                  "   bound       (%d) with max of %.4g in column %d\n",
+                  int(this->num_bound_violations), this->bound_violation,
+                  int(this->col_of_max_bound_violation));
+    if (this->num_integrality_violations)
+      highsLogDev(log_options, HighsLogType::kWarning,
+                  "   integrality (%d) with max of %.4g in column %d\n",
+                  int(this->num_integrality_violations),
+                  this->integrality_violation,
+                  int(this->col_of_max_integrality_violation));
+    if (this->num_row_violations)
+      highsLogDev(log_options, HighsLogType::kWarning,
+                  "   row         (%d) with max of %.4g in row %d\n",
+                  int(this->num_row_violations), this->row_violation,
+                  int(this->row_of_max_row_violation));
+  } else {
     highsLogUser(log_options, HighsLogType::kWarning,
-		 "%s with objective %g has untransformed violations: "
-		 "bound = %.4g; integrality = %.4g; row = %.4g\n",
-		 source.c_str(),
-		 objective_value, this->bound_violation,
-		 this->integrality_violation, this->row_violation);
+                 "%s with objective %g has untransformed violations: "
+                 "bound = %.4g; integrality = %.4g; row = %.4g\n",
+                 source.c_str(), objective_value, this->bound_violation,
+                 this->integrality_violation, this->row_violation);
   }
 }
-

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -60,10 +60,11 @@ HighsMipSolver::HighsMipSolver(HighsCallback& callback,
 #endif
     // Initial solution can be infeasible, but need to set values for violation
     // and objective
+    MipViolation violation;
     HighsCDouble quad_solution_objective_;
     solutionFeasible(orig_model_, solution.col_value, &solution.row_value,
-                     bound_violation_, row_violation_, integrality_violation_,
-                     quad_solution_objective_);
+                     violation, quad_solution_objective_);
+    violation.copy(bound_violation_, row_violation_, integrality_violation_);
     solution_objective_ = double(quad_solution_objective_);
     solution_ = solution.col_value;
   }
@@ -1349,13 +1350,15 @@ std::array<char, 128> getGapString(const double gap_,
 bool HighsMipSolver::solutionFeasible(const HighsLp* lp,
                                       const std::vector<double>& col_value,
                                       const std::vector<double>* pass_row_value,
-                                      double& bound_violation,
-                                      double& row_violation,
-                                      double& integrality_violation,
+				      MipViolation& violation,
                                       HighsCDouble& obj) const {
-  bound_violation = 0;
-  row_violation = 0;
-  integrality_violation = 0;
+  violation.clear();
+  double& bound_violation = violation.bound_violation;
+  double& row_violation = violation.row_violation;
+  double& integrality_violation = violation.integrality_violation;
+  assert(bound_violation == 0);
+  assert(row_violation == 0);
+  assert(integrality_violation == 0);
   const double mip_feasibility_tolerance =
       options_mip_->mip_feasibility_tolerance;
 
@@ -1466,3 +1469,15 @@ void MipViolation::clear() {
   this->row_violation = 0;
   this->integrality_violation = 0; 
 }
+
+void MipViolation::copy(double& bound_violation_,
+			double& row_violation_,
+			double& integrality_violation_) const {
+  bound_violation_ = this->bound_violation;
+  row_violation_ = this->row_violation;
+  integrality_violation_ = this->integrality_violation;
+}
+
+void MipViolation::log(const HighsLogOptions& log_options) const {
+}
+

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -1460,3 +1460,9 @@ void HighsMipSolver::setProfiling(HighsProfiling* profiling) {
   assert(profiling);
   this->profiling_ = profiling;
 }
+
+void MipViolation::clear() {
+  this->bound_violation = 0;
+  this->row_violation = 0;
+  this->integrality_violation = 0; 
+}

--- a/highs/mip/HighsMipSolver.cpp
+++ b/highs/mip/HighsMipSolver.cpp
@@ -64,7 +64,7 @@ HighsMipSolver::HighsMipSolver(HighsCallback& callback,
     HighsCDouble quad_solution_objective_;
     solutionFeasible(orig_model_, solution.col_value, &solution.row_value,
                      violation, quad_solution_objective_);
-    violation.copy(bound_violation_, row_violation_, integrality_violation_);
+    violation.copy(bound_violation_, integrality_violation_, row_violation_);
     solution_objective_ = double(quad_solution_objective_);
     solution_ = solution.col_value;
   }
@@ -1466,8 +1466,14 @@ void HighsMipSolver::setProfiling(HighsProfiling* profiling) {
 
 void MipViolation::clear() {
   this->bound_violation = 0;
-  this->row_violation = 0;
   this->integrality_violation = 0; 
+  this->row_violation = 0;
+  this->num_bound_violations = 0;
+  this->num_integrality_violations = 0;
+  this->num_row_violations = 0;
+  this->col_of_max_bound_violation = 0;
+  this->col_of_max_integrality_violation = 0;
+  this->row_of_max_row_violation = 0;
 }
 
 void MipViolation::copy(double& bound_violation_,
@@ -1478,6 +1484,35 @@ void MipViolation::copy(double& bound_violation_,
   integrality_violation_ = this->integrality_violation;
 }
 
-void MipViolation::log(const HighsLogOptions& log_options) const {
+void MipViolation::log(const HighsLogOptions& log_options,
+		       const double objective_value,
+		       const std::string& source) const {
+  if (*(log_options.log_dev_level) > 0) {
+    highsLogDev(log_options, HighsLogType::kWarning,
+		"%s with objective %g has untransformed violations:\n",
+		source.c_str(), objective_value);
+    highsLogDev(log_options, HighsLogType::kWarning,
+		"   bound       (%d) with max of %.4g in column %d\n",
+		int(this->num_bound_violations),
+		this->bound_violation,
+		int(this->col_of_max_bound_violation));
+    highsLogDev(log_options, HighsLogType::kWarning,
+		"   integrality (%d) with max of %.4g in column %d\n",
+		int(this->num_integrality_violations),
+		this->integrality_violation,
+		int(this->col_of_max_integrality_violation));
+    highsLogDev(log_options, HighsLogType::kWarning,
+		"   row         (%d) with max of %.4g in row %d\n",
+		int(this->num_row_violations),
+		this->row_violation,
+		int(this->row_of_max_row_violation));
+  } else {      
+    highsLogUser(log_options, HighsLogType::kWarning,
+		 "%s with objective %g has untransformed violations: "
+		 "bound = %.4g; integrality = %.4g; row = %.4g\n",
+		 source.c_str(),
+		 objective_value, this->bound_violation,
+		 this->integrality_violation, this->row_violation);
+  }
 }
 

--- a/highs/mip/HighsMipSolver.h
+++ b/highs/mip/HighsMipSolver.h
@@ -38,6 +38,10 @@ struct MipViolation {
   double row_violation;
   double integrality_violation;
   void clear();
+  void copy(double& bound_violation_,
+	    double& row_violation_,
+	    double& integrality_violation_) const;
+  void log(const HighsLogOptions& log_options) const;
 };
 
 class HighsMipSolver {
@@ -148,8 +152,7 @@ class HighsMipSolver {
   void callbackGetCutPool() const;
   bool solutionFeasible(const HighsLp* lp, const std::vector<double>& col_value,
                         const std::vector<double>* pass_row_value,
-                        double& bound_violation, double& row_violation,
-                        double& integrality_violation, HighsCDouble& obj) const;
+                        MipViolation& violation, HighsCDouble& obj) const;
 
   std::vector<HighsModelStatus> initialiseTerminatorRecord(
       HighsInt num_instance) const;

--- a/highs/mip/HighsMipSolver.h
+++ b/highs/mip/HighsMipSolver.h
@@ -33,6 +33,13 @@ struct HighsTerminator {
   void report(const HighsLogOptions log_options) const;
 };
 
+struct MipViolation {
+  double bound_violation;
+  double row_violation;
+  double integrality_violation;
+  void clear();
+};
+
 class HighsMipSolver {
  public:
   HighsCallback* callback_;

--- a/highs/mip/HighsMipSolver.h
+++ b/highs/mip/HighsMipSolver.h
@@ -44,12 +44,10 @@ struct MipViolation {
   HighsInt col_of_max_integrality_violation;
   HighsInt row_of_max_row_violation;
   void clear();
-  void copy(double& bound_violation_,
-	    double& integrality_violation_,
-	    double& row_violation_) const;
-  void log(const HighsLogOptions& log_options,
-	   const double objective_value,
-	   const std::string& source) const;
+  void copy(double& bound_violation_, double& integrality_violation_,
+            double& row_violation_) const;
+  void log(const HighsLogOptions& log_options, const double objective_value,
+           const std::string& source) const;
 };
 
 class HighsMipSolver {

--- a/highs/mip/HighsMipSolver.h
+++ b/highs/mip/HighsMipSolver.h
@@ -35,13 +35,21 @@ struct HighsTerminator {
 
 struct MipViolation {
   double bound_violation;
-  double row_violation;
   double integrality_violation;
+  double row_violation;
+  HighsInt num_bound_violations;
+  HighsInt num_integrality_violations;
+  HighsInt num_row_violations;
+  HighsInt col_of_max_bound_violation;
+  HighsInt col_of_max_integrality_violation;
+  HighsInt row_of_max_row_violation;
   void clear();
   void copy(double& bound_violation_,
-	    double& row_violation_,
-	    double& integrality_violation_) const;
-  void log(const HighsLogOptions& log_options) const;
+	    double& integrality_violation_,
+	    double& row_violation_) const;
+  void log(const HighsLogOptions& log_options,
+	   const double objective_value,
+	   const std::string& source) const;
 };
 
 class HighsMipSolver {

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1186,10 +1186,10 @@ try_again:
       mipsolver.orig_model_, solution.col_value, &solution.row_value,
       violation,
       mipsolver_quad_objective_value);
-  double bound_violation_;
-  double row_violation_;
-  double integrality_violation_;
-  violation.copy(bound_violation_, row_violation_, integrality_violation_);
+  double bound_violation_ = 0;
+  double integrality_violation_ = 0;
+  double row_violation_ = 0;
+  violation.copy(bound_violation_, integrality_violation_, row_violation_);
   double mipsolver_objective_value = double(mipsolver_quad_objective_value);
   if (!feasible && allow_try_again) {
     // printf(
@@ -1299,11 +1299,8 @@ try_again:
               mipsolver.options_mip_->mip_feasibility_tolerance &&
           mipsolver.row_violation_ <=
               mipsolver.options_mip_->mip_feasibility_tolerance;
-      highsLogUser(mipsolver.options_mip_->log_options, HighsLogType::kWarning,
-                   "Solution with objective %g has untransformed violations: "
-                   "bound = %.4g; integrality = %.4g; row = %.4g\n",
-                   mipsolver_objective_value, bound_violation_,
-                   integrality_violation_, row_violation_);
+      violation.log(mipsolver.options_mip_->log_options,
+		    mipsolver_objective_value, "Solution");
       if (!currentFeasible) {
         // if the current incumbent is non existent or also not feasible we
         // still store the new one
@@ -2806,19 +2803,14 @@ void HighsMipSolverData::queryExternalSolution(
       const bool feasible = mipsolver.solutionFeasible(
           mipsolver.orig_model_, user_solution, nullptr, violation,
           user_solution_quad_objective_value);
-      double bound_violation_;
-      double row_violation_;
-      double integrality_violation_;
-      violation.copy(bound_violation_, row_violation_, integrality_violation_);
+      double bound_violation_ = 0;
+      double integrality_violation_ = 0;
+      double row_violation_ = 0;
+      violation.copy(bound_violation_, integrality_violation_, row_violation_);
       double user_solution_objective_value =
           double(user_solution_quad_objective_value);
       if (!feasible) {
-        highsLogUser(
-            mipsolver.options_mip_->log_options, HighsLogType::kWarning,
-            "User-supplied solution has with objective %g has violations: "
-            "bound = %.4g; integrality = %.4g; row = %.4g\n",
-            user_solution_objective_value, bound_violation_,
-            integrality_violation_, row_violation_);
+	violation.log(mipsolver.options_mip_->log_options, user_solution_objective_value, "User-supplied solution");
         return;
       }
       std::vector<double> reduced_user_solution;

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1170,7 +1170,10 @@ double HighsMipSolverData::transformNewIntegerFeasibleSolution(
   solution.col_value = sol;
   solution.value_valid = true;
   // Perform primal postsolve to get the original column values
-  postSolveStack.undoPrimal(*mipsolver.options_mip_, solution);
+  // For #3216 report column 2404 (or possibly 578) for 3216.lp
+  const HighsInt report_3216_col = -2404;//578;
+  this->reportOriginalPresolvedCol(report_3216_col, sol);
+  postSolveStack.undoPrimal(*mipsolver.options_mip_, solution, report_3216_col);
   // Determine the row values, as they aren't computed in primal
   // postsolve
   HighsStatus return_status =
@@ -2847,6 +2850,32 @@ bool HighsMipSolverData::terminatorTerminated() const {
 void HighsMipSolverData::terminatorReport() const {
   if (this->terminatorActive())
     mipsolver.terminator_.report(mipsolver.options_mip_->log_options);
+}
+
+void HighsMipSolverData::reportOriginalPresolvedCol(const HighsInt original_col,
+						    const std::vector<double>presolved_solution) {
+  if (original_col < 0 || original_col >= mipsolver.orig_model_->num_col_) return;
+  // Find this column in the presolved model
+  HighsInt presolved_col = postSolveStack.getPresolvedColumnIndex(original_col);
+  printf("Original col = %d (%s) [%g, %g] %s",
+	 int(original_col),
+	 mipsolver.orig_model_->col_names_[original_col].c_str(),
+	 mipsolver.orig_model_->col_lower_[original_col],
+	 mipsolver.orig_model_->col_upper_[original_col],
+	 mipsolver.orig_model_->integrality_[original_col] ==
+	 HighsVarType::kContinuous ? "Continuous" : "Discrete");
+  if (presolved_col > 0) {
+    printf("; Presolved col = %d (%s) [%g, %g] %s has value %g\n",
+	   int(presolved_col),
+	   mipsolver.model_->col_names_[presolved_col].c_str(),
+	   mipsolver.model_->col_lower_[presolved_col],
+	   mipsolver.model_->col_upper_[presolved_col],
+	   mipsolver.model_->integrality_[presolved_col] ==
+	   HighsVarType::kContinuous ? "Continuous" : "Discrete",
+	   presolved_solution[presolved_col]);
+  } else {
+    printf("; Not in presolved model\n");
+  }
 }
 
 static double possInfRelDiff(const double v0, const double v1,

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1181,15 +1181,15 @@ try_again:
 
   // compute the objective value in the original space
   MipViolation violation;
-  violation.clear();
-  double bound_violation_ = 0;
-  double row_violation_ = 0;
-  double integrality_violation_ = 0;
   HighsCDouble mipsolver_quad_objective_value = 0;
   bool feasible = mipsolver.solutionFeasible(
       mipsolver.orig_model_, solution.col_value, &solution.row_value,
-      bound_violation_, row_violation_, integrality_violation_,
+      violation,
       mipsolver_quad_objective_value);
+  double bound_violation_;
+  double row_violation_;
+  double integrality_violation_;
+  violation.copy(bound_violation_, row_violation_, integrality_violation_);
   double mipsolver_objective_value = double(mipsolver_quad_objective_value);
   if (!feasible && allow_try_again) {
     // printf(
@@ -2801,14 +2801,15 @@ void HighsMipSolverData::queryExternalSolution(
       // (reduced_c)^T(reduced_x) = original_sense*[original_offset +
       // (original_c)^T(original_x) - reduced_offset]
       const auto& user_solution = callback->data_in.user_solution;
-      double bound_violation_ = 0;
-      double row_violation_ = 0;
-      double integrality_violation_ = 0;
+      MipViolation violation;
       HighsCDouble user_solution_quad_objective_value = 0;
       const bool feasible = mipsolver.solutionFeasible(
-          mipsolver.orig_model_, user_solution, nullptr, bound_violation_,
-          row_violation_, integrality_violation_,
+          mipsolver.orig_model_, user_solution, nullptr, violation,
           user_solution_quad_objective_value);
+      double bound_violation_;
+      double row_violation_;
+      double integrality_violation_;
+      violation.copy(bound_violation_, row_violation_, integrality_violation_);
       double user_solution_objective_value =
           double(user_solution_quad_objective_value);
       if (!feasible) {

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1170,10 +1170,9 @@ double HighsMipSolverData::transformNewIntegerFeasibleSolution(
   solution.col_value = sol;
   solution.value_valid = true;
   // Perform primal postsolve to get the original column values
-  // For #3216 report column 2404 (or possibly 578) for 3216.lp
-  const HighsInt report_3216_col = -2404;  // 578;
-  this->reportOriginalPresolvedCol(report_3216_col, sol);
-  postSolveStack.undoPrimal(*mipsolver.options_mip_, solution, report_3216_col);
+  const HighsInt report_col = -kHighsIInf;
+  this->reportOriginalPresolvedCol(report_col, sol);
+  postSolveStack.undoPrimal(*mipsolver.options_mip_, solution, report_col);
   // Determine the row values, as they aren't computed in primal
   // postsolve
   HighsStatus return_status =

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1183,8 +1183,7 @@ try_again:
   MipViolation violation;
   HighsCDouble mipsolver_quad_objective_value = 0;
   bool feasible = mipsolver.solutionFeasible(
-      mipsolver.orig_model_, solution.col_value, &solution.row_value,
-      violation,
+      mipsolver.orig_model_, solution.col_value, &solution.row_value, violation,
       mipsolver_quad_objective_value);
   double bound_violation_ = 0;
   double integrality_violation_ = 0;
@@ -1300,7 +1299,7 @@ try_again:
           mipsolver.row_violation_ <=
               mipsolver.options_mip_->mip_feasibility_tolerance;
       violation.log(mipsolver.options_mip_->log_options,
-		    mipsolver_objective_value, "Solution");
+                    mipsolver_objective_value, "Solution");
       if (!currentFeasible) {
         // if the current incumbent is non existent or also not feasible we
         // still store the new one
@@ -2810,7 +2809,8 @@ void HighsMipSolverData::queryExternalSolution(
       double user_solution_objective_value =
           double(user_solution_quad_objective_value);
       if (!feasible) {
-	violation.log(mipsolver.options_mip_->log_options, user_solution_objective_value, "User-supplied solution");
+        violation.log(mipsolver.options_mip_->log_options,
+                      user_solution_objective_value, "User-supplied solution");
         return;
       }
       std::vector<double> reduced_user_solution;

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1171,7 +1171,7 @@ double HighsMipSolverData::transformNewIntegerFeasibleSolution(
   solution.value_valid = true;
   // Perform primal postsolve to get the original column values
   // For #3216 report column 2404 (or possibly 578) for 3216.lp
-  const HighsInt report_3216_col = -2404;//578;
+  const HighsInt report_3216_col = -2404;  // 578;
   this->reportOriginalPresolvedCol(report_3216_col, sol);
   postSolveStack.undoPrimal(*mipsolver.options_mip_, solution, report_3216_col);
   // Determine the row values, as they aren't computed in primal
@@ -2852,27 +2852,31 @@ void HighsMipSolverData::terminatorReport() const {
     mipsolver.terminator_.report(mipsolver.options_mip_->log_options);
 }
 
-void HighsMipSolverData::reportOriginalPresolvedCol(const HighsInt original_col,
-						    const std::vector<double>presolved_solution) {
-  if (original_col < 0 || original_col >= mipsolver.orig_model_->num_col_) return;
+void HighsMipSolverData::reportOriginalPresolvedCol(
+    const HighsInt original_col, const std::vector<double> presolved_solution) {
+  if (original_col < 0 || original_col >= mipsolver.orig_model_->num_col_)
+    return;
   // Find this column in the presolved model
   HighsInt presolved_col = postSolveStack.getPresolvedColumnIndex(original_col);
-  printf("Original col = %d (%s) [%g, %g] %s",
-	 int(original_col),
-	 mipsolver.orig_model_->col_names_[original_col].c_str(),
-	 mipsolver.orig_model_->col_lower_[original_col],
-	 mipsolver.orig_model_->col_upper_[original_col],
-	 mipsolver.orig_model_->integrality_[original_col] ==
-	 HighsVarType::kContinuous ? "Continuous" : "Discrete");
+  printf("Original col = %d (%s) [%g, %g] %s", int(original_col),
+         mipsolver.orig_model_->col_names_[original_col].c_str(),
+         mipsolver.orig_model_->col_lower_[original_col],
+         mipsolver.orig_model_->col_upper_[original_col],
+         mipsolver.orig_model_->integrality_[original_col] ==
+                 HighsVarType::kContinuous
+             ? "Continuous"
+             : "Discrete");
   if (presolved_col > 0) {
     printf("; Presolved col = %d (%s) [%g, %g] %s has value %g\n",
-	   int(presolved_col),
-	   mipsolver.model_->col_names_[presolved_col].c_str(),
-	   mipsolver.model_->col_lower_[presolved_col],
-	   mipsolver.model_->col_upper_[presolved_col],
-	   mipsolver.model_->integrality_[presolved_col] ==
-	   HighsVarType::kContinuous ? "Continuous" : "Discrete",
-	   presolved_solution[presolved_col]);
+           int(presolved_col),
+           mipsolver.model_->col_names_[presolved_col].c_str(),
+           mipsolver.model_->col_lower_[presolved_col],
+           mipsolver.model_->col_upper_[presolved_col],
+           mipsolver.model_->integrality_[presolved_col] ==
+                   HighsVarType::kContinuous
+               ? "Continuous"
+               : "Discrete",
+           presolved_solution[presolved_col]);
   } else {
     printf("; Not in presolved model\n");
   }

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1180,6 +1180,8 @@ double HighsMipSolverData::transformNewIntegerFeasibleSolution(
 try_again:
 
   // compute the objective value in the original space
+  MipViolation violation;
+  violation.clear();
   double bound_violation_ = 0;
   double row_violation_ = 0;
   double integrality_violation_ = 0;

--- a/highs/mip/HighsMipSolverData.h
+++ b/highs/mip/HighsMipSolverData.h
@@ -288,6 +288,8 @@ struct HighsMipSolverData {
   const HighsCutPool& getCutPool() const { return cutpools[0]; }
   const HighsLpRelaxation& getLp() const { return lps[0]; }
   const HighsPseudocost& getPseudoCost() const { return pseudocosts[0]; }
+  void reportOriginalPresolvedCol(const HighsInt original_col,
+				  const std::vector<double>presolved_solution);
 };
 
 #endif

--- a/highs/mip/HighsMipSolverData.h
+++ b/highs/mip/HighsMipSolverData.h
@@ -289,7 +289,7 @@ struct HighsMipSolverData {
   const HighsLpRelaxation& getLp() const { return lps[0]; }
   const HighsPseudocost& getPseudoCost() const { return pseudocosts[0]; }
   void reportOriginalPresolvedCol(const HighsInt original_col,
-				  const std::vector<double>presolved_solution);
+                                  const std::vector<double> presolved_solution);
 };
 
 #endif

--- a/highs/mip/HighsMipWorker.cpp
+++ b/highs/mip/HighsMipWorker.cpp
@@ -92,17 +92,16 @@ std::pair<bool, double> HighsMipWorker::transformNewIntegerFeasibleSolution(
   if (kAllowDeveloperAssert) assert(return_status == HighsStatus::kOk);
 
   // compute the objective value in the original space
-  double bound_violation_ = 0;
-  double row_violation_ = 0;
-  double integrality_violation_ = 0;
-
+  MipViolation violation;
   HighsCDouble mipsolver_quad_objective_value = 0;
-
   bool feasible = mipsolver_.solutionFeasible(
       mipsolver_.orig_model_, solution.col_value, &solution.row_value,
-      bound_violation_, row_violation_, integrality_violation_,
+      violation,
       mipsolver_quad_objective_value);
-
+  double bound_violation_;
+  double row_violation_;
+  double integrality_violation_;
+  violation.copy(bound_violation_, row_violation_, integrality_violation_);
   const double transformed_solobj = static_cast<double>(
       static_cast<HighsInt>(mipsolver_.orig_model_->sense_) *
           mipsolver_quad_objective_value -

--- a/highs/mip/HighsMipWorker.cpp
+++ b/highs/mip/HighsMipWorker.cpp
@@ -98,10 +98,10 @@ std::pair<bool, double> HighsMipWorker::transformNewIntegerFeasibleSolution(
       mipsolver_.orig_model_, solution.col_value, &solution.row_value,
       violation,
       mipsolver_quad_objective_value);
-  double bound_violation_;
-  double row_violation_;
-  double integrality_violation_;
-  violation.copy(bound_violation_, row_violation_, integrality_violation_);
+  double bound_violation_ = 0;
+  double integrality_violation_ = 0;
+  double row_violation_ = 0;
+  violation.copy(bound_violation_, integrality_violation_, row_violation_);
   const double transformed_solobj = static_cast<double>(
       static_cast<HighsInt>(mipsolver_.orig_model_->sense_) *
           mipsolver_quad_objective_value -

--- a/highs/mip/HighsMipWorker.cpp
+++ b/highs/mip/HighsMipWorker.cpp
@@ -96,8 +96,7 @@ std::pair<bool, double> HighsMipWorker::transformNewIntegerFeasibleSolution(
   HighsCDouble mipsolver_quad_objective_value = 0;
   bool feasible = mipsolver_.solutionFeasible(
       mipsolver_.orig_model_, solution.col_value, &solution.row_value,
-      violation,
-      mipsolver_quad_objective_value);
+      violation, mipsolver_quad_objective_value);
   double bound_violation_ = 0;
   double integrality_violation_ = 0;
   double row_violation_ = 0;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -101,6 +101,8 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
                 static_cast<int>(this->reductionLimit));
   }
   this->in_initial_sweep_ = false;
+  // last_reduction_ is used to identify when HPresolve::checkLimits
+  // is called for the first time following a reduction
   this->last_reduction_ = -kHighsIInf;
 }
 
@@ -6828,11 +6830,8 @@ HPresolve::Result HPresolve::checkLimits(HighsPostsolveStack& postsolve_stack) {
 
   if ((numreductions & 1023u) == 0) HPRESOLVE_CHECKED_CALL(checkTimeLimit());
 
-  if (numreductions >= this->reductionLimit - 1 &&
-      numreductions > this->last_reduction_) {
-    printf("HPresolve::checkLimits Performed %d reductions (limit = %d)\n",
-           int(numreductions), int(reductionLimit));
-  }
+  // Record the value of numreductions so that the next call with an
+  // increase in numreductions can be identified
   this->last_reduction_ = numreductions;
   return numreductions >= this->reductionLimit ? Result::kStopped : Result::kOk;
 }
@@ -7740,9 +7739,6 @@ HPresolve::Result HPresolve::presolveChangedRows(
   changedRows.swap(changedRowIndices);
   for (HighsInt row : changedRows) {
     if (rowDeleted[row]) continue;
-    if (this->last_reduction_ == reductionLimit - 1) {
-      printf("HPresolve::presolveChangedRows Row %d\n", int(row));
-    }
     HPRESOLVE_CHECKED_CALL(rowPresolve(postsolve_stack, row));
     changedRowFlag[row] = rowDeleted[row];
   }

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -103,7 +103,7 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
   this->in_initial_sweep_ = false;
   // last_reduction_ is used to identify when HPresolve::checkLimits
   // is called for the first time following a reduction
-  this->last_reduction_ = -kHighsIInf;
+  this->last_reduction_ = 0;
 }
 
 // for MIP presolve

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -101,6 +101,7 @@ void HPresolve::setInput(HighsLp& model_, const HighsOptions& options_,
                 static_cast<int>(this->reductionLimit));
   }
   this->in_initial_sweep_ = false;
+  this->last_reduction_ = -kHighsIInf;
 }
 
 // for MIP presolve
@@ -6827,7 +6828,13 @@ HPresolve::Result HPresolve::checkLimits(HighsPostsolveStack& postsolve_stack) {
 
   if ((numreductions & 1023u) == 0) HPRESOLVE_CHECKED_CALL(checkTimeLimit());
 
-  return numreductions >= reductionLimit ? Result::kStopped : Result::kOk;
+  if (numreductions >= this->reductionLimit - 1 &&
+      numreductions > this->last_reduction_) {
+    printf("HPresolve::checkLimits Performed %d reductions (limit = %d)\n",
+           int(numreductions), int(reductionLimit));
+  }
+  this->last_reduction_ = numreductions;
+  return numreductions >= this->reductionLimit ? Result::kStopped : Result::kOk;
 }
 
 void HPresolve::storeCurrentProblemSize() {
@@ -7733,6 +7740,9 @@ HPresolve::Result HPresolve::presolveChangedRows(
   changedRows.swap(changedRowIndices);
   for (HighsInt row : changedRows) {
     if (rowDeleted[row]) continue;
+    if (this->last_reduction_ == reductionLimit - 1) {
+      printf("HPresolve::presolveChangedRows Row %d\n", int(row));
+    }
     HPRESOLVE_CHECKED_CALL(rowPresolve(postsolve_stack, row));
     changedRowFlag[row] = rowDeleted[row];
   }

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -109,6 +109,7 @@ class HPresolve {
 
   bool shrinkProblemEnabled;
   size_t reductionLimit;
+  size_t last_reduction_;
   bool in_initial_sweep_;
 
   // vectors storing singleton rows and columns

--- a/highs/presolve/HighsPostsolveStack.h
+++ b/highs/presolve/HighsPostsolveStack.h
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <cmath>
 #include <numeric>
+#include <sstream>
 #include <tuple>
 #include <vector>
 
@@ -262,6 +263,55 @@ class HighsPostsolveStack {
     reductions.emplace_back(type, position);
   }
 
+  std::string presolveTypeToString(const ReductionType& type) const {
+    switch (type) {
+    case ReductionType::kLinearTransform: {
+      return "Linear transform";
+    }
+    case ReductionType::kFreeColSubstitution: {
+      return "Free col substitution";
+    }
+    case ReductionType::kDoubletonEquation: {
+      return "Doubleton equation";
+    }
+    case ReductionType::kEqualityRowAddition: {
+      return "Equality row addition";
+    }
+    case ReductionType::kEqualityRowAdditions: {
+      return "Equality row additions";
+    }
+    case ReductionType::kSingletonRow: {
+      return "Singleton row";
+    }
+    case ReductionType::kFixedCol: {
+      return "Fixed col";
+    }
+    case ReductionType::kRedundantRow: {
+      return "Redundant Row";
+    }
+    case ReductionType::kForcingRow: {
+      return "Forcing row";
+    }
+    case ReductionType::kForcingColumn: {
+      return "Forcing column";
+    }
+    case ReductionType::kForcingColumnRemovedRow: {
+      return "Forcing column removed row";
+    }
+    case ReductionType::kDuplicateRow: {
+      return "Duplicate row";
+    }
+    case ReductionType::kDuplicateColumn: {
+      return "Duplicate column";
+    }
+    case ReductionType::kSlackColSubstitution: {
+      return "Slack col substitution";
+    }
+    default:
+      return "Unknown";
+    }
+  }
+
  public:
   const HighsInt* getOrigRowsIndex() const { return origRowIndex.data(); }
 
@@ -275,6 +325,25 @@ class HighsPostsolveStack {
   HighsInt getOrigColIndex(HighsInt col) const {
     assert(static_cast<size_t>(col) < origColIndex.size());
     return origColIndex[col];
+  }
+
+  HighsInt getPresolvedIndex(const HighsInt original_index, const std::vector<HighsInt>& original_indices) const {
+    auto it = std::find(original_indices.begin(), original_indices.end(), original_index);
+    // If found, calculate the index by subtracting the base iterator
+    if (it != original_indices.end()) {
+      HighsInt presolved_index = it - original_indices.begin();
+      assert(original_indices[presolved_index] == original_index);
+      return presolved_index;
+    }
+    return -1;
+  }
+
+  HighsInt getPresolvedColumnIndex(const HighsInt original_col_index) const {
+    return getPresolvedIndex(original_col_index, origColIndex);
+  }
+
+  HighsInt getPresolvedRowIndex(const HighsInt original_row_index) const {
+    return getPresolvedIndex(original_row_index, origRowIndex);
   }
 
   void appendCutsToModel(HighsInt numCuts) {
@@ -679,27 +748,39 @@ class HighsPostsolveStack {
                            HighsBasisStatus::kNonbasic);
     }
 
-    /*
-    // Initialise to illegal values so that initial values are logged
-    double report_col_value = kHighsInf;
-    double report_col_dual = kHighsInf;
-    HighsBasisStatus report_col_status = HighsBasisStatus::kNonbasic;
-    size_t check_reduction = -kHighsIinf;
+    std::stringstream ss;
 
     auto solutionLogging = [&](const std::string& message) {
       printf("\n%s\n", message.c_str());
-      for (HighsInt iCol = 0; iCol < origNumCol; iCol++)
-        printf("Col %9d value = %11.4g; dual = %11.4g; status = %s\n",
-               int(iCol), solution.col_value[iCol], solution.col_dual[iCol],
-               utilBasisStatusToString(basis.col_status[iCol]).c_str());
+      for (HighsInt iCol = 0; iCol < origNumCol; iCol++) {
+	ss.str(std::string());
+	ss << highsFormatToString("Col %9d value = %11.4g",
+               int(iCol), solution.col_value[iCol]);
+	if (perform_dual_postsolve)
+	  ss << highsFormatToString("; dual = %11.4g;", solution.col_dual[iCol]);
+	if (perform_basis_postsolve)
+	  ss << highsFormatToString("; status = %s",
+				    utilBasisStatusToString(basis.col_status[iCol]).c_str());
+	printf("%s\n", ss.str().c_str());
+	/*	
       for (HighsInt iRow = 0; iRow < origNumRow; iRow++)
         printf("Row %9d value = %11.4g; dual = %11.4g; status = %s\n",
                int(iRow), solution.row_value[iRow], solution.row_dual[iRow],
                utilBasisStatusToString(basis.row_status[iRow]).c_str());
-    };
+	       highsFprintfString(file, log_options, ss.str());
+	*/
+      }
+   };
+
+    // Initialise to illegal values so that initial values are logged
+    size_t check_reduction = -kHighsIInf;
+    double report_col_value = kHighsInf;
+    double report_col_dual = kHighsInf;
+    HighsBasisStatus report_col_status = HighsBasisStatus::kNonbasic;
 
     auto reportColLogging = [&](const HighsInt reduction) {
       assert(report_col >= 0);
+      if (static_cast<size_t>(report_col) >=  solution.col_value.size()) return;
       double col_value = solution.col_value[report_col];
       double col_dual = solution.dual_valid ? solution.col_dual[report_col] : 0;
       HighsBasisStatus col_status = basis.valid ? basis.col_status[report_col]
@@ -708,9 +789,9 @@ class HighsPostsolveStack {
       if (solution.dual_valid) report = report || col_dual != report_col_dual;
       if (basis.valid) report = report || col_status != report_col_status;
       if (reduction >= 0) {
+	ReductionType type = reductions[reduction].first;
         if (report)
-          printf("After reduction %9d (type %2d):", int(reduction),
-                 int(reductions[reduction].first));
+          printf("After reduction %9d (type %s):", int(reduction), presolveTypeToString(type).c_str());
       } else if (reduction == -1) {
         report = true;
         printf("Before undo:                        ");
@@ -731,7 +812,7 @@ class HighsPostsolveStack {
     if (report_col >= 0) reportColLogging(-1);
     if (reductions.size() == check_reduction)
       solutionLogging("After solving presolved LP");
-    */
+
     // now undo the changes
     for (size_t i = reductions.size(); i > 0; --i) {
       /*
@@ -841,9 +922,9 @@ class HighsPostsolveStack {
                  int(reductions[i - 1].first));
           if (kAllowDeveloperAssert) assert(1 == 0);
       }
-      //      if (report_col >= 0) reportColLogging(i - 1);
+      if (report_col >= 0) reportColLogging(i - 1);
     }
-    //    if (report_col >= 0) reportColLogging(-2);
+    if (report_col >= 0) reportColLogging(-2);
 
 #ifdef DEBUG_EXTRA
     // solution should not contain NaN or Inf

--- a/highs/presolve/HighsPostsolveStack.h
+++ b/highs/presolve/HighsPostsolveStack.h
@@ -332,12 +332,9 @@ class HighsPostsolveStack {
       const std::vector<HighsInt>& original_indices) const {
     auto it = std::find(original_indices.begin(), original_indices.end(),
                         original_index);
-    // If found, calculate the index by subtracting the base iterator
-    if (it != original_indices.end()) {
-      HighsInt presolved_index = it - original_indices.begin();
-      assert(original_indices[presolved_index] == original_index);
-      return presolved_index;
-    }
+    // If found, return the index after subtracting the base iterator
+    if (it != original_indices.end())
+      return static_cast<HighsInt>(it - original_indices.begin());
     return -1;
   }
 
@@ -788,7 +785,9 @@ class HighsPostsolveStack {
     double report_col_value = kHighsInf;
 
     // Lambda for logging the solution for a specific column whenever its value
-    changes auto reportColLogging = [&](const HighsInt reduction) {
+    changes
+
+    auto reportColLogging = [&](const HighsInt reduction) {
       assert(report_col >= 0);
       if (static_cast<size_t>(report_col) >= solution.col_value.size()) return;
       double col_value = solution.col_value[report_col];
@@ -821,7 +820,7 @@ class HighsPostsolveStack {
 
     if (report_col >= 0) reportColLogging(-1);
 
-    size_t check_reduction = -kHighsIInf;
+    size_t check_reduction = kHighsSize_tInf;
     if (reductions.size() == check_reduction)
       solutionLogging("After solving presolved LP");
     */

--- a/highs/presolve/HighsPostsolveStack.h
+++ b/highs/presolve/HighsPostsolveStack.h
@@ -265,50 +265,50 @@ class HighsPostsolveStack {
 
   std::string presolveTypeToString(const ReductionType& type) const {
     switch (type) {
-    case ReductionType::kLinearTransform: {
-      return "Linear transform";
-    }
-    case ReductionType::kFreeColSubstitution: {
-      return "Free col substitution";
-    }
-    case ReductionType::kDoubletonEquation: {
-      return "Doubleton equation";
-    }
-    case ReductionType::kEqualityRowAddition: {
-      return "Equality row addition";
-    }
-    case ReductionType::kEqualityRowAdditions: {
-      return "Equality row additions";
-    }
-    case ReductionType::kSingletonRow: {
-      return "Singleton row";
-    }
-    case ReductionType::kFixedCol: {
-      return "Fixed col";
-    }
-    case ReductionType::kRedundantRow: {
-      return "Redundant Row";
-    }
-    case ReductionType::kForcingRow: {
-      return "Forcing row";
-    }
-    case ReductionType::kForcingColumn: {
-      return "Forcing column";
-    }
-    case ReductionType::kForcingColumnRemovedRow: {
-      return "Forcing column removed row";
-    }
-    case ReductionType::kDuplicateRow: {
-      return "Duplicate row";
-    }
-    case ReductionType::kDuplicateColumn: {
-      return "Duplicate column";
-    }
-    case ReductionType::kSlackColSubstitution: {
-      return "Slack col substitution";
-    }
-    default:
-      return "Unknown";
+      case ReductionType::kLinearTransform: {
+        return "Linear transform";
+      }
+      case ReductionType::kFreeColSubstitution: {
+        return "Free col substitution";
+      }
+      case ReductionType::kDoubletonEquation: {
+        return "Doubleton equation";
+      }
+      case ReductionType::kEqualityRowAddition: {
+        return "Equality row addition";
+      }
+      case ReductionType::kEqualityRowAdditions: {
+        return "Equality row additions";
+      }
+      case ReductionType::kSingletonRow: {
+        return "Singleton row";
+      }
+      case ReductionType::kFixedCol: {
+        return "Fixed col";
+      }
+      case ReductionType::kRedundantRow: {
+        return "Redundant Row";
+      }
+      case ReductionType::kForcingRow: {
+        return "Forcing row";
+      }
+      case ReductionType::kForcingColumn: {
+        return "Forcing column";
+      }
+      case ReductionType::kForcingColumnRemovedRow: {
+        return "Forcing column removed row";
+      }
+      case ReductionType::kDuplicateRow: {
+        return "Duplicate row";
+      }
+      case ReductionType::kDuplicateColumn: {
+        return "Duplicate column";
+      }
+      case ReductionType::kSlackColSubstitution: {
+        return "Slack col substitution";
+      }
+      default:
+        return "Unknown";
     }
   }
 
@@ -327,8 +327,11 @@ class HighsPostsolveStack {
     return origColIndex[col];
   }
 
-  HighsInt getPresolvedIndex(const HighsInt original_index, const std::vector<HighsInt>& original_indices) const {
-    auto it = std::find(original_indices.begin(), original_indices.end(), original_index);
+  HighsInt getPresolvedIndex(
+      const HighsInt original_index,
+      const std::vector<HighsInt>& original_indices) const {
+    auto it = std::find(original_indices.begin(), original_indices.end(),
+                        original_index);
     // If found, calculate the index by subtracting the base iterator
     if (it != original_indices.end()) {
       HighsInt presolved_index = it - original_indices.begin();
@@ -753,24 +756,26 @@ class HighsPostsolveStack {
     auto solutionLogging = [&](const std::string& message) {
       printf("\n%s\n", message.c_str());
       for (HighsInt iCol = 0; iCol < origNumCol; iCol++) {
-	ss.str(std::string());
-	ss << highsFormatToString("Col %9d value = %11.4g",
-               int(iCol), solution.col_value[iCol]);
-	if (perform_dual_postsolve)
-	  ss << highsFormatToString("; dual = %11.4g;", solution.col_dual[iCol]);
-	if (perform_basis_postsolve)
-	  ss << highsFormatToString("; status = %s",
-				    utilBasisStatusToString(basis.col_status[iCol]).c_str());
-	printf("%s\n", ss.str().c_str());
-	/*	
+        ss.str(std::string());
+        ss << highsFormatToString("Col %9d value = %11.4g", int(iCol),
+                                  solution.col_value[iCol]);
+        if (perform_dual_postsolve)
+          ss << highsFormatToString("; dual = %11.4g;",
+                                    solution.col_dual[iCol]);
+        if (perform_basis_postsolve)
+          ss << highsFormatToString(
+              "; status = %s",
+              utilBasisStatusToString(basis.col_status[iCol]).c_str());
+        printf("%s\n", ss.str().c_str());
+        /*
       for (HighsInt iRow = 0; iRow < origNumRow; iRow++)
         printf("Row %9d value = %11.4g; dual = %11.4g; status = %s\n",
                int(iRow), solution.row_value[iRow], solution.row_dual[iRow],
                utilBasisStatusToString(basis.row_status[iRow]).c_str());
-	       highsFprintfString(file, log_options, ss.str());
-	*/
+               highsFprintfString(file, log_options, ss.str());
+        */
       }
-   };
+    };
 
     // Initialise to illegal values so that initial values are logged
     size_t check_reduction = -kHighsIInf;
@@ -780,7 +785,7 @@ class HighsPostsolveStack {
 
     auto reportColLogging = [&](const HighsInt reduction) {
       assert(report_col >= 0);
-      if (static_cast<size_t>(report_col) >=  solution.col_value.size()) return;
+      if (static_cast<size_t>(report_col) >= solution.col_value.size()) return;
       double col_value = solution.col_value[report_col];
       double col_dual = solution.dual_valid ? solution.col_dual[report_col] : 0;
       HighsBasisStatus col_status = basis.valid ? basis.col_status[report_col]
@@ -789,9 +794,10 @@ class HighsPostsolveStack {
       if (solution.dual_valid) report = report || col_dual != report_col_dual;
       if (basis.valid) report = report || col_status != report_col_status;
       if (reduction >= 0) {
-	ReductionType type = reductions[reduction].first;
+        ReductionType type = reductions[reduction].first;
         if (report)
-          printf("After reduction %9d (type %s):", int(reduction), presolveTypeToString(type).c_str());
+          printf("After reduction %9d (type %s):", int(reduction),
+                 presolveTypeToString(type).c_str());
       } else if (reduction == -1) {
         report = true;
         printf("Before undo:                        ");

--- a/highs/presolve/HighsPostsolveStack.h
+++ b/highs/presolve/HighsPostsolveStack.h
@@ -751,8 +751,11 @@ class HighsPostsolveStack {
                            HighsBasisStatus::kNonbasic);
     }
 
+    /*
+    // Code for logging when debugging
     std::stringstream ss;
 
+    // Lambda for logging the whole solution
     auto solutionLogging = [&](const std::string& message) {
       printf("\n%s\n", message.c_str());
       for (HighsInt iCol = 0; iCol < origNumCol; iCol++) {
@@ -763,36 +766,33 @@ class HighsPostsolveStack {
           ss << highsFormatToString("; dual = %11.4g;",
                                     solution.col_dual[iCol]);
         if (perform_basis_postsolve)
-          ss << highsFormatToString(
-              "; status = %s",
-              utilBasisStatusToString(basis.col_status[iCol]).c_str());
+          ss << highsFormatToString("; status = %s",
+				    utilBasisStatusToString(basis.col_status[iCol]).c_str());
         printf("%s\n", ss.str().c_str());
-        /*
-      for (HighsInt iRow = 0; iRow < origNumRow; iRow++)
-        printf("Row %9d value = %11.4g; dual = %11.4g; status = %s\n",
-               int(iRow), solution.row_value[iRow], solution.row_dual[iRow],
-               utilBasisStatusToString(basis.row_status[iRow]).c_str());
-               highsFprintfString(file, log_options, ss.str());
-        */
+      }
+      for (HighsInt iRow = 0; iRow < origNumRow; iRow++) {
+        ss.str(std::string());
+	ss << highsFormatToString("Row %9d value = %11.4g", int(iRow),
+				  solution.row_value[iRow]);
+	if (perform_dual_postsolve)
+	  ss << highsFormatToString("; dual = %11.4g;",
+				    solution.row_dual[iRow]);
+	if (perform_basis_postsolve)
+	  ss << highsFormatToString("; status = %s",
+				    utilBasisStatusToString(basis.row_status[iRow]).c_str());
+        printf("%s\n", ss.str().c_str());
       }
     };
 
     // Initialise to illegal values so that initial values are logged
-    size_t check_reduction = -kHighsIInf;
     double report_col_value = kHighsInf;
-    double report_col_dual = kHighsInf;
-    HighsBasisStatus report_col_status = HighsBasisStatus::kNonbasic;
 
+    // Lambda for logging the solution for a specific column whenever its value changes
     auto reportColLogging = [&](const HighsInt reduction) {
       assert(report_col >= 0);
       if (static_cast<size_t>(report_col) >= solution.col_value.size()) return;
       double col_value = solution.col_value[report_col];
-      double col_dual = solution.dual_valid ? solution.col_dual[report_col] : 0;
-      HighsBasisStatus col_status = basis.valid ? basis.col_status[report_col]
-                                                : HighsBasisStatus::kNonbasic;
       bool report = col_value != report_col_value;
-      if (solution.dual_valid) report = report || col_dual != report_col_dual;
-      if (basis.valid) report = report || col_status != report_col_status;
       if (reduction >= 0) {
         ReductionType type = reductions[reduction].first;
         if (report)
@@ -806,19 +806,26 @@ class HighsPostsolveStack {
         printf("After last reduction:               ");
       }
       if (!report) return;
-      printf(" Col %7d value = %11.4g", int(report_col), col_value);
-      if (solution.dual_valid) printf(", dual = %11.4g", col_dual);
-      if (basis.valid)
-        printf(" status = %s", utilBasisStatusToString(col_status).c_str());
-      printf("\n");
+      ss.str(std::string());
+      ss << highsFormatToString(" Col %7d value = %11.4g",
+				int(report_col), col_value);
+      if (perform_dual_postsolve)
+	ss << highsFormatToString(", dual = %11.4g",
+				  solution.col_dual[report_col]);
+      if (perform_basis_postsolve)
+	ss << highsFormatToString(" status = %s",
+				  utilBasisStatusToString(basis.col_status[report_col]).c_str());
+      printf("%s\n", ss.str().c_str());
       report_col_value = col_value;
-      report_col_dual = col_dual;
-      report_col_status = col_status;
     };
+
     if (report_col >= 0) reportColLogging(-1);
+
+    size_t check_reduction = -kHighsIInf;
     if (reductions.size() == check_reduction)
       solutionLogging("After solving presolved LP");
-
+    */
+    
     // now undo the changes
     for (size_t i = reductions.size(); i > 0; --i) {
       /*
@@ -928,9 +935,9 @@ class HighsPostsolveStack {
                  int(reductions[i - 1].first));
           if (kAllowDeveloperAssert) assert(1 == 0);
       }
-      if (report_col >= 0) reportColLogging(i - 1);
+      //      if (report_col >= 0) reportColLogging(i - 1);
     }
-    if (report_col >= 0) reportColLogging(-2);
+    //    if (report_col >= 0) reportColLogging(-2);
 
 #ifdef DEBUG_EXTRA
     // solution should not contain NaN or Inf
@@ -954,19 +961,6 @@ class HighsPostsolveStack {
     solution.dual_valid = false;
     undo(options, solution, basis, report_col, thread_safe);
   }
-
-  /*
-    // Not used
-  /// undo presolve steps for primal and dual solution
-  void undoPrimalDual(const HighsOptions& options, HighsSolution& solution) {
-    reductionValues.resetPosition();
-    HighsBasis basis;
-    basis.valid = false;
-    assert(solution.value_valid);
-    assert(solution.dual_valid);
-    undo(options, solution, basis);
-  }
-  */
 
   // Only used for debugging
   void undoUntil(const HighsOptions& options, HighsSolution& solution,

--- a/highs/presolve/HighsPostsolveStack.h
+++ b/highs/presolve/HighsPostsolveStack.h
@@ -767,19 +767,19 @@ class HighsPostsolveStack {
                                     solution.col_dual[iCol]);
         if (perform_basis_postsolve)
           ss << highsFormatToString("; status = %s",
-				    utilBasisStatusToString(basis.col_status[iCol]).c_str());
+                                    utilBasisStatusToString(basis.col_status[iCol]).c_str());
         printf("%s\n", ss.str().c_str());
       }
       for (HighsInt iRow = 0; iRow < origNumRow; iRow++) {
         ss.str(std::string());
-	ss << highsFormatToString("Row %9d value = %11.4g", int(iRow),
-				  solution.row_value[iRow]);
-	if (perform_dual_postsolve)
-	  ss << highsFormatToString("; dual = %11.4g;",
-				    solution.row_dual[iRow]);
-	if (perform_basis_postsolve)
-	  ss << highsFormatToString("; status = %s",
-				    utilBasisStatusToString(basis.row_status[iRow]).c_str());
+        ss << highsFormatToString("Row %9d value = %11.4g", int(iRow),
+                                  solution.row_value[iRow]);
+        if (perform_dual_postsolve)
+          ss << highsFormatToString("; dual = %11.4g;",
+                                    solution.row_dual[iRow]);
+        if (perform_basis_postsolve)
+          ss << highsFormatToString("; status = %s",
+                                    utilBasisStatusToString(basis.row_status[iRow]).c_str());
         printf("%s\n", ss.str().c_str());
       }
     };
@@ -787,8 +787,8 @@ class HighsPostsolveStack {
     // Initialise to illegal values so that initial values are logged
     double report_col_value = kHighsInf;
 
-    // Lambda for logging the solution for a specific column whenever its value changes
-    auto reportColLogging = [&](const HighsInt reduction) {
+    // Lambda for logging the solution for a specific column whenever its value
+    changes auto reportColLogging = [&](const HighsInt reduction) {
       assert(report_col >= 0);
       if (static_cast<size_t>(report_col) >= solution.col_value.size()) return;
       double col_value = solution.col_value[report_col];
@@ -808,13 +808,13 @@ class HighsPostsolveStack {
       if (!report) return;
       ss.str(std::string());
       ss << highsFormatToString(" Col %7d value = %11.4g",
-				int(report_col), col_value);
+                                int(report_col), col_value);
       if (perform_dual_postsolve)
-	ss << highsFormatToString(", dual = %11.4g",
-				  solution.col_dual[report_col]);
+        ss << highsFormatToString(", dual = %11.4g",
+                                  solution.col_dual[report_col]);
       if (perform_basis_postsolve)
-	ss << highsFormatToString(" status = %s",
-				  utilBasisStatusToString(basis.col_status[report_col]).c_str());
+        ss << highsFormatToString(" status = %s",
+                                  utilBasisStatusToString(basis.col_status[report_col]).c_str());
       printf("%s\n", ss.str().c_str());
       report_col_value = col_value;
     };
@@ -825,7 +825,7 @@ class HighsPostsolveStack {
     if (reductions.size() == check_reduction)
       solutionLogging("After solving presolved LP");
     */
-    
+
     // now undo the changes
     for (size_t i = reductions.size(); i > 0; --i) {
       /*


### PR DESCRIPTION
Introduces the struct `MipViolation` to gather data from `HighsMipSolver::solutionFeasible` rather than just `bound_violation_`, `row_violation_`, `integrality_violation_`. This allows more informative logging of "untransformed violations" when `log_dev_level` is positive. 

Introduced `reportOriginalPresolvedCol(report_col, sol);` to log model data (in both the original and presolved problem) about a column `report_col` (when non-negative) before calling `postSolveStack.undoPrimal` in `HighsMipSolverData::transformNewIntegerFeasibleSolution` since model data is unknown in `postSolveStack.undo`.

Introduced `getPresolvedColumnIndex` and `getPresolvedRowIndex` in `HighsPostSolveStack.h` so that the index of a column/row in the presolved model can be determined, allowing the model data for the column/row in the presolved problem to be logged.

Introduced `presolveTypeToString` in `HighsPostSolveStack.h` so that presolve reductions can be logged more clearly. 

Introduced `last_reduction_ ` as a data member of `HighsPresolve` so that calls to `HighsPresolve::checkLimits` following a reduction can be identified, simplifying the task of stopping VScode before the last (error-causing) reduction has been performed. 