### PR TITLE
Fix lost integrality

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1826,3 +1826,25 @@ TEST_CASE("pr-3260", "[highs_test_mip_solver]") {
   const double optimal_objective = 0.0;
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
 }
+
+TEST_CASE("pr-3268", "[highs_test_mip_solver]") {
+  HighsLp lp;
+  lp.num_col_ = 5;
+  lp.num_row_ = 3;
+  lp.sense_ = ObjSense::kMaximize;
+  lp.col_cost_ = {0, 0, 0, 0, 0};
+  lp.col_lower_ = {-1, -1, -2, 0, 1};
+  lp.col_upper_ = {kHighsInf, 0, 0, 1, 2};
+  lp.row_lower_ = {-kHighsInf, -4, 2};
+  lp.row_upper_ = {-5, -4, 2};
+  lp.a_matrix_.start_ = {0, 2, 4, 6, 8, 10};
+  lp.a_matrix_.index_ = {1, 2, 0, 1, 0, 1, 0, 2, 1, 2};
+  lp.a_matrix_.value_ = {2, -2, 1, -6, 3, 2, -1, 1, -2, 1};
+  lp.integrality_ = {HighsVarType::kContinuous, HighsVarType::kInteger,
+                     HighsVarType::kInteger, HighsVarType::kInteger,
+                     HighsVarType::kSemiInteger};
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  solve(highs, kHighsOnString, HighsModelStatus::kInfeasible);
+}

--- a/highs/mip/HighsMipSolverData.cpp
+++ b/highs/mip/HighsMipSolverData.cpp
@@ -1190,7 +1190,7 @@ try_again:
   double bound_violation_ = 0;
   double integrality_violation_ = 0;
   double row_violation_ = 0;
-  violation.copy(bound_violation_, integrality_violation_, row_violation_);
+  violation.copy(bound_violation_, row_violation_, integrality_violation_);
   double mipsolver_objective_value = double(mipsolver_quad_objective_value);
   if (!feasible && allow_try_again) {
     // printf(

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -7774,6 +7774,17 @@ HPresolve::Result HPresolve::aggregator(HighsPostsolveStack& postsolve_stack) {
 
 void HPresolve::substitute(HighsInt substcol, HighsInt staycol, double offset,
                            double scale) {
+  // Preserve explicit integrality, i.e., upgrade implied integral
+  // column if it is substituting an integral column
+  if (model->integrality_[substcol] == HighsVarType::kInteger &&
+      model->integrality_[staycol] == HighsVarType::kImplicitInteger) {
+    model->integrality_[staycol] = HighsVarType::kInteger;
+    for (const HighsSliceNonzero& nonzero : getColumnVector(staycol)) {
+      ++rowsizeInteger[nonzero.index()];
+      --rowsizeImplInt[nonzero.index()];
+    }
+  }
+
   // substitute the column in each row where it occurs
   for (HighsInt coliter = colhead[substcol]; coliter != -1;) {
     HighsInt colrow = Arow[coliter];


### PR DESCRIPTION
## Description

This fixes an error where an implied-integral column is used to substitute an integral column and integrality is not preserved, i.e., the column that stays is not upgraded to be integral. This can domino into the implied-integral column losing the conditions that actually enforce its implied integrality, and all subsequent solutions contain integrality violations.
The fix is to check this case in `substitute` and update the staying column's type and appropriate values that track `rowsizeInteger` in advance of the substitution (I hope I caught all of the correct ones). The instance that showed this bug also came from @odow and his LLM fuzzer.

The instance also revealed a second error that was swapping row and integer violation. This looks like a simple typo.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)