### PR TITLE
Improved user logging for dependent equations search, and parallel simplex

### DIFF
--- a/docs/src/parallel.md
+++ b/docs/src/parallel.md
@@ -2,9 +2,9 @@
 
 ## Generally
 
-HiGHS currently has limited opportunities for exploiting parallel
+HiGHS has increasing opportunities for exploiting parallel
 computing. When using a CPU, these are currently restricted to the
-dual simplex solver for LP, the factorisation-based interior point solver,
+dual simplex solver for LP, the factorisation-based interior point solver (HiPO),
 and the MIP solver. Details of these and future plans are set out below.
 HiGHS has an implementation of a first order method (PDLP) for solving LPs
 that can exploit the availability of a [GPU](@ref gpu).
@@ -24,10 +24,9 @@ concurrent Highs instances must use the same value of `threads`.
 
 By default, the HiGHS dual simplex solver runs in serial. However, it
 has a variant allowing concurrent processing. This variant is used
-when the [parallel](@ref option-parallel) option is set "on", by
-specifying `--parallel` when running the [executable](@ref executable)
-via the command line, or by setting it via a library call in an
-application.
+when the [parallel](@ref option-parallel) option is set to "on" and
+[simplex\_strategy](@ref option-simplex-strategy) is set to
+`kSimplexStrategyDualTasks` (2) or `kSimplexStrategyDualMulti` (3).
 
 The concurrency used will be the value of
 [simplex\_max\_concurrency](@ref option-simplex-max-concurrency). If

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -7472,10 +7472,10 @@ HPresolve::Result HPresolve::removeDependentEquations(
   factor.setTimeLimit(time_limit);
   // Determine rank deficiency of the equations
   if (!silent)
-    highsLogUser(options->log_options, HighsLogType::kInfo,
-                 "Dependent equations search running with time "
-                 "limit of %.2fs\n",
-                 time_limit);
+    highsLogDev(options->log_options, HighsLogType::kInfo,
+                "   Dependent equations search running with time "
+                "limit of %.2fs\n",
+                time_limit);
   double time_taken = -this->timer->read();
   HighsInt build_return = factor.build();
   time_taken += this->timer->read();
@@ -7494,21 +7494,23 @@ HPresolve::Result HPresolve::removeDependentEquations(
             static_cast<int>(num_variables), static_cast<int>(model->num_col_),
             static_cast<int>(num_nz), static_cast<int>(num_removed_row),
             static_cast<int>(num_removed_nz), time_taken);
-      highsLogUser(options->log_options, HighsLogType::kInfo,
-                   "Dependent equations search terminated after %.3gs due to "
-                   "expected time exceeding limit\n",
-                   time_taken);
+      highsLogUser(
+          options->log_options, HighsLogType::kInfo,
+          "   Dependent equations search terminated after %.3gs due to "
+          "expected time exceeding limit\n",
+          time_taken);
     }
     return returnOk();
   } else {
     double pct_off_timeout =
         1e2 * std::fabs(time_taken - time_limit) / time_limit;
     if (!silent && pct_off_timeout < 1.0)
-      highsLogUser(options->log_options, HighsLogType::kWarning,
-                   "Dependent equations search finished within %.2f%% of limit "
-                   "of %.2fs: "
-                   "risk of non-deterministic behaviour if solve is repeated\n",
-                   pct_off_timeout, time_limit);
+      highsLogUser(
+          options->log_options, HighsLogType::kWarning,
+          "   Dependent equations search finished within %.2f%% of limit "
+          "of %.2fs: "
+          "risk of non-deterministic behaviour if solve is repeated\n",
+          pct_off_timeout, time_limit);
   }
   // build_return as rank_deficiency must be valid
   assert(build_return >= 0);
@@ -7525,26 +7527,35 @@ HPresolve::Result HPresolve::removeDependentEquations(
     }
   }
   if (!silent) {
-    highsLogUser(
-        options->log_options, HighsLogType::kInfo,
-        "Search of %d equation%s with %d / %d variable%s and %d nonzero%s "
-        "removed %d dependent equation%s and %d nonzero%s "
-        "in %.2fs with bounds in (%.2fs, %.2fs) and limit = %.2fs",
-        // clang-format off
-        static_cast<int>(num_equations), highsIntToPlural(num_equations).c_str(),
-        static_cast<int>(num_variables),
-	static_cast<int>(model->num_col_), highsIntToPlural(num_variables).c_str(),
-	static_cast<int>(num_nz), highsIntToPlural(num_nz).c_str(),
-	static_cast<int>(num_removed_row), highsIntToPlural(num_removed_row).c_str(),
-        static_cast<int>(num_removed_nz), highsIntToPlural(num_removed_nz).c_str(),
-        // clang-format on
-        time_taken, factor.min_time_bound_, factor.max_time_bound_, time_limit);
-    if (num_fictitious_rows_skipped)
-      highsLogDev(options->log_options, HighsLogType::kInfo,
-                  ", avoiding %d fictitious row%s",
-                  static_cast<int>(num_fictitious_rows_skipped),
-                  highsIntToPlural(num_fictitious_rows_skipped).c_str());
-    highsLogUser(options->log_options, HighsLogType::kInfo, "\n");
+    std::stringstream ss;
+    ss.str(std::string());
+    ss << highsFormatToString("Dependent equations search");
+    if (options->log_dev_level > 0)
+      ss << highsFormatToString(
+          " with %d / %d variable%s and %d nonzero%s",
+          static_cast<int>(num_variables), static_cast<int>(model->num_col_),
+          highsIntToPlural(num_variables).c_str(), static_cast<int>(num_nz),
+          highsIntToPlural(num_nz).c_str());
+    ss << highsFormatToString(" removed %d equation%s and %d nonzero%s",
+                              static_cast<int>(num_removed_row),
+                              highsIntToPlural(num_removed_row).c_str(),
+                              static_cast<int>(num_removed_nz),
+                              highsIntToPlural(num_removed_nz).c_str());
+    if (options->log_dev_level > 0) {
+      ss << highsFormatToString(" in %.2fs with bounds in (%.2f, %.2f)s",
+                                time_taken, factor.min_time_bound_,
+                                factor.max_time_bound_);
+      if (num_fictitious_rows_skipped)
+        ss << highsFormatToString(
+            ", avoiding %d fictitious row%s",
+            static_cast<int>(num_fictitious_rows_skipped),
+            highsIntToPlural(num_fictitious_rows_skipped).c_str());
+      highsLogDev(options->log_options, HighsLogType::kInfo, "%s\n",
+                  ss.str().c_str());
+    } else {
+      highsLogUser(options->log_options, HighsLogType::kInfo, "%s\n",
+                   ss.str().c_str());
+    }
   }
   return returnOk();
 }

--- a/highs/simplex/HEkk.cpp
+++ b/highs/simplex/HEkk.cpp
@@ -1077,6 +1077,27 @@ HighsStatus HEkk::solve(const bool force_phase2) {
                    simplexStrategyToString(kSimplexStrategyDualMulti).c_str(),
                    int(info_.num_concurrency));
     } else {
+      std::stringstream ss;
+      ss.str(std::string());
+      assert(simplex_strategy == kSimplexStrategyChoose ||
+             simplex_strategy == kSimplexStrategyDual);
+      ss << highsFormatToString(
+          "Choosing to use %s%s",
+          options_->parallel == kHighsOnString ? "serial " : "",
+          simplexStrategyToString(kSimplexStrategyDual).c_str());
+      if (options_->parallel == kHighsOnString) {
+        ss << highsFormatToString(" despite setting parallel = on\n");
+        ss << highsFormatToString(
+            "To force parallel dual simplex, set simplex_strategy to "
+            "kSimplexStrategyDualTasks = %d or (preferably) "
+            "kSimplexStrategyDualMulti = %d\n",
+            kSimplexStrategyDualTasks, kSimplexStrategyDualMulti);
+      }
+      highsLogUser(options_->log_options, HighsLogType::kInfo, "%s\n",
+                   ss.str().c_str());
+
+      printf("HEkk::solve simplex strategy = %d; parallel = %s\n",
+             int(simplex_strategy), options_->parallel.c_str());
       highsLogUser(options_->log_options, HighsLogType::kInfo, "Using %s\n",
                    simplexStrategyToString(kSimplexStrategyDual).c_str());
     }


### PR DESCRIPTION
## Description

Dependent equations search in presolve produced a logging line that is only relevant to developers, so logging has been rationalised so that a simple line is given via `highsLogUser` and the original line is  given via `highsLogDev` (when `log_dev_level > 0`).

Prompted by testing #3233, I realised that we give no explanation why `parallel=on` does not result in parallel dual simplex being run. It used to trigger the use of parallel dual simplex if `simplex_strategy=kSimplexStrategyDual` or `simplex_strategy=kSimplexStrategyChoose`, but now parallel simplex is only used if `simplex_strategy=kSimplexStrategyDualTasks` or  `simplex_strategy=kSimplexStrategyDualMulti`. This is because users will be setting `parallel=on` to get the parallel MIP solver, and we don't want them running parallel dual simplex as a result - since it's less robust and typically is little faster than serial. Hence a logging line has been added to flag up the change in behaviour.

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)