### PR TITLE
Protect large int bounds

### DIFF
--- a/highs/mip/HighsCutGeneration.cpp
+++ b/highs/mip/HighsCutGeneration.cpp
@@ -964,9 +964,9 @@ bool HighsCutGeneration::preprocessBaseInequality(bool& hasUnboundedInts,
     } else {
       if (upper[i] != kHighsInf &&
           std::abs(vals[i] * upper[i]) >
-              feastol / std::numeric_limits<double>::epsilon())
+              1 / std::numeric_limits<double>::epsilon())
         return false;
-      if (upper[i] == kHighsInf) {
+      if (upper[i] >= kHighsIInf) {
         hasUnboundedInts = true;
         hasGeneralInts = true;
       } else if (upper[i] != 1.0) {

--- a/highs/mip/HighsCutGeneration.cpp
+++ b/highs/mip/HighsCutGeneration.cpp
@@ -7,6 +7,8 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 #include "mip/HighsCutGeneration.h"
 
+#include <limits>
+
 #include "../extern/pdqsort/pdqsort.h"
 #include "mip/HighsDomain.h"
 #include "mip/HighsMipSolverData.h"
@@ -960,6 +962,10 @@ bool HighsCutGeneration::preprocessBaseInequality(bool& hasUnboundedInts,
 
       hasContinuous = true;
     } else {
+      if (upper[i] != kHighsInf &&
+          std::abs(vals[i] * upper[i]) >
+              feastol / std::numeric_limits<double>::epsilon())
+        return false;
       if (upper[i] == kHighsInf) {
         hasUnboundedInts = true;
         hasGeneralInts = true;

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -2769,8 +2769,7 @@ bool HighsDomain::ConflictSet::explainBoundChangeGeq(
     const HighsInt* inds, const double* vals, HighsInt len, double rhs,
     double maxAct) {
   if (maxAct == kHighsInf ||
-      std::abs(maxAct) * std::numeric_limits<double>::epsilon() >
-          localdom.feastol())
+      std::abs(maxAct) > 1 / std::numeric_limits<double>::epsilon())
     return false;
 
   // get the coefficient value of the column for which we want to explain
@@ -2884,8 +2883,7 @@ bool HighsDomain::ConflictSet::explainBoundChangeLeq(
     const HighsInt* inds, const double* vals, HighsInt len, double rhs,
     double minAct) {
   if (minAct == -kHighsInf ||
-      std::abs(minAct) * std::numeric_limits<double>::epsilon() >
-          localdom.feastol())
+      std::abs(minAct) > 1 / std::numeric_limits<double>::epsilon())
     return false;
   // get the coefficient value of the column for which we want to explain
   // the bound change
@@ -3394,8 +3392,7 @@ bool HighsDomain::ConflictSet::explainInfeasibilityGeq(const HighsInt* inds,
                                                        HighsInt len, double rhs,
                                                        double maxAct) {
   if (maxAct == kHighsInf ||
-      std::abs(maxAct) * std::numeric_limits<double>::epsilon() >
-          localdom.feastol())
+      std::abs(maxAct) > 1 / std::numeric_limits<double>::epsilon())
     return false;
 
   HighsInt infeasible_pos = kHighsIInf;
@@ -3443,8 +3440,7 @@ bool HighsDomain::ConflictSet::explainInfeasibilityLeq(const HighsInt* inds,
                                                        HighsInt len, double rhs,
                                                        double minAct) {
   if (minAct == -kHighsInf ||
-      std::abs(minAct) * std::numeric_limits<double>::epsilon() >
-          localdom.feastol())
+      std::abs(minAct) > 1 / std::numeric_limits<double>::epsilon())
     return false;
 
   HighsInt infeasible_pos = kHighsIInf;

--- a/highs/mip/HighsDomain.cpp
+++ b/highs/mip/HighsDomain.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <numeric>
 #include <queue>
 
@@ -2767,7 +2768,10 @@ bool HighsDomain::ConflictSet::explainBoundChangeGeq(
     const std::set<LocalDomChg>& currentFrontier, const LocalDomChg& domchg,
     const HighsInt* inds, const double* vals, HighsInt len, double rhs,
     double maxAct) {
-  if (maxAct == kHighsInf) return false;
+  if (maxAct == kHighsInf ||
+      std::abs(maxAct) * std::numeric_limits<double>::epsilon() >
+          localdom.feastol())
+    return false;
 
   // get the coefficient value of the column for which we want to explain
   // the bound change
@@ -2879,7 +2883,10 @@ bool HighsDomain::ConflictSet::explainBoundChangeLeq(
     const std::set<LocalDomChg>& currentFrontier, const LocalDomChg& domchg,
     const HighsInt* inds, const double* vals, HighsInt len, double rhs,
     double minAct) {
-  if (minAct == -kHighsInf) return false;
+  if (minAct == -kHighsInf ||
+      std::abs(minAct) * std::numeric_limits<double>::epsilon() >
+          localdom.feastol())
+    return false;
   // get the coefficient value of the column for which we want to explain
   // the bound change
   double domchgVal = 0;
@@ -3386,7 +3393,10 @@ bool HighsDomain::ConflictSet::explainInfeasibilityGeq(const HighsInt* inds,
                                                        const double* vals,
                                                        HighsInt len, double rhs,
                                                        double maxAct) {
-  if (maxAct == kHighsInf) return false;
+  if (maxAct == kHighsInf ||
+      std::abs(maxAct) * std::numeric_limits<double>::epsilon() >
+          localdom.feastol())
+    return false;
 
   HighsInt infeasible_pos = kHighsIInf;
   if (localdom.infeasible_) infeasible_pos = localdom.infeasible_pos;
@@ -3432,7 +3442,10 @@ bool HighsDomain::ConflictSet::explainInfeasibilityLeq(const HighsInt* inds,
                                                        const double* vals,
                                                        HighsInt len, double rhs,
                                                        double minAct) {
-  if (minAct == -kHighsInf) return false;
+  if (minAct == -kHighsInf ||
+      std::abs(minAct) * std::numeric_limits<double>::epsilon() >
+          localdom.feastol())
+    return false;
 
   HighsInt infeasible_pos = kHighsIInf;
   if (localdom.infeasible_) infeasible_pos = localdom.infeasible_pos;


### PR DESCRIPTION
## Description

This adds two more fixes that are similar to #3241 (problems with large integer bounds). The problematic instance now solves correctly for both `presolve=on` and `presolve=off`. 

Over MIPLIB 2017 three seeds the only affected instance was `glass4` (https://miplib.zib.de/instance_details_glass4.html), which was neutral on seed 0, better on seed 1, and worse on seed 2. Absolutely no overhead was observed anywhere else (technically 0.2% faster, but that can't be anything but noise)

@fwesselm I hope I am using `epsilon()` here correctly.  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)