### PR TITLE
Reset dual-implied bounds when upgrading equalities

### DIFF
--- a/check/TestPresolve.cpp
+++ b/check/TestPresolve.cpp
@@ -1236,3 +1236,25 @@ TEST_CASE("issue-3140", "[highs_test_presolve]") {
 
   highs.resetGlobalScheduler(true);
 }
+
+TEST_CASE("dual-bound-relaxation-unbounded", "[highs_test_presolve]") {
+  HighsLp lp;
+  lp.num_col_ = 3;
+  lp.num_row_ = 2;
+  lp.col_cost_ = {0, -5, 0};
+  lp.col_lower_ = {0, 0, 0};
+  lp.col_upper_ = {kHighsInf, kHighsInf, 1};
+  lp.row_lower_ = {-kHighsInf, -kHighsInf};
+  lp.row_upper_ = {0, 1};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.start_ = {0, 2, 4, 6};
+  lp.a_matrix_.index_ = {0, 1, 0, 1, 0, 1};
+  lp.a_matrix_.value_ = {1, -1, -1, 1, -1, 1};
+
+  // The feasible ray x0 = x1 = t, x2 = 0 has objective -5*t.
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  REQUIRE(highs.passModel(lp) == HighsStatus::kOk);
+  REQUIRE(highs.run() == HighsStatus::kOk);
+  REQUIRE(highs.getModelStatus() == HighsModelStatus::kUnbounded);
+}

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -3920,7 +3920,18 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
 
   // Convert to equality constraint and record for dual postsolve
   if (!isEquation(row)) {
+    auto resetDependentDualImpliedBounds = [&]() {
+      for (const HighsSliceNonzero& nonzero : getRowVector(row)) {
+        auto& affectedRows = implRowDualSourceByCol[nonzero.index()];
+        for (auto it = affectedRows.begin(); it != affectedRows.end();) {
+          const HighsInt affectedRow = *it++;
+          if (affectedRow != row)
+            resetRowDualImpliedBounds(affectedRow, nonzero.index());
+        }
+      }
+    };
     if (isImpliedEquationAtLower(row)) {
+      if (rowDualLower[row] != -kHighsInf) resetDependentDualImpliedBounds();
       model->row_upper_[row] = model->row_lower_[row];
       postsolve_stack.impliedEquation(row, true, getRowVector(row));
       // Since row upper bound is now finite, lower bound on row dual is
@@ -3930,6 +3941,7 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
         HPRESOLVE_CHECKED_CALL(
             checkRedundantBounds(rowDualLowerSource[row], row));
     } else if (isImpliedEquationAtUpper(row)) {
+      if (rowDualUpper[row] != kHighsInf) resetDependentDualImpliedBounds();
       model->row_lower_[row] = model->row_upper_[row];
       postsolve_stack.impliedEquation(row, false, getRowVector(row));
       // Since row lower bound is now finite, upper bound on row dual is


### PR DESCRIPTION
## Description

This is another instance found by @odow and his LLM fuzzer. The issue seems to be that when upgrading a row to an equality, the implied dual bounds on other rows are not notified. This means that there can be a stale implied bound lying around, and in this three column LP example, it is used for some additional reduction (I think it was a substitution). This lead to an incorrect return status in the test I added (instance directly from @odow )

The fix I added was to reset all the dependent implied bounds when upgrading the row to an equality (I will test this over the weekend). @fwesselm This is another presolve change where I'm a bit out of my depth.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)