### PR TITLE
Fix highspy test_user_interrupts

### DIFF
--- a/highspy/highspy/highs.py
+++ b/highspy/highspy/highs.py
@@ -219,7 +219,7 @@ class Highs(_Highs):
 
         if solver_thread is not None and interrupt_limit <= 0:
             try:
-                while not result[0]:
+                while result is None or not result[0]:
                     result = self.wait(0.1)
                 return result[1]
 
@@ -230,7 +230,7 @@ class Highs(_Highs):
         elif interrupt_limit > 0:
             for count in range(interrupt_limit):
                 try:
-                    while not result[0]:
+                    while result is None or not result[0]:
                         result = self.wait(0.1)
                     return result[1]
 


### PR DESCRIPTION
<!--
Thank you for contributing to HiGHS!

Please make sure this PR targets the `latest` branch, not `master`.
-->

## Description

`joinSolve`'s wait loops (`while not result[0]: result = self.wait(0.1)`) assume `self.wait()` always returns a `(bool, HighsStatus | None)` tuple. `test_user_interrupts` replaces `wait` with a lambda that raises `SIGINT` to simulate Ctrl+C during a blocking wait, expecting the resulting `KeyboardInterrupt` to propagate out of that call and get caught by the surrounding `except KeyboardInterrupt`. On some platforms/timings the interrupt doesn't propagate synchronously, so the lambda returns `None` instead, and the next loop check crashes with `TypeError: 'NoneType' object is not subscriptable` — matching the trace in #3265.

Guards both wait loops in `joinSolve` against a `None` result (`result is None or not result[0]`) so this keeps polling instead of crashing. Production `wait()` never returns anything but a tuple, so this only affects the race.

<!-- What does this PR change, and why? -->

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [ ] This PR targets the `latest` branch
- [ ] Tests are passing
- [ ] Documentation was updated where relevant
- [ ] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

<!-- Please uncomment if the PR closes a related issue. -->

## Related issue
Closes #3265
