### PR TITLE
Fix traininstance6 bug

### DIFF
--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1107,16 +1107,16 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
   for (HighsInt i = 0; i != len; ++i) {
     if (mipsolver.isColContinuous(inds[i])) continue;
 
-    double boundVal = static_cast<double>((rhs - minact) / vals[i]);
+    HighsCDouble impliedBound = (rhs - minact) / vals[i];
     if (vals[i] > 0) {
-      boundVal = std::floor(boundVal + globaldom.col_lower_[inds[i]] +
-                            globaldom.feastol());
+      const double boundVal = std::floor(static_cast<double>(
+          impliedBound + globaldom.col_lower_[inds[i]] + globaldom.feastol()));
       globaldom.changeBound(HighsBoundType::kUpper, inds[i], boundVal,
                             HighsDomain::Reason::unspecified());
       if (globaldom.infeasible()) return;
     } else {
-      boundVal = std::ceil(boundVal + globaldom.col_upper_[inds[i]] -
-                           globaldom.feastol());
+      const double boundVal = std::ceil(static_cast<double>(
+          impliedBound + globaldom.col_upper_[inds[i]] - globaldom.feastol()));
       globaldom.changeBound(HighsBoundType::kLower, inds[i], boundVal,
                             HighsDomain::Reason::unspecified());
       if (globaldom.infeasible()) return;
@@ -1147,10 +1147,9 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
         if (globaldom.isFixed(col)) continue;
 
         if (vals[perm[j]] > 0) {
-          double implcolub =
-              static_cast<double>(impliedActivity +
-                                  vals[perm[j]] * globaldom.col_lower_[col]) /
-              vals[perm[j]];
+          double implcolub = static_cast<double>(
+              (impliedActivity + vals[perm[j]] * globaldom.col_lower_[col]) /
+              vals[perm[j]]);
           if (mipsolver.isColIntegral(col))
             implcolub = std::floor(implcolub + mipsolver.mipdata_->feastol);
 
@@ -1173,10 +1172,9 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
             implics.addVUB(col, bincol, coef, constant);
           }
         } else {
-          double implcollb =
-              static_cast<double>(impliedActivity +
-                                  vals[perm[j]] * globaldom.col_upper_[col]) /
-              vals[perm[j]];
+          double implcollb = static_cast<double>(
+              (impliedActivity + vals[perm[j]] * globaldom.col_upper_[col]) /
+              vals[perm[j]]);
           if (mipsolver.isColIntegral(col))
             implcollb = std::ceil(implcollb - mipsolver.mipdata_->feastol);
 

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1109,7 +1109,7 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
 
     HighsCDouble impliedBound = (rhs - minact) / vals[i];
     const double boundTol =
-        std::max(globaldom.feastol(), 1e-10 / std::abs(vals[i]));
+        std::max(globaldom.feastol(), globaldom.epsilon() / std::abs(vals[i]));
     if (vals[i] > 0) {
       const double boundVal = std::floor(static_cast<double>(
           impliedBound + globaldom.col_lower_[inds[i]] + boundTol));

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1108,8 +1108,8 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
     if (mipsolver.isColContinuous(inds[i])) continue;
 
     HighsCDouble impliedBound = (rhs - minact) / vals[i];
-    const double boundTol = std::max(
-        globaldom.feastol(), mipsolver.mipdata_->epsilon / std::abs(vals[i]));
+    const double boundTol =
+        std::max(globaldom.feastol(), 1e-10 / std::abs(vals[i]));
     if (vals[i] > 0) {
       const double boundVal = std::floor(static_cast<double>(
           impliedBound + globaldom.col_lower_[inds[i]] + boundTol));

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1108,15 +1108,17 @@ void HighsCliqueTable::extractCliquesFromCut(const HighsMipSolver& mipsolver,
     if (mipsolver.isColContinuous(inds[i])) continue;
 
     HighsCDouble impliedBound = (rhs - minact) / vals[i];
+    const double boundTol = std::max(
+        globaldom.feastol(), mipsolver.mipdata_->epsilon / std::abs(vals[i]));
     if (vals[i] > 0) {
       const double boundVal = std::floor(static_cast<double>(
-          impliedBound + globaldom.col_lower_[inds[i]] + globaldom.feastol()));
+          impliedBound + globaldom.col_lower_[inds[i]] + boundTol));
       globaldom.changeBound(HighsBoundType::kUpper, inds[i], boundVal,
                             HighsDomain::Reason::unspecified());
       if (globaldom.infeasible()) return;
     } else {
       const double boundVal = std::ceil(static_cast<double>(
-          impliedBound + globaldom.col_upper_[inds[i]] - globaldom.feastol()));
+          impliedBound + globaldom.col_upper_[inds[i]] - boundTol));
       globaldom.changeBound(HighsBoundType::kLower, inds[i], boundVal,
                             HighsDomain::Reason::unspecified());
       if (globaldom.infeasible()) return;

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -66,8 +66,7 @@ static inline double boundRange(double upper_bound, double lower_bound,
                       : tolerance);
 }
 
-bool HighsDomain::termIsZero(double val, double lb, double ub,
-                                    double epsilon) {
+bool HighsDomain::termIsZero(double val, double lb, double ub, double epsilon) {
   const double absVal = std::abs(val);
   if (absVal <= std::numeric_limits<double>::min()) return true;
   return absVal <= epsilon &&

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -66,6 +66,14 @@ static inline double boundRange(double upper_bound, double lower_bound,
                       : tolerance);
 }
 
+bool HighsDomain::termIsZero(double val, double lb, double ub,
+                                    double epsilon) {
+  const double absVal = std::abs(val);
+  if (absVal <= std::numeric_limits<double>::min()) return true;
+  return absVal <= epsilon &&
+         absVal * std::max(std::abs(lb), std::abs(ub)) <= epsilon;
+}
+
 HighsDomain::HighsDomain(HighsMipSolver& mipsolver) : mipsolver(&mipsolver) {
   col_lower_ = mipsolver.model_->col_lower_;
   col_upper_ = mipsolver.model_->col_upper_;

--- a/highs/mip/HighsDomain.h
+++ b/highs/mip/HighsDomain.h
@@ -417,6 +417,8 @@ class HighsDomain {
     return *this;
   }
 
+  static bool termIsZero(double val, double lb, double ub, double epsilon);
+
   void computeMinActivity(HighsInt start, HighsInt end, const HighsInt* ARindex,
                           const double* ARvalue, HighsInt& ninfmin,
                           HighsCDouble& activitymin) const;

--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -971,10 +971,10 @@ void HighsLpRelaxation::storeDualInfProof() {
       continue;
     else if (weight > 0) {
       if (lp.row_upper_[iRow] == kHighsInf) continue;
-      upper += weight * lp.row_upper_[iRow];
+      upper += static_cast<HighsCDouble>(weight) * lp.row_upper_[iRow];
     } else {
       if (lp.row_lower_[iRow] == -kHighsInf) continue;
-      upper += weight * lp.row_lower_[iRow];
+      upper += static_cast<HighsCDouble>(weight) * lp.row_lower_[iRow];
     }
 
     HighsInt len;
@@ -982,7 +982,8 @@ void HighsLpRelaxation::storeDualInfProof() {
     const double* vals;
     getRow(iRow, len, inds, vals);
 
-    for (HighsInt j = 0; j < len; ++j) row_ap.add(inds[j], weight * vals[j]);
+    for (HighsInt j = 0; j < len; ++j)
+      row_ap.add(inds[j], static_cast<HighsCDouble>(weight) * vals[j]);
   }
 
   const HighsDomain& globaldomain =

--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -877,7 +877,10 @@ bool HighsLpRelaxation::computeDualProof(const HighsDomain& globaldomain,
 
     double val = double(exactVal);
 
-    if (std::fabs(val) <= mipsolver.options_mip_->small_matrix_value) continue;
+    if (HighsDomain::termIsZero(val, globaldomain.col_lower_[i],
+                                globaldomain.col_upper_[i],
+                                mipsolver.mipdata_->epsilon))
+      continue;
 
     bool removeValue = std::fabs(val) <= mipsolver.mipdata_->feastol;
 
@@ -989,6 +992,11 @@ void HighsLpRelaxation::storeDualInfProof() {
 
   for (HighsInt i : row_ap.getNonzeros()) {
     double val = row_ap.getValue(i);
+
+    if (HighsDomain::termIsZero(val, globaldomain.col_lower_[i],
+                                globaldomain.col_upper_[i],
+                                mipsolver.mipdata_->epsilon))
+      continue;
 
     bool removeValue = std::abs(val) <= mipsolver.mipdata_->feastol;
 

--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -867,15 +867,15 @@ bool HighsLpRelaxation::computeDualProof(const HighsDomain& globaldomain,
     HighsInt start = lp.a_matrix_.start_[i];
     HighsInt end = lp.a_matrix_.start_[i + 1];
 
-    HighsCDouble sum = lp.col_cost_[i];
+    HighsCDouble exactVal = lp.col_cost_[i];
 
     for (HighsInt j = start; j != end; ++j) {
       if (row_dual[lp.a_matrix_.index_[j]] == 0) continue;
       // @FlipRowDual += became -=
-      sum -= lp.a_matrix_.value_[j] * row_dual[lp.a_matrix_.index_[j]];
+      exactVal -= lp.a_matrix_.value_[j] * row_dual[lp.a_matrix_.index_[j]];
     }
 
-    double val = double(sum);
+    double val = double(exactVal);
 
     if (std::fabs(val) <= mipsolver.options_mip_->small_matrix_value) continue;
 
@@ -897,11 +897,11 @@ bool HighsLpRelaxation::computeDualProof(const HighsDomain& globaldomain,
     if (removeValue) {
       if (val < 0) {
         if (globaldomain.col_upper_[i] == kHighsInf) return false;
-        upper -= val * globaldomain.col_upper_[i];
+        upper -= exactVal * globaldomain.col_upper_[i];
       } else {
         if (globaldomain.col_lower_[i] == -kHighsInf) return false;
 
-        upper -= val * globaldomain.col_lower_[i];
+        upper -= exactVal * globaldomain.col_lower_[i];
       }
 
       continue;
@@ -990,7 +990,10 @@ void HighsLpRelaxation::storeDualInfProof() {
   for (HighsInt i : row_ap.getNonzeros()) {
     double val = row_ap.getValue(i);
 
-    if (std::fabs(val) <= mipsolver.mipdata_->epsilon) continue;
+    if (std::fabs(val) <= mipsolver.mipdata_->epsilon &&
+        ((val < 0 && globaldomain.col_upper_[i] <= 0) ||
+         (val > 0 && globaldomain.col_lower_[i] >= 0)))
+      continue;
 
     bool removeValue = std::abs(val) <= mipsolver.mipdata_->feastol;
 
@@ -1013,13 +1016,13 @@ void HighsLpRelaxation::storeDualInfProof() {
           hasdualproof = false;
           return;
         }
-        upper -= val * globaldomain.col_upper_[i];
+        upper -= val * static_cast<HighsCDouble>(globaldomain.col_upper_[i]);
       } else {
         if (globaldomain.col_lower_[i] == -kHighsInf) {
           hasdualproof = false;
           return;
         }
-        upper -= val * globaldomain.col_lower_[i];
+        upper -= val * static_cast<HighsCDouble>(globaldomain.col_lower_[i]);
       }
 
       continue;

--- a/highs/mip/HighsLpRelaxation.cpp
+++ b/highs/mip/HighsLpRelaxation.cpp
@@ -990,11 +990,6 @@ void HighsLpRelaxation::storeDualInfProof() {
   for (HighsInt i : row_ap.getNonzeros()) {
     double val = row_ap.getValue(i);
 
-    if (std::fabs(val) <= mipsolver.mipdata_->epsilon &&
-        ((val < 0 && globaldomain.col_upper_[i] <= 0) ||
-         (val > 0 && globaldomain.col_lower_[i] >= 0)))
-      continue;
-
     bool removeValue = std::abs(val) <= mipsolver.mipdata_->feastol;
 
     if (!removeValue &&

--- a/highs/mip/HighsTransformedLp.cpp
+++ b/highs/mip/HighsTransformedLp.cpp
@@ -340,7 +340,9 @@ bool HighsTransformedLp::transform(std::vector<double>& vals,
 
     double maxError = 0.0;
     auto IsZero = [&](HighsInt col, double val) {
-      if (std::abs(val) <= mip.options_mip_->small_matrix_value) return true;
+      if (HighsDomain::termIsZero(val, getLb(col), getUb(col),
+                                  mip.mipdata_->epsilon))
+        return true;
       return false;
     };
 
@@ -527,8 +529,11 @@ bool HighsTransformedLp::untransform(std::vector<double>& vals,
     bool abort = false;
     auto IsZero = [&](HighsInt col, double val) {
       assert(col < mip.numCol());
+      if (HighsDomain::termIsZero(val, globaldom_.col_lower_[col],
+                                  globaldom_.col_upper_[col],
+                                  mip.mipdata_->epsilon))
+        return true;
       double absval = std::abs(val);
-      if (absval <= mip.options_mip_->small_matrix_value) return true;
 
       if (absval <= mip.mipdata_->feastol) {
         if (val > 0) {


### PR DESCRIPTION
## Description

I occasionally get fails on `traininstance6` and `traininstance2` from MIPLIB, and I believe I finally tracked the issue down! In `computeDualProof` and `storeDualInfProof`, terms with a coefficient `<= epsilon` are zeroed out (not relaxed out), which can potentially strengthen the inequality past the point of feasibility. This specifically happens if (1) there's a lot of terms or (2) some of the columns have large bounds. I've then upgraded all the accumulating terms to `HighsCDouble` and added a new check for zero-ing out terms that `val * max(abs(lb), abs(ub)) <= epsilon`, i.e., no binaries have a behavioural change. (The isolated bug actually only required the `HighsCDouble`, but I followed the rabbit-hole for the larger terms first, and I believe the code's better with the change).

I also tried to fix Problem 4 from #2874 while doing this. The issue there is that a cut is potentially scaled by `1e-6` purely for the purpose of trying to extract domain changes. This scales any incorrectness in our cuts by too much, so I've increased the feasibility tolerance check whenever `val < 1e-3`.      

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [ ] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

Closes #2874 