### PR TITLE
Avoid stalling in `HighsRedcostFixing::addRootRedcost`

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1741,3 +1741,44 @@ TEST_CASE("issue-2900", "[highs_test_mip_solver]") {
   solve(highs, kHighsOffString, require_model_status, optimal_objective);
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
 }
+
+TEST_CASE("redcost-fixing-large-bounds", "[highs_test_mip_solver]") {
+  // Regression: addRootRedcost must not stall when an integer variable
+  // has a finite bound exceeding kHighsIInf (e.g. 1e19 > 9.2e18).
+  HighsLp lp;
+  lp.num_col_ = 1;
+  lp.num_row_ = 0;
+  lp.sense_ = ObjSense::kMinimize;
+  lp.offset_ = 0;
+  lp.col_cost_ = {1.0};
+  lp.col_lower_ = {0.0};
+  lp.col_upper_ = {1e19};
+  lp.integrality_ = {HighsVarType::kInteger};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.start_ = {0, 0};
+
+  Highs highs;
+  highs.setOptionValue("output_flag", false);
+  highs.passModel(lp);
+
+  HighsCallback callback(&highs);
+  const HighsOptions& options = highs.getOptions();
+  HighsSolution solution;
+  HighsMipSolver mipsolver(callback, options, lp, solution);
+  mipsolver.mipdata_ =
+      std::unique_ptr<HighsMipSolverData>(new HighsMipSolverData(mipsolver));
+  mipsolver.mipdata_->feastol = 1e-6;
+  mipsolver.mipdata_->lower_bound = 0.0;
+  mipsolver.mipdata_->setupDomainPropagation();
+  mipsolver.mipdata_->integral_cols.push_back(0);
+
+  std::vector<double> lpredcost = {1.0};
+  double lpobjective = 0.0;
+
+  mipsolver.mipdata_->redcostfixing.addRootRedcost(mipsolver, lpredcost,
+                                                   lpobjective);
+
+  auto lurkingBounds = mipsolver.mipdata_->redcostfixing.getLurkingBounds(
+      mipsolver, mipsolver.mipdata_->getDomain());
+  REQUIRE(!lurkingBounds.empty());
+}

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -301,7 +301,7 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
               mipsolver.mipdata_->getDomain().col_lower_[col]),
           static_cast<HighsInt>(
               mipsolver.mipdata_->getDomain().col_upper_[col]),
-          mipsolver.mipdata_->getDomain().col_upper_[col] != kHighsInf,
+          mipsolver.mipdata_->getDomain().col_upper_[col] < kHighsIInf,
           lpobjective, lpredcost[col], maxNumSteps, maxNumStepsExp,
           lurkingColUpper[col], lurkingColLower[col]);
     } else if (lpredcost[col] < -mipsolver.mipdata_->feastol) {
@@ -316,7 +316,7 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
               mipsolver.mipdata_->getDomain().col_upper_[col]),
           static_cast<HighsInt>(
               mipsolver.mipdata_->getDomain().col_lower_[col]),
-          mipsolver.mipdata_->getDomain().col_lower_[col] != -kHighsInf,
+          mipsolver.mipdata_->getDomain().col_lower_[col] > -kHighsIInf,
           lpobjective, lpredcost[col], maxNumSteps, maxNumStepsExp,
           lurkingColLower[col], lurkingColUpper[col]);
     }

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -239,20 +239,20 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
           return;
         }
 
-        HighsInt lastBound;
+        int64_t lastBound;
         if (!isOtherBoundFinite)
-          lastBound = bound + direction * maxNumSteps;
+          lastBound = static_cast<int64_t>(bound) + direction * maxNumSteps;
         else
-          lastBound = otherBound - direction;
+          lastBound = static_cast<int64_t>(otherBound) - direction;
 
-        HighsInt step = 1;
-        HighsInt range = direction * (lastBound - bound);
+        int64_t step = 1;
+        int64_t range = direction * (lastBound - static_cast<int64_t>(bound));
         if (range > maxNumSteps)
           step = (range + maxNumSteps - 1) >> maxNumStepsExp;
         double shift = direction * (1 - 10 * mipsolver.mipdata_->feastol);
         step *= direction;
 
-        for (HighsInt lurkingBound = bound;
+        for (int64_t lurkingBound = bound;
              direction * lurkingBound <= direction * lastBound;
              lurkingBound += step) {
           double fracBound = lurkingBound - bound + shift;

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -289,38 +289,31 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
       };
 
   for (HighsInt col : mipsolver.mipdata_->integral_cols) {
-    if (lpredcost[col] > mipsolver.mipdata_->feastol &&
-        mipsolver.mipdata_->getDomain().col_lower_[col] > -kHighsIInf) {
+    double lb = mipsolver.mipdata_->getDomain().col_lower_[col];
+    double ub = mipsolver.mipdata_->getDomain().col_upper_[col];
+
+    if (lpredcost[col] > mipsolver.mipdata_->feastol && lb > -kHighsIInf) {
       // col <= (cutoffbound - lpobj)/redcost + lb
       // so for lurkub = lb to ub - 1 we can compute the necessary cutoff
       // bound to reach this bound which is:
       //  lurkub = (cutoffbound - lpobj)/redcost + lb
       //  cutoffbound = (lurkub - lb) * redcost + lpobj
-      findLurkingBounds(
-          col, HighsInt{1},
-          static_cast<HighsInt>(
-              mipsolver.mipdata_->getDomain().col_lower_[col]),
-          static_cast<HighsInt>(
-              mipsolver.mipdata_->getDomain().col_upper_[col]),
-          mipsolver.mipdata_->getDomain().col_upper_[col] < kHighsIInf,
-          lpobjective, lpredcost[col], maxNumSteps, maxNumStepsExp,
-          lurkingColUpper[col], lurkingColLower[col]);
+      findLurkingBounds(col, HighsInt{1}, static_cast<HighsInt>(lb),
+                        static_cast<HighsInt>(ub), ub < kHighsIInf, lpobjective,
+                        lpredcost[col], maxNumSteps, maxNumStepsExp,
+                        lurkingColUpper[col], lurkingColLower[col]);
     } else if (lpredcost[col] < -mipsolver.mipdata_->feastol &&
-               mipsolver.mipdata_->getDomain().col_upper_[col] < kHighsIInf) {
+               ub < kHighsIInf) {
       // col >= (cutoffbound - lpobj)/redcost + ub
       // so for lurklb = lb + 1 to ub we can compute the necessary cutoff
       // bound to reach this bound which is:
       //  lurklb = (cutoffbound - lpobj)/redcost + ub
       //  cutoffbound = (lurklb - ub) * redcost + lpobj
-      findLurkingBounds(
-          col, HighsInt{-1},
-          static_cast<HighsInt>(
-              mipsolver.mipdata_->getDomain().col_upper_[col]),
-          static_cast<HighsInt>(
-              mipsolver.mipdata_->getDomain().col_lower_[col]),
-          mipsolver.mipdata_->getDomain().col_lower_[col] > -kHighsIInf,
-          lpobjective, lpredcost[col], maxNumSteps, maxNumStepsExp,
-          lurkingColLower[col], lurkingColUpper[col]);
+      findLurkingBounds(col, HighsInt{-1}, static_cast<HighsInt>(ub),
+                        static_cast<HighsInt>(lb), lb > -kHighsIInf,
+                        lpobjective, lpredcost[col], maxNumSteps,
+                        maxNumStepsExp, lurkingColLower[col],
+                        lurkingColUpper[col]);
     }
   }
 }

--- a/highs/mip/HighsRedcostFixing.cpp
+++ b/highs/mip/HighsRedcostFixing.cpp
@@ -289,7 +289,8 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
       };
 
   for (HighsInt col : mipsolver.mipdata_->integral_cols) {
-    if (lpredcost[col] > mipsolver.mipdata_->feastol) {
+    if (lpredcost[col] > mipsolver.mipdata_->feastol &&
+        mipsolver.mipdata_->getDomain().col_lower_[col] > -kHighsIInf) {
       // col <= (cutoffbound - lpobj)/redcost + lb
       // so for lurkub = lb to ub - 1 we can compute the necessary cutoff
       // bound to reach this bound which is:
@@ -304,7 +305,8 @@ void HighsRedcostFixing::addRootRedcost(const HighsMipSolver& mipsolver,
           mipsolver.mipdata_->getDomain().col_upper_[col] < kHighsIInf,
           lpobjective, lpredcost[col], maxNumSteps, maxNumStepsExp,
           lurkingColUpper[col], lurkingColLower[col]);
-    } else if (lpredcost[col] < -mipsolver.mipdata_->feastol) {
+    } else if (lpredcost[col] < -mipsolver.mipdata_->feastol &&
+               mipsolver.mipdata_->getDomain().col_upper_[col] < kHighsIInf) {
       // col >= (cutoffbound - lpobj)/redcost + ub
       // so for lurklb = lb + 1 to ub we can compute the necessary cutoff
       // bound to reach this bound which is:


### PR DESCRIPTION
<!--
Thank you for contributing to HiGHS!

Please make sure this PR targets the `latest` branch, not `master`.
-->

## Description

<!-- What does this PR change, and why? -->

- Avoid stalling in `HighsRedcostFixing::addRootRedcost` for huge bounds (`>= kHighsIInf`) on integer variables.
- Add a unit test.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

<!-- Please uncomment if the PR closes a related issue. -->
<!--
## Related issue
Closes #
-->