### PR TITLE
Make Xcode 26.6 happy. Move HMW destructor to .cpp

### DIFF
--- a/highs/mip/HighsMipWorker.cpp
+++ b/highs/mip/HighsMipWorker.cpp
@@ -35,6 +35,11 @@ HighsMipWorker::HighsMipWorker(const HighsMipSolver& mipsolver,
   sepa_ptr_->setLpRelaxation(lp_);
 }
 
+HighsMipWorker::~HighsMipWorker() {
+  search_ptr_.reset();
+  sepa_ptr_.reset();
+}
+
 const HighsMipSolver& HighsMipWorker::getMipSolver() const {
   return mipsolver_;
 }

--- a/highs/mip/HighsMipWorker.h
+++ b/highs/mip/HighsMipWorker.h
@@ -87,10 +87,7 @@ class HighsMipWorker {
                  HighsDomain* domain, HighsCutPool* cutpool,
                  HighsConflictPool* conflictpool, HighsPseudocost* pseudocost);
 
-  ~HighsMipWorker() {
-    search_ptr_.reset();
-    sepa_ptr_.reset();
-  }
+  ~HighsMipWorker();
 
   void resetSearch();
 


### PR DESCRIPTION
## Description

Moves `HighsMipWorker` destructor from `HighsMipWorker.h` to `HighsMipWorker.cpp`. Destroying the `std::unique_pointer` to `HighsSearch` apparently needs more than a forward declaration for `Xcode 26.6`.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

Closes #3227 