### PR TITLE
Fix bug in strengthen coefficients

### DIFF
--- a/highs/presolve/HPresolve.cpp
+++ b/highs/presolve/HPresolve.cpp
@@ -4582,12 +4582,14 @@ HPresolve::Result HPresolve::rowPresolve(HighsPostsolveStack& postsolve_stack,
           HighsInt col = Acol[rowiter];
           double val = direction * Avalue[rowiter];
 
-          // get lower and upper bounds
-          double col_lower = impliedRowBounds.getImplVarLower(row, col);
-          double col_upper = impliedRowBounds.getImplVarUpper(row, col);
-
           // skip continuous variables
           if (model->integrality_[col] == HighsVarType::kContinuous) continue;
+
+          // get lower and upper bounds
+          double col_lower = std::ceil(
+              impliedRowBounds.getImplVarLower(row, col) - primal_feastol);
+          double col_upper = std::floor(
+              impliedRowBounds.getImplVarUpper(row, col) + primal_feastol);
 
           if (val > maxAbsCoefValue + primal_feastol) {
             assert(col_upper != kHighsInf);


### PR DESCRIPTION
## Description

This fixes another instance that @odow generated with his LLM fuzzer. The issue is that a non-continuous column is using some fractional implied bound, which dominoes into an error elsewhere. I've marked this as a draft PR as I'm not 100% confident on the generalisation of the fix here yet (@fwesselm nearly forgot about this, so wanted to create a draft PR)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/ERGO-Code/HiGHS/blob/latest/CONTRIBUTING.md)
- [x] This PR targets the `latest` branch
- [x] Tests are passing
- [x] Documentation was updated where relevant
- [x] This PR is not primarily AI-generated (per the AI contributions policy in CONTRIBUTING.md)