### PR TITLE
Initialize optimal objective value

### DIFF
--- a/check/TestQpOracle.cpp
+++ b/check/TestQpOracle.cpp
@@ -474,7 +474,7 @@ TEST_CASE("hessian-oracle-primal1", "[qp-oracle]") {
                               solution.data()));
     }
   }
-  //  std::remove(write_model_filename.c_str());
+  std::remove(write_model_filename.c_str());
 
   h.resetGlobalScheduler(true);
 }

--- a/check/TestQpOracle.cpp
+++ b/check/TestQpOracle.cpp
@@ -459,7 +459,7 @@ TEST_CASE("hessian-oracle-primal1", "[qp-oracle]") {
   REQUIRE(h.passModel(lp) == HighsStatus::kOk);
   REQUIRE(h.passHessian(lp.num_col_, oracleCallSquareHessian,
                         &square_hessian) == HighsStatus::kOk);
-  double optimal_obective_value;
+  double optimal_obective_value = kHighsInf;
   std::vector<double> solution;
   for (auto& solver : solvers) {
     h.setOptionValue("solver", solver);


### PR DESCRIPTION
<!--
Thank you for contributing to HiGHS!

Please make sure this PR targets the `latest` branch, not `master`.
-->

## Description

<!-- What does this PR change, and why? -->

```
[435 / 496] 9 / 39 tests; Compiling check/TestQpOracle.cpp; 2s processwrapper-sandbox ... (4 actions running)
INFO: From Compiling check/TestQpOracle.cpp:
In file included from check/TestQpOracle.cpp:6:
check/TestQpOracle.cpp: In function 'void C_A_T_C_H_T_E_S_T_4()':
check/TestQpOracle.cpp:472:29: warning: 'optimal_obective_value' may be used uninitialized [-Wmaybe-uninitialized]
  472 |       REQUIRE(valuesRelEqual(h.getObjectiveValue(), optimal_obective_value));
      |               ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check/TestQpOracle.cpp:462:10: note: 'optimal_obective_value' was declared here
  462 |   double optimal_obective_value;
      |          ^~~~~~~~~~~~~~~~~~~~~~
```


## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [ ] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

<!-- Please uncomment if the PR closes a related issue. -->
<!--
## Related issue
Closes #
-->