### PR TITLE
Enhance clique extraction

### DIFF
--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1782,3 +1782,73 @@ TEST_CASE("redcost-fixing-large-bounds", "[highs_test_mip_solver]") {
       mipsolver, mipsolver.mipdata_->getDomain());
   REQUIRE(!lurkingBounds.empty());
 }
+
+TEST_CASE("clique-extract-origin", "[highs_test_mip_solver]") {
+  // extractCliques must pass the row origin so that
+  // runCliqueMerging can delete subsumed rows.
+  // Model: 4 binary variables, 4 rows:
+  //   row 0: x0 + x1 + x2 <= 1       (set packing, 3-clique)
+  //   row 1: -x0 + x3 >= 0           (x3 >= x0, implication)
+  //   row 2: -x1 + x3 >= 0           (x3 >= x1, implication)
+  //   row 3: -x2 + x3 >= 0           (x3 >= x2, implication)
+  // Rows 1-3 transform into size-2 cliques. Clique merging extends the
+  // 3-clique from row 0 with (x3,0) and subsumes the size-2 cliques,
+  // deleting their origin rows.
+  const HighsInt ncols = 4;
+  const HighsInt nrows = 4;
+  HighsLp lp;
+  lp.num_col_ = ncols;
+  lp.num_row_ = nrows;
+  lp.sense_ = ObjSense::kMinimize;
+  lp.offset_ = 0;
+  lp.col_cost_ = {1.0, 1.0, 1.0, 1.0};
+  lp.col_lower_ = {0.0, 0.0, 0.0, 0.0};
+  lp.col_upper_ = {1.0, 1.0, 1.0, 1.0};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kInteger,
+                     HighsVarType::kInteger, HighsVarType::kInteger};
+  lp.row_lower_ = {-kHighsInf, 0.0, 0.0, 0.0};
+  lp.row_upper_ = {1.0, kHighsInf, kHighsInf, kHighsInf};
+  // CSC matrix:
+  //        row0  row1  row2  row3
+  // x0:      1    -1     0     0
+  // x1:      1     0    -1     0
+  // x2:      1     0     0    -1
+  // x3:      0     1     1     1
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.start_ = {0, 2, 4, 6, 9};
+  lp.a_matrix_.index_ = {0, 1, 0, 2, 0, 3, 1, 2, 3};
+  lp.a_matrix_.value_ = {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 1.0, 1.0};
+
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.passModel(lp);
+
+  HighsCallback callback(&highs);
+  const HighsOptions& options = highs.getOptions();
+  HighsSolution solution;
+  HighsMipSolver mipsolver(callback, options, lp, solution);
+  mipsolver.mipdata_ =
+      std::unique_ptr<HighsMipSolverData>(new HighsMipSolverData(mipsolver));
+  mipsolver.mipdata_->feastol = 1e-6;
+  mipsolver.mipdata_->postSolveStack.initializeIndexMaps(nrows, ncols);
+  mipsolver.mipdata_->setupDomainPropagation();
+
+  HighsCliqueTable& cliquetable = mipsolver.mipdata_->cliquetable;
+  HighsDomain& domain = mipsolver.mipdata_->getDomain();
+
+  cliquetable.extractCliques(mipsolver);
+  cliquetable.runCliqueMerging(domain);
+
+  std::vector<HighsInt> deleted = cliquetable.getDeletedRows();
+  std::sort(deleted.begin(), deleted.end());
+  // rows 1, 2, 3 should be deleted (subsumed by the merged 4-clique)
+  // row 0 is kept as the origin of the merged clique
+  REQUIRE(deleted == std::vector<HighsInt>{1, 2, 3});
+
+  // the 3-clique from row 0 should have been extended with (x3, 0)
+  REQUIRE(cliquetable.haveCommonClique({0, 1}, {3, 0}));
+  REQUIRE(cliquetable.haveCommonClique({1, 1}, {3, 0}));
+  REQUIRE(cliquetable.haveCommonClique({2, 1}, {3, 0}));
+
+  highs.resetGlobalScheduler(true);
+}

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1916,3 +1916,55 @@ TEST_CASE("clique-extract-origin-unequal-coeff", "[highs_test_mip_solver]") {
 
   highs.resetGlobalScheduler(true);
 }
+
+TEST_CASE("clique-no-delete-ranged-row", "[highs_test_mip_solver]") {
+  // Negative test: ranged rows must not be deleted by clique merging because
+  // the extracted clique is a relaxation (only captures one side).
+  //   row 0: x0 + x1 + x2 <= 1       (set packing, 3-clique)
+  //   row 1: 0 <= -x0 + x3 <= 1      (ranged)
+  //   row 2: 0 <= -x1 + x3 <= 1      (ranged)
+  //   row 3: 0 <= -x2 + x3 <= 1      (ranged)
+  const HighsInt ncols = 4;
+  const HighsInt nrows = 4;
+  HighsLp lp;
+  lp.num_col_ = ncols;
+  lp.num_row_ = nrows;
+  lp.sense_ = ObjSense::kMinimize;
+  lp.offset_ = 0;
+  lp.col_cost_ = {1.0, 1.0, 1.0, 1.0};
+  lp.col_lower_ = {0.0, 0.0, 0.0, 0.0};
+  lp.col_upper_ = {1.0, 1.0, 1.0, 1.0};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kInteger,
+                     HighsVarType::kInteger, HighsVarType::kInteger};
+  lp.row_lower_ = {-kHighsInf, 0.0, 0.0, 0.0};
+  lp.row_upper_ = {1.0, 1.0, 1.0, 1.0};
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.start_ = {0, 2, 4, 6, 9};
+  lp.a_matrix_.index_ = {0, 1, 0, 2, 0, 3, 1, 2, 3};
+  lp.a_matrix_.value_ = {1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, 1.0, 1.0};
+
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.passModel(lp);
+
+  HighsCallback callback(&highs);
+  const HighsOptions& options = highs.getOptions();
+  HighsSolution solution;
+  HighsMipSolver mipsolver(callback, options, lp, solution);
+  mipsolver.mipdata_ =
+      std::unique_ptr<HighsMipSolverData>(new HighsMipSolverData(mipsolver));
+  mipsolver.mipdata_->feastol = 1e-6;
+  mipsolver.mipdata_->postSolveStack.initializeIndexMaps(nrows, ncols);
+  mipsolver.mipdata_->setupDomainPropagation();
+
+  HighsCliqueTable& cliquetable = mipsolver.mipdata_->cliquetable;
+  HighsDomain& domain = mipsolver.mipdata_->getDomain();
+
+  cliquetable.extractCliques(mipsolver);
+  cliquetable.runCliqueMerging(domain);
+
+  const std::vector<HighsInt>& deleted = cliquetable.getDeletedRows();
+  REQUIRE(deleted.empty());
+
+  highs.resetGlobalScheduler(true);
+}

--- a/check/TestMipSolver.cpp
+++ b/check/TestMipSolver.cpp
@@ -1852,3 +1852,67 @@ TEST_CASE("clique-extract-origin", "[highs_test_mip_solver]") {
 
   highs.resetGlobalScheduler(true);
 }
+
+TEST_CASE("clique-extract-origin-unequal-coeff", "[highs_test_mip_solver]") {
+  // Same as clique-extract-origin but row 0 has unequal coefficients,
+  // exercising the sub-clique extraction loop instead of the equal-
+  // coefficient path.
+  //   row 0: x0 + 2*x1 + 2*x2 <= 2  (unequal coeffs, clique covers all 3)
+  //   row 1: -x0 + x3 >= 0
+  //   row 2: -x1 + x3 >= 0
+  //   row 3: -x2 + x3 >= 0
+  const HighsInt ncols = 4;
+  const HighsInt nrows = 4;
+  HighsLp lp;
+  lp.num_col_ = ncols;
+  lp.num_row_ = nrows;
+  lp.sense_ = ObjSense::kMinimize;
+  lp.offset_ = 0;
+  lp.col_cost_ = {1.0, 1.0, 1.0, 1.0};
+  lp.col_lower_ = {0.0, 0.0, 0.0, 0.0};
+  lp.col_upper_ = {1.0, 1.0, 1.0, 1.0};
+  lp.integrality_ = {HighsVarType::kInteger, HighsVarType::kInteger,
+                     HighsVarType::kInteger, HighsVarType::kInteger};
+  lp.row_lower_ = {-kHighsInf, 0.0, 0.0, 0.0};
+  lp.row_upper_ = {2.0, kHighsInf, kHighsInf, kHighsInf};
+  // CSC matrix:
+  //        row0  row1  row2  row3
+  // x0:      1    -1     0     0
+  // x1:      2     0    -1     0
+  // x2:      2     0     0    -1
+  // x3:      0     1     1     1
+  lp.a_matrix_.format_ = MatrixFormat::kColwise;
+  lp.a_matrix_.start_ = {0, 2, 4, 6, 9};
+  lp.a_matrix_.index_ = {0, 1, 0, 2, 0, 3, 1, 2, 3};
+  lp.a_matrix_.value_ = {1.0, -1.0, 2.0, -1.0, 2.0, -1.0, 1.0, 1.0, 1.0};
+
+  Highs highs;
+  highs.setOptionValue("output_flag", dev_run);
+  highs.passModel(lp);
+
+  HighsCallback callback(&highs);
+  const HighsOptions& options = highs.getOptions();
+  HighsSolution solution;
+  HighsMipSolver mipsolver(callback, options, lp, solution);
+  mipsolver.mipdata_ =
+      std::unique_ptr<HighsMipSolverData>(new HighsMipSolverData(mipsolver));
+  mipsolver.mipdata_->feastol = 1e-6;
+  mipsolver.mipdata_->postSolveStack.initializeIndexMaps(nrows, ncols);
+  mipsolver.mipdata_->setupDomainPropagation();
+
+  HighsCliqueTable& cliquetable = mipsolver.mipdata_->cliquetable;
+  HighsDomain& domain = mipsolver.mipdata_->getDomain();
+
+  cliquetable.extractCliques(mipsolver);
+  cliquetable.runCliqueMerging(domain);
+
+  std::vector<HighsInt> deleted = cliquetable.getDeletedRows();
+  std::sort(deleted.begin(), deleted.end());
+  REQUIRE(deleted == std::vector<HighsInt>{1, 2, 3});
+
+  REQUIRE(cliquetable.haveCommonClique({0, 1}, {3, 0}));
+  REQUIRE(cliquetable.haveCommonClique({1, 1}, {3, 0}));
+  REQUIRE(cliquetable.haveCommonClique({2, 1}, {3, 0}));
+
+  highs.resetGlobalScheduler(true);
+}

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -851,7 +851,7 @@ void HighsCliqueTable::extractCliques(
     const HighsMipSolver& mipsolver, std::vector<HighsInt>& inds,
     std::vector<double>& vals, std::vector<int8_t>& complementation, double rhs,
     HighsInt nbin, std::vector<HighsInt>& perm, std::vector<CliqueVar>& clique,
-    double feastol) {
+    double feastol, HighsInt origin) {
   HighsImplications& implics = mipsolver.mipdata_->implications;
   HighsDomain& globaldom = mipsolver.mipdata_->getDomain();
 
@@ -939,7 +939,8 @@ void HighsCliqueTable::extractCliques(
         clique.emplace_back(inds[pos], 1);
     }
 
-    addClique(mipsolver, clique.data(), nbin);
+    addClique(mipsolver, clique.data(), nbin, false,
+              nbin == ntotal ? origin : kHighsIInf);
     if (globaldom.infeasible()) return;
     // printf("extracted this clique:\n");
     // printClique(clique);
@@ -1334,7 +1335,7 @@ void HighsCliqueTable::extractCliques(HighsMipSolver& mipsolver,
       entries[col] += val;
     }
 
-    auto checkRow = [&](double rhs, HighsInt direction) {
+    auto checkRow = [&](HighsInt row, double rhs, HighsInt direction) {
       if (direction * rhs == kHighsInf) return;
       rhs = direction * (rhs - offset);
       inds.clear();
@@ -1372,13 +1373,13 @@ void HighsCliqueTable::extractCliques(HighsMipSolver& mipsolver,
 
       if (!freevar && nbin != 0) {
         extractCliques(mipsolver, inds, vals, complementation, rhs, nbin, perm,
-                       clique, mipsolver.mipdata_->feastol);
+                       clique, mipsolver.mipdata_->feastol, row);
         if (globaldom.infeasible()) return;
       }
     };
 
-    checkRow(mipsolver.rowUpper(i), HighsInt{1});
-    checkRow(mipsolver.rowLower(i), HighsInt{-1});
+    checkRow(i, mipsolver.rowUpper(i), HighsInt{1});
+    checkRow(i, mipsolver.rowLower(i), HighsInt{-1});
 
     entries.clear();
   }

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -980,6 +980,8 @@ void HighsCliqueTable::extractCliques(
       // if (clique.size() > 2) runCliqueSubsumption(globaldom, clique);
       // runCliqueMerging(globaldom, clique);
       // if (clique.size() >= 2) {
+      // if all variables are binary and form one clique, pass row origin
+      // so clique merging can delete the subsumed row
       addClique(
           mipsolver, clique.data(), static_cast<HighsInt>(clique.size()), false,
           static_cast<HighsInt>(clique.size()) == ntotal ? origin : kHighsIInf);

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -1384,8 +1384,13 @@ void HighsCliqueTable::extractCliques(HighsMipSolver& mipsolver,
       }
     };
 
-    checkRow(i, mipsolver.rowUpper(i), HighsInt{1});
-    checkRow(i, mipsolver.rowLower(i), HighsInt{-1});
+    // only pass row origin for one-sided inequalities; a clique is a
+    // relaxation of a ranged row so it cannot be deleted
+    bool isRanged = mipsolver.rowUpper(i) != kHighsInf &&
+                    mipsolver.rowLower(i) != -kHighsInf;
+    HighsInt rowOrigin = isRanged ? kHighsIInf : i;
+    checkRow(rowOrigin, mipsolver.rowUpper(i), HighsInt{1});
+    checkRow(rowOrigin, mipsolver.rowLower(i), HighsInt{-1});
 
     entries.clear();
   }

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -980,7 +980,9 @@ void HighsCliqueTable::extractCliques(
       // if (clique.size() > 2) runCliqueSubsumption(globaldom, clique);
       // runCliqueMerging(globaldom, clique);
       // if (clique.size() >= 2) {
-      addClique(mipsolver, clique.data(), static_cast<HighsInt>(clique.size()));
+      addClique(
+          mipsolver, clique.data(), static_cast<HighsInt>(clique.size()), false,
+          static_cast<HighsInt>(clique.size()) == ntotal ? origin : kHighsIInf);
       if (globaldom.infeasible()) return;
       //}
     }

--- a/highs/mip/HighsCliqueTable.cpp
+++ b/highs/mip/HighsCliqueTable.cpp
@@ -939,6 +939,8 @@ void HighsCliqueTable::extractCliques(
         clique.emplace_back(inds[pos], 1);
     }
 
+    // if all variables are binary, pass row origin so clique merging
+    // can delete the subsumed row
     addClique(mipsolver, clique.data(), nbin, false,
               nbin == ntotal ? origin : kHighsIInf);
     if (globaldom.infeasible()) return;

--- a/highs/mip/HighsCliqueTable.h
+++ b/highs/mip/HighsCliqueTable.h
@@ -150,7 +150,8 @@ class HighsCliqueTable {
                       std::vector<HighsInt>& inds, std::vector<double>& vals,
                       std::vector<int8_t>& complementation, double rhs,
                       HighsInt nbin, std::vector<HighsInt>& perm,
-                      std::vector<CliqueVar>& clique, double feastol);
+                      std::vector<CliqueVar>& clique, double feastol,
+                      HighsInt origin = kHighsIInf);
 
   void processInfeasibleVertices(HighsDomain& domain);
 

--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -1584,6 +1584,116 @@ HPresolve::Result HPresolve::dominatedColumns(
   return Result::kOk;
 }
 
+HPresolve::Result HPresolve::normaliseAllBinaryCliqueRows() {
+  struct nonZero {
+    HighsInt index;
+    double value;
+    int8_t complementation;
+    HighsInt position;
+  };
+
+  auto transformAllBinaryRow = [&](HighsInt row, std::vector<nonZero>& nzs,
+                                   HighsCDouble& rhs, HighsInt direction) {
+    nzs.clear();
+    rhs *= direction;
+
+    storeRow(row);
+    for (HighsInt rowiter : rowpositions) {
+      HighsInt col = Acol[rowiter];
+      double val = direction * Avalue[rowiter];
+
+      if (val < 0) {
+        nzs.push_back(nonZero{col, -val, -1, rowiter});
+        rhs -= static_cast<HighsCDouble>(val) * model->col_upper_[col];
+      } else {
+        nzs.push_back(nonZero{col, val, 1, rowiter});
+        rhs -= static_cast<HighsCDouble>(val) * model->col_lower_[col];
+      }
+    }
+  };
+
+  std::vector<nonZero> nzs;
+
+  for (HighsInt row = 0; row < model->num_row_; row++) {
+    // skip deleted and ranged rows
+    if (rowDeleted[row] || (isRanged(row) && !isEquation(row))) continue;
+
+    // skip rows that are not all-binary
+    bool allBinary = true;
+    bool isSetPpc = model->row_upper_[row] == 1.0;
+    for (const auto& nz : getRowVector(row)) {
+      allBinary = allBinary &&
+                  model->integrality_[nz.index()] == HighsVarType::kInteger &&
+                  model->col_lower_[nz.index()] == 0.0 &&
+                  model->col_upper_[nz.index()] == 1.0;
+      isSetPpc = isSetPpc && allBinary && nz.value() == 1.0;
+      if (!allBinary) break;
+    }
+    if (!allBinary || isSetPpc) continue;
+
+    // transform row
+    HighsInt direction =
+        model->row_upper_[row] < kHighsInf ? HighsInt{1} : HighsInt{-1};
+    HighsCDouble rhs =
+        direction > 0 ? model->row_upper_[row] : model->row_lower_[row];
+
+    // transform the row
+    transformAllBinaryRow(row, nzs, rhs, direction);
+
+    HighsInt n = static_cast<HighsInt>(nzs.size());
+    if (n < 2) continue;
+
+    // sort by descending coefficient value
+    std::vector<HighsInt> perm(n);
+    std::iota(perm.begin(), perm.end(), 0);
+    pdqsort(perm.begin(), perm.end(), [&](HighsInt a, HighsInt b) {
+      return nzs[a].value > nzs[b].value;
+    });
+
+    // trivial fixings: variables with coefficient > rhs must be zero
+    // in the complemented space
+    HighsInt start = 0;
+    for (HighsInt j = 0; j < n; ++j) {
+      if (nzs[perm[j]].value <= rhs + primal_feastol) break;
+      HighsInt col = nzs[perm[j]].index;
+      if (nzs[perm[j]].complementation == -1)
+        HPRESOLVE_CHECKED_CALL(changeColLower(col, 1.0));
+      else
+        HPRESOLVE_CHECKED_CALL(changeColUpper(col, 0.0));
+      ++start;
+    }
+
+    // skip row if there are less than two remaining variables or two smallest
+    // remaining coefficients do not form a clique
+    if (n - start < 2 ||
+        nzs[perm[n - 2]].value + nzs[perm[n - 1]].value <= rhs + primal_feastol)
+      continue;
+
+    // normalize remaining coefficients to ±1
+    HighsInt numNeg = 0;
+    for (HighsInt j = start; j < n; ++j) {
+      HighsInt pos = nzs[perm[j]].position;
+      double target = static_cast<double>(nzs[perm[j]].complementation);
+      double delta = target - Avalue[pos];
+      if (delta != 0.0) addToMatrix(row, nzs[perm[j]].index, delta);
+      if (nzs[perm[j]].complementation == -1) ++numNeg;
+    }
+
+    // update row bounds
+    model->row_upper_[row] = 1.0 - numNeg;
+    if (isEquation(row))
+      model->row_lower_[row] = 1.0 - numNeg;
+    else {
+      model->row_lower_[row] = -kHighsInf;
+      if (direction == -1) {
+        changeRowDualLower(row, -kHighsInf);
+        changeRowDualUpper(row, 0);
+      }
+    }
+  }
+  return Result::kOk;
+}
+
 HPresolve::Result HPresolve::prepareProbing(
     HighsPostsolveStack& postsolve_stack, bool& firstCall) {
   HighsDomain& domain = mipsolver->mipdata_->getDomain();
@@ -1611,6 +1721,8 @@ HPresolve::Result HPresolve::prepareProbing(
         implColUpper[i] < model->col_upper_[i])
       HPRESOLVE_CHECKED_CALL(changeColUpper(i, implColUpper[i]));
   }
+
+  HPRESOLVE_CHECKED_CALL(normaliseAllBinaryCliqueRows());
 
   // prepare for domain propagation
   mipsolver->mipdata_->setupDomainPropagation();

--- a/highs/presolve/HPresolve.h
+++ b/highs/presolve/HPresolve.h
@@ -410,6 +410,8 @@ class HPresolve {
                    double row_upper, const std::vector<HighsInt>& row_indices,
                    const std::vector<double>& row_values);
 
+  Result normaliseAllBinaryCliqueRows();
+
   Result prepareProbing(HighsPostsolveStack& postsolve_stack, bool& firstCall);
 
   Result finaliseProbing(HighsPostsolveStack& postsolve_stack, bool firstCall,


### PR DESCRIPTION
<!--
Thank you for contributing to HiGHS!

Please make sure this PR targets the `latest` branch, not `master`.
-->

## Description

<!-- What does this PR change, and why? -->

1. `HPresolve::normaliseCliqueRows` scales all-binary rows to `+-1` coefficients and `<=` form for clique extraction if possible.
2. On `neos-631710` the normalisation enables clique merging to detect and remove 166500 binary-binary implication (clique) rows, reducing the presolved model to 3076 rows.
3. Added unit tests.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)

<!-- Please uncomment if the PR closes a related issue. -->
<!--
## Related issue
Closes #
-->