### PR TITLE
Make feasibility jump code more robust (Fix #3262)

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1730,6 +1730,33 @@ TEST_CASE("issue-3171", "[highs_test_mip_solver]") {
   solve(highs, kHighsOnString, require_model_status, optimal_objective);
 }
 
+TEST_CASE("issue-3262", "[highs_test_mip_solver]") {
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+
+  HighsLp lp;
+  lp.sense_ = ObjSense::kMinimize;
+  lp.num_col_ = 2;
+  lp.num_row_ = 3;
+  lp.col_lower_ = {-kHighsInf, -kHighsInf};
+  lp.col_upper_ = {kHighsInf, kHighsInf};
+  lp.col_cost_ = {0., 0.};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kContinuous};
+  lp.row_lower_ = {1., -kHighsInf, 1.};
+  lp.row_upper_ = {kHighsInf, 307., kHighsInf};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.start_ = {0, 2, 5};
+  lp.a_matrix_.index_ = {1, 2, 0, 1, 2};
+  lp.a_matrix_.value_ = {-100., 1., -1., 1., -1.};
+
+  highs.passModel(lp);
+  highs.setOptionValue("presolve", "off");
+
+  REQUIRE_NOTHROW(highs.run());
+
+  highs.resetGlobalScheduler(true);
+}
+
 TEST_CASE("issue-2900", "[highs_test_mip_solver]") {
   std::string filename =
       std::string(HIGHS_DIR) + "/check/instances/issue-2900.mps";

--- a/highs/mip/feasibilityjump.hh
+++ b/highs/mip/feasibilityjump.hh
@@ -549,6 +549,9 @@ class FeasibilityJumpSolver {
       if (problem.vars.size() == 0) break;
 
       uint32_t var = selectVariable();
+      if (var == UINT_MAX){
+        break;
+      }
       doVariableMove(var);
     }
 
@@ -603,7 +606,6 @@ class FeasibilityJumpSolver {
           bestVar = varIdx;
         }
       }
-      assert(bestVar != UINT_MAX);
       return bestVar;
     }
 


### PR DESCRIPTION
## Description

This fixes the issue that @odow identified in #3262.

Details:
* The ultimate cause is a move score that eventually hits minus infinity, at which point minus infinity no longer works as "a value less than any value that appears" when taking a maximum.
* This PR fixes a proximate cause (variable index equal to sentinel value). This could occur for other reasons (for example, an empty row), and is a lot easier than fixing the fundamentals of the algorithm (which one way or another we may replace anyhow).
* The new test problem has a slight modification so that the origin isn't feasible. This is just to future-proof the test a bit in case we expand the scope of the trivial heuristics. (At the moment they don't run for this problem [because it contains a continuous variable](https://github.com/ERGO-Code/HiGHS/blob/5a91a74429b2e4feddf929999c07439181863744/highs/mip/HighsMipSolverData.cpp#L272). Any thoughts on this @jajhall?)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

## Related issue
Closes #3262
