### PR TITLE
Fix #3216

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1656,3 +1656,51 @@ TEST_CASE("MIP-equality-clique-fixing", "[highs_test_mip_solver]") {
 
   highs.resetGlobalScheduler(true);
 }
+
+TEST_CASE("MIP-equality-clique-fixing-to-zero", "[highs_test_mip_solver]") {
+  // Same as above but with val=0 clique entries: the active value is 0.
+  // Fixing all but one variable to 1 (inactive) should fix the last to 0.
+  const HighsInt ncols = 5;
+  HighsLp lp;
+  lp.num_col_ = ncols;
+  lp.num_row_ = 0;
+  lp.col_cost_.assign(ncols, 0.0);
+  lp.col_lower_.assign(ncols, 0.0);
+  lp.col_upper_.assign(ncols, 1.0);
+  lp.integrality_.assign(ncols, HighsVarType::kInteger);
+  lp.a_matrix_.start_.assign(ncols + 1, 0);
+
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.passModel(lp);
+
+  HighsCallback callback(&highs);
+  const HighsOptions& options = highs.getOptions();
+  HighsSolution solution;
+  HighsMipSolver mipsolver(callback, options, lp, solution);
+  mipsolver.mipdata_ =
+      std::unique_ptr<HighsMipSolverData>(new HighsMipSolverData(mipsolver));
+  mipsolver.mipdata_->feastol = 1e-6;
+  mipsolver.mipdata_->setupDomainPropagation();
+
+  HighsCliqueTable& cliquetable = mipsolver.mipdata_->cliquetable;
+  HighsDomain& domain = mipsolver.mipdata_->getDomain();
+
+  // Add equality clique with val=0: (1-x0) + (1-x1) + ... + (1-x4) = 1
+  HighsCliqueTable::CliqueVar clique[] = {
+      {0, 0}, {1, 0}, {2, 0}, {3, 0}, {4, 0}};
+  cliquetable.doAddClique(clique, 5, true);
+  cliquetable.setPresolveFlag(true);
+
+  // Fix x0..x3 = 1 via vertexInfeasible (makes their val=0 entry infeasible)
+  for (HighsInt i = 0; i < 4; i++) {
+    domain.fixCol(i, 1.0);
+    cliquetable.vertexInfeasible(domain, i, 0);
+  }
+
+  // The last variable x4 must now be fixed to 0
+  REQUIRE(domain.isFixed(4));
+  REQUIRE(domain.col_upper_[4] == 0.0);
+
+  highs.resetGlobalScheduler(true);
+}

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -2,6 +2,9 @@
 #include "Highs.h"
 #include "SpecialLps.h"
 #include "catch.hpp"
+#include "mip/HighsCliqueTable.h"
+#include "mip/HighsMipSolver.h"
+#include "mip/HighsMipSolverData.h"
 
 const bool dev_run = false;
 const double double_equal_tolerance = 1e-5;
@@ -1602,6 +1605,54 @@ TEST_CASE("issue-3118a", "[highs_test_mip_solver]") {
     REQUIRE(highs.assessPrimalSolution(valid, integral, feasible) ==
             HighsStatus::kOk);
   }
+
+  highs.resetGlobalScheduler(true);
+}
+
+TEST_CASE("MIP-equality-clique-fixing", "[highs_test_mip_solver]") {
+  // Regression test: when an equality clique has all but one variable fixed,
+  // the last active variable must be fixed before the clique is removed.
+  const HighsInt ncols = 5;
+  HighsLp lp;
+  lp.num_col_ = ncols;
+  lp.num_row_ = 0;
+  lp.col_cost_.assign(ncols, 0.0);
+  lp.col_lower_.assign(ncols, 0.0);
+  lp.col_upper_.assign(ncols, 1.0);
+  lp.integrality_.assign(ncols, HighsVarType::kInteger);
+  lp.a_matrix_.start_.assign(ncols + 1, 0);
+
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.passModel(lp);
+
+  HighsCallback callback(&highs);
+  const HighsOptions& options = highs.getOptions();
+  HighsSolution solution;
+  HighsMipSolver mipsolver(callback, options, lp, solution);
+  mipsolver.mipdata_ =
+      std::unique_ptr<HighsMipSolverData>(new HighsMipSolverData(mipsolver));
+  mipsolver.mipdata_->feastol = 1e-6;
+  mipsolver.mipdata_->setupDomainPropagation();
+
+  HighsCliqueTable& cliquetable = mipsolver.mipdata_->cliquetable;
+  HighsDomain& domain = mipsolver.mipdata_->getDomain();
+
+  // Add equality clique: x0 + x1 + x2 + x3 + x4 = 1
+  HighsCliqueTable::CliqueVar clique[] = {
+      {0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}};
+  cliquetable.doAddClique(clique, 5, true);
+  cliquetable.setPresolveFlag(true);
+
+  // Fix x0..x3 = 0 via vertexInfeasible (simulates what cleanupFixed does)
+  for (HighsInt i = 0; i < 4; i++) {
+    domain.fixCol(i, 0.0);
+    cliquetable.vertexInfeasible(domain, i, 1);
+  }
+
+  // The last variable x4 must now be fixed to 1
+  REQUIRE(domain.isFixed(4));
+  REQUIRE(domain.col_lower_[4] == 1.0);
 
   highs.resetGlobalScheduler(true);
 }

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -836,6 +836,17 @@ void HighsCliqueTable::removeClique(HighsInt cliqueid) {
   numEntries -= len;
 }
 
+void HighsCliqueTable::fixLastActiveAndRemove(HighsDomain& globaldom,
+                                              HighsInt cliqueid) {
+  if (cliques[cliqueid].equality && cliques[cliqueid].numActive() == 1)
+    for (HighsInt i = cliques[cliqueid].start; i != cliques[cliqueid].end; ++i)
+      if (!globaldom.isFixed(cliqueentries[i].col)) {
+        fixCol(globaldom, cliqueentries[i].complement(), false);
+        break;
+      }
+  removeClique(cliqueid);
+}
+
 void HighsCliqueTable::extractCliques(
     const HighsMipSolver& mipsolver, std::vector<HighsInt>& inds,
     std::vector<double>& vals, std::vector<int8_t>& complementation, double rhs,
@@ -1519,7 +1530,8 @@ void HighsCliqueTable::processInfeasibleVertices(HighsDomain& globaldom) {
       // may be found by probing and will be deleted upon rebuild anyways
       vHashLists.for_each([&](HighsInt cliqueid) {
         cliques[cliqueid].numZeroFixed += 1;
-        if (cliques[cliqueid].numActive() <= 1) removeClique(cliqueid);
+        if (cliques[cliqueid].numActive() <= 1)
+          fixLastActiveAndRemove(globaldom, cliqueid);
       });
       continue;
     }
@@ -1534,7 +1546,7 @@ void HighsCliqueTable::processInfeasibleVertices(HighsDomain& globaldom) {
 
       cliques[cliqueid].numZeroFixed += 1;
       if (cliques[cliqueid].numActive() <= 1) {
-        removeClique(cliqueid);
+        fixLastActiveAndRemove(globaldom, cliqueid);
       } else if (cliques[cliqueid].numZeroFixed >=
                  std::max(
                      HighsInt{10},

--- a/highs/mip/HighsCliqueTable.h
+++ b/highs/mip/HighsCliqueTable.h
@@ -210,6 +210,8 @@ class HighsCliqueTable {
 
   void removeClique(HighsInt cliqueid);
 
+  void fixLastActiveAndRemove(HighsDomain& globaldom, HighsInt cliqueid);
+
   void resolveSubstitution(CliqueVar& v) const;
 
   void resolveSubstitution(HighsInt& col, double& val, double& rhs) const;

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1708,7 +1708,10 @@ HPresolve::Result HPresolve::finaliseProbing(
       if (newLowerBnd) numBndsTightened++;
       if (newUpperBnd) numBndsTightened++;
     }
-    HPRESOLVE_CHECKED_CALL(checkLimits(postsolve_stack));
+    // Do not check limits here: rows have already been deleted by the
+    // clique table above without postsolve entries, relying on all
+    // column fixings being applied to justify their redundancy.
+    // HPRESOLVE_CHECKED_CALL(checkLimits(postsolve_stack));
   }
 
   // finally apply substitutions


### PR DESCRIPTION
Fix #3216 
- Correctly fix last non-fixed entry in equality cliques.
- Do not exit early when making bound modifications in `HPresolve::finaliseProbing`.
- Added a unit test.